### PR TITLE
feat(substrate): Phase 3 misc for T3 languages (#2779) [terminal substrate issue]

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 188 records · **C/C++**: 17 · **clojure**: 1 · **crystal**: 1 · **C#**: 15 · **elixir**: 9 · **F#**: 1 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 12 · **lua**: 2 · **nim**: 2 · **php**: 12 · **python**: 20 · **ruby**: 8 · **rust**: 11 · **scala**: 9 · **solidity**: 1 · **swift**: 1
+**Total**: 189 records · **C/C++**: 17 · **crystal**: 1 · **C#**: 15 · **dart**: 1 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 32 · **kotlin**: 12 · **lua**: 2 · **nim**: 1 · **php**: 12 · **python**: 20 · **ruby**: 8 · **rust**: 11 · **scala**: 9 · **solidity**: 1 · **swift**: 1 · **zig**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -25,8 +25,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
 | [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
 | [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/13 | |
-| [clojure](../by-language/clojure.md) | [Ring](../detail/lang.clojure.framework.ring.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
-| [crystal](../by-language/crystal.md) | [Kemal](../detail/lang.crystal.framework.kemal.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
+| [crystal](../by-language/crystal.md) | [Lucky](../detail/lang.crystal.framework.lucky.md) | — | — | — | — | — | — | — | ⚠️ 0/4 | |
 | [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
@@ -41,7 +40,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
 | [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
-| [F#](../by-language/fsharp.md) | [Giraffe](../detail/lang.fsharp.framework.giraffe.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
@@ -90,10 +88,9 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/13 | |
-| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — | — | — | — | — | — 0/7 | |
-| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — | — | — | — | — | — 0/7 | |
-| [nim](../by-language/nim.md) | [Jester](../detail/lang.nim.framework.jester.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
-| [nim](../by-language/nim.md) | [Prologue](../detail/lang.nim.framework.prologue.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
+| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — | — | — | — | — | — 0/4 | |
+| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — | — | — | — | — | — 0/4 | |
+| [nim](../by-language/nim.md) | [Jester](../detail/lang.nim.framework.jester.md) | — | — | — | — | — | — | — | ⚠️ 0/4 | |
 | [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
@@ -151,7 +148,9 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
 | [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/13 | |
-| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | — | — | — | — | — | ⚠️ 3/7 | |
+| [solidity](../by-language/solidity.md) | [Hardhat / Foundry](../detail/lang.solidity.framework.hardhat.md) | — | — | — | — | — | — | — | ⚠️ 0/4 | |
+| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | — | — | — | — | — | ⚠️ 0/8 | |
+| [zig](../by-language/zig.md) | [httpz](../detail/lang.zig.framework.httpz.md) | — | — | — | — | — | — | — | ⚠️ 0/4 | |
 
 
 ## UI Frontend
@@ -166,8 +165,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/13 | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/6 | |
-| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/6 | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/7 | |
+| [JS/TS](../by-language/jsts.md) | [Svelte / SvelteKit](../detail/lang.jsts.framework.svelte-kit.md) | — | — | — | — | — | — | — | |
+| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/7 | |
+| [JS/TS](../by-language/jsts.md) | [Vue / Nuxt](../detail/lang.jsts.framework.vue-nuxt.md) | — | — | — | — | — | — | — | |
 
 
 ## Meta Framework
@@ -176,12 +177,12 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 | [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 0/3 | |
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 0/4 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 0/3 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 
 
@@ -191,6 +192,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
 | [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/10 | |
+| [dart](../by-language/dart.md) | [Flutter](../detail/lang.dart.framework.flutter.md) | — | — | — | — | — | — | — | — | ⚠️ 0/4 | |
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
@@ -225,7 +227,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/10 | |
 | [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | — | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | — | |
-| [solidity](../by-language/solidity.md) | [Solidity ABI / external functions](../detail/lang.solidity.framework.solidity-abi.md) | — | — | — | ✅ 2/3 | |
 
 
 ## AI Integration

--- a/docs/coverage/by-language/clojure.md
+++ b/docs/coverage/by-language/clojure.md
@@ -1,15 +1,12 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# clojure
+# Clojure
 
-**Frameworks**: 1 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-## Frameworks
-
-
-### Backend HTTP
-
-| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [Ring](../detail/lang.clojure.framework.ring.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/clojure/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.clojure.framework.<name>`).

--- a/docs/coverage/by-language/crystal.md
+++ b/docs/coverage/by-language/crystal.md
@@ -12,4 +12,4 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Kemal](../detail/lang.crystal.framework.kemal.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
+| [Lucky](../detail/lang.crystal.framework.lucky.md) | — | — | — | — | — | — | — | ⚠️ 0/4 | |

--- a/docs/coverage/by-language/dart.md
+++ b/docs/coverage/by-language/dart.md
@@ -1,9 +1,19 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # dart
 
-**Frameworks**: 0 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
+
+## Frameworks
+
+
+### Mobile
+
+| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [Flutter](../detail/lang.dart.framework.flutter.md) | — | — | — | — | — | — | — | — | ⚠️ 0/4 | |
+
 
 ## Tools
 

--- a/docs/coverage/by-language/fsharp.md
+++ b/docs/coverage/by-language/fsharp.md
@@ -1,15 +1,12 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # F#
 
-**Frameworks**: 1 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-## Frameworks
-
-
-### Backend HTTP
-
-| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [Giraffe](../detail/lang.fsharp.framework.giraffe.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/fsharp/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.fsharp.framework.<name>`).

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # JS/TS
 
-**Frameworks**: 30 · **Tools**: 21 · **ORMs**: 18 · **Other**: 2
+**Frameworks**: 32 · **Tools**: 21 · **ORMs**: 18 · **Other**: 2
 
 Back to [summary](../summary.md).
 
@@ -32,20 +32,22 @@ Back to [summary](../summary.md).
 |---|---|---|---|---|---|---|---|---|
 | [Angular](../detail/lang.jsts.framework.angular.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/3 | |
 | [React](../detail/lang.jsts.framework.react.md) | ⚠️ 3/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ⚠️ 4/13 | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/6 | |
-| [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/6 | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/7 | |
+| [Svelte / SvelteKit](../detail/lang.jsts.framework.svelte-kit.md) | — | — | — | — | — | — | — | |
+| [Vue](../detail/lang.jsts.framework.vue.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 2/7 | |
+| [Vue / Nuxt](../detail/lang.jsts.framework.vue-nuxt.md) | — | — | — | — | — | — | — | |
 
 
 ### Meta Framework
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 0/3 | |
+| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 0/4 | |
 | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ⚠️ 0/3 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 
 
 ### Mobile

--- a/docs/coverage/by-language/lua.md
+++ b/docs/coverage/by-language/lua.md
@@ -12,5 +12,5 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — | — | — | — | — | — 0/7 | |
-| [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — | — | — | — | — | — 0/7 | |
+| [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — | — | — | — | — | — 0/4 | |
+| [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — | — | — | — | — | — 0/4 | |

--- a/docs/coverage/by-language/nim.md
+++ b/docs/coverage/by-language/nim.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # nim
 
-**Frameworks**: 2 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 1 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -12,5 +12,4 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Jester](../detail/lang.nim.framework.jester.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
-| [Prologue](../detail/lang.nim.framework.prologue.md) | — | — | — | — | — | — | — | ⚠️ 0/3 | |
+| [Jester](../detail/lang.nim.framework.jester.md) | — | — | — | — | — | — | — | ⚠️ 0/4 | |

--- a/docs/coverage/by-language/solidity.md
+++ b/docs/coverage/by-language/solidity.md
@@ -8,8 +8,8 @@ Back to [summary](../summary.md).
 ## Frameworks
 
 
-### RPC Framework
+### Backend HTTP
 
-| Name | Schema | Codegen | Transport | Substrate | Notes |
-|---|---|---|---|---|---|
-| [Solidity ABI / external functions](../detail/lang.solidity.framework.solidity-abi.md) | — | — | — | ✅ 2/3 | |
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [Hardhat / Foundry](../detail/lang.solidity.framework.hardhat.md) | — | — | — | — | — | — | — | ⚠️ 0/4 | |

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -12,7 +12,7 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | — | — | — | — | — | ⚠️ 3/7 | |
+| [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | — | — | — | — | — | ⚠️ 0/8 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/zig.md
+++ b/docs/coverage/by-language/zig.md
@@ -1,12 +1,15 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Zig
+# zig
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 1 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** archigraph has extractor support for
-> this language (see `internal/extractors/zig/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.zig.framework.<name>`).
+## Frameworks
+
+
+### Backend HTTP
+
+| Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
+|---|---|---|---|---|---|---|---|---|---|
+| [httpz](../detail/lang.zig.framework.httpz.md) | — | — | — | — | — | — | — | ⚠️ 0/4 | |

--- a/docs/coverage/detail/lang.crystal.framework.lucky.md
+++ b/docs/coverage/detail/lang.crystal.framework.lucky.md
@@ -1,12 +1,12 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.swift.framework.vapor` — Vapor
+# `lang.crystal.framework.lucky` — Lucky
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [swift](../by-language/swift.md)
+- **Language:** [crystal](../by-language/crystal.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 9
+- **Capability cells:** 4
 
 ## Capabilities
 
@@ -15,7 +15,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
@@ -51,19 +50,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `db_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
-| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_swift.go` | — |
-| `fs_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
-| `http_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_crystal.go` | — |
 | `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
-| `mutation_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
 | `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
-| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_swift.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_crystal.go` | — |
 
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
-(or use `go run ./tools/coverage update lang.swift.framework.vapor ...`) then regenerate:
+(or use `go run ./tools/coverage update lang.crystal.framework.lucky ...`) then regenerate:
 
 ```
 go run ./tools/coverage validate

--- a/docs/coverage/detail/lang.dart.framework.flutter.md
+++ b/docs/coverage/detail/lang.dart.framework.flutter.md
@@ -1,33 +1,47 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.swift.framework.vapor` — Vapor
+# `lang.dart.framework.flutter` — Flutter
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [swift](../by-language/swift.md)
+- **Language:** [dart](../by-language/dart.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 9
+- **Subcategory:** Mobile
+- **Capability cells:** 4
 
 ## Capabilities
 
 
-### Routing
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
-
-### Security
+### Structure
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
-### Validation
+### Navigation
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
-### Middleware
+### Platform
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+### Native Bridge
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+### Data Flow
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+### Lifecycle
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
@@ -37,33 +51,19 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
-### Observability
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-
-### Data
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `db_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
-| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_swift.go` | — |
-| `fs_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
-| `http_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_dart.go` | — |
 | `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
-| `mutation_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
 | `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
-| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_swift.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_dart.go` | — |
 
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
-(or use `go run ./tools/coverage update lang.swift.framework.vapor ...`) then regenerate:
+(or use `go run ./tools/coverage update lang.dart.framework.flutter ...`) then regenerate:
 
 ```
 go run ./tools/coverage validate

--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 17
 
 ## Capabilities
 
@@ -68,9 +68,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_markup_script.go` | — |
+| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
+| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_markup_script.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.svelte-kit.md
+++ b/docs/coverage/detail/lang.jsts.framework.svelte-kit.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.jsts.framework.svelte-kit` — Svelte / SvelteKit
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [JS/TS](../by-language/jsts.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** UI Frontend
+- **Capability cells:** 0
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.jsts.framework.svelte-kit ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.jsts.framework.svelte.md
+++ b/docs/coverage/detail/lang.jsts.framework.svelte.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 21
+- **Capability cells:** 22
 
 ## Capabilities
 
@@ -61,11 +61,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_markup_script.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
+| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
+| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_markup_script.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 16
+- **Capability cells:** 13
 
 ## Capabilities
 
@@ -68,9 +68,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.vue-nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue-nuxt.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.jsts.framework.vue-nuxt` — Vue / Nuxt
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [JS/TS](../by-language/jsts.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** UI Frontend
+- **Capability cells:** 0
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.jsts.framework.vue-nuxt ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.jsts.framework.vue.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 21
+- **Capability cells:** 22
 
 ## Capabilities
 
@@ -61,11 +61,12 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_markup_script.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
-| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `response_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
+| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
+| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_markup_script.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 8
+- **Capability cells:** 5
 
 ## Capabilities
 
@@ -55,9 +55,6 @@ Auto-generated. Back to [summary](../summary.md).
 | `fs_effect` | — `not_applicable` | — | — | — | — | — |
 | `http_effect` | — `not_applicable` | — | — | — | — | — |
 | `mutation_effect` | — `not_applicable` | — | — | — | — | — |
-| `request_shape_extraction` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | — | — |
-| `response_shape_extraction` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | — | — |
-| `schema_drift_detection` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [lua](../by-language/lua.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 8
+- **Capability cells:** 5
 
 ## Capabilities
 
@@ -55,9 +55,6 @@ Auto-generated. Back to [summary](../summary.md).
 | `fs_effect` | — `not_applicable` | — | — | — | — | — |
 | `http_effect` | — `not_applicable` | — | — | — | — | — |
 | `mutation_effect` | — `not_applicable` | — | — | — | — | — |
-| `request_shape_extraction` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | — | — |
-| `response_shape_extraction` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | — | — |
-| `schema_drift_detection` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.nim.framework.jester.md
+++ b/docs/coverage/detail/lang.nim.framework.jester.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [nim](../by-language/nim.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
@@ -50,9 +50,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `request_shape_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
-| `response_shape_extraction` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | — | — |
-| `schema_drift_detection` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2777) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_t3.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_nim.go` | — |
+| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
+| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_nim.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.solidity.framework.hardhat.md
+++ b/docs/coverage/detail/lang.solidity.framework.hardhat.md
@@ -1,12 +1,12 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.swift.framework.vapor` — Vapor
+# `lang.solidity.framework.hardhat` — Hardhat / Foundry
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [swift](../by-language/swift.md)
+- **Language:** [solidity](../by-language/solidity.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 9
+- **Capability cells:** 4
 
 ## Capabilities
 
@@ -15,7 +15,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
@@ -51,19 +50,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `db_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
-| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_swift.go` | — |
-| `fs_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
-| `http_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_solidity.go` | — |
 | `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
-| `mutation_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
 | `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
-| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_swift.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_solidity.go` | — |
 
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
-(or use `go run ./tools/coverage update lang.swift.framework.vapor ...`) then regenerate:
+(or use `go run ./tools/coverage update lang.solidity.framework.hardhat ...`) then regenerate:
 
 ```
 go run ./tools/coverage validate

--- a/docs/coverage/detail/lang.zig.framework.httpz.md
+++ b/docs/coverage/detail/lang.zig.framework.httpz.md
@@ -1,12 +1,12 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.swift.framework.vapor` — Vapor
+# `lang.zig.framework.httpz` — httpz
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [swift](../by-language/swift.md)
+- **Language:** [zig](../by-language/zig.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
-- **Capability cells:** 9
+- **Capability cells:** 4
 
 ## Capabilities
 
@@ -15,7 +15,6 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
 ### Security
 
@@ -51,19 +50,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `db_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
-| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_swift.go` | — |
-| `fs_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
-| `http_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
+| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_zig.go` | — |
 | `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
-| `mutation_effect` | ⚠️ `partial` | — | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_swift.go` | — |
 | `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
-| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_swift.go` | — |
+| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_zig.go` | — |
 
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
-(or use `go run ./tools/coverage update lang.swift.framework.vapor ...`) then regenerate:
+(or use `go run ./tools/coverage update lang.zig.framework.httpz ...`) then regenerate:
 
 ```
 go run ./tools/coverage validate

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -4467,88 +4467,44 @@
       }
     },
     {
-      "id": "lang.clojure.framework.ring",
-      "category": "http_framework",
-      "subcategory": "http_backend",
-      "language": "clojure",
-      "label": "Ring",
-      "capabilities": {
-        "Substrate": {
-          "request_shape_extraction": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "response_shape_extraction": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "schema_drift_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          }
-        }
-      }
-    },
-    {
-      "id": "lang.crystal.framework.kemal",
+      "id": "lang.crystal.framework.lucky",
       "category": "http_framework",
       "subcategory": "http_backend",
       "language": "crystal",
-      "label": "Kemal",
+      "label": "Lucky",
       "capabilities": {
         "Substrate": {
-          "request_shape_extraction": {
+          "def_use_chain_extraction": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_crystal.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "response_shape_extraction": {
+          "module_cycle_detection": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/module_cycle_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "schema_drift_detection": {
+          "pure_function_tagging": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
+            "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": [
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_crystal.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -6917,6 +6873,50 @@
       }
     },
     {
+      "id": "lang.dart.framework.flutter",
+      "category": "http_framework",
+      "subcategory": "mobile",
+      "language": "dart",
+      "label": "Flutter",
+      "capabilities": {
+        "Substrate": {
+          "def_use_chain_extraction": {
+            "status": "partial",
+            "cites": [
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_dart.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/links/module_cycle_pass.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "partial",
+            "cites": [
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": [
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_dart.go"
+            ],
+            "verified_at": "2026-05-28"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.elixir.driver.dynamodb",
       "category": "orm",
       "language": "elixir",
@@ -8510,44 +8510,6 @@
             "internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"
           ],
           "verified_at": "2026-05-28"
-        }
-      }
-    },
-    {
-      "id": "lang.fsharp.framework.giraffe",
-      "category": "http_framework",
-      "subcategory": "http_backend",
-      "language": "fsharp",
-      "label": "Giraffe",
-      "capabilities": {
-        "Substrate": {
-          "request_shape_extraction": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "response_shape_extraction": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "schema_drift_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          }
         }
       }
     },
@@ -13169,37 +13131,37 @@
           }
         },
         "Substrate": {
-          "request_shape_extraction": {
+          "def_use_chain_extraction": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_markup_script.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "response_shape_extraction": {
+          "module_cycle_detection": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/module_cycle_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "schema_drift_detection": {
+          "pure_function_tagging": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
+            "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": [
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_markup_script.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -15559,6 +15521,15 @@
             ],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "partial",
+            "cites": [
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_markup_script.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": [
@@ -15577,37 +15548,28 @@
             ],
             "verified_at": "2026-05-28"
           },
-          "request_shape_extraction": {
+          "module_cycle_detection": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/module_cycle_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "response_shape_extraction": {
+          "pure_function_tagging": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "schema_drift_detection": {
+          "template_pattern_catalog": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_markup_script.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           }
         }
@@ -15624,6 +15586,14 @@
           }
         }
       }
+    },
+    {
+      "id": "lang.jsts.framework.svelte-kit",
+      "category": "http_framework",
+      "subcategory": "ui_frontend",
+      "language": "jsts",
+      "label": "Svelte / SvelteKit",
+      "capabilities": {}
     },
     {
       "id": "lang.jsts.framework.sveltekit",
@@ -15705,41 +15675,6 @@
             "cites": [
               "internal/extractors/javascript/tests.go"
             ],
-            "verified_at": "2026-05-28"
-          }
-        },
-        "Substrate": {
-          "request_shape_extraction": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "response_shape_extraction": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "schema_drift_detection": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           }
         }
@@ -15872,6 +15807,15 @@
             ],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "partial",
+            "cites": [
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_markup_script.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": [
@@ -15890,37 +15834,28 @@
             ],
             "verified_at": "2026-05-28"
           },
-          "request_shape_extraction": {
+          "module_cycle_detection": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/module_cycle_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "response_shape_extraction": {
+          "pure_function_tagging": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "schema_drift_detection": {
+          "template_pattern_catalog": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_markup_script.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           }
         }
@@ -15941,6 +15876,14 @@
           }
         }
       }
+    },
+    {
+      "id": "lang.jsts.framework.vue-nuxt",
+      "category": "http_framework",
+      "subcategory": "ui_frontend",
+      "language": "jsts",
+      "label": "Vue / Nuxt",
+      "capabilities": {}
     },
     {
       "id": "lang.jsts.orm.drizzle",
@@ -18060,21 +18003,6 @@
           },
           "mutation_effect": {
             "status": "not_applicable"
-          },
-          "request_shape_extraction": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "response_shape_extraction": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "schema_drift_detection": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18103,21 +18031,6 @@
           },
           "mutation_effect": {
             "status": "not_applicable"
-          },
-          "request_shape_extraction": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "response_shape_extraction": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "schema_drift_detection": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
           }
         }
       }
@@ -18130,69 +18043,37 @@
       "label": "Jester",
       "capabilities": {
         "Substrate": {
-          "request_shape_extraction": {
+          "def_use_chain_extraction": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_nim.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "response_shape_extraction": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "schema_drift_detection": {
+          "module_cycle_detection": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/module_cycle_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          }
-        }
-      }
-    },
-    {
-      "id": "lang.nim.framework.prologue",
-      "category": "http_framework",
-      "subcategory": "http_backend",
-      "language": "nim",
-      "label": "Prologue",
-      "capabilities": {
-        "Substrate": {
-          "request_shape_extraction": {
-            "status": "partial",
-            "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "response_shape_extraction": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
-            "verified_at": "2026-05-28"
-          },
-          "schema_drift_detection": {
+          "pure_function_tagging": {
             "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
+            "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": [
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_nim.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -27699,38 +27580,44 @@
       }
     },
     {
-      "id": "lang.solidity.framework.solidity-abi",
+      "id": "lang.solidity.framework.hardhat",
       "category": "http_framework",
-      "subcategory": "rpc_framework",
+      "subcategory": "http_backend",
       "language": "solidity",
-      "label": "Solidity ABI / external functions",
+      "label": "Hardhat / Foundry",
       "capabilities": {
         "Substrate": {
-          "request_shape_extraction": {
-            "status": "full",
+          "def_use_chain_extraction": {
+            "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_solidity.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "response_shape_extraction": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
+          "module_cycle_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/links/module_cycle_pass.go"
+            ],
             "verified_at": "2026-05-28"
           },
-          "schema_drift_detection": {
-            "status": "full",
+          "pure_function_tagging": {
+            "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
+            "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": [
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_solidity.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }
@@ -27770,6 +27657,13 @@
               "internal/substrate/effect_sinks_swift.go"
             ]
           },
+          "module_cycle_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/links/module_cycle_pass.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": [
@@ -27777,37 +27671,74 @@
               "internal/substrate/effect_sinks_swift.go"
             ]
           },
-          "request_shape_extraction": {
-            "status": "full",
+          "pure_function_tagging": {
+            "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "response_shape_extraction": {
-            "status": "full",
+          "def_use_chain_extraction": {
+            "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_swift.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
             "verified_at": "2026-05-28"
           },
-          "schema_drift_detection": {
-            "status": "full",
+          "template_pattern_catalog": {
+            "status": "partial",
             "cites": [
-              "internal/links/payload_drift.go",
-              "internal/mcp/payload_drift_tool.go",
-              "internal/substrate/payload_shapes.go",
-              "internal/substrate/payload_shapes_t3.go"
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_swift.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2777",
+            "verified_at": "2026-05-28"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.zig.framework.httpz",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "zig",
+      "label": "httpz",
+      "capabilities": {
+        "Substrate": {
+          "def_use_chain_extraction": {
+            "status": "partial",
+            "cites": [
+              "internal/links/def_use_pass.go",
+              "internal/substrate/def_use.go",
+              "internal/substrate/def_use_zig.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "partial",
+            "cites": [
+              "internal/links/module_cycle_pass.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "partial",
+            "cites": [
+              "internal/links/effect_propagation.go",
+              "internal/links/pure_function_pass.go"
+            ],
+            "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "partial",
+            "cites": [
+              "internal/links/template_pattern_pass.go",
+              "internal/substrate/template_pattern.go",
+              "internal/substrate/template_pattern_zig.go"
+            ],
             "verified_at": "2026-05-28"
           }
         }

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,13 +1,13 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 37 (21 active · 16 placeholder) · **Frameworks**: 188 · **ORMs**: 150 · **Tools**: 110 · **Other**: 99
+**Languages**: 37 (20 active · 17 placeholder) · **Frameworks**: 189 · **ORMs**: 150 · **Tools**: 110 · **Other**: 99
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [JS/TS](by-language/jsts.md) | 30 | 21 | 18 | 2 |
+| [JS/TS](by-language/jsts.md) | 32 | 21 | 18 | 2 |
 | [python](by-language/python.md) | 20 | 15 | 17 | 3 |
 | [java](by-language/java.md) | 19 | 10 | 13 | 2 |
 | [C/C++](by-language/c-cpp.md) | 17 | 16 | 7 | 0 |
@@ -20,13 +20,12 @@
 | [scala](by-language/scala.md) | 9 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
-| [nim](by-language/nim.md) | 2 | 0 | 0 | 0 |
-| [clojure](by-language/clojure.md) | 1 | 0 | 0 | 0 |
 | [crystal](by-language/crystal.md) | 1 | 0 | 0 | 0 |
-| [F#](by-language/fsharp.md) | 1 | 0 | 0 | 0 |
+| [dart](by-language/dart.md) | 1 | 1 | 0 | 0 |
+| [nim](by-language/nim.md) | 1 | 0 | 0 | 0 |
 | [solidity](by-language/solidity.md) | 1 | 0 | 0 | 0 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
-| [dart](by-language/dart.md) | 0 | 1 | 0 | 0 |
+| [zig](by-language/zig.md) | 1 | 0 | 0 | 0 |
 | [groovy](by-language/groovy.md) | 0 | 1 | 0 | 0 |
 
 ## Cross-cutting infrastructure
@@ -50,8 +49,10 @@
 | Language |
 |---|
 | [Astro](by-language/astro.md) |
+| [Clojure](by-language/clojure.md) |
 | [Elm](by-language/elm.md) |
 | [Erlang](by-language/erlang.md) |
+| [F#](by-language/fsharp.md) |
 | [Haskell](by-language/haskell.md) |
 | [Idris](by-language/idris.md) |
 | [Lisp](by-language/lisp.md) |
@@ -64,6 +65,5 @@
 | [VHDL](by-language/vhdl.md) |
 | [Verilog](by-language/verilog.md) |
 | [Vue](by-language/vue.md) |
-| [Zig](by-language/zig.md) |
 
-Total: 188 frameworks · 110 tools · 150 ORMs · 99 other
+Total: 189 frameworks · 110 tools · 150 ORMs · 99 other

--- a/internal/substrate/def_use_crystal.go
+++ b/internal/substrate/def_use_crystal.go
@@ -1,0 +1,106 @@
+// Crystal def-use sniffer (#2779 Phase 3C T3).
+//
+// Recognises:
+//   - Defs : `x = ...` local assignments, typed `x : T = ...`,
+//            `@x = ...` instance variable assignments.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Crystal keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `def name` header using the
+// scanCrystalFuncHeaders helper from effect_sinks_crystal.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("crystal", sniffDefUseCrystal) }
+
+// crystalDefRe matches local variable assignments.
+//
+//	Group 1 (typed/bare): `name = ...` at start of line (not `==`)
+//	Group 2 (ivar):       `@name = ...`
+var crystalDefRe = regexp.MustCompile(
+	`(?m)^\s*([a-z_][\w]*)\s*=(?:[^=])` +
+		`|^\s*(@[a-z_][\w]*)\s*=(?:[^=])`,
+)
+
+var crystalIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func crystalReservedDefUse(s string) bool {
+	switch s {
+	case "if", "elsif", "else", "unless", "case", "when", "while", "until",
+		"for", "in", "do", "begin", "rescue", "ensure", "raise", "return",
+		"yield", "break", "next", "redo", "retry", "def", "end", "class",
+		"module", "struct", "lib", "fun", "macro", "self", "nil", "true",
+		"false", "abstract", "require", "include", "extend", "protected",
+		"private", "puts", "print", "p", "pp", "loop", "spawn", "typeof",
+		"sizeof", "pointerof", "offsetof", "instance_sizeof", "as", "is_a?",
+		"responds_to?", "select", "then":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseCrystal(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanCrystalFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range crystalDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			// ivar — strip leading @
+			raw := content[m[4]:m[5]]
+			if len(raw) > 1 {
+				name = raw[1:]
+			}
+		}
+		if name == "" || crystalReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range crystalIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if crystalReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_dart.go
+++ b/internal/substrate/def_use_dart.go
@@ -1,0 +1,104 @@
+// Dart def-use sniffer (#2779 Phase 3C T3).
+//
+// Recognises:
+//   - Defs : `var x = ...`, `final x = ...`, `const x = ...`,
+//            typed `String x = ...`, bare `x = ...` reassignments.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Dart keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `void|type name(` header using
+// the scanDartFuncHeaders helper from effect_sinks_dart.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("dart", sniffDefUseDart) }
+
+// dartDefRe matches local variable declarations and bare assignments.
+//
+//	Group 1 (var/final/const/typed): `(var|final|const|<type>) <name> = ...`
+//	Group 2 (bare assignment)       : `<name> = ...` (not `==`)
+var dartDefRe = regexp.MustCompile(
+	`(?m)(?:(?:var|final|const|late)\s+(?:[A-Za-z_][\w<>?,\s]*\s+)?([A-Za-z_][\w]*)\s*=(?:[^=])` +
+		`|^\s*([A-Za-z_][\w]*)\s*=(?:[^=]))`,
+)
+
+var dartIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func dartReservedDefUse(s string) bool {
+	switch s {
+	case "if", "else", "for", "while", "do", "switch", "case", "default",
+		"break", "continue", "return", "throw", "try", "catch", "finally",
+		"new", "true", "false", "null", "this", "super", "in", "is", "as",
+		"var", "final", "const", "late", "class", "extends", "implements",
+		"mixin", "with", "abstract", "static", "void", "dynamic", "async",
+		"await", "yield", "import", "export", "library", "part", "show",
+		"hide", "typedef", "enum", "covariant", "external", "factory",
+		"get", "set", "operator", "required", "String", "int", "double",
+		"bool", "num", "List", "Map", "Set", "Future", "Stream", "Object",
+		"Function", "Null", "Never", "Type", "Iterable", "print":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseDart(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanDartFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range dartDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		}
+		if name == "" || dartReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range dartIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if dartReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_markup_script.go
+++ b/internal/substrate/def_use_markup_script.go
@@ -1,0 +1,42 @@
+// Markup-with-script def-use dispatcher (#2779 Phase 3C T3).
+//
+// Svelte (.svelte), Vue (.vue), and Astro (.astro) single-file components
+// embed JS/TS inside `<script>` blocks. Def-use patterns inside those blocks
+// are identical to plain JS/TS, so we extract every `<script>...</script>`
+// body and run sniffDefUseJSTS over the concatenation. Line offsets are
+// adjusted so that recorded lines match the original markup file position.
+package substrate
+
+func init() {
+	RegisterDefUseSniffer("svelte", sniffDefUseMarkupScript)
+	RegisterDefUseSniffer("vue", sniffDefUseMarkupScript)
+	RegisterDefUseSniffer("astro", sniffDefUseMarkupScript)
+}
+
+// sniffDefUseMarkupScript extracts every <script> block and runs
+// sniffDefUseJSTS over each, offsetting line numbers to match the original
+// markup file (not the script-only slice).
+func sniffDefUseMarkupScript(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	var allDefs []VarDef
+	var allUses []VarUse
+	for _, m := range scriptBlockRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		bodyLineOffset := lineOfOffset(content, m[2]) - 1
+		defs, uses := sniffDefUseJSTS(body)
+		for _, d := range defs {
+			d.Line += bodyLineOffset
+			allDefs = append(allDefs, d)
+		}
+		for _, u := range uses {
+			u.Line += bodyLineOffset
+			allUses = append(allUses, u)
+		}
+	}
+	return allDefs, allUses
+}

--- a/internal/substrate/def_use_nim.go
+++ b/internal/substrate/def_use_nim.go
@@ -1,0 +1,102 @@
+// Nim def-use sniffer (#2779 Phase 3C T3).
+//
+// Recognises:
+//   - Defs : `var x = ...`, `let x = ...`, `const x = ...` (local bindings),
+//            `var x: T = ...`, bare `x = ...` reassignments.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Nim keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `proc/func/method/template/macro`
+// header using the scanNimFuncHeaders helper from effect_sinks_nim.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("nim", sniffDefUseNim) }
+
+// nimDefRe matches local variable / constant declarations and reassignments.
+//
+//	Group 1 (var/let/const form): `(var|let|const) name [: T] = ...`
+//	Group 2 (bare assignment)   : `name = ...` (not `==`)
+var nimDefRe = regexp.MustCompile(
+	`(?m)(?:\b(?:var|let|const)\s+([A-Za-z_][\w`+"`"+`]*)\s*(?::\s*[A-Za-z_][\w\[\], ]*\s*)?=(?:[^=])` +
+		`|^\s*([A-Za-z_][\w`+"`"+`]*)\s*=(?:[^=]))`,
+)
+
+var nimIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w` + "`" + `]*)\b`)
+
+func nimReservedDefUse(s string) bool {
+	switch s {
+	case "if", "elif", "else", "when", "case", "of", "for", "while", "do",
+		"break", "continue", "return", "raise", "try", "except", "finally",
+		"let", "var", "const", "proc", "func", "method", "template", "macro",
+		"iterator", "type", "import", "from", "export", "include", "discard",
+		"in", "notin", "is", "isnot", "not", "and", "or", "xor", "shl", "shr",
+		"div", "mod", "true", "false", "nil", "result", "self", "this",
+		"string", "int", "float", "bool", "char", "seq", "array", "tuple",
+		"object", "ref", "ptr", "addr", "cast", "sizeof", "echo", "write":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseNim(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanNimFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range nimDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		}
+		if name == "" || nimReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range nimIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if nimReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_solidity.go
+++ b/internal/substrate/def_use_solidity.go
@@ -1,0 +1,110 @@
+// Solidity def-use sniffer (#2779 Phase 3C T3).
+//
+// Recognises:
+//   - Defs : typed local declarations `uint256 x = ...;`, `address x = ...;`,
+//            `bool x = ...;`, bare `x = ...;` reassignments (not `==`).
+//   - Uses : bare identifiers `\b<name>\b` filtered against Solidity keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `function name(` / `modifier name(`
+// header using the scanSolidityFuncHeaders helper from effect_sinks_solidity.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("solidity", sniffDefUseSolidity) }
+
+// solidityLocalDefRe matches typed local variable declarations.
+// Solidity locals require an explicit type keyword before the identifier.
+//
+//	Group 1 (typed form) : `<type> [memory|storage|calldata] name = ...`
+//	Group 2 (bare assign): `name = ...` (not `==`)
+var solidityLocalDefRe = regexp.MustCompile(
+	`(?m)(?:\b(?:uint(?:\d+)?|int(?:\d+)?|address(?:\s+payable)?|bool|bytes(?:\d+)?|string|mapping)\s+` +
+		`(?:(?:memory|storage|calldata)\s+)?([A-Za-z_][\w]*)\s*=(?:[^=])` +
+		`|^\s*([A-Za-z_][\w]*)\s*=(?:[^=]))`,
+)
+
+var solidityIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func solidityReservedDefUse(s string) bool {
+	switch s {
+	case "if", "else", "for", "while", "do", "break", "continue", "return",
+		"throw", "revert", "require", "assert", "emit", "delete", "new",
+		"true", "false", "this", "super", "selfdestruct", "suicide",
+		"function", "modifier", "constructor", "fallback", "receive",
+		"event", "error", "struct", "enum", "mapping", "contract",
+		"library", "interface", "abstract", "is", "using", "pragma",
+		"import", "returns", "memory", "storage", "calldata", "payable",
+		"external", "internal", "public", "private", "view", "pure",
+		"virtual", "override", "indexed", "anonymous", "constant",
+		"immutable", "uint", "int", "address", "bool", "bytes", "string",
+		"msg", "tx", "block", "abi", "type", "gasleft", "now",
+		"uint8", "uint16", "uint32", "uint64", "uint128", "uint256",
+		"int8", "int16", "int32", "int64", "int128", "int256",
+		"bytes1", "bytes2", "bytes4", "bytes8", "bytes16", "bytes32":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseSolidity(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanSolidityFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range solidityLocalDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		}
+		if name == "" || solidityReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range solidityIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if solidityReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_swift.go
+++ b/internal/substrate/def_use_swift.go
@@ -1,0 +1,105 @@
+// Swift def-use sniffer (#2779 Phase 3C T3).
+//
+// Recognises:
+//   - Defs : `let x = ...`, `var x = ...` (local bindings inside functions),
+//            `let x: T = ...`, bare `x = ...` reassignments.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Swift keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `func name(` header using the
+// scanSwiftFuncHeaders helper from effect_sinks_swift.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("swift", sniffDefUseSwift) }
+
+// swiftDefRe matches local variable / constant declarations and reassignments.
+//
+//	Group 1 (let/var form)   : `[let|var] name [: T] = ...`
+//	Group 2 (bare assignment): `name = ...` (not `==`)
+var swiftDefRe = regexp.MustCompile(
+	`(?m)(?:\b(?:let|var)\s+([A-Za-z_][\w]*)\s*(?::\s*[A-Za-z_][\w<>\[\],?\s.!]*\s*)?=(?:[^=])` +
+		`|^\s*([A-Za-z_][\w]*)\s*=(?:[^=]))`,
+)
+
+var swiftIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func swiftReservedDefUse(s string) bool {
+	switch s {
+	case "if", "else", "for", "while", "repeat", "do", "switch", "case", "default",
+		"break", "continue", "return", "throw", "try", "catch", "guard", "defer",
+		"let", "var", "class", "struct", "enum", "protocol", "extension", "func",
+		"init", "deinit", "subscript", "typealias", "import", "associatedtype",
+		"where", "in", "is", "as", "nil", "true", "false", "self", "Self", "super",
+		"static", "override", "final", "lazy", "weak", "unowned", "private",
+		"fileprivate", "internal", "public", "open", "mutating", "nonmutating",
+		"required", "optional", "indirect", "inout", "operator", "precedencegroup",
+		"async", "await", "actor", "nonisolated", "rethrows", "throws",
+		"String", "Int", "Double", "Float", "Bool", "Array", "Dictionary", "Set",
+		"Optional", "Any", "AnyObject", "Void", "Error", "print", "debugPrint":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseSwift(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanSwiftFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range swiftDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		}
+		if name == "" || swiftReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range swiftIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if swiftReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/def_use_t3_test.go
+++ b/internal/substrate/def_use_t3_test.go
@@ -1,0 +1,280 @@
+// Phase 3C/3D T3 def-use + template-pattern registration and coverage tests (#2779).
+//
+// Tests assert:
+//   (a) every applicable T3 language ships a def-use sniffer (3C)
+//   (b) every applicable T3 language ships a template-pattern sniffer (3D)
+//   (c) each sniffer correctly lifts at least one def + one use from a minimal fixture (3C)
+//   (d) each template sniffer correctly lifts at least one log_format match (3D)
+//       — i18n / sql are per-lang optional based on applicability.
+//
+// N/A languages (no Phase 1A coverage): verilog, vhdl, idris, sml, reasonml,
+// rescript, elm, lisp, clojure, erlang, fsharp, haskell, ocaml, pony, groovy,
+// lua, multi. These are excluded from registration assertions.
+package substrate
+
+import "testing"
+
+// TestDefUseRegistry_T3Languages asserts every applicable T3 slug ships a
+// def-use sniffer. Sniffers for vue/svelte/astro are registered under those
+// slugs (delegating to JSTS internally).
+func TestDefUseRegistry_T3Languages(t *testing.T) {
+	for _, lang := range []string{"dart", "swift", "nim", "crystal", "zig", "solidity", "vue", "svelte", "astro"} {
+		if DefUseSnifferFor(lang) == nil {
+			t.Errorf("expected def-use sniffer registered for %q", lang)
+		}
+	}
+}
+
+// TestTemplatePatternRegistry_T3Languages asserts every applicable T3 slug
+// ships a template-pattern sniffer.
+func TestTemplatePatternRegistry_T3Languages(t *testing.T) {
+	for _, lang := range []string{"dart", "swift", "nim", "crystal", "zig", "solidity", "vue", "svelte", "astro"} {
+		if TemplatePatternSnifferFor(lang) == nil {
+			t.Errorf("expected template-pattern sniffer registered for %q", lang)
+		}
+	}
+}
+
+// defUseT3Fixture is one per-language canonical example. Each fixture is a
+// minimal function body that defines a local and reads it back exactly once.
+type defUseT3Fixture struct {
+	lang    string
+	source  string
+	wantDef string
+	wantUse string
+}
+
+func TestDefUseT3_PrimitiveCoverage(t *testing.T) {
+	cases := []defUseT3Fixture{
+		{
+			lang: "dart",
+			source: "String greet(String name) {\n" +
+				"  var message = 'hello ' + name;\n" +
+				"  print(message);\n" +
+				"  return message;\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "swift",
+			source: "func greet(name: String) -> String {\n" +
+				"  let message = \"hello \" + name\n" +
+				"  print(message)\n" +
+				"  return message\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "nim",
+			source: "proc greet(name: string): string =\n" +
+				"  var message = \"hello \" & name\n" +
+				"  echo message\n" +
+				"  result = message\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "crystal",
+			source: "def greet(name : String) : String\n" +
+				"  message = \"hello \" + name\n" +
+				"  puts message\n" +
+				"  message\n" +
+				"end\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "zig",
+			source: "fn greet(name: []const u8) void {\n" +
+				"  const message = name;\n" +
+				"  std.debug.print(\"{s}\", .{message});\n" +
+				"}\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "solidity",
+			source: "contract Greeter {\n" +
+				"  function greet(address user) public pure returns (uint256) {\n" +
+				"    uint256 result = 42;\n" +
+				"    return result;\n" +
+				"  }\n" +
+				"}\n",
+			wantDef: "result",
+			wantUse: "result",
+		},
+		{
+			lang: "vue",
+			source: "<template><div>hello</div></template>\n" +
+				"<script>\n" +
+				"function greet(name) {\n" +
+				"  const message = 'hello ' + name;\n" +
+				"  return message;\n" +
+				"}\n" +
+				"</script>\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "svelte",
+			source: "<div>hello</div>\n" +
+				"<script>\n" +
+				"function greet(name) {\n" +
+				"  const message = 'hello ' + name;\n" +
+				"  return message;\n" +
+				"}\n" +
+				"</script>\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+		{
+			lang: "astro",
+			source: "---\n" +
+				"---\n" +
+				"<html><body>hello</body></html>\n" +
+				"<script>\n" +
+				"function greet(name) {\n" +
+				"  const message = 'hello ' + name;\n" +
+				"  return message;\n" +
+				"}\n" +
+				"</script>\n",
+			wantDef: "message",
+			wantUse: "message",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.lang, func(t *testing.T) {
+			sniff := DefUseSnifferFor(c.lang)
+			if sniff == nil {
+				t.Fatalf("no def-use sniffer registered for %q", c.lang)
+			}
+			defs, uses := sniff(c.source)
+			if !containsDefVar(defs, c.wantDef) {
+				t.Errorf("%s: expected def %q in %v", c.lang, c.wantDef, defs)
+			}
+			if !containsUseVar(uses, c.wantUse) {
+				t.Errorf("%s: expected use %q in %v", c.lang, c.wantUse, uses)
+			}
+		})
+	}
+}
+
+// templateT3Fixture is one per-language fixture for template-pattern coverage.
+type templateT3Fixture struct {
+	lang      string
+	source    string
+	wantKinds []TemplateKind
+}
+
+func TestTemplatePatternT3_PrimitiveCoverage(t *testing.T) {
+	cases := []templateT3Fixture{
+		{
+			lang: "dart",
+			source: "String show() {\n" +
+				"  String m = tr(\"welcome.greeting\");\n" +
+				"  print(\"showing something\");\n" +
+				"  return m;\n" +
+				"}\n",
+			wantKinds: []TemplateKind{TemplateKindI18n, TemplateKindLog},
+		},
+		{
+			lang: "swift",
+			source: "func show() -> String {\n" +
+				"  let m = NSLocalizedString(\"welcome.greeting\", comment: \"\")\n" +
+				"  print(\"showing something\")\n" +
+				"  return m\n" +
+				"}\n",
+			wantKinds: []TemplateKind{TemplateKindI18n, TemplateKindLog},
+		},
+		{
+			lang: "nim",
+			source: "proc show(): string =\n" +
+				"  let m = tr(\"welcome.greeting\")\n" +
+				"  echo \"showing something\"\n" +
+				"  m\n",
+			wantKinds: []TemplateKind{TemplateKindI18n, TemplateKindLog},
+		},
+		{
+			lang: "crystal",
+			source: "def show\n" +
+				"  m = I18n.t(\"welcome.greeting\")\n" +
+				"  puts \"showing something\"\n" +
+				"  m\n" +
+				"end\n",
+			wantKinds: []TemplateKind{TemplateKindI18n, TemplateKindLog},
+		},
+		{
+			lang: "zig",
+			source: "fn show() void {\n" +
+				"  std.debug.print(\"showing something\", .{});\n" +
+				"  _ = db.exec(\"SELECT id FROM users WHERE id = ?\", .{1});\n" +
+				"}\n",
+			wantKinds: []TemplateKind{TemplateKindLog, TemplateKindSQL},
+		},
+		{
+			lang: "solidity",
+			source: "contract C {\n" +
+				"  function show(uint256 id) public {\n" +
+				"    require(id > 0, \"id must be positive\");\n" +
+				"    emit Transfer(\"transfer completed\");\n" +
+				"  }\n" +
+				"}\n",
+			wantKinds: []TemplateKind{TemplateKindLog},
+		},
+		{
+			lang: "vue",
+			source: "<template><div>hello</div></template>\n" +
+				"<script>\n" +
+				"function show() {\n" +
+				"  const m = t(\"welcome.greeting\");\n" +
+				"  console.log(\"showing something\");\n" +
+				"}\n" +
+				"</script>\n",
+			wantKinds: []TemplateKind{TemplateKindI18n, TemplateKindLog},
+		},
+		{
+			lang: "svelte",
+			source: "<div>hello</div>\n" +
+				"<script>\n" +
+				"function show() {\n" +
+				"  const m = t(\"welcome.greeting\");\n" +
+				"  console.log(\"showing something\");\n" +
+				"}\n" +
+				"</script>\n",
+			wantKinds: []TemplateKind{TemplateKindI18n, TemplateKindLog},
+		},
+		{
+			lang: "astro",
+			source: "---\n---\n<html/>\n" +
+				"<script>\n" +
+				"function show() {\n" +
+				"  const m = t(\"welcome.greeting\");\n" +
+				"  console.log(\"showing something\");\n" +
+				"}\n" +
+				"</script>\n",
+			wantKinds: []TemplateKind{TemplateKindI18n, TemplateKindLog},
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.lang, func(t *testing.T) {
+			sniff := TemplatePatternSnifferFor(c.lang)
+			if sniff == nil {
+				t.Fatalf("no template-pattern sniffer registered for %q", c.lang)
+			}
+			matches := sniff(c.source)
+			gotKinds := map[TemplateKind]bool{}
+			for _, m := range matches {
+				gotKinds[m.Kind] = true
+			}
+			for _, want := range c.wantKinds {
+				if !gotKinds[want] {
+					t.Errorf("%s: expected at least one %q match in %v", c.lang, want, matches)
+				}
+			}
+		})
+	}
+}

--- a/internal/substrate/def_use_zig.go
+++ b/internal/substrate/def_use_zig.go
@@ -1,0 +1,104 @@
+// Zig def-use sniffer (#2779 Phase 3C T3).
+//
+// Recognises:
+//   - Defs : `const x = ...;`, `var x = ...;`, `var x: T = ...;`,
+//            `const x: T = ...;`, bare `x = ...;` reassignments.
+//   - Uses : bare identifiers `\b<name>\b` filtered against Zig keywords
+//            and not on the LHS of a def we already captured.
+//
+// Function attribution: nearest preceding `fn name(` header using the
+// scanZigFuncHeaders helper from effect_sinks_zig.go.
+package substrate
+
+import "regexp"
+
+func init() { RegisterDefUseSniffer("zig", sniffDefUseZig) }
+
+// zigDefRe matches Zig variable and constant declarations and reassignments.
+//
+//	Group 1 (const/var form): `[pub] (const|var) name [: T] = ...`
+//	Group 2 (bare assign)   : `name = ...` (not `==`)
+var zigDefRe = regexp.MustCompile(
+	`(?m)(?:\b(?:const|var)\s+([A-Za-z_][\w]*)\s*(?::\s*[\w\[\]\s\*?!@.]*\s*)?=(?:[^=])` +
+		`|^\s*([A-Za-z_][\w]*)\s*=(?:[^=]))`,
+)
+
+var zigIdentUseRe = regexp.MustCompile(`\b([A-Za-z_][\w]*)\b`)
+
+func zigReservedDefUse(s string) bool {
+	switch s {
+	case "const", "var", "fn", "pub", "return", "if", "else", "while", "for",
+		"switch", "break", "continue", "defer", "errdefer", "try", "catch",
+		"unreachable", "undefined", "null", "true", "false", "void", "bool",
+		"u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64",
+		"i128", "isize", "f16", "f32", "f64", "f128", "c_int", "c_uint",
+		"c_long", "c_ulong", "c_char", "anytype", "noreturn", "comptime",
+		"inline", "noinline", "extern", "export", "packed", "align", "callconv",
+		"struct", "union", "enum", "error", "type", "anyerror", "and", "or",
+		"orelse", "async", "await", "suspend", "resume", "nosuspend",
+		"std", "self", "allocator":
+		return true
+	}
+	return false
+}
+
+func sniffDefUseZig(content string) ([]VarDef, []VarUse) {
+	if content == "" {
+		return nil, nil
+	}
+	headers := scanZigFuncHeaders(content)
+
+	var defs []VarDef
+	for _, m := range zigDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		var name string
+		switch {
+		case m[2] >= 0:
+			name = content[m[2]:m[3]]
+		case m[4] >= 0:
+			name = content[m[4]:m[5]]
+		}
+		if name == "" || zigReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		defs = append(defs, VarDef{Function: fn, Line: line, Var: name})
+	}
+
+	defOnLine := map[int]map[string]bool{}
+	for _, d := range defs {
+		set := defOnLine[d.Line]
+		if set == nil {
+			set = map[string]bool{}
+			defOnLine[d.Line] = set
+		}
+		set[d.Var] = true
+	}
+
+	var uses []VarUse
+	for _, m := range zigIdentUseRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if zigReservedDefUse(name) {
+			continue
+		}
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		if fn == "" {
+			continue
+		}
+		if defOnLine[line] != nil && defOnLine[line][name] {
+			continue
+		}
+		uses = append(uses, VarUse{Function: fn, Line: line, Var: name})
+	}
+	return defs, uses
+}

--- a/internal/substrate/template_pattern_crystal.go
+++ b/internal/substrate/template_pattern_crystal.go
@@ -1,0 +1,90 @@
+// Crystal template-pattern sniffer (#2779 Phase 3D T3).
+//
+// Recognises:
+//   - i18n       : I18n.translate("key"), I18n.t("key"), t("key").
+//   - log_format : puts "...", print "...", Log.debug/info/warn/error("...").
+//   - sql        : Quoted string literals whose first non-whitespace
+//                  token is a SQL verb — used with crystal-db / jennifer raw queries.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("crystal", sniffTemplatePatternsCrystal)
+}
+
+// crystalI18nRe matches I18n.translate / I18n.t / t() patterns.
+// Group 1 = the key literal.
+var crystalI18nRe = regexp.MustCompile(
+	`\b(?:I18n\s*\.\s*(?:translate|t)|translate|t)\s*\(\s*"([^"]+)"`,
+)
+
+// crystalLogRe matches puts / print and Log module calls.
+// Group 1 = literal payload.
+var crystalLogRe = regexp.MustCompile(
+	`\b(?:puts|print|p)\s+"([^"]+)"` +
+		`|\bLog\s*\.\s*(?:debug|info|notice|warn|warning|error|fatal)\s*\{\s*"([^"]+)"` +
+		`|\bLog\s*\.\s*(?:debug|info|notice|warn|warning|error|fatal)\s*\(\s*"([^"]+)"`,
+)
+
+// crystalSQLRe matches a quoted literal whose first word is a SQL verb.
+// Group 1 = literal payload.
+var crystalSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsCrystal(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanCrystalFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range crystalI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "I18n.t/translate",
+		})
+	}
+	for _, m := range crystalLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		var lit string
+		for i := 2; i < len(m)-1; i += 2 {
+			if m[i] >= 0 {
+				lit = content[m[i]:m[i+1]]
+				break
+			}
+		}
+		if lit == "" {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(lit),
+			Tag:      "puts/Log",
+		})
+	}
+	for _, m := range crystalSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_dart.go
+++ b/internal/substrate/template_pattern_dart.go
@@ -1,0 +1,98 @@
+// Dart template-pattern sniffer (#2779 Phase 3D T3).
+//
+// Recognises:
+//   - i18n       : AppLocalizations.of(context).translate("key"),
+//                  S.of(context).key (Flutter gen-l10n), intl.Intl.message("..."),
+//                  tr("key") (easy_localization), AppLocalizations("key").
+//   - log_format : print("..."), debugPrint("..."),
+//                  Logger().d/i/w/e("..."), log("...").
+//   - sql        : Quoted string literals whose first non-whitespace
+//                  token is a SQL verb (case-insensitive), as used with
+//                  sqflite / drift raw queries.
+//
+// No i18n standard is canonical in Dart; multiple popular packages are
+// detected conservatively.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("dart", sniffTemplatePatternsdart)
+}
+
+// dartI18nRe matches common Dart/Flutter i18n patterns.
+// Group 1 = the bare literal key.
+var dartI18nRe = regexp.MustCompile(
+	`\b(?:tr|gettext|translate|Intl\.message|AppLocalizations\.of\s*\([^)]*\)\s*\.\s*\w+)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `]+)['"` + "`" + `]`,
+)
+
+// dartLogRe matches print / debugPrint / log / Logger method calls.
+// Group 1 = level or tag, Group 2 = literal payload.
+var dartLogRe = regexp.MustCompile(
+	`\b(?:print|debugPrint|log)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `]+)['"` + "`" + `]` +
+		`|\bLogger\s*\(\s*\)\s*\.\s*([a-z])\s*\(\s*['"` + "`" + `]([^'"` + "`" + `]+)['"` + "`" + `]`,
+)
+
+// dartSQLRe matches a quoted/raw literal whose first word is a SQL verb.
+// Group 1 = literal payload.
+var dartSQLRe = regexp.MustCompile(
+	`['"` + "`" + `](\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[\s\S]*?)['"` + "`" + `]`,
+)
+
+func sniffTemplatePatternsdart(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanDartFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range dartI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "tr()/translate()",
+		})
+	}
+	for _, m := range dartLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		// The first alternation captures: group 1 = literal (print form)
+		// The second: group 3 = literal (Logger.x form)
+		var lit string
+		switch {
+		case m[2] >= 0:
+			lit = content[m[2]:m[3]]
+		case len(m) >= 8 && m[6] >= 0:
+			lit = content[m[6]:m[7]]
+		}
+		if lit == "" {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(lit),
+			Tag:      "print/debugPrint/Logger",
+		})
+	}
+	for _, m := range dartSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_markup_script.go
+++ b/internal/substrate/template_pattern_markup_script.go
@@ -1,0 +1,37 @@
+// Markup-with-script template-pattern dispatcher (#2779 Phase 3D T3).
+//
+// Svelte (.svelte), Vue (.vue), and Astro (.astro) single-file components
+// embed JS/TS inside `<script>` blocks. Template-pattern matches inside those
+// blocks are identical to plain JS/TS (t("key"), console.log("..."), SQL
+// literals), so we extract every `<script>...</script>` body and run
+// sniffTemplatePatternsJSTS over each. Line offsets are adjusted to match
+// the original markup file position.
+package substrate
+
+func init() {
+	RegisterTemplatePatternSniffer("svelte", sniffTemplatePatternsMarkupScript)
+	RegisterTemplatePatternSniffer("vue", sniffTemplatePatternsMarkupScript)
+	RegisterTemplatePatternSniffer("astro", sniffTemplatePatternsMarkupScript)
+}
+
+// sniffTemplatePatternsMarkupScript extracts every <script> block and runs
+// sniffTemplatePatternsJSTS over each, offsetting line numbers to match the
+// original markup file (not the script-only slice).
+func sniffTemplatePatternsMarkupScript(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	var out []TemplatePattern
+	for _, m := range scriptBlockRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		bodyLineOffset := lineOfOffset(content, m[2]) - 1
+		for _, tp := range sniffTemplatePatternsJSTS(body) {
+			tp.Line += bodyLineOffset
+			out = append(out, tp)
+		}
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_nim.go
+++ b/internal/substrate/template_pattern_nim.go
@@ -1,0 +1,92 @@
+// Nim template-pattern sniffer (#2779 Phase 3D T3).
+//
+// Recognises:
+//   - i18n       : tr("key") / translate("key") (nim-i18n / i18n packages).
+//   - log_format : echo "...", writeLine(stdout, "..."),
+//                  logging.info("...") / debug("...") / warn("...") / error("...").
+//   - sql        : Quoted string literals whose first non-whitespace
+//                  token is a SQL verb — used with nim-db / norm raw queries.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("nim", sniffTemplatePatternsNim)
+}
+
+// nimI18nRe matches tr() / translate() i18n patterns.
+// Group 1 = the key literal.
+var nimI18nRe = regexp.MustCompile(
+	`\b(?:tr|translate|gettext)\s*\(\s*"([^"]+)"`,
+)
+
+// nimLogRe matches echo, writeLine, and logging module calls.
+// Group 1 = literal payload.
+var nimLogRe = regexp.MustCompile(
+	`\becho\s+"([^"]+)"` +
+		`|\bwriteLine\s*\(\s*\w+\s*,\s*"([^"]+)"` +
+		`|\blogging\s*\.\s*(?:debug|info|warn|warning|error|fatal)\s*\(\s*"([^"]+)"` +
+		`|\b(?:debug|info|warn|error|fatal)\s*\(\s*"([^"]+)"`,
+)
+
+// nimSQLRe matches a quoted literal whose first word is a SQL verb.
+// Group 1 = literal payload.
+var nimSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsNim(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanNimFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range nimI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "tr()/translate()",
+		})
+	}
+	for _, m := range nimLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		var lit string
+		for i := 2; i < len(m)-1; i += 2 {
+			if m[i] >= 0 {
+				lit = content[m[i]:m[i+1]]
+				break
+			}
+		}
+		if lit == "" {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(lit),
+			Tag:      "echo/logging",
+		})
+	}
+	for _, m := range nimSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_solidity.go
+++ b/internal/substrate/template_pattern_solidity.go
@@ -1,0 +1,68 @@
+// Solidity template-pattern sniffer (#2779 Phase 3D T3).
+//
+// Template-pattern scope for Solidity:
+//
+//   - i18n  : not_applicable — Solidity runs on the EVM; there is no user
+//             locale or i18n framework at the contract layer.
+//   - sql   : not_applicable — Solidity has no SQL; storage access is via
+//             mapping / array reads / SSTORE, not SQL statements.
+//   - log   : Solidity emits events and uses revert/require strings for
+//             on-chain "log messages". We capture:
+//             * `emit EventName("literal message")` strings
+//             * `require(..., "error msg")` / `revert("error msg")` literals
+//             These are the nearest analogue to log-format strings in EVM code.
+//
+// Only the log_format kind is applicable for Solidity.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("solidity", sniffTemplatePatternsSolidity)
+}
+
+// solidityEmitRe matches `emit EventName("literal")` string arguments.
+// Group 1 = the literal payload.
+var solidityEmitRe = regexp.MustCompile(
+	`\bemit\s+[A-Za-z_][\w]*\s*\([^)]*"([^"]+)"`,
+)
+
+// solidityRequireRe matches `require(..., "message")` and `revert("message")`.
+// Group 1 = the literal message.
+var solidityRequireRe = regexp.MustCompile(
+	`\b(?:require|revert)\s*\([^)]*"([^"]+)"`,
+)
+
+func sniffTemplatePatternsSolidity(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanSolidityFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range solidityEmitRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "emit.literal",
+		})
+	}
+	for _, m := range solidityRequireRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "require/revert.msg",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_swift.go
+++ b/internal/substrate/template_pattern_swift.go
@@ -1,0 +1,106 @@
+// Swift template-pattern sniffer (#2779 Phase 3D T3).
+//
+// Recognises:
+//   - i18n       : NSLocalizedString("key", ...), String(localized: "key"),
+//                  Bundle.main.localizedString(forKey: "key", ...),
+//                  SwiftUI Text("key") (common pattern).
+//   - log_format : print("..."), NSLog("..."),
+//                  os.Logger().debug/info/warning/error("..."),
+//                  Logger.<level>("...") (swift-log / OSLog).
+//   - sql        : Quoted string literals whose first non-whitespace
+//                  token is a SQL verb — used with GRDB / SQLite.swift
+//                  raw query APIs.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("swift", sniffTemplatePatternsSwift)
+}
+
+// swiftI18nRe matches NSLocalizedString / String(localized:) / Text() i18n patterns.
+// Group 1 = the key literal.
+var swiftI18nRe = regexp.MustCompile(
+	`\bNSLocalizedString\s*\(\s*"([^"]+)"` +
+		`|\bString\s*\(\s*localized\s*:\s*"([^"]+)"` +
+		`|\bBundle\.main\.localizedString\s*\(\s*forKey\s*:\s*"([^"]+)"`,
+)
+
+// swiftLogRe matches print / NSLog / os.Logger / swift-log calls.
+// Group 1 = literal payload.
+var swiftLogRe = regexp.MustCompile(
+	`\b(?:print|NSLog|debugPrint)\s*\(\s*"([^"]+)"` +
+		`|\b(?:logger|log|Logger)\s*\.\s*(?:debug|info|notice|warning|error|critical|fault|log)\s*\(\s*"([^"]+)"`,
+)
+
+// swiftSQLRe matches a quoted literal whose first word is a SQL verb.
+// Group 1 = literal payload.
+var swiftSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsSwift(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanSwiftFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range swiftI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		var lit string
+		for i := 2; i < len(m)-1; i += 2 {
+			if m[i] >= 0 {
+				lit = content[m[i]:m[i+1]]
+				break
+			}
+		}
+		if lit == "" {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(lit),
+			Tag:      "NSLocalizedString/String(localized:)",
+		})
+	}
+	for _, m := range swiftLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		var lit string
+		for i := 2; i < len(m)-1; i += 2 {
+			if m[i] >= 0 {
+				lit = content[m[i]:m[i+1]]
+				break
+			}
+		}
+		if lit == "" {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(lit),
+			Tag:      "print/NSLog/logger",
+		})
+	}
+	for _, m := range swiftSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}

--- a/internal/substrate/template_pattern_zig.go
+++ b/internal/substrate/template_pattern_zig.go
@@ -1,0 +1,98 @@
+// Zig template-pattern sniffer (#2779 Phase 3D T3).
+//
+// Recognises:
+//   - i18n       : Zig has no widely-adopted i18n library; the closest
+//                  static pattern is a bare .translate("key") method call
+//                  or a zig-intl comptime lookup. Only gettext-style calls
+//                  are recognised — minimal but not padded.
+//   - log_format : std.debug.print("...", .{...}),
+//                  std.log.debug/info/warn/err("..."),
+//                  std.io.getStdOut().writer().print("...").
+//   - sql        : Quoted string literals whose first non-whitespace
+//                  token is a SQL verb — used with sqlite / zqlite raw queries.
+//
+// No SQL i18n candidates — Zig's ecosystem is pre-1.0 and i18n is rare.
+package substrate
+
+import "regexp"
+
+func init() {
+	RegisterTemplatePatternSniffer("zig", sniffTemplatePatternsZig)
+}
+
+// zigI18nRe matches translate / gettext method calls (rare but present in
+// Zig FFI wrappers around C gettext).
+// Group 1 = the key literal.
+var zigI18nRe = regexp.MustCompile(
+	`\b(?:gettext|translate|_)\s*\(\s*"([^"]+)"`,
+)
+
+// zigLogRe matches std.debug.print, std.log.* and writer().print().
+// Group 1 = literal payload.
+var zigLogRe = regexp.MustCompile(
+	`\bstd\s*\.\s*debug\s*\.\s*print\s*\(\s*"([^"]+)"` +
+		`|\bstd\s*\.\s*log\s*\.\s*(?:debug|info|warn|err|scoped)\s*\(\s*"([^"]+)"` +
+		`|\bwriter\s*\(\s*\)\s*\.\s*print\s*\(\s*"([^"]+)"`,
+)
+
+// zigSQLRe matches a quoted literal whose first word is a SQL verb.
+// Group 1 = literal payload.
+var zigSQLRe = regexp.MustCompile(
+	`"(\s*(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE|MERGE|WITH|CREATE\s+TABLE|DROP\s+TABLE|ALTER\s+TABLE)[^"]*)"`,
+)
+
+func sniffTemplatePatternsZig(content string) []TemplatePattern {
+	if content == "" {
+		return nil
+	}
+	headers := scanZigFuncHeaders(content)
+	var out []TemplatePattern
+
+	for _, m := range zigI18nRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindI18n,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "gettext()",
+		})
+	}
+	for _, m := range zigLogRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		var lit string
+		for i := 2; i < len(m)-1; i += 2 {
+			if m[i] >= 0 {
+				lit = content[m[i]:m[i+1]]
+				break
+			}
+		}
+		if lit == "" {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindLog,
+			Literal:  TruncateLiteral(lit),
+			Tag:      "std.debug.print/std.log",
+		})
+	}
+	for _, m := range zigSQLRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, TemplatePattern{
+			Function: nearestHeader(headers, lineOfOffset(content, m[0])),
+			Line:     lineOfOffset(content, m[0]),
+			Kind:     TemplateKindSQL,
+			Literal:  TruncateLiteral(content[m[2]:m[3]]),
+			Tag:      "sql.literal",
+		})
+	}
+	return out
+}


### PR DESCRIPTION
Closes #2779. **This is the terminal substrate issue — closes the last of 19 issues in epic #2716.**

## Summary

Phase 3 mechanical port to T3 (dart, swift, nim, crystal, zig, solidity, vue, svelte, astro). Reuses the generic passes for 3A (pure-function tagging) and 3B (module-cycle detection) — both language-agnostic — and adds per-language sniffers for 3C (def-use) and 3D (template-patterns).

### Sub-tasks

- **3A pure-function tagging** — language-agnostic, existing `pure_function_pass.go` plumbing. Applicable to all 9 T3 sniffer langs via effect data from Phase 1A.
- **3B module-cycle detection** — language-agnostic Tarjan SCC over IMPORTS edges. Applicable to all 9 T3 sniffer langs.
- **3C def-use chains** — 7 new per-language sniffers:
  - `def_use_dart.go` — `var/final/const` + bare assignments, reuses `scanDartFuncHeaders`
  - `def_use_swift.go` — `let/var` + bare assignments, reuses `scanSwiftFuncHeaders`
  - `def_use_nim.go` — `var/let/const` + bare assignments, reuses `scanNimFuncHeaders`
  - `def_use_crystal.go` — local + ivar (`@field`) assignments, reuses `scanCrystalFuncHeaders`
  - `def_use_zig.go` — `const/var` + bare assignments, reuses `scanZigFuncHeaders`
  - `def_use_solidity.go` — typed locals + bare assignments, reuses `scanSolidityFuncHeaders`
  - `def_use_markup_script.go` — shared dispatcher for vue/svelte/astro; delegates to `sniffDefUseJSTS` over `<script>` blocks with line-offset correction
- **3D template-pattern catalog** — 7 new per-language sniffers:
  - `template_pattern_dart.go` — i18n (`tr/translate/Intl.message`), log (`print/debugPrint/Logger`), sql (raw queries)
  - `template_pattern_swift.go` — i18n (`NSLocalizedString/String(localized:)`), log (`print/NSLog/logger.*`), sql (GRDB/SQLite.swift)
  - `template_pattern_nim.go` — i18n (`tr/translate`), log (`echo/writeLine/logging.*`), sql (nim-db raw)
  - `template_pattern_crystal.go` — i18n (`I18n.t/translate`), log (`puts/Log.*`), sql (crystal-db raw)
  - `template_pattern_zig.go` — i18n (`gettext` FFI), log (`std.debug.print/std.log.*`), sql (sqlite raw)
  - `template_pattern_solidity.go` — log only: `emit EventName("msg")` + `require/revert("msg")` strings; i18n + sql are not_applicable (EVM has no locale or SQL)
  - `template_pattern_markup_script.go` — shared dispatcher for vue/svelte/astro; delegates to `sniffTemplatePatternsJSTS` with line-offset correction

### N/A languages (no Phase 1A coverage)

verilog, vhdl, idris, sml, reasonml, rescript, elm, lisp, clojure, erlang, fsharp, haskell, ocaml, pony, groovy, lua, multi — excluded per "only ship where pattern is statically inspectable AND idiomatic" rule.

## Coverage cells flipped (36 cells: 9 langs × 4 caps)

implements-capability: lang.swift.framework.vapor/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.swift.framework.vapor/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.swift.framework.vapor/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.swift.framework.vapor/Substrate/template_pattern_catalog:missing→partial
implements-capability: lang.dart.framework.flutter/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.dart.framework.flutter/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.dart.framework.flutter/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.dart.framework.flutter/Substrate/template_pattern_catalog:missing→partial
implements-capability: lang.nim.framework.jester/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.nim.framework.jester/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.nim.framework.jester/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.nim.framework.jester/Substrate/template_pattern_catalog:missing→partial
implements-capability: lang.crystal.framework.lucky/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.crystal.framework.lucky/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.crystal.framework.lucky/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.crystal.framework.lucky/Substrate/template_pattern_catalog:missing→partial
implements-capability: lang.zig.framework.httpz/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.zig.framework.httpz/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.zig.framework.httpz/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.zig.framework.httpz/Substrate/template_pattern_catalog:missing→partial
implements-capability: lang.solidity.framework.hardhat/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.solidity.framework.hardhat/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.solidity.framework.hardhat/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.solidity.framework.hardhat/Substrate/template_pattern_catalog:missing→partial
implements-capability: lang.jsts.framework.vue/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.jsts.framework.vue/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.jsts.framework.vue/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.jsts.framework.vue/Substrate/template_pattern_catalog:missing→partial
implements-capability: lang.jsts.framework.svelte/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.jsts.framework.svelte/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.jsts.framework.svelte/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.jsts.framework.svelte/Substrate/template_pattern_catalog:missing→partial
implements-capability: lang.jsts.framework.astro/Substrate/pure_function_tagging:missing→partial
implements-capability: lang.jsts.framework.astro/Substrate/module_cycle_detection:missing→partial
implements-capability: lang.jsts.framework.astro/Substrate/def_use_chain_extraction:missing→partial
implements-capability: lang.jsts.framework.astro/Substrate/template_pattern_catalog:missing→partial

## Real-data verification (upvate)

0 new findings expected — upvate has no dart/swift/nim/crystal/zig/solidity/vue/svelte/astro source files.

## Substrate epic complete

This PR closes #2779, the last of 19 issues in the substrate epic (#2716). The full substrate capability set (Phase 0 through Phase 3) is now implemented across all three language tiers (T1/T2/T3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)