### PR TITLE
fix(mcp): inspect handler no longer leaks session-meta (indexed_sha/indexed_ref) (#2780)

### DIFF
--- a/internal/mcp/inspect_trio_2640_2641_2642_test.go
+++ b/internal/mcp/inspect_trio_2640_2641_2642_test.go
@@ -5,7 +5,8 @@ package mcp
 // #2640: calls[] filters unresolved edges by default; include_unresolved=true
 //        shows all with annotation.
 // #2641: called_by always present (empty array when no callers).
-// #2642: metadata block exposes indexed_ref/sha/at/age_seconds.
+// #2642: metadata block exposes index-staleness fields (indexed_at/age_seconds).
+//        #2780: indexed_ref/indexed_sha removed — owned by whoami only.
 
 import (
 	"context"
@@ -182,18 +183,15 @@ func TestInspect_IncludesMetadata(t *testing.T) {
 		t.Fatalf("metadata is %T, want map[string]any", rawMeta)
 	}
 
-	// indexed_ref must be non-empty and match the document.
-	ref, _ := meta["indexed_ref"].(string)
-	if ref == "" {
-		t.Errorf("metadata.indexed_ref is empty; expected %q", doc.IndexedRef)
+	// #2780: indexed_ref and indexed_sha are session-stable provenance fields
+	// owned exclusively by archigraph_whoami. inspect's metadata block carries
+	// only the staleness signal (indexed_at/age_seconds), so these keys must NOT
+	// be present here — see TestNoSessionMetaInNonWhoamiHandlers.
+	if _, ok := meta["indexed_ref"]; ok {
+		t.Error("metadata.indexed_ref must not be present on inspect (#2780); it belongs to whoami")
 	}
-	if ref != doc.IndexedRef {
-		t.Errorf("metadata.indexed_ref = %q, want %q", ref, doc.IndexedRef)
-	}
-
-	// indexed_sha must be present.
-	if _, ok := meta["indexed_sha"]; !ok {
-		t.Error("metadata.indexed_sha key missing")
+	if _, ok := meta["indexed_sha"]; ok {
+		t.Error("metadata.indexed_sha must not be present on inspect (#2780); it belongs to whoami")
 	}
 
 	// indexed_at must be a non-empty RFC3339 string.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1324,21 +1324,24 @@ func inspectDiscriminators(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []m
 	return out
 }
 
-// inspectMetadata returns index provenance fields for the inspect response.
-// Surfaces indexed_ref, indexed_sha, indexed_at, and age_seconds so agents
-// know whether the line-number data might be stale. (#2642)
+// inspectMetadata returns index-staleness fields for the inspect response.
+// Surfaces indexed_at and age_seconds so agents know whether the line-number
+// data might be stale. (#2642)
+//
+// #2780: indexed_ref and indexed_sha are deliberately NOT included here. Those
+// session-stable provenance fields are the exclusive domain of archigraph_whoami
+// (per the #2290/#2335 cleanup). Re-embedding them in inspect — a per-call,
+// inspect-heavy handler — both wastes tokens and violates the single-source
+// contract enforced by TestNoSessionMetaInNonWhoamiHandlers. The staleness
+// signal (indexed_at/age_seconds) is what #2642 actually needed and is retained.
 func inspectMetadata(lr *LoadedRepo) map[string]any {
 	meta := map[string]any{
-		"indexed_ref": "",
-		"indexed_sha": "",
 		"indexed_at":  "",
 		"age_seconds": 0,
 	}
 	if lr == nil || lr.Doc == nil {
 		return meta
 	}
-	meta["indexed_ref"] = lr.Doc.IndexedRef
-	meta["indexed_sha"] = lr.Doc.IndexedSHA
 	if !lr.Doc.GeneratedAt.IsZero() {
 		indexedAt := lr.Doc.GeneratedAt.UTC()
 		meta["indexed_at"] = indexedAt.Format(time.RFC3339)


### PR DESCRIPTION
## Summary
- Fixes #2780: `TestNoSessionMetaInNonWhoamiHandlers/handleGetNode_(inspect)` has been failing on clean `origin/main`, forcing a "pre-existing failure" caveat onto every recent PR.
- Root cause: the inspect metadata block added in #2642 re-introduced the session-stable provenance fields `indexed_ref`/`indexed_sha`, which the #2290/#2335 cleanup had explicitly removed. These belong exclusively to `archigraph_whoami`, and `TestNoSessionMetaInNonWhoamiHandlers` enforces that non-whoami handlers must not embed them.
- Fix (path **a** — strip): removed `indexed_ref`/`indexed_sha` from `inspectMetadata` while retaining the staleness signal (`indexed_at`/`age_seconds`) that was #2642's actual purpose. Updated the #2642 test (`TestInspect_IncludesMetadata`) to assert the banned keys are now absent.

## Test plan
- [x] `go test ./internal/mcp/` — green (all `TestNoSessionMetaInNonWhoamiHandlers` subtests pass)
- [x] `go test ./tools/coverage/` — green
- [x] `go build ./...` — clean
- [x] `go run ./tools/coverage gen` — no coverage-matrix diff
- [x] Rebased on `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)