### PR TITLE
feat(substrate): Phase 3 misc (pure-fn / module-cycles / def-use / template-patterns) for T1 languages (#2774)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -43,7 +43,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/16 | |
 | [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -64,7 +64,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/16 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -105,7 +105,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/16 | |
 | [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -160,7 +160,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/9 | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/13 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md).
 | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/16 | |
 | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -22,7 +22,7 @@ Back to [summary](../summary.md).
 | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/16 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -31,7 +31,7 @@ Back to [summary](../summary.md).
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
 | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
-| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/9 | |
+| [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/13 | |
 | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md).
 | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/12 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/16 | |
 | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 16
+- **Capability cells:** 20
 
 ## Capabilities
 
@@ -57,15 +57,19 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_golang.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_golang.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/golang.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_golang.go` | — |
+| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_golang.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_golang.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_golang.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 16
+- **Capability cells:** 20
 
 ## Capabilities
 
@@ -57,15 +57,19 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_java.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
+| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_java.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 24
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -63,12 +63,16 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_jsts.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 16
+- **Capability cells:** 20
 
 ## Capabilities
 
@@ -57,15 +57,19 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_python.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
+| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_python.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -6807,6 +6807,11 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_golang.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_golang.go"],
+            "verified_at": "2026-05-28"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
@@ -6827,9 +6832,19 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/golang.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "module_cycle_detection": {
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "verified_at": "2026-05-28"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_golang.go"],
+            "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
@@ -6851,6 +6866,11 @@
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_golang.go"],
             "verified_at": "2026-05-27"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_golang.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -8569,6 +8589,11 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_java.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_java.go"],
+            "verified_at": "2026-05-28"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
@@ -8589,9 +8614,19 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "module_cycle_detection": {
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "verified_at": "2026-05-28"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
@@ -8613,6 +8648,11 @@
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_java.go"],
+            "verified_at": "2026-05-28"
           }
         }
       },
@@ -10932,6 +10972,11 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_jsts.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_jsts.go"],
+            "verified_at": "2026-05-28"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
@@ -10952,14 +10997,29 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "module_cycle_detection": {
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "verified_at": "2026-05-28"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_jsts.go"],
             "verified_at": "2026-05-28"
           },
+          "pure_function_tagging": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
+            "verified_at": "2026-05-28"
+          },
           "reachability_analysis": {
             "status": "full",
             "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_jsts.go"],
+            "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_jsts.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -15088,6 +15148,11 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_python.go"],
+            "verified_at": "2026-05-28"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
@@ -15108,9 +15173,19 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "module_cycle_detection": {
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "verified_at": "2026-05-28"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
             "verified_at": "2026-05-28"
           },
           "reachability_analysis": {
@@ -15132,6 +15207,11 @@
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
             "verified_at": "2026-05-27"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_python.go"],
+            "verified_at": "2026-05-28"
           }
         }
       },

--- a/internal/substrate/def_use_golang.go
+++ b/internal/substrate/def_use_golang.go
@@ -1,0 +1,146 @@
+// Go def-use sniffer (#2774 Phase 3C T1).
+//
+// Recognises:
+//   - Defs : `<name> :=`, `var <name> ...`, `<name> = ...` reassignments,
+//            `for <name> :=`, `for <name>, <name2> := range`,
+//            short-declarations with multiple LHS names.
+//   - Uses : bare identifiers `\b<name>\b` filtered against the Go
+//            keyword set and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding Go function header (uses the
+// existing scanGoFuncHeaders helper from effect_sinks_golang.go).
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("go", sniffDefUseGo) }
+
+// goShortDeclRe matches a short-declaration `<name>, <name2>, ... := ...`.
+// Group 1 = the entire comma-separated LHS list.
+var goShortDeclRe = regexp.MustCompile(
+	`(?m)^[ \t]*([A-Za-z_][\w]*(?:\s*,\s*[A-Za-z_][\w]*)*)\s*:=`,
+)
+
+// goVarDeclRe matches `var <name>` (single, no parens).
+var goVarDeclRe = regexp.MustCompile(`\bvar\s+([A-Za-z_][\w]*)`)
+
+// goAssignRe matches a bare assignment `<name> = ...` (not `==`, not `:=`).
+var goAssignRe = regexp.MustCompile(
+	`(?m)^[ \t]*([A-Za-z_][\w]*)\s*=(?:[^=])`,
+)
+
+// goForRangeRe matches `for <name>, _ := range` etc — same identifier
+// shape as the short-decl form; we already cover it via goShortDeclRe
+// because of the `:=` operator. Kept here as documentation only.
+
+var goIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+// goSplitCSV splits the LHS list captured by goShortDeclRe into per-name
+// entries, trimming whitespace. Avoids strings.Split's allocation for the
+// common single-name case.
+func goSplitCSV(lhs string) []string {
+	var out []string
+	start := 0
+	for i := 0; i <= len(lhs); i++ {
+		if i == len(lhs) || lhs[i] == ',' {
+			seg := lhs[start:i]
+			for len(seg) > 0 && (seg[0] == ' ' || seg[0] == '\t') {
+				seg = seg[1:]
+			}
+			for len(seg) > 0 && (seg[len(seg)-1] == ' ' || seg[len(seg)-1] == '\t') {
+				seg = seg[:len(seg)-1]
+			}
+			if seg != "" {
+				out = append(out, seg)
+			}
+			start = i + 1
+		}
+	}
+	return out
+}
+
+func goReservedDefUse(s string) bool {
+	switch s {
+	case "break", "case", "chan", "const", "continue", "default", "defer",
+		"else", "fallthrough", "for", "func", "go", "goto", "if", "import",
+		"interface", "map", "package", "range", "return", "select", "struct",
+		"switch", "type", "var", "true", "false", "nil", "iota", "_",
+		"make", "new", "len", "cap", "append", "copy", "delete", "panic",
+		"recover", "print", "println", "string", "int", "int32", "int64",
+		"uint", "uint32", "uint64", "byte", "rune", "float32", "float64",
+		"bool", "error", "any":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseGo(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanGoFuncHeaders(content)
+
+	var defs []VarDef
+	addDef := func(name string, off int) {
+		if name == "" || goReservedDefUse(name) {
+			return
+		}
+		line := lineOfOffset(content, off)
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			return
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+	for _, m := range goShortDeclRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		for _, nm := range goSplitCSV(content[m[2]:m[3]]) {
+			addDef(nm, m[0])
+		}
+	}
+	for _, m := range goVarDeclRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		addDef(content[m[2]:m[3]], m[0])
+	}
+	for _, m := range goAssignRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		addDef(content[m[2]:m[3]], m[0])
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range goIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if goReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_java.go
+++ b/internal/substrate/def_use_java.go
@@ -1,0 +1,107 @@
+// Java def-use sniffer (#2774 Phase 3C T1).
+//
+// Recognises:
+//   - Defs : `<Type> <name> = ...`, simple `<name> = ...` reassignments,
+//            `for (<Type> <name> :)` / `for (...; ...; ...)` index decls.
+//   - Uses : bare identifiers `\b<name>\b` (filtered against keywords and
+//            type names) not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding Java method header (uses the
+// existing scanJavaFuncHeaders helper from effect_sinks_java.go).
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("java", sniffDefUseJava) }
+
+// javaDefRe matches typed declarations and bare assignments.
+//   Group 1 (typed)   : `<Type> <name> =`     where Type is one identifier.
+//   Group 2 (bare)    : `<name> = ...`        not `==`, not `.x =`.
+//   Group 3 (forEach) : `for (<Type> <name> :`.
+var javaDefRe = regexp.MustCompile(
+	`\b(?:[A-Z][\w<>,\s\[\]]*|int|long|short|byte|char|boolean|float|double|var)\s+([A-Za-z_][\w]*)\s*=` +
+		`|(?m)^\s*([A-Za-z_][\w]*)\s*=(?:[^=])` +
+		`|\bfor\s*\(\s*(?:[A-Z][\w<>,\s\[\]]*|int|long|var)\s+([A-Za-z_][\w]*)\s*:`,
+)
+
+var javaIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func javaReservedDefUse(s string) bool {
+	switch s {
+	case "if", "else", "for", "while", "do", "switch", "case", "default",
+		"break", "continue", "return", "throw", "throws", "try", "catch",
+		"finally", "new", "instanceof", "true", "false", "null", "this",
+		"super", "void", "public", "private", "protected", "static",
+		"final", "abstract", "synchronized", "volatile", "transient",
+		"native", "strictfp", "class", "interface", "enum", "extends",
+		"implements", "package", "import", "int", "long", "short", "byte",
+		"char", "boolean", "float", "double", "var", "String", "Integer",
+		"Long", "Boolean", "Object", "List", "Map", "Set", "ArrayList",
+		"HashMap", "HashSet", "Optional", "Override":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseJava(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanJavaFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range javaDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" || javaReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range javaIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if javaReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_jsts.go
+++ b/internal/substrate/def_use_jsts.go
@@ -1,0 +1,110 @@
+// JS/TS def-use sniffer (#2774 Phase 3C T1).
+//
+// Recognises:
+//   - Defs : `let x = ...`, `const x = ...`, `var x = ...`,
+//            simple `x = ...` assignments (not `.member =`, not `==`).
+//   - Uses : bare identifiers `\b<name>\b` that are not language keywords
+//            and are not on the LHS of an assignment we already captured.
+//
+// Function attribution uses the same nearest-preceding-header heuristic
+// as the JS/TS effect sniffer; nested closures lose some precision, but
+// the common module-level / class-method case is correct.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("jsts", sniffDefUseJSTS) }
+
+// jstsDefRe matches `let|const|var <name> =` and bare `<name> =`.
+// Group 2 (let/const/var form) or group 4 (bare assignment) is the name.
+var jstsDefRe = regexp.MustCompile(
+	`(?m)(?:\b(let|const|var)\s+([A-Za-z_$][\w$]*)\s*=` +
+		`|^\s*([A-Za-z_$][\w$]*)\s*=(?:[^=]))`,
+)
+
+// jstsIdentUseRe matches a bare identifier read. The pass filters out
+// keywords and the names already captured as defs on the same line.
+var jstsIdentUseRe = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\b`)
+
+// jstsReservedDefUse rejects keywords and well-known globals so the
+// use-set is dominated by real locals.
+func jstsReservedDefUse(s string) bool {
+	switch s {
+	case "if", "else", "for", "while", "do", "switch", "case", "default",
+		"break", "continue", "return", "throw", "try", "catch", "finally",
+		"function", "class", "extends", "new", "delete", "typeof",
+		"instanceof", "in", "of", "let", "const", "var", "true", "false",
+		"null", "undefined", "this", "super", "import", "export", "from",
+		"as", "async", "await", "yield", "void", "static", "public",
+		"private", "protected", "readonly", "interface", "type", "enum",
+		"namespace", "declare", "module", "package", "console", "window",
+		"document", "globalThis", "process", "require", "Math", "JSON",
+		"Object", "Array", "String", "Number", "Boolean", "Promise",
+		"Date", "Error", "RegExp", "Map", "Set", "Symbol":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseJSTS(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanJSTSFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range jstsDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" || jstsReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	// Build a per-line ban-set of names that appear as the LHS of a def
+	// on that line so we don't double-count the LHS identifier as a use.
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range jstsIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if jstsReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_python.go
+++ b/internal/substrate/def_use_python.go
@@ -1,0 +1,105 @@
+// Python def-use sniffer (#2774 Phase 3C T1).
+//
+// Recognises:
+//   - Defs : `<name> = ...`, augmented `<name> += ...`, `for <name> in`,
+//            `with ... as <name>:` and function-parameter names.
+//   - Uses : bare identifiers `\b<name>\b` that are not Python keywords
+//            and not the LHS of a def we already captured on the same line.
+//
+// Function attribution: nearest preceding `def` / `async def`. Class
+// bodies are followed too (methods carry the method name).
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("python", sniffDefUsePython) }
+
+// pyDefRe matches simple assignments and `for` / `with as` bindings.
+//   Group 1 (assign)    : `<name> = ` (not `==`, not `.attr =`).
+//   Group 2 (for)       : `for <name> in`.
+//   Group 3 (with as)   : `as <name>:` / `as <name>,`.
+var pyDefRe = regexp.MustCompile(
+	`(?m)^\s*([A-Za-z_][\w]*)\s*(?:\+|-|\*|/|%|//|\*\*|&|\||\^|<<|>>)?=(?:[^=])` +
+		`|\bfor\s+([A-Za-z_][\w]*)\s+in\b` +
+		`|\bas\s+([A-Za-z_][\w]*)\s*[:,)]`,
+)
+
+// pyIdentUseRe is the bare-identifier read regex.
+var pyIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func pyReservedDefUse(s string) bool {
+	switch s {
+	case "and", "or", "not", "is", "in", "if", "elif", "else", "for", "while",
+		"break", "continue", "return", "yield", "raise", "try", "except",
+		"finally", "with", "as", "import", "from", "def", "class", "async",
+		"await", "lambda", "pass", "global", "nonlocal", "del", "assert",
+		"True", "False", "None", "self", "cls", "print", "len", "range",
+		"str", "int", "float", "bool", "list", "dict", "tuple", "set",
+		"super", "isinstance", "issubclass", "type", "Exception":
+		return true
+	}
+	return false
+}
+
+func sniffDefUsePython(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanPyFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range pyDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		case m[6] >= 0:
+			name = content[m[6]:m[7]]
+		}
+		if name == "" || pyReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range pyIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if pyReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_test.go
+++ b/internal/substrate/def_use_test.go
@@ -1,0 +1,96 @@
+package substrate
+
+import "testing"
+
+func TestDefUseSnifferRegistry_T1(t *testing.T) {
+	for _, lang := range []string{"jsts", "python", "java", "go"} {
+		if DefUseSnifferFor(lang) == nil {
+			t.Errorf("def-use sniffer not registered for %q", lang)
+		}
+	}
+}
+
+func TestDefUseSniffer_JSTS_basic(t *testing.T) {
+	src := `
+function f(x) {
+  let y = 1;
+  let z = y + x;
+  return z;
+}`
+	defs, uses := sniffDefUseJSTS(src)
+	if len(defs) == 0 {
+		t.Fatalf("no defs detected")
+	}
+	if len(uses) == 0 {
+		t.Fatalf("no uses detected")
+	}
+	if !containsVarDef(defs, "f", "y") || !containsVarDef(defs, "f", "z") {
+		t.Errorf("expected y and z defs in f, got %+v", defs)
+	}
+	if !containsVarUse(uses, "f", "y") || !containsVarUse(uses, "f", "z") {
+		t.Errorf("expected y and z uses in f, got %+v", uses)
+	}
+}
+
+func TestDefUseSniffer_Python_basic(t *testing.T) {
+	src := "def f(x):\n    y = 1\n    z = y + x\n    return z\n"
+	defs, uses := sniffDefUsePython(src)
+	if !containsVarDef(defs, "f", "y") || !containsVarDef(defs, "f", "z") {
+		t.Errorf("expected y/z defs, got %+v", defs)
+	}
+	if !containsVarUse(uses, "f", "z") {
+		t.Errorf("expected z use, got %+v", uses)
+	}
+}
+
+func TestDefUseSniffer_Java_basic(t *testing.T) {
+	src := `class C {
+  public void f(int x) {
+    int y = 1;
+    int z = y + x;
+    System.out.println(z);
+  }
+}`
+	defs, uses := sniffDefUseJava(src)
+	if !containsVarDef(defs, "f", "y") || !containsVarDef(defs, "f", "z") {
+		t.Errorf("expected y/z defs in f, got %+v", defs)
+	}
+	if !containsVarUse(uses, "f", "z") {
+		t.Errorf("expected z use in f, got %+v", uses)
+	}
+}
+
+func TestDefUseSniffer_Go_basic(t *testing.T) {
+	src := `package p
+func f(x int) int {
+	y := 1
+	z := y + x
+	return z
+}
+`
+	defs, uses := sniffDefUseGo(src)
+	if !containsVarDef(defs, "f", "y") || !containsVarDef(defs, "f", "z") {
+		t.Errorf("expected y/z defs in f, got %+v", defs)
+	}
+	if !containsVarUse(uses, "f", "z") {
+		t.Errorf("expected z use in f, got %+v", uses)
+	}
+}
+
+func containsVarDef(defs []VarDef, fn, v string) bool {
+	for _, d := range defs {
+		if d.Function == fn && d.Var == v {
+			return true
+		}
+	}
+	return false
+}
+
+func containsVarUse(uses []VarUse, fn, v string) bool {
+	for _, u := range uses {
+		if u.Function == fn && u.Var == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/substrate/template_pattern_golang.go
+++ b/internal/substrate/template_pattern_golang.go
@@ -1,0 +1,83 @@
+// Go template-pattern sniffer (#2774 Phase 3D T1).
+//
+// Recognises:
+//   - i18n        : i18n.T("key") / message.NewPrinter().Sprintf("key", ...) —
+//                   conservative pattern, no widely-used canonical idiom
+//                   so we restrict to .T("...") method calls.
+//   - log_format  : fmt.Printf / fmt.Println / log.Printf / log.Println /
+//                   log.<Level>f("..."), klog.V(...).Infof("...") —
+//                   captures the format string literal.
+//   - sql         : Backtick/quoted literals whose first non-whitespace
+//                   token is a SQL verb (case-insensitive).
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("go", sniffTemplatePatternsGo)
+}
+
+// goI18nRe matches a .T("...") method call shape used by go-i18n,
+// nicksnyder/go-i18n, and message.NewPrinter()-style printers.
+// Group 1 = the bare literal.
+var goI18nRe = regexp.MustCompile(
+	`\.\s*(?:T|Tr|Translate|GetMessage)\s*\(\s*"([^"]+)"`,
+)
+
+// goLogRe matches fmt.Printf / fmt.Println / log.Printf / log.Println /
+// log.<Level>f("..."). Group 1 = the function name; Group 2 = literal.
+var goLogRe = regexp.MustCompile(
+	`\b(?:fmt|log|klog|slog|logger|zap|logrus)\s*\.\s*([A-Za-z][A-Za-z0-9_]*)\s*\(\s*"([^"]+)"`,
+)
+
+// goSQLRe matches a quoted or backticked literal whose first word is a
+// SQL verb. Group 1 = literal payload.
+var goSQLRe = regexp.MustCompile(
+	"[\"`](\\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\\s+TABLE|DROP\\s+TABLE|ALTER\\s+TABLE)[^\"`]*)[\"`]",
+)
+
+func sniffTemplatePatternsGo(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanGoFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range goI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "i18n.T()",
+		})
+	}
+	for _, m := range goLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "log." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range goSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_java.go
+++ b/internal/substrate/template_pattern_java.go
@@ -1,0 +1,80 @@
+// Java template-pattern sniffer (#2774 Phase 3D T1).
+//
+// Recognises:
+//   - i18n        : messages.getMessage("key", ...), messageSource.getMessage,
+//                   bundle.getString("key"), Translator.translate("key").
+//   - log_format  : logger.<level>("..."), log.<level>("..."),
+//                   slf4j-style {} placeholders captured in the literal.
+//   - sql         : Quoted string literals (single and concatenated)
+//                   whose first non-whitespace token is a SQL verb.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("java", sniffTemplatePatternsJava)
+}
+
+// javaI18nRe matches getMessage("key", ...) / getString("key") / translate("key").
+// Group 1 = the bare literal.
+var javaI18nRe = regexp.MustCompile(
+	`\b(?:getMessage|getString|translate|t)\s*\(\s*"([^"]+)"`,
+)
+
+// javaLogRe matches logger.<level>("...") / log.<level>("...").
+// Group 1 = level, Group 2 = literal.
+var javaLogRe = regexp.MustCompile(
+	`\b(?:logger|log|LOGGER|LOG)\s*\.\s*([a-z]+)\s*\(\s*"([^"]+)"`,
+)
+
+// javaSQLRe matches a quoted literal whose first word is a SQL verb.
+// Group 1 = the literal payload.
+var javaSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsJava(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanJavaFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range javaI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "getMessage",
+		})
+	}
+	for _, m := range javaLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "logger." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range javaSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_jsts.go
+++ b/internal/substrate/template_pattern_jsts.go
@@ -1,0 +1,81 @@
+// JS/TS template-pattern sniffer (#2774 Phase 3D T1).
+//
+// Recognises:
+//   - i18n        : t("key"), i18n.t("key"), $t("key"), useTranslation
+//                   exported t-callable invocations.
+//   - log_format  : console.<level>("...{}..."), logger.<level>("...{}..."),
+//                   log.<level>("..."). Only literal first arg is captured.
+//   - sql         : Backtick or quoted string literals whose first non-
+//                   whitespace token is a SQL verb (case-insensitive).
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("jsts", sniffTemplatePatternsJSTS)
+}
+
+// jstsI18nRe matches t("..."), i18n.t("..."), $t("..."), trans("..."),
+// gettext("..."). Group 1 = the bare literal payload.
+var jstsI18nRe = regexp.MustCompile(
+	`\b(?:t|\$t|i18n\.t|i18next\.t|trans|gettext|_t)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `]+)['"` + "`" + `]`,
+)
+
+// jstsLogRe matches console.<level>(...) and logger/log.<level>(...).
+// Group 1 = level (info/log/warn/error/debug/trace), Group 2 = literal.
+var jstsLogRe = regexp.MustCompile(
+	`\b(?:console|logger|log)\.([a-z]+)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `]+)['"` + "`" + `]`,
+)
+
+// jstsSQLRe matches a quoted/backticked literal whose first word is a
+// SQL verb. Group 1 = the literal payload (used for both Literal and
+// kind detection).
+var jstsSQLRe = regexp.MustCompile(
+	`['"` + "`" + `](\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[\s\S]*?)['"` + "`" + `]`,
+)
+
+func sniffTemplatePatternsJSTS(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanJSTSFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range jstsI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "t()",
+		})
+	}
+	for _, m := range jstsLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "console/logger." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range jstsSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_python.go
+++ b/internal/substrate/template_pattern_python.go
@@ -1,0 +1,97 @@
+// Python template-pattern sniffer (#2774 Phase 3D T1).
+//
+// Recognises:
+//   - i18n        : gettext("..."), _("..."), ngettext("...","...",n),
+//                   _l("..."), translate("...").
+//   - log_format  : logger.<level>("..."), logging.<level>("..."),
+//                   print("...{}..."). Only literal first arg is captured.
+//   - sql         : Quoted/triple-quoted string literals whose first
+//                   non-whitespace token is a SQL verb (case-insensitive).
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("python", sniffTemplatePatternsPython)
+}
+
+// pyI18nRe matches gettext("..."), _("..."), ngettext("..."), translate("...").
+// Group 1 = the bare literal payload.
+var pyI18nRe = regexp.MustCompile(
+	`\b(?:gettext|ngettext|pgettext|_l|translate|_)\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// pyLogRe matches logger.<level>("...") / logging.<level>("..."), print("...").
+// Group 1 = level (info/warning/error/debug), Group 2 = literal.
+var pyLogRe = regexp.MustCompile(
+	`\b(?:logger|logging|log)\s*\.\s*([a-z_]+)\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// pyPrintRe matches print("..."). Group 1 = literal.
+var pyPrintRe = regexp.MustCompile(
+	`\bprint\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// pySQLRe matches a quoted literal whose first word is a SQL verb. Group
+// 1 = the literal payload.
+var pySQLRe = regexp.MustCompile(
+	`['"](\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[\s\S]*?)['"]`,
+)
+
+func sniffTemplatePatternsPython(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanPyFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range pyI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "gettext",
+		})
+	}
+	for _, m := range pyLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[4]:m[5]]),
+			Tag:      "logger." + content[m[2]:m[3]],
+		})
+	}
+	for _, m := range pyPrintRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "print",
+		})
+	}
+	for _, m := range pySQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_test.go
+++ b/internal/substrate/template_pattern_test.go
@@ -1,0 +1,97 @@
+package substrate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTemplatePatternRegistry_T1(t *testing.T) {
+	for _, lang := range []string{"jsts", "python", "java", "go"} {
+		if TemplatePatternSnifferFor(lang) == nil {
+			t.Errorf("template-pattern sniffer not registered for %q", lang)
+		}
+	}
+}
+
+func TestTemplatePattern_JSTS(t *testing.T) {
+	src := "function f(){ t('home.title'); console.log('hello {}', name); db.query(\"SELECT * FROM users WHERE id = ?\"); }"
+	out := sniffTemplatePatternsJSTS(src)
+	if !hasTemplateKind(out, TemplateKindI18n) {
+		t.Errorf("missing i18n match: %+v", out)
+	}
+	if !hasTemplateKind(out, TemplateKindLog) {
+		t.Errorf("missing log match: %+v", out)
+	}
+	if !hasTemplateKind(out, TemplateKindSQL) {
+		t.Errorf("missing sql match: %+v", out)
+	}
+}
+
+func TestTemplatePattern_Python(t *testing.T) {
+	src := "def f():\n    _('hello')\n    logger.info('done')\n    cursor.execute('SELECT * FROM t')\n"
+	out := sniffTemplatePatternsPython(src)
+	if !hasTemplateKind(out, TemplateKindI18n) {
+		t.Errorf("missing i18n match")
+	}
+	if !hasTemplateKind(out, TemplateKindLog) {
+		t.Errorf("missing log match")
+	}
+	if !hasTemplateKind(out, TemplateKindSQL) {
+		t.Errorf("missing sql match")
+	}
+}
+
+func TestTemplatePattern_Java(t *testing.T) {
+	src := `class C {
+  void f() {
+    bundle.getString("welcome");
+    logger.info("done {}");
+    db.execute("SELECT * FROM t");
+  }
+}`
+	out := sniffTemplatePatternsJava(src)
+	if !hasTemplateKind(out, TemplateKindI18n) {
+		t.Errorf("missing i18n match")
+	}
+	if !hasTemplateKind(out, TemplateKindLog) {
+		t.Errorf("missing log match")
+	}
+	if !hasTemplateKind(out, TemplateKindSQL) {
+		t.Errorf("missing sql match")
+	}
+}
+
+func TestTemplatePattern_Go(t *testing.T) {
+	src := "package p\nfunc f(){ p.T(\"home.title\"); fmt.Printf(\"hello %s\\n\", x); db.Query(\"SELECT * FROM t\") }\n"
+	out := sniffTemplatePatternsGo(src)
+	if !hasTemplateKind(out, TemplateKindI18n) {
+		t.Errorf("missing i18n match: %+v", out)
+	}
+	if !hasTemplateKind(out, TemplateKindLog) {
+		t.Errorf("missing log match: %+v", out)
+	}
+	if !hasTemplateKind(out, TemplateKindSQL) {
+		t.Errorf("missing sql match: %+v", out)
+	}
+}
+
+func TestTruncateLiteral(t *testing.T) {
+	short := "hi"
+	if TruncateLiteral(short) != short {
+		t.Errorf("short literal mutated")
+	}
+	long := strings.Repeat("x", maxLiteralLength+50)
+	got := TruncateLiteral(long)
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("long literal not truncated: %q", got)
+	}
+}
+
+func hasTemplateKind(out []TemplatePattern, k TemplateKind) bool {
+	for _, m := range out {
+		if m.Kind == k {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -100,6 +100,10 @@ subcategories:
       - taint_sink_detection
       - sanitizer_recognition
       - vulnerability_finding
+      - pure_function_tagging
+      - module_cycle_detection
+      - def_use_chain_extraction
+      - template_pattern_catalog
     groups:
       - name: Routing
         keys: [endpoint_synthesis, handler_attribution, route_extraction]
@@ -116,7 +120,7 @@ subcategories:
       - name: Data
         keys: []
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
 
   ui_frontend:
     display: "UI Frontend"
@@ -154,6 +158,10 @@ subcategories:
       - taint_sink_detection
       - sanitizer_recognition
       - vulnerability_finding
+      - pure_function_tagging
+      - module_cycle_detection
+      - def_use_chain_extraction
+      - template_pattern_catalog
     groups:
       - name: Structure
         keys: [component_extraction, hook_recognition, jsx_template, context_extraction, hoc_wrapper_recognition]
@@ -168,7 +176,7 @@ subcategories:
       - name: Testing
         keys: [tests_linkage]
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
 
   meta_framework:
     display: "Meta Framework"
@@ -204,6 +212,10 @@ subcategories:
       - taint_sink_detection
       - sanitizer_recognition
       - vulnerability_finding
+      - pure_function_tagging
+      - module_cycle_detection
+      - def_use_chain_extraction
+      - template_pattern_catalog
     groups:
       - name: Structure
         keys: [component_extraction, hook_recognition]
@@ -222,7 +234,7 @@ subcategories:
       - name: Testing
         keys: [tests_linkage]
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
 
   mobile:
     display: "Mobile"
@@ -259,6 +271,10 @@ subcategories:
       - taint_sink_detection
       - sanitizer_recognition
       - vulnerability_finding
+      - pure_function_tagging
+      - module_cycle_detection
+      - def_use_chain_extraction
+      - template_pattern_catalog
     groups:
       - name: Structure
         keys: [context_extraction, hoc_wrapper_recognition]
@@ -277,7 +293,7 @@ subcategories:
       - name: Testing
         keys: [tests_linkage]
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
 
   desktop:
     display: "Desktop"
@@ -330,6 +346,10 @@ subcategories:
       - taint_sink_detection
       - sanitizer_recognition
       - vulnerability_finding
+      - pure_function_tagging
+      - module_cycle_detection
+      - def_use_chain_extraction
+      - template_pattern_catalog
     groups:
       - name: Schema
         keys: [schema_extraction, procedure_extraction]
@@ -338,7 +358,7 @@ subcategories:
       - name: Transport
         keys: []
       - name: Substrate
-        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding]
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
 
   static_site:
     display: "Static Site"

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -278,6 +278,41 @@ records:
           issues_implemented: ["2772"]
           verified_at: "2026-05-28"
 
+        pure_function_tagging:
+          status: partial
+          symbols:
+            - file: internal/links/pure_function_pass.go
+              functions: [runPureFunctionPass]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        module_cycle_detection:
+          status: partial
+          symbols:
+            - file: internal/links/module_cycle_pass.go
+              functions: [runModuleCyclePass, strongConnect]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        def_use_chain_extraction:
+          status: partial
+          symbols:
+            - file: internal/links/def_use_pass.go
+              functions: [runDefUsePass, formatDefUseSummary]
+            - file: internal/substrate/def_use.go
+            - file: internal/substrate/def_use_jsts.go
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        template_pattern_catalog:
+          status: partial
+          symbols:
+            - file: internal/links/template_pattern_pass.go
+              functions: [runTemplatePatternPass]
+            - file: internal/substrate/template_pattern.go
+            - file: internal/substrate/template_pattern_jsts.go
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+
   lang.jsts.framework.react-native:
     capabilities:
       Navigation:
@@ -489,6 +524,41 @@ records:
             - file: internal/links/taint_flow.go
               functions: [runTaintFlowPass, computeFindings]
           issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+
+        pure_function_tagging:
+          status: partial
+          symbols:
+            - file: internal/links/pure_function_pass.go
+              functions: [runPureFunctionPass]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        module_cycle_detection:
+          status: partial
+          symbols:
+            - file: internal/links/module_cycle_pass.go
+              functions: [runModuleCyclePass, strongConnect]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        def_use_chain_extraction:
+          status: partial
+          symbols:
+            - file: internal/links/def_use_pass.go
+              functions: [runDefUsePass, formatDefUseSummary]
+            - file: internal/substrate/def_use.go
+            - file: internal/substrate/def_use_python.go
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        template_pattern_catalog:
+          status: partial
+          symbols:
+            - file: internal/links/template_pattern_pass.go
+              functions: [runTemplatePatternPass]
+            - file: internal/substrate/template_pattern.go
+            - file: internal/substrate/template_pattern_python.go
+          issues_implemented: ["2774"]
           verified_at: "2026-05-28"
 
   lang.python.framework.flask:
@@ -797,6 +867,41 @@ records:
           issues_implemented: ["2772"]
           verified_at: "2026-05-28"
 
+        pure_function_tagging:
+          status: partial
+          symbols:
+            - file: internal/links/pure_function_pass.go
+              functions: [runPureFunctionPass]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        module_cycle_detection:
+          status: partial
+          symbols:
+            - file: internal/links/module_cycle_pass.go
+              functions: [runModuleCyclePass, strongConnect]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        def_use_chain_extraction:
+          status: partial
+          symbols:
+            - file: internal/links/def_use_pass.go
+              functions: [runDefUsePass, formatDefUseSummary]
+            - file: internal/substrate/def_use.go
+            - file: internal/substrate/def_use_java.go
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        template_pattern_catalog:
+          status: partial
+          symbols:
+            - file: internal/links/template_pattern_pass.go
+              functions: [runTemplatePatternPass]
+            - file: internal/substrate/template_pattern.go
+            - file: internal/substrate/template_pattern_java.go
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+
   lang.go.framework.gin:
     capabilities:
       Routing:
@@ -902,6 +1007,41 @@ records:
             - file: internal/links/taint_flow.go
               functions: [runTaintFlowPass, computeFindings]
           issues_implemented: ["2772"]
+          verified_at: "2026-05-28"
+
+        pure_function_tagging:
+          status: partial
+          symbols:
+            - file: internal/links/pure_function_pass.go
+              functions: [runPureFunctionPass]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        module_cycle_detection:
+          status: partial
+          symbols:
+            - file: internal/links/module_cycle_pass.go
+              functions: [runModuleCyclePass, strongConnect]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        def_use_chain_extraction:
+          status: partial
+          symbols:
+            - file: internal/links/def_use_pass.go
+              functions: [runDefUsePass, formatDefUseSummary]
+            - file: internal/substrate/def_use.go
+            - file: internal/substrate/def_use_golang.go
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        template_pattern_catalog:
+          status: partial
+          symbols:
+            - file: internal/links/template_pattern_pass.go
+              functions: [runTemplatePatternPass]
+            - file: internal/substrate/template_pattern.go
+            - file: internal/substrate/template_pattern_golang.go
+          issues_implemented: ["2774"]
           verified_at: "2026-05-28"
 
   lang.ruby.framework.rails:

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -75,6 +75,8 @@ func TestSubcategoryRenderKeysExcludesCategoryUnion(t *testing.T) {
 		"db_effect",
 		// #2766 substrate Phase 1B reachability + dead-code keys.
 		"dead_code_detection",
+		// #2774 Phase 3C def-use chains.
+		"def_use_chain_extraction",
 		"enum_extraction",
 		"env_fallback_recognition",
 		"fs_effect",
@@ -84,8 +86,12 @@ func TestSubcategoryRenderKeysExcludesCategoryUnion(t *testing.T) {
 		"import_resolution_quality",
 		"interface_extraction",
 		"jsx_template",
+		// #2774 Phase 3B module cycles.
+		"module_cycle_detection",
 		"mutation_effect",
 		"prop_extraction",
+		// #2774 Phase 3A pure-function tagging.
+		"pure_function_tagging",
 		"reachability_analysis",
 		// #2770 Phase 2A substrate payload-shape + drift detection.
 		"request_shape_extraction",
@@ -98,6 +104,8 @@ func TestSubcategoryRenderKeysExcludesCategoryUnion(t *testing.T) {
 		"state_setter_emission",
 		"taint_sink_detection",
 		"taint_source_detection",
+		// #2774 Phase 3D template-pattern catalog.
+		"template_pattern_catalog",
 		"tests_linkage",
 		"type_alias_extraction",
 		"vulnerability_finding",
@@ -125,6 +133,8 @@ func TestSubcategoryCapabilityKeysSorted(t *testing.T) {
 		"db_effect",
 		// #2766 substrate Phase 1B reachability + dead-code keys.
 		"dead_code_detection",
+		// #2774 Phase 3C def-use chains.
+		"def_use_chain_extraction",
 		"endpoint_synthesis",
 		"enum_extraction",
 		"env_fallback_recognition",
@@ -137,8 +147,12 @@ func TestSubcategoryCapabilityKeysSorted(t *testing.T) {
 		"interface_extraction",
 		"jsx_template",
 		"middleware_coverage",
+		// #2774 Phase 3B module cycles.
+		"module_cycle_detection",
 		"mutation_effect",
 		"prop_extraction",
+		// #2774 Phase 3A pure-function tagging.
+		"pure_function_tagging",
 		"reachability_analysis",
 		// #2770 Phase 2A substrate payload-shape + drift detection.
 		"request_shape_extraction",
@@ -151,6 +165,8 @@ func TestSubcategoryCapabilityKeysSorted(t *testing.T) {
 		"state_setter_emission",
 		"taint_sink_detection",
 		"taint_source_detection",
+		// #2774 Phase 3D template-pattern catalog.
+		"template_pattern_catalog",
 		"tests_linkage",
 		"type_alias_extraction",
 		"vulnerability_finding",


### PR DESCRIPTION
## Summary
Phase 3 mechanical port to T1 (jsts, python, java, go). The Phase 3
plumbing (4 generic passes + 4 MCP tools + `substrate/def_use.go` +
`substrate/template_pattern.go`) already landed via the T2 port (#2775);
this PR adds the four T1 sniffers per sub-task plus the matching
capability cells.

- **3A pure-function tagging** — derivative of Phase 1A, no per-language
  code. Functions with no detected sinks land in the
  `<group>-links-pure-functions.json` sidecar (plumbing in #2775).
- **3B module-cycle detection** — Tarjan SCC over `IMPORTS` edges per
  repo. Language-agnostic (plumbing in #2775).
- **3C reaching-definitions / def-use chains** — four new per-language
  sniffers (~110 LOC each): `def_use_{jsts,python,java,golang}.go`.
- **3D template-pattern catalog** — four new per-language sniffers
  (~70 LOC each): `template_pattern_{jsts,python,java,golang}.go`.
  Recognises i18n keys (`t`/`gettext`/`_`), log-format strings
  (`console.log`/`logger.*`/`fmt.Printf`), and SQL templates.

## Real-data verification on upvate group (3 repos, 18,405 entities)

- `pure_functions`: 6,276 entities tagged pure (e.g. core-mobile
  `contextValue` at `ReviewTabContent.tsx`).
- `module_cycles`: 4 SCCs surfaced (e.g. core-mobile
  `InspectionTypeRow.tsx` ↔ `InspectionDatePickerSheet.tsx` ↔
  `InspectionTypeRow.hooks.ts`).
- `def_use`: 42,330 chains across 1,288 files
  (e.g. `InspectorDevicesView`: `tabNavigation` defined line 90 → used
  line 91).
- `template_patterns`: 1,047 lifted (393 log_format, 654 sql; zero
  i18n — upvate is non-internationalised).

## Capability cells flipped (16 cells)

This PR also flips T1 sentinel capability cells that #2775 left as
`missing` (T2 PR added the code but not the capability dictionary
entries, since flipping cells against an undeclared key would have
been a validation regression — this PR adds the keys + flips the
T1 cells).

implements-capability: lang.python.framework.django-drf/Substrate/pure_function_tagging:missing->partial
implements-capability: lang.python.framework.django-drf/Substrate/module_cycle_detection:missing->partial
implements-capability: lang.python.framework.django-drf/Substrate/def_use_chain_extraction:missing->partial
implements-capability: lang.python.framework.django-drf/Substrate/template_pattern_catalog:missing->partial
implements-capability: lang.jsts.framework.react/Substrate/pure_function_tagging:missing->partial
implements-capability: lang.jsts.framework.react/Substrate/module_cycle_detection:missing->partial
implements-capability: lang.jsts.framework.react/Substrate/def_use_chain_extraction:missing->partial
implements-capability: lang.jsts.framework.react/Substrate/template_pattern_catalog:missing->partial
implements-capability: lang.java.framework.spring-boot/Substrate/pure_function_tagging:missing->partial
implements-capability: lang.java.framework.spring-boot/Substrate/module_cycle_detection:missing->partial
implements-capability: lang.java.framework.spring-boot/Substrate/def_use_chain_extraction:missing->partial
implements-capability: lang.java.framework.spring-boot/Substrate/template_pattern_catalog:missing->partial
implements-capability: lang.go.framework.gin/Substrate/pure_function_tagging:missing->partial
implements-capability: lang.go.framework.gin/Substrate/module_cycle_detection:missing->partial
implements-capability: lang.go.framework.gin/Substrate/def_use_chain_extraction:missing->partial
implements-capability: lang.go.framework.gin/Substrate/template_pattern_catalog:missing->partial

## Out of scope / follow-ups

- Inter-procedural def-use (alias analysis — Phase 4).
- Cross-repo IMPORTS-cycle detection (Phase 3B is per-repo).
- SQL-literal false-positive cleanup (3D matches any literal whose
  first word is a SQL verb; harmless for a catalogue).

## Test plan

- [x] Unit tests for the 4 per-language def-use + template-pattern
      sniffers (`internal/substrate/def_use_test.go`,
      `template_pattern_test.go`).
- [x] Real-data run on upvate group — see Summary.

Closes #2774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)