### PR TITLE
fix(substrate): datastore engine label reads the DB driver (#2807)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -1103,12 +1103,17 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 		case "python_re_function":
 			return "re", "function", true
 		case "python_dbapi_function":
-			// Fold all DB-API 2.0 cursor verbs to a single
-			// `ext:sqlite3` placeholder (sqlite3 is the stdlib DB-API
-			// reference implementation and already on the known-
-			// packages allowlist). The concrete driver (psycopg2 / pymysql
-			// / etc.) is identified at the IMPORTS edge.
-			return "sqlite3", "function", true
+			// Fold DB-API 2.0 cursor verbs to the concrete driver the file
+			// imports (#2807). The verb names (`execute`/`cursor`/...) are
+			// engine-agnostic, so the only signal for which database engine
+			// the code talks to is the driver import on the same file. A
+			// hardcoded `sqlite3` placeholder mislabels mysql.connector /
+			// psycopg2 / etc. code as SQLite (iter9 q05/q09/q12). We read
+			// the driver root from `fromImports` and fold to its canonical
+			// placeholder; when no recognised driver is on the file we fall
+			// back to a generic `python-dbapi` placeholder (NOT sqlite3 —
+			// no hard default to a concrete engine).
+			return pythonDBAPIDriverPlaceholder(fromImports), "function", true
 		case "python_bs4_function":
 			return "bs4", "function", true
 		case "python_urllib_function":
@@ -14997,7 +15002,8 @@ var pythonDBAPIImportRoots = map[string]struct{}{
 	"sqlite3":           {},
 	"psycopg2":          {},
 	"psycopg":           {},
-	"mysql":             {},
+	"mysql":             {}, // mysql.connector
+	"MySQLdb":           {}, // mysqlclient
 	"pymysql":           {},
 	"cx_Oracle":         {},
 	"cx_oracle":         {},
@@ -15007,6 +15013,97 @@ var pythonDBAPIImportRoots = map[string]struct{}{
 	"asyncpg":           {},
 	"aiomysql":          {},
 	"aiosqlite":         {},
+	"pyodbc":            {},
+	"pymssql":           {},
+}
+
+// pythonDBAPIDriverPlaceholder maps the file's DB-API driver import to the
+// canonical external-package placeholder that names the concrete database
+// engine (#2807). The DB-API cursor verbs (`execute`/`cursor`/...) are
+// engine-agnostic, so the driver import is the only structural signal for
+// which engine the code talks to. We return the driver's own package name
+// (all entries below are on knownExternalPackages, so the resolver routes
+// the edge to ExternalKnown rather than synthesising a junk ext:* node).
+//
+// When the file imports several drivers we prefer a concrete non-SQLite
+// engine over sqlite3 (sqlite3 is the stdlib fallback and a no-op import in
+// much code), so a file that uses both mysql.connector and sqlite3 is
+// labelled by its server engine. When NO recognised driver is on the file
+// we return the generic `python-dbapi` placeholder — there is no hard
+// default to a concrete engine (the old code defaulted to sqlite3, which
+// mislabelled every server-DB consumer).
+func pythonDBAPIDriverPlaceholder(imports map[string]bool) string {
+	const generic = "python-dbapi"
+	if len(imports) == 0 {
+		return generic
+	}
+	best := ""
+	for p := range imports {
+		root := pythonImportRoot(p)
+		// django.db.* paths are DB-API-shaped but carry no engine signal
+		// (the engine lives in settings.DATABASES), so they leave `best`
+		// untouched and only contribute the generic fallback.
+		placeholder, ok := pythonDBAPIDriverPlaceholders[root]
+		if !ok {
+			continue
+		}
+		if best == "" {
+			best = placeholder
+			continue
+		}
+		// Prefer a concrete server engine over the sqlite3 stdlib fallback.
+		if best == "sqlite3" && placeholder != "sqlite3" {
+			best = placeholder
+		}
+	}
+	if best == "" {
+		return generic
+	}
+	return best
+}
+
+// pythonDBAPIDriverPlaceholders maps a driver import root to its canonical
+// external-package placeholder. Every value is on knownExternalPackages so
+// the resolver routes to ExternalKnown. Drivers for the same engine fold to
+// one canonical name (e.g. every MySQL driver → "mysql") so downstream
+// engine-label readers see a single stable token per engine.
+var pythonDBAPIDriverPlaceholders = map[string]string{
+	// MySQL family
+	"mysql":    "mysql", // mysql.connector
+	"MySQLdb":  "mysql", // mysqlclient
+	"pymysql":  "mysql",
+	"aiomysql": "mysql",
+	// PostgreSQL family
+	"psycopg2": "psycopg2",
+	"psycopg":  "psycopg2",
+	"asyncpg":  "psycopg2",
+	// SQLite family
+	"sqlite3":   "sqlite3",
+	"aiosqlite": "sqlite3",
+	// SQL Server family
+	"pyodbc":  "pyodbc",
+	"pymssql": "pyodbc",
+	// Oracle family
+	"cx_Oracle": "cx_Oracle",
+	"cx_oracle": "cx_Oracle",
+	"oracledb":  "cx_Oracle",
+	// Snowflake / ClickHouse
+	"snowflake":         "snowflake-connector-python",
+	"clickhouse_driver": "clickhouse-driver",
+}
+
+// pythonDBAPIEngineLabel maps a canonical driver placeholder (as returned
+// by pythonDBAPIDriverPlaceholder) to a human engine label. Used by
+// engine-label readers and exercised by the driver-matrix test (#2807).
+var pythonDBAPIEngineLabel = map[string]string{
+	"mysql":                      "MySQL",
+	"psycopg2":                   "PostgreSQL",
+	"sqlite3":                    "SQLite",
+	"pyodbc":                     "SQL Server",
+	"cx_Oracle":                  "Oracle",
+	"snowflake-connector-python": "Snowflake",
+	"clickhouse-driver":          "ClickHouse",
+	"python-dbapi":               "unknown",
 }
 
 // pythonDBAPIBareNames — receiver-stripped DB-API 2.0 verbs.
@@ -15994,94 +16091,104 @@ var knownExternalPackages = map[string]struct{}{
 	// Wave-4 (Django + Flask + Mongo + Postgres real-world). Python
 	// drivers and frameworks the resolver currently tags external-
 	// unknown because the allowlist had no row for them.
-	"pymongo":                {},
-	"motor":                  {},
-	"bson":                   {},
-	"psycopg2":               {},
-	"psycopg":                {},
-	"asyncpg":                {},
-	"mysqlclient":            {},
-	"pymysql":                {},
-	"flask_sqlalchemy":       {},
-	"flask_jwt_extended":     {},
-	"flask_jwt":              {},
-	"flask_login":            {},
-	"flask_migrate":          {},
-	"flask_caching":          {},
-	"flask_cache":            {},
-	"flask_restful":          {},
-	"flask_restplus":         {},
-	"flask_restx":            {},
-	"flask_marshmallow":      {},
-	"flask_apispec":          {},
-	"flask_bcrypt":           {},
-	"flask_cors":             {},
-	"flask_wtf":              {},
-	"flask_mail":             {},
-	"flask_session":          {},
-	"flask_socketio":         {},
-	"marshmallow":            {},
-	"marshmallow_sqlalchemy": {},
-	"webargs":                {},
-	"werkzeug":               {},
-	"jinja2":                 {},
-	"itsdangerous":           {},
-	"pyjwt":                  {},
-	"passlib":                {},
-	"cryptography":           {},
-	"arrow":                  {},
-	"pendulum":               {},
-	"dateutil":               {},
-	"factory_boy":            {},
-	"decouple":               {},
-	"python_dotenv":          {},
-	"environs":               {},
-	"dynaconf":               {},
-	"hypothesis":             {},
-	"pytest_factoryboy":      {},
-	"pytest_django":          {},
-	"pytest_flask":           {},
-	"pytest_mock":            {},
-	"pytest_asyncio":         {},
-	"webtest":                {},
-	"responses":              {},
-	"vcr":                    {},
-	"sentry_sdk":             {},
-	"structlog":              {},
-	"loguru":                 {},
-	"tenacity":               {},
-	"backoff":                {},
-	"prometheus_client":      {},
-	"aiohttp":                {},
-	"aiofiles":               {},
-	"uvicorn":                {},
-	"gunicorn":               {},
-	"starlette":              {},
-	"orjson":                 {},
-	"ujson":                  {},
-	"msgpack":                {},
-	"yaml":                   {},
-	"pyyaml":                 {},
-	"toml":                   {},
-	"tomllib":                {},
-	"tomli":                  {},
-	"lxml":                   {},
-	"bs4":                    {},
-	"beautifulsoup4":         {},
-	"pillow":                 {},
-	"pil":                    {},
-	"openpyxl":               {},
-	"xlrd":                   {},
-	"matplotlib":             {},
-	"seaborn":                {},
-	"sklearn":                {},
-	"scikit_learn":           {},
-	"torch":                  {},
-	"tensorflow":             {},
-	"transformers":           {},
-	"langchain":              {},
-	"openai":                 {},
-	"anthropic":              {},
+	"pymongo":     {},
+	"motor":       {},
+	"bson":        {},
+	"psycopg2":    {},
+	"psycopg":     {},
+	"asyncpg":     {},
+	"mysqlclient": {},
+	"pymysql":     {},
+	// DB-API driver placeholders (#2807). pythonDBAPIDriverPlaceholder
+	// folds cursor-verb call sites to these so the resolver routes to
+	// ExternalKnown rather than synthesising an ext:<verb> node, and the
+	// engine label reads the concrete driver. mysql/psycopg2/sqlite3 are
+	// already listed above/elsewhere; these are the remaining engines.
+	"pyodbc":                     {}, // SQL Server (also pymssql folds here)
+	"cx_oracle":                  {}, // Oracle (cx_Oracle / oracledb fold here)
+	"snowflake-connector-python": {}, // Snowflake
+	"clickhouse-driver":          {}, // ClickHouse
+	"python-dbapi":               {}, // generic fallback: driver not recognised
+	"flask_sqlalchemy":           {},
+	"flask_jwt_extended":         {},
+	"flask_jwt":                  {},
+	"flask_login":                {},
+	"flask_migrate":              {},
+	"flask_caching":              {},
+	"flask_cache":                {},
+	"flask_restful":              {},
+	"flask_restplus":             {},
+	"flask_restx":                {},
+	"flask_marshmallow":          {},
+	"flask_apispec":              {},
+	"flask_bcrypt":               {},
+	"flask_cors":                 {},
+	"flask_wtf":                  {},
+	"flask_mail":                 {},
+	"flask_session":              {},
+	"flask_socketio":             {},
+	"marshmallow":                {},
+	"marshmallow_sqlalchemy":     {},
+	"webargs":                    {},
+	"werkzeug":                   {},
+	"jinja2":                     {},
+	"itsdangerous":               {},
+	"pyjwt":                      {},
+	"passlib":                    {},
+	"cryptography":               {},
+	"arrow":                      {},
+	"pendulum":                   {},
+	"dateutil":                   {},
+	"factory_boy":                {},
+	"decouple":                   {},
+	"python_dotenv":              {},
+	"environs":                   {},
+	"dynaconf":                   {},
+	"hypothesis":                 {},
+	"pytest_factoryboy":          {},
+	"pytest_django":              {},
+	"pytest_flask":               {},
+	"pytest_mock":                {},
+	"pytest_asyncio":             {},
+	"webtest":                    {},
+	"responses":                  {},
+	"vcr":                        {},
+	"sentry_sdk":                 {},
+	"structlog":                  {},
+	"loguru":                     {},
+	"tenacity":                   {},
+	"backoff":                    {},
+	"prometheus_client":          {},
+	"aiohttp":                    {},
+	"aiofiles":                   {},
+	"uvicorn":                    {},
+	"gunicorn":                   {},
+	"starlette":                  {},
+	"orjson":                     {},
+	"ujson":                      {},
+	"msgpack":                    {},
+	"yaml":                       {},
+	"pyyaml":                     {},
+	"toml":                       {},
+	"tomllib":                    {},
+	"tomli":                      {},
+	"lxml":                       {},
+	"bs4":                        {},
+	"beautifulsoup4":             {},
+	"pillow":                     {},
+	"pil":                        {},
+	"openpyxl":                   {},
+	"xlrd":                       {},
+	"matplotlib":                 {},
+	"seaborn":                    {},
+	"sklearn":                    {},
+	"scikit_learn":               {},
+	"torch":                      {},
+	"tensorflow":                 {},
+	"transformers":               {},
+	"langchain":                  {},
+	"openai":                     {},
+	"anthropic":                  {},
 	// Python stdlib top-level
 	"os":              {},
 	"sys":             {},

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -4463,10 +4463,12 @@ func pythonGateCases() []pythonGateCase {
 		// re (regex).
 		{"re", "re", "sub", "re"},
 		{"re", "regex", "findall", "re"},
-		// DB-API 2.0.
+		// DB-API 2.0 — the cursor-verb call site folds to the concrete
+		// driver the file imports so the engine label is correct (#2807).
+		// django.db carries no engine signal → generic python-dbapi.
 		{"dbapi", "sqlite3", "execute", "sqlite3"},
-		{"dbapi", "psycopg2", "cursor", "sqlite3"},
-		{"dbapi", "django.db", "executemany", "sqlite3"},
+		{"dbapi", "psycopg2", "cursor", "psycopg2"},
+		{"dbapi", "django.db", "executemany", "python-dbapi"},
 		// bs4 / lxml.
 		{"bs4", "bs4", "find_all", "bs4"},
 		{"bs4", "lxml", "xpath", "bs4"},
@@ -4511,6 +4513,75 @@ func TestPythonPerImportGates_WithImport_LiftsToCanonical(t *testing.T) {
 			want := "ext:" + c.wantCanonical
 			if doc.Relationships[1].ToID != want {
 				t.Fatalf("gate=%q name=%q: ToID=%q, want %q", c.gate, c.bareName, doc.Relationships[1].ToID, want)
+			}
+		})
+	}
+}
+
+// TestPythonDBAPIDriverPlaceholder_EngineMatrix is the driver-matrix
+// guard for #2807: the DB-API cursor-verb fold must read the concrete
+// driver import so the engine label matches the real database engine,
+// instead of the old hard-coded sqlite3 default that mislabelled every
+// server-DB consumer as SQLite.
+func TestPythonDBAPIDriverPlaceholder_EngineMatrix(t *testing.T) {
+	cases := []struct {
+		name        string
+		imports     []string
+		placeholder string // pythonDBAPIDriverPlaceholder result
+		engine      string // pythonDBAPIEngineLabel[placeholder]
+	}{
+		// MySQL family — the iter9 q05/q09/q12 regression: mysql.connector
+		// was reported as SQLite.
+		{"mysql.connector", []string{"mysql.connector"}, "mysql", "MySQL"},
+		{"MySQLdb", []string{"MySQLdb"}, "mysql", "MySQL"},
+		{"pymysql", []string{"pymysql"}, "mysql", "MySQL"},
+		{"aiomysql", []string{"aiomysql"}, "mysql", "MySQL"},
+		// Postgres family.
+		{"psycopg2", []string{"psycopg2.extras"}, "psycopg2", "PostgreSQL"},
+		{"psycopg3", []string{"psycopg"}, "psycopg2", "PostgreSQL"},
+		{"asyncpg", []string{"asyncpg"}, "psycopg2", "PostgreSQL"},
+		// SQLite family — still labelled SQLite when the driver really is sqlite3.
+		{"sqlite3", []string{"sqlite3"}, "sqlite3", "SQLite"},
+		{"aiosqlite", []string{"aiosqlite"}, "sqlite3", "SQLite"},
+		// SQL Server family.
+		{"pyodbc", []string{"pyodbc"}, "pyodbc", "SQL Server"},
+		{"pymssql", []string{"pymssql"}, "pyodbc", "SQL Server"},
+		// Oracle.
+		{"cx_Oracle", []string{"cx_Oracle"}, "cx_Oracle", "Oracle"},
+		{"oracledb", []string{"oracledb"}, "cx_Oracle", "Oracle"},
+		// Snowflake / ClickHouse.
+		{"snowflake", []string{"snowflake.connector"}, "snowflake-connector-python", "Snowflake"},
+		{"clickhouse", []string{"clickhouse_driver"}, "clickhouse-driver", "ClickHouse"},
+		// No hard default to SQLite: unrecognised / engine-less imports
+		// fall back to the generic placeholder labelled "unknown".
+		{"django.db only", []string{"django.db"}, "python-dbapi", "unknown"},
+		{"no imports", nil, "python-dbapi", "unknown"},
+		{"unrelated import", []string{"os"}, "python-dbapi", "unknown"},
+		// Multi-driver: prefer the concrete server engine over the sqlite3
+		// stdlib fallback (sync_viewset.py imports both mysql.connector
+		// and psycopg2/sqlite3 in the wild).
+		{"mysql+sqlite -> mysql", []string{"sqlite3", "mysql.connector"}, "mysql", "MySQL"},
+		{"sqlite+psycopg2 -> psycopg2", []string{"sqlite3", "psycopg2"}, "psycopg2", "PostgreSQL"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			imports := map[string]bool{}
+			for _, imp := range c.imports {
+				imports[imp] = true
+			}
+			got := pythonDBAPIDriverPlaceholder(imports)
+			if got != c.placeholder {
+				t.Fatalf("pythonDBAPIDriverPlaceholder(%v) = %q; want %q", c.imports, got, c.placeholder)
+			}
+			// The returned placeholder must route to ExternalKnown so the
+			// resolver does not synthesise a junk ext:* node.
+			if !IsKnownExternalPackage(got) {
+				t.Fatalf("placeholder %q is not on knownExternalPackages allowlist", got)
+			}
+			if eng := pythonDBAPIEngineLabel[got]; eng != c.engine {
+				t.Fatalf("engine label for %q = %q; want %q", got, eng, c.engine)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Fixes #2807: the Python DB-API cursor-verb fold in `external.classifyExternal` hard-coded `ext:sqlite3` for every `execute`/`cursor`/... call site, so code using `mysql.connector`, `psycopg2`, etc. was mislabelled as SQLite. iter9 q05/q09/q12 reported "SQLite staging DB" for upvate_core's `mysql.connector` consumers.
- The cursor verbs are engine-agnostic, so the driver import is the only structural engine signal. `classifyExternal` now reads the driver root from the file's IMPORTS set (reusing the #2804 driver-recognition surface) and folds to the concrete driver placeholder.

### Driver -> placeholder -> engine matrix
| driver import | placeholder | engine |
|---|---|---|
| mysql.connector / MySQLdb / pymysql / aiomysql | `mysql` | MySQL |
| psycopg2 / psycopg / asyncpg | `psycopg2` | PostgreSQL |
| sqlite3 / aiosqlite | `sqlite3` | SQLite |
| pyodbc / pymssql | `pyodbc` | SQL Server |
| cx_Oracle / oracledb | `cx_Oracle` | Oracle |
| snowflake.connector | `snowflake-connector-python` | Snowflake |
| clickhouse_driver | `clickhouse-driver` | ClickHouse |
| unrecognised / engine-less (bare `django.db`, none) | `python-dbapi` | unknown |

- **No hard default to SQLite** — unknown drivers fold to a generic `python-dbapi` placeholder labelled `unknown`.
- Multi-driver files prefer a concrete server engine over the `sqlite3` stdlib fallback.
- New driver placeholders added to `knownExternalPackages` so the resolver routes them to ExternalKnown (no junk `ext:*` nodes).

Implements-capability: `substrate.datastore.engine-label.driver-aware`

## Before / after (live, upvate_core)
The three entities iter9 q05/q09/q12 referenced — all import `mysql.connector`:

| file | before | after |
|---|---|---|
| core/views/sync_viewset.py | ext:sqlite3 / SQLite | **ext:mysql / MySQL** |
| core/views/import_viewset.py | ext:sqlite3 / SQLite | **ext:mysql / MySQL** |
| core/helper/ecb_ocr_staging.py | ext:sqlite3 / SQLite | **ext:mysql / MySQL** |

Verified by feeding the real file imports through `external.Synthesize` with a locally-built binary (no shared-daemon restart).

## Test plan
- [x] Driver-matrix unit test `TestPythonDBAPIDriverPlaceholder_EngineMatrix` (MySQL/Postgres/SQLite/SQL Server/Oracle/Snowflake/ClickHouse + generic + multi-driver preference)
- [x] Updated existing `pythonGateCases` dbapi expectations (psycopg2 -> psycopg2, django.db -> python-dbapi)
- [x] `go test ./internal/external/ ./internal/substrate/ ./internal/links/ ./tools/coverage/` pass
- [x] Coverage matrix regenerated (no cell change)
- [ ] Note: `internal/mcp` `TestNoSessionMetaInNonWhoamiHandlers` fails on origin/main pre-existing (session-meta keys in inspect handler), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)