### PR TITLE
fix(substrate): effects classifier no longer reports IO code as pure (#2804)

### DIFF
--- a/internal/links/effect_propagation.go
+++ b/internal/links/effect_propagation.go
@@ -140,7 +140,14 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 	binder := newEffectBinder(graphs)
 	directByEntity := map[string]*substrate.EffectSet{}
 	for k, set := range direct {
-		if eid := binder.lookup(k.repo, k.file, k.fn); eid != "" {
+		// A single source function may be represented by more than one
+		// graph entity sharing (file, name): a decorator-wrapper node
+		// (Celery Task / ScheduledJob) and the Operation body, for
+		// instance. The sniffer attributes the sink to the bare function
+		// name, so we stamp the direct effects onto EVERY matching entity
+		// — otherwise the wrapper reports `pure` even though its body does
+		// IO (#2804: process_ecb_pdf_job's Task node).
+		for _, eid := range binder.lookupAll(k.repo, k.file, k.fn) {
 			fullID := entityKey(k.repo, eid)
 			if existing := directByEntity[fullID]; existing != nil {
 				existing.Union(*set)
@@ -279,22 +286,27 @@ func effectSetsEqual(a, b substrate.EffectSet) bool {
 	return true
 }
 
-// effectBinder maps (repo, file, function-name) to a graph entity ID
+// effectBinder maps (repo, file, function-name) to graph entity IDs
 // using the per-repo entity list. Function entities are indexed by
 // their Name; constructors and methods may collide with bare names
 // from sibling files in the same repo — we resolve by file first, so
 // each (file, name) pair binds locally.
+//
+// A (file, name) pair may legitimately map to MORE THAN ONE entity:
+// decorator-wrapper kinds (Celery Task / ScheduledJob) coexist with the
+// Operation body for the same source function. We keep every match so
+// the sniffer's effects stamp onto all of them (#2804).
 type effectBinder struct {
-	// byFile[repo][file][name] = entityID
-	byFile map[string]map[string]map[string]string
+	// byFile[repo][file][name] = []entityID
+	byFile map[string]map[string]map[string][]string
 }
 
 func newEffectBinder(graphs []repoGraph) *effectBinder {
-	b := &effectBinder{byFile: map[string]map[string]map[string]string{}}
+	b := &effectBinder{byFile: map[string]map[string]map[string][]string{}}
 	for _, g := range graphs {
 		repoIdx := b.byFile[g.Repo]
 		if repoIdx == nil {
-			repoIdx = map[string]map[string]string{}
+			repoIdx = map[string]map[string][]string{}
 			b.byFile[g.Repo] = repoIdx
 		}
 		for _, e := range g.Entities {
@@ -306,58 +318,77 @@ func newEffectBinder(graphs []repoGraph) *effectBinder {
 			}
 			fileIdx := repoIdx[e.SourceFile]
 			if fileIdx == nil {
-				fileIdx = map[string]string{}
+				fileIdx = map[string][]string{}
 				repoIdx[e.SourceFile] = fileIdx
 			}
-			// Last-wins on duplicate (file, name) — same identifier
-			// declared twice in one file is rare and the propagation
-			// pass cannot tell them apart without line info; we accept
-			// the precision loss in Phase 1A.
-			fileIdx[e.Name] = e.ID
+			// Accumulate (never overwrite) so a decorator-wrapper node and
+			// its Operation body — same (file, name) — both bind.
+			fileIdx[e.Name] = append(fileIdx[e.Name], e.ID)
 		}
 	}
 	return b
 }
 
-// lookup returns the entity ID for (repo, file, name), or "" when none
-// is bound. Falls back to a bare-name match within the same file in
-// case the sniffer captured a name that has a method-bearing receiver
-// qualifier in the graph (e.g. extractor stores "Repo.Save" but the
-// sniffer captured "Save"); we try a suffix-match on `.Name`.
-func (b *effectBinder) lookup(repo, file, name string) string {
+// lookupAll returns every entity ID bound to (repo, file, name), or nil
+// when none is bound. Falls back to a bare-name suffix match within the
+// same file in case the sniffer captured a name that has a method-bearing
+// receiver qualifier in the graph (e.g. extractor stores "Repo.Save" but
+// the sniffer captured "Save"); the suffix path returns only when exactly
+// one distinct qualified name matches, to avoid mis-attributing a sink to
+// an unrelated same-suffix method.
+func (b *effectBinder) lookupAll(repo, file, name string) []string {
 	fileIdx := b.byFile[repo][file]
 	if fileIdx == nil {
-		return ""
+		return nil
 	}
-	if id := fileIdx[name]; id != "" {
-		return id
+	if ids := fileIdx[name]; len(ids) > 0 {
+		return ids
 	}
-	// Suffix match: extractor may have stored a qualified name. Avoid
-	// O(n²) by only scanning when the bare-name lookup missed and only
-	// returning when exactly one candidate ends in "."+name.
+	// Suffix match: extractor may have stored a qualified name. Only
+	// return when exactly one qualified key ends in "."+name.
 	suffix := "." + name
-	var match string
-	hits := 0
-	for k, id := range fileIdx {
+	var match []string
+	keys := 0
+	for k, ids := range fileIdx {
 		if strings.HasSuffix(k, suffix) {
-			match = id
-			hits++
-			if hits > 1 {
-				return ""
+			match = ids
+			keys++
+			if keys > 1 {
+				return nil
 			}
 		}
 	}
 	return match
 }
 
+// lookup returns a single bound entity ID for (repo, file, name), or ""
+// when none is bound. When (file, name) maps to several entities (e.g. a
+// decorator-wrapper Task plus its Operation body) it returns the first —
+// preserving the pre-#2804 single-binding contract for taint /
+// payload-drift / def-use callers that key one fact per function.
+// Effect attribution uses lookupAll instead so every matching entity
+// receives the stamp.
+func (b *effectBinder) lookup(repo, file, name string) string {
+	if ids := b.lookupAll(repo, file, name); len(ids) > 0 {
+		return ids[0]
+	}
+	return ""
+}
+
 // isFunctionLikeKind reports whether kind names a function-shaped entity
 // the propagation pass should annotate. Mirrors the kinds the CALLS
-// extractor emits across T1 languages.
+// extractor emits across T1 languages, plus decorator-wrapper kinds
+// (Celery Task, scheduled job, async process) that own a function body
+// and must inherit that body's effects (#2804).
 func isFunctionLikeKind(kind string) bool {
 	switch kind {
 	case "SCOPE.Function", "SCOPE.Operation", "SCOPE.Class", "SCOPE.UIComponent", "SCOPE.JSX":
 		return true
+	case "SCOPE.Task", "SCOPE.ScheduledJob", "SCOPE.Process":
+		return true
 	case "function", "method", "operation":
+		return true
+	case "Task", "ScheduledJob", "Process":
 		return true
 	}
 	return false

--- a/internal/links/effect_propagation_test.go
+++ b/internal/links/effect_propagation_test.go
@@ -138,6 +138,122 @@ func top() { mid() }
 	}
 }
 
+// TestEffectPropagation_QualifiedNameAndViaHelper is the #2804
+// regression. It reproduces two failures that combined to make an
+// IO-heavy Celery task report `pure`:
+//
+//  1. The graph stores methods under their QUALIFIED name
+//     ("ProposalViewSet.send_proposals") while the sniffer attributes
+//     sinks to the bare name ("send_proposals"); the binder must still
+//     connect them.
+//  2. A task delegates its DB write to a helper it CALLS — the task body
+//     has only S3/env sinks, so DB must arrive transitively.
+func TestEffectPropagation_QualifiedNameAndViaHelper(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "task.py", `
+import os
+import boto3
+
+class Pipeline:
+    def process_job(self, payload):
+        s3 = boto3.client("s3", region_name=os.getenv("AWS_REGION"))
+        s3.download_file(payload["bucket"], payload["key"], "/tmp/x.pdf")
+        persist_to_db(payload)
+`)
+	writeFile(t, root, "helper.py", `
+import mysql.connector
+
+def persist_to_db(row):
+    conn = mysql.connector.connect(host="db")
+    cur = conn.cursor()
+    cur.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+`)
+	graphs := []repoGraph{{
+		Repo:     "upvate-core",
+		FileRoot: root,
+		Entities: []entityNode{
+			// Method stored under its qualified name, as the real extractor emits.
+			{ID: "job", Name: "Pipeline.process_job", Kind: "SCOPE.Operation", SourceFile: "task.py"},
+			{ID: "helper", Name: "persist_to_db", Kind: "SCOPE.Operation", SourceFile: "helper.py"},
+		},
+		Edges: []edgeRef{
+			{FromID: "job", ToID: "helper", Kind: "CALLS"},
+		},
+	}}
+	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	job := graphs[0].Entities[0].Properties
+	if job == nil {
+		t.Fatal("process_job not stamped — qualified-name binding regression (#2804)")
+	}
+	effs := job[EffectPropertyKeyList]
+	// Direct sinks on the task body.
+	for _, want := range []string{"http_out", "env_read"} {
+		if !strings.Contains(effs, want) {
+			t.Errorf("process_job effects=%q; want direct %q", effs, want)
+		}
+	}
+	// Transitive sinks inherited from the helper it calls.
+	for _, want := range []string{"db_read", "db_write"} {
+		if !strings.Contains(effs, want) {
+			t.Errorf("process_job effects=%q; want transitive %q (via persist_to_db)", effs, want)
+		}
+	}
+	// Helper is the direct DB owner.
+	if got := graphs[0].Entities[1].Properties[EffectPropertyKeySource]; got != "direct" {
+		t.Errorf("persist_to_db effect_source=%q; want direct", got)
+	}
+}
+
+// TestEffectPropagation_DecoratorWrapperAndBody is the second half of the
+// #2804 regression: a Celery task is represented by TWO entities sharing
+// (file, name) — a decorator-wrapper Task node and the Operation body.
+// The sniffer attributes sinks to the bare function name, so BOTH must be
+// stamped; before the fix the Task node bound to nothing (its kind was
+// not function-like) and reported `pure`, exactly as
+// process_ecb_pdf_job's Task node did live.
+func TestEffectPropagation_DecoratorWrapperAndBody(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "task.py", `
+import os
+import boto3
+
+@shared_task(bind=True)
+def process_job(self, payload):
+    s3 = boto3.client("s3", region_name=os.getenv("AWS_REGION"))
+    s3.download_file(payload["bucket"], payload["key"], "/tmp/x.pdf")
+`)
+	graphs := []repoGraph{{
+		Repo:     "upvate-core",
+		FileRoot: root,
+		Entities: []entityNode{
+			// Decorator-wrapper node (the @shared_task line) and the
+			// function body — both named process_job in the same file.
+			{ID: "task", Name: "process_job", Kind: "Task", SourceFile: "task.py"},
+			{ID: "op", Name: "process_job", Kind: "SCOPE.Operation", SourceFile: "task.py"},
+		},
+	}}
+	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, ent := range graphs[0].Entities {
+		effs := ent.Properties[EffectPropertyKeyList]
+		if effs == "" {
+			t.Fatalf("%s node (%s) left unstamped — decorator-wrapper binding regression (#2804)", ent.Kind, ent.ID)
+		}
+		for _, want := range []string{"http_out", "env_read"} {
+			if !strings.Contains(effs, want) {
+				t.Errorf("%s node effects=%q; want %q", ent.Kind, effs, want)
+			}
+		}
+		if got := ent.Properties[EffectPropertyKeySource]; got != "direct" {
+			t.Errorf("%s node effect_source=%q; want direct", ent.Kind, got)
+		}
+	}
+}
+
 func confFromProps(props map[string]string, effect string) float64 {
 	if props == nil {
 		return 0

--- a/internal/mcp/effects_tool.go
+++ b/internal/mcp/effects_tool.go
@@ -12,15 +12,27 @@
 //     "explanation":   "..."
 //   }
 //
-// The effect set is read off entity.Properties (stamped by
-// internal/links/effect_propagation.go). An entity with no effect
-// properties is reported as "pure" with low confidence — per #2764
-// spec absence of detection does not prove absence of effect.
+// The effect set is read from the on-disk effects sidecar
+// (<group>-links-effects.json, written by
+// internal/links/effect_propagation.go) — the canonical source — with a
+// fallback to entity.Properties for the in-process link-run case. An
+// entity present in neither is reported as "pure" with low confidence —
+// per #2764 spec absence of detection does not prove absence of effect.
+//
+// Reading off entity.Properties alone is insufficient: the propagation
+// pass stamps properties on an ephemeral in-memory graph during the link
+// run and never persists them to graph.fb, so the daemon-loaded graph
+// that serves MCP has empty effect properties. Before #2804 this made
+// every entity report "pure" (the marquee Phase 1A failure). We now load
+// the sidecar that the pass does persist.
 package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -30,6 +42,58 @@ import (
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
+// effectsSidecarEntry mirrors links.effectEntry — the per-entity record
+// in <group>-links-effects.json. Kept local (unexported in links) so the
+// MCP surface can decode it without widening the links API.
+type effectsSidecarEntry struct {
+	EntityID    string              `json:"entity_id"`
+	Effects     []string            `json:"effects"`
+	Confidences map[string]float64  `json:"confidences"`
+	Sinks       map[string][]string `json:"sinks,omitempty"`
+	Source      string              `json:"source"`
+}
+
+type effectsSidecarDoc struct {
+	Version int                   `json:"version"`
+	Method  string                `json:"method"`
+	Entries []effectsSidecarEntry `json:"entries"`
+}
+
+// effectsSidecarPath is the conventional path for the
+// <group>-links-effects.json sidecar written by
+// internal/links/effect_propagation.go. Mirrors reachabilitySidecarPath.
+func effectsSidecarPath(group string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".archigraph", "groups", group+"-links-effects.json")
+}
+
+// loadEffectsSidecar reads + parses the sidecar into a map keyed by the
+// prefixed entity ID ("<repo>::<local>"). ok=false on any failure
+// (missing file is the common, non-error case → fall back to in-memory
+// properties).
+func loadEffectsSidecar(group string) (map[string]effectsSidecarEntry, bool) {
+	path := effectsSidecarPath(group)
+	if path == "" {
+		return nil, false
+	}
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var doc effectsSidecarDoc
+	if err := json.Unmarshal(buf, &doc); err != nil {
+		return nil, false
+	}
+	idx := make(map[string]effectsSidecarEntry, len(doc.Entries))
+	for _, e := range doc.Entries {
+		idx[e.EntityID] = e
+	}
+	return idx, true
+}
+
 // handleEffects implements archigraph_effects. The entity_id parameter
 // accepts an id, qualified name, label, or cross-repo prefixed id
 // ("<repo>:<id>"), mirroring archigraph_inspect's resolver semantics.
@@ -38,17 +102,21 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 	if key == "" {
 		return mcpapi.NewToolResultError("missing required argument: entity_id"), nil
 	}
-	_, lg, errRes := s.resolveAndGroup(req)
+	groupName, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil
 	}
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
 
+	// Canonical effects live in the on-disk sidecar written by the link
+	// pass; entity.Properties are only populated during an in-process run.
+	sidecar, _ := loadEffectsSidecar(groupName)
+
 	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
 		if r, ok := lg.Repos[rprefix]; ok && r.Doc != nil {
 			if e, ok := r.LabelIndex.ByID[local]; ok {
-				return jsonResult(buildEffectsPayload(r.Repo, e)), nil
+				return jsonResult(buildEffectsPayload(r.Repo, e, sidecar)), nil
 			}
 		}
 	}
@@ -84,13 +152,17 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 			"how_to_choose": "Re-call archigraph_effects with the prefixed id field (e.g. \"repo:1234abcd\").",
 		}), nil
 	}
-	return jsonResult(buildEffectsPayload(matches[0].repo, matches[0].ent)), nil
+	return jsonResult(buildEffectsPayload(matches[0].repo, matches[0].ent, sidecar)), nil
 }
 
 // buildEffectsPayload constructs the JSON-serialisable response body
 // from a resolved graph entity. Centralised so cross-repo prefixed
 // and label-lookup paths emit byte-identical shapes.
-func buildEffectsPayload(repo string, e *graph.Entity) map[string]any {
+//
+// Effect data is read from the on-disk sidecar (canonical) when present
+// for this entity, otherwise from entity.Properties (in-process run),
+// otherwise reported as pure.
+func buildEffectsPayload(repo string, e *graph.Entity, sidecar map[string]effectsSidecarEntry) map[string]any {
 	out := map[string]any{
 		"entity_id": prefixedID(repo, e.ID),
 		"resolved": map[string]any{
@@ -102,6 +174,21 @@ func buildEffectsPayload(repo string, e *graph.Entity) map[string]any {
 			"source_file":    e.SourceFile,
 		},
 	}
+
+	// Canonical path: sidecar entry keyed by prefixed entity ID.
+	if entry, ok := sidecar[prefixedID(repo, e.ID)]; ok && len(entry.Effects) > 0 {
+		out["effects"] = entry.Effects
+		out["effect_source"] = entry.Source
+		out["confidences"] = entry.Confidences
+		out["confidence"] = maxConfidence(entry.Confidences)
+		if len(entry.Sinks) > 0 {
+			out["sinks"] = entry.Sinks
+		}
+		out["explanation"] = explanationFor(entry.Effects, entry.Source)
+		return out
+	}
+
+	// Fallback: in-memory properties (populated only during a live link run).
 	rawEffs := ""
 	if e.Properties != nil {
 		rawEffs = e.Properties[links.EffectPropertyKeyList]
@@ -115,14 +202,30 @@ func buildEffectsPayload(repo string, e *graph.Entity) map[string]any {
 		return out
 	}
 	effs := splitNonEmpty(rawEffs)
+	confs := parseConfidences(e.Properties[links.EffectPropertyKeyConfidence])
 	out["effects"] = effs
 	out["effect_source"] = e.Properties[links.EffectPropertyKeySource]
-	out["confidences"] = parseConfidences(e.Properties[links.EffectPropertyKeyConfidence])
+	out["confidences"] = confs
+	out["confidence"] = maxConfidence(confs)
 	if sinks := parseSinks(e.Properties[links.EffectPropertyKeySinks]); len(sinks) > 0 {
 		out["sinks"] = sinks
 	}
 	out["explanation"] = explanationFor(effs, e.Properties[links.EffectPropertyKeySource])
 	return out
+}
+
+// maxConfidence returns the strongest per-effect confidence — the
+// headline confidence for the entity's effect classification. An entity
+// with a direct 1.0 sink reads as high-confidence even if it also has a
+// weak transitive effect. Zero when the map is empty.
+func maxConfidence(confs map[string]float64) float64 {
+	max := 0.0
+	for _, v := range confs {
+		if v > max {
+			max = v
+		}
+	}
+	return max
 }
 
 // parseConfidences decodes the comma-joined "<effect>=<float>" form

--- a/internal/mcp/effects_tool_test.go
+++ b/internal/mcp/effects_tool_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/links"
+)
+
+// TestBuildEffectsPayload_SidecarWins is the #2804 regression at the MCP
+// boundary: effect data is persisted only to the on-disk sidecar (entity
+// .Properties are empty in the daemon-loaded graph). The payload builder
+// must read the sidecar, not report `pure`.
+func TestBuildEffectsPayload_SidecarWins(t *testing.T) {
+	e := &graph.Entity{ID: "9986b358cfb5dacd", Name: "ProposalViewSet.send_proposals", Kind: "SCOPE.Operation"}
+	sidecar := map[string]effectsSidecarEntry{
+		"upvate-core::9986b358cfb5dacd": {
+			EntityID:    "upvate-core::9986b358cfb5dacd",
+			Effects:     []string{"db_read", "db_write", "fs_read", "fs_write"},
+			Confidences: map[string]float64{"db_read": 0.85, "db_write": 0.85, "fs_read": 0.9, "fs_write": 1.0},
+			Sinks:       map[string][]string{"db_write": {"orm.write"}},
+			Source:      "direct",
+		},
+	}
+
+	out := buildEffectsPayload("upvate-core", e, sidecar)
+
+	if got := out["effect_source"]; got != "direct" {
+		t.Fatalf("effect_source=%v; want direct (sidecar must override empty properties)", got)
+	}
+	effs, ok := out["effects"].([]string)
+	if !ok || len(effs) != 4 {
+		t.Fatalf("effects=%v; want the 4 sidecar effects", out["effects"])
+	}
+	if got := out["confidence"]; got != 1.0 {
+		t.Errorf("headline confidence=%v; want 1.0 (max per-effect), not the 0.3 pure default", got)
+	}
+}
+
+// TestBuildEffectsPayload_PureWhenAbsent verifies the fallback contract:
+// an entity in neither the sidecar nor entity.Properties is reported pure
+// with the documented low confidence.
+func TestBuildEffectsPayload_PureWhenAbsent(t *testing.T) {
+	e := &graph.Entity{ID: "deadbeef", Name: "add", Kind: "SCOPE.Function"}
+	out := buildEffectsPayload("upvate-core", e, map[string]effectsSidecarEntry{})
+	if got := out["effect_source"]; got != "pure" {
+		t.Fatalf("effect_source=%v; want pure", got)
+	}
+	if got := out["confidence"]; got != 0.3 {
+		t.Errorf("confidence=%v; want 0.3", got)
+	}
+}
+
+// TestBuildEffectsPayload_PropertiesFallback verifies the in-process path
+// (live link run) still works when no sidecar entry exists but properties
+// are stamped.
+func TestBuildEffectsPayload_PropertiesFallback(t *testing.T) {
+	e := &graph.Entity{
+		ID:   "abc",
+		Name: "svc",
+		Kind: "SCOPE.Function",
+		Properties: map[string]string{
+			links.EffectPropertyKeyList:       "http_out",
+			links.EffectPropertyKeyConfidence: "http_out=0.95",
+			links.EffectPropertyKeySource:     "transitive",
+		},
+	}
+	out := buildEffectsPayload("upvate-core", e, map[string]effectsSidecarEntry{})
+	if got := out["effect_source"]; got != "transitive" {
+		t.Fatalf("effect_source=%v; want transitive", got)
+	}
+	if got := out["confidence"]; got != 0.95 {
+		t.Errorf("confidence=%v; want 0.95", got)
+	}
+}

--- a/internal/substrate/effect_sinks_python.go
+++ b/internal/substrate/effect_sinks_python.go
@@ -3,10 +3,15 @@
 // Recognises Python sink primitives:
 //
 //   - http_out  : requests.<verb>(), httpx.<verb>(), urllib.request.urlopen,
-//                 aiohttp.ClientSession (.<verb>), urllib3.request
+//                 aiohttp.ClientSession (.<verb>), urllib3.request,
+//                 boto3.client/resource(...) + AWS client ops (S3 upload/
+//                 download/put/get/copy, SQS send/receive, SNS publish,
+//                 Lambda invoke) — every boto3 call crosses the network
 //   - db_read   : Django ORM Model.objects.<filter|get|all|...>,
 //                 SQLAlchemy session.query / .execute (SELECT),
-//                 raw cursor.execute("SELECT ..."), cursor.fetchall/fetchone
+//                 raw cursor.execute("SELECT ..."), cursor.fetchall/fetchone,
+//                 DB-API driver connect/cursor (mysql.connector, psycopg2,
+//                 sqlite3, pymysql, MySQLdb, cx_Oracle, pyodbc, asyncpg)
 //   - db_write  : Django .save() / .create() / .update() / .delete() /
 //                 .bulk_create / .bulk_update,
 //                 SQLAlchemy session.add / .commit / .delete,
@@ -16,6 +21,7 @@
 //   - fs_write  : open(..., "w"|"a"|"x"|"wb"|...), pathlib.Path.write_*,
 //                 os.mkdir, os.remove, os.rename, shutil.copy*
 //   - mutation  : self.<attr> = ... (assignment to a method receiver)
+//   - env_read  : os.getenv(...), os.environ[...] / os.environ.get(...)
 //
 // Function attribution uses the same "nearest preceding header" heuristic
 // as the JS/TS sniffer; Python's indentation rules make this more reliable
@@ -33,11 +39,18 @@ var pyFuncHeaderRe = regexp.MustCompile(
 	`(?m)^\s*(?:async\s+)?def\s+([A-Za-z_][\w]*)\s*\(`,
 )
 
-// pyHTTPRe matches HTTP-client primitives.
+// pyHTTPRe matches outbound HTTP / network-client primitives. Includes
+// the common requests/httpx/urllib3/aiohttp clients plus boto3/botocore
+// AWS clients (S3/SQS/... upload/download/get/put/list/copy/send) — every
+// boto3 call crosses the network, so we classify it as http_out (the
+// lattice has no separate "network" element). urlopen and the bare
+// `.get("http://...")` shape are also caught.
 var pyHTTPRe = regexp.MustCompile(
 	`\b(?:requests|httpx|urllib3)\s*\.\s*(?:get|post|put|patch|delete|head|options|request)\s*\(` +
-		`|\burllib\s*\.\s*request\s*\.\s*urlopen\s*\(` +
+		`|\burllib\s*\.\s*request\s*\.\s*urlopen\s*\(|\burlopen\s*\(` +
 		`|\baiohttp\s*\.\s*ClientSession\b` +
+		`|\bboto3\s*\.\s*(?:client|resource)\s*\(` +
+		`|\.\s*(?:upload_file|upload_fileobj|download_file|download_fileobj|put_object|get_object|copy_object|delete_object|list_objects(?:_v2)?|head_object|generate_presigned_url|send_message|receive_message|publish|invoke)\s*\(` +
 		`|\.\s*(?:get|post|put|patch|delete|head|options)\s*\(\s*['"]https?://`,
 )
 
@@ -58,10 +71,28 @@ var pyCursorSelectRe = regexp.MustCompile(
 	`\.\s*execute\s*\(\s*['"](?i:\s*(?:SELECT|WITH)\b)`,
 )
 
-// pyDBWriteRe matches ORM / session write primitives.
+// pyDBConnectRe matches raw-driver connection / cursor primitives for the
+// common DB-API drivers (mysql.connector, psycopg2, sqlite3, pymysql,
+// MySQLdb, cx_Oracle, pyodbc, asyncpg) plus a bare `.cursor()` call and
+// `cursor.execute(<non-literal>)` where the SQL is a variable (so the
+// SELECT/WRITE keyword sniffers can't see it). Establishing a connection
+// or opening a cursor is itself DB I/O — we classify it db_read as the
+// conservative "this function talks to a database" signal; explicit
+// writes are still upgraded to db_write by pyCursorWriteRe / pyDBWriteRe.
+var pyDBConnectRe = regexp.MustCompile(
+	`\b(?:mysql\s*\.\s*connector|psycopg2|psycopg|sqlite3|pymysql|MySQLdb|cx_Oracle|pyodbc|asyncpg)\s*\.\s*(?:connect|Connection)\s*\(` +
+		`|\.\s*cursor\s*\(\s*\)` +
+		`|\.\s*execute\s*\(\s*[A-Za-z_]`,
+)
+
+// pyDBWriteRe matches ORM / session / raw-connection write primitives.
+// A bare `.commit(` / `.rollback(` is a transaction boundary on any
+// DB-API connection (conn.commit()), so it counts as db_write even when
+// the receiver is not a named `session`.
 var pyDBWriteRe = regexp.MustCompile(
 	`\.\s*(?:save|delete|update|bulk_create|bulk_update|create|get_or_create|update_or_create)\s*\(` +
-		`|\bsession\s*\.\s*(?:add|add_all|delete|commit|flush|merge)\s*\(`,
+		`|\bsession\s*\.\s*(?:add|add_all|delete|commit|flush|merge)\s*\(` +
+		`|\.\s*(?:commit|rollback)\s*\(\s*\)`,
 )
 
 // pyCursorWriteRe matches raw cursor INSERT/UPDATE/DELETE.
@@ -95,6 +126,16 @@ var pyMutationRe = regexp.MustCompile(
 	`\bself\s*\.\s*[A-Za-z_][\w]*\s*=(?:[^=])`,
 )
 
+// pyEnvReadRe matches process-environment reads: os.environ[...] /
+// os.environ.get(...) / os.getenv(...) / os.environb. Module-style
+// `environ` (from os import environ) is also caught via the bare form.
+var pyEnvReadRe = regexp.MustCompile(
+	`\bos\s*\.\s*getenv\s*\(` +
+		`|\bos\s*\.\s*environb?\s*(?:\.\s*get\s*\(|\[)` +
+		`|\bgetenv\s*\(` +
+		`|\benviron\s*\.\s*get\s*\(`,
+)
+
 func sniffEffectsPython(content string) []EffectMatch {
 	if content == "" {
 		return nil
@@ -104,11 +145,13 @@ func sniffEffectsPython(content string) []EffectMatch {
 	out = appendPyMatches(out, content, headers, pyHTTPRe, EffectHTTPOut, "requests/httpx", 1.0)
 	out = appendPyMatches(out, content, headers, pyDBReadRe, EffectDBRead, "orm.read", 0.85)
 	out = appendPyMatches(out, content, headers, pyCursorSelectRe, EffectDBRead, "cursor.execute(SELECT)", 1.0)
+	out = appendPyMatches(out, content, headers, pyDBConnectRe, EffectDBRead, "db.connect/cursor", 0.8)
 	out = appendPyMatches(out, content, headers, pyDBWriteRe, EffectDBWrite, "orm.write", 0.85)
 	out = appendPyMatches(out, content, headers, pyCursorWriteRe, EffectDBWrite, "cursor.execute(WRITE)", 1.0)
 	out = appendPyMatches(out, content, headers, pyFSReadRe, EffectFSRead, "open/pathlib", 0.9)
 	out = appendPyMatches(out, content, headers, pyFSWriteRe, EffectFSWrite, "open(w)/shutil", 1.0)
 	out = appendPyMatches(out, content, headers, pyMutationRe, EffectMutation, "self.field=", 0.7)
+	out = appendPyMatches(out, content, headers, pyEnvReadRe, EffectEnvRead, "os.environ/getenv", 1.0)
 	return out
 }
 

--- a/internal/substrate/effects.go
+++ b/internal/substrate/effects.go
@@ -3,7 +3,7 @@
 // Effect classification tags every function with the set of side-effect
 // primitives it executes directly:
 //
-//   {db_read, db_write, http_out, fs_read, fs_write, mutation}
+//   {db_read, db_write, http_out, fs_read, fs_write, mutation, env_read}
 //
 // A function with none of these is pure (low confidence — absence of
 // detection does not prove absence of effect).
@@ -50,15 +50,29 @@ const (
 	// receiver field in OO, struct-field write through a pointer in
 	// Go, ...). Not local-variable assignment.
 	EffectMutation Effect = "mutation"
+	// EffectEnvRead — read of process environment / external config
+	// (os.environ, os.getenv, process.env, System.getenv, ...). A weak
+	// effect (it does not mutate the world) but a meaningful taint
+	// source and a signal that a function is environment-coupled, so
+	// callers that need "is this function pure?" must see it.
+	EffectEnvRead Effect = "env_read"
 )
 
-// AllEffects returns the canonical sorted list of effect names.
+// AllEffects returns the canonical sorted list of effect names. The
+// order is load-bearing: EffectSet packs effects into bit positions by
+// this index, so appending (never reordering) preserves on-disk and
+// in-memory layout.
 func AllEffects() []Effect {
 	return []Effect{
 		EffectDBRead, EffectDBWrite, EffectHTTPOut,
 		EffectFSRead, EffectFSWrite, EffectMutation,
+		EffectEnvRead,
 	}
 }
+
+// effectSlots is the number of lattice elements; sizes the bit-packed
+// EffectSet arrays. Must equal len(AllEffects()).
+const effectSlots = 7
 
 // EffectMatch is one detected sink primitive inside a function body.
 //
@@ -127,17 +141,18 @@ func EffectLanguages() []string {
 // union effects across CALLS edges without allocating a fresh map per
 // merge. The zero value is the empty (pure) set.
 type EffectSet struct {
-	// bits packs the six lattice elements into one byte. Order matches
-	// AllEffects() so position 0 = db_read ... position 5 = mutation.
+	// bits packs the lattice elements into one byte (effectSlots ≤ 8).
+	// Order matches AllEffects() so position 0 = db_read ... position
+	// 6 = env_read.
 	bits uint8
 	// confidence stores the per-effect confidence (0..255 scaled by
 	// 100 → 1.00 max). Index aligns with bits.
-	confidence [6]uint8
+	confidence [effectSlots]uint8
 	// sinks lists short sink-tag strings ("fetch", "requests.get", ...)
 	// per effect; surfaced by archigraph_effects so the agent can see
 	// which primitive triggered each effect. Bounded to a few entries
 	// per effect — see addSink for the cap.
-	sinks [6][]string
+	sinks [effectSlots][]string
 }
 
 // effectIndex returns the bit position of e in EffectSet, or -1 when e
@@ -224,7 +239,7 @@ func (s *EffectSet) Sinks(e Effect) []string {
 // the strongest evidence across the union). Sink tags are deduplicated
 // up to maxSinksPerEffect.
 func (s *EffectSet) Union(other EffectSet) {
-	for i := 0; i < 6; i++ {
+	for i := 0; i < effectSlots; i++ {
 		if other.bits&(1<<uint(i)) == 0 {
 			continue
 		}
@@ -243,7 +258,7 @@ func (s *EffectSet) Union(other EffectSet) {
 // per CALLS hop (each hop multiplies by 0.95 per the issue spec, bounded
 // at a floor of 0.5 so deeply transitive evidence never disappears).
 func (s *EffectSet) UnionScaled(other EffectSet, scale float64) {
-	for i := 0; i < 6; i++ {
+	for i := 0; i < effectSlots; i++ {
 		if other.bits&(1<<uint(i)) == 0 {
 			continue
 		}
@@ -267,7 +282,7 @@ func (s *EffectSet) AsList() []Effect {
 	if s.bits == 0 {
 		return nil
 	}
-	out := make([]Effect, 0, 6)
+	out := make([]Effect, 0, effectSlots)
 	for i, e := range AllEffects() {
 		if s.bits&(1<<uint(i)) != 0 {
 			out = append(out, e)

--- a/internal/substrate/effects_test.go
+++ b/internal/substrate/effects_test.go
@@ -145,6 +145,54 @@ def read_config():
 	mustHave(t, byEffect, EffectMutation, "assign")
 }
 
+// TestSniffEffectsPython_IOHeavySinks is the #2804 regression: a Celery
+// task / DRF action that performs S3 (boto3), env reads, and raw DB
+// access must NOT be classified pure. Mirrors the shapes from
+// core/tasks/ecb_pdf_pipeline.py and core/views/contract_viewset.py that
+// previously reported {} / 0.3 / pure.
+func TestSniffEffectsPython_IOHeavySinks(t *testing.T) {
+	const src = `
+import os
+import boto3
+import mysql.connector
+
+class Pipeline:
+    def run_job(self, payload):
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+            region_name=os.environ.get("AWS_REGION"),
+        )
+        s3.download_file(payload["bucket"], payload["key"], "/tmp/x.pdf")
+        s3.upload_fileobj(open("/tmp/x.pdf", "rb"), "out", "y.pdf")
+
+    def write_controller(self, row):
+        conn = mysql.connector.connect(host=os.environ["DB_HOST"])
+        cur = conn.cursor()
+        cur.execute(insert_sql, row)
+        conn.commit()
+
+    def read_with_psycopg(self):
+        c = psycopg2.connect("dsn")
+        cur = c.cursor()
+        cur.execute("SELECT 1")
+`
+	got := sniffEffectsPython(src)
+	if len(got) == 0 {
+		t.Fatal("expected python matches; got none")
+	}
+	by := groupByEffect(got)
+	// boto3 client + S3 ops cross the network → http_out.
+	mustHave(t, by, EffectHTTPOut, "run_job")
+	// os.getenv / os.environ.get / os.environ[...] → env_read.
+	mustHave(t, by, EffectEnvRead, "run_job")
+	mustHave(t, by, EffectEnvRead, "write_controller")
+	// raw DB-API driver connect/cursor → db_read; commit → db_write.
+	mustHave(t, by, EffectDBRead, "write_controller")
+	mustHave(t, by, EffectDBWrite, "write_controller")
+	mustHave(t, by, EffectDBRead, "read_with_psycopg")
+}
+
 func TestSniffEffectsJava_PrimitiveCoverage(t *testing.T) {
 	const src = `
 package x;


### PR DESCRIPTION
implements-capability: substrate.effects.classify
implements-capability: substrate.effects.propagate

Fixes #2804

## Summary
`archigraph_effects` reported `pure` / confidence 0.3 on IO-heavy Python (Celery tasks, DRF actions). Root cause was **three compounding faults** — missing sinks, a persistence gap, and unbound decorator-wrapper nodes:

1. **Missing Python sinks** (`internal/substrate/effect_sinks_python.go`): added boto3/AWS clients (S3/SQS/SNS/Lambda — every call crosses the network -> `http_out`), raw DB-API drivers (`mysql.connector`, `psycopg2`, `sqlite3`, `pymysql`, `MySQLdb`, `cx_Oracle`, `pyodbc`, `asyncpg`) incl. `connect`/`cursor`/`commit`/`rollback`, and process-env reads (`os.environ` / `os.getenv`). Introduces a new `env_read` lattice element; `EffectSet` grows 6->7 slots (append-only, bit layout preserved).
2. **Persistence gap** (`internal/mcp/effects_tool.go`): the tool read effects off `entity.Properties`, which the propagation pass only stamps on the ephemeral in-memory graph during a link run and never persists — so the daemon-loaded graph served empty properties and everything looked `pure`. The tool now loads the persisted `<group>-links-effects.json` sidecar (canonical) with a properties fallback, and reports a headline confidence = max per-effect (replacing the flat 0.3).
3. **Decorator-wrapper nodes unbound** (`internal/links/effect_propagation.go`): a Celery task is two entities sharing `(file, name)` — a `Task` wrapper and the `Operation` body. The binder indexed only function-like kinds and last-wins on collision, so the `Task` node bound to nothing and reported `pure`. The binder now keeps every `(file, name)` match (`lookupAll`) and treats `Task`/`ScheduledJob`/`Process` as function-like; `lookup()` keeps its single-result contract for the taint/payload-drift/def-use callers.

## Before / after (live, upvate group)
Before: all three anchors reported `effects:[]`, `effect_source:pure`, `confidence:0.3` (sidecar had no entry for the Task node at all).

After regenerating the links pass with the rebuilt binary (deterministic across repeated runs):
- `process_ecb_pdf_job` Operation (`upvate-core::29dae68d219b7e56`): `{db_read, db_write, http_out, fs_read, fs_write, env_read}`, source=direct
- `process_ecb_pdf_job` Task (`upvate-core::d50b41383793d6d7`): `{http_out, fs_read, fs_write, env_read}`, source=direct (db is transitive via a helper; the Task wrapper has no CALLS edges, so it carries the direct body sinks — no longer pure)
- `ProposalViewSet.send_proposals` (`upvate-core::9986b358cfb5dacd`): `{db_read, db_write, http_out, fs_read, fs_write}`, source=direct

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/substrate/ ./internal/links/ ./tools/coverage/` — green
- [x] `go test ./internal/mcp/ -run Effects` — green
- [x] new regressions: `TestSniffEffectsPython_IOHeavySinks`, `TestEffectPropagation_QualifiedNameAndViaHelper`, `TestEffectPropagation_DecoratorWrapperAndBody`, `TestBuildEffectsPayload_SidecarWins`/`_PureWhenAbsent`/`_PropertiesFallback`
- [x] `go run ./tools/coverage gen` — no matrix change
- [x] live `links pass upvate` -> all three anchors non-pure with cited sinks, deterministic across reruns
- [ ] daemon restart required for the running MCP server to serve the new binary + regenerated sidecar

Note: pre-existing unrelated `internal/mcp` failure `TestNoSessionMetaInNonWhoamiHandlers` is present on `main` and untouched here. Out of scope and not regressed: #2807 (MySQL-vs-SQLite engine label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)