### PR TITLE
feat(links): annotate http_endpoints with transitive effect tags (#2811)

### DIFF
--- a/internal/dashboard/enrichment_frontmatter.go
+++ b/internal/dashboard/enrichment_frontmatter.go
@@ -65,6 +65,10 @@ type EnrichmentFrontmatter struct {
 	Responses     map[string]any   `json:"responses,omitempty"`
 	Auth          string           `json:"auth,omitempty"`
 	TablesTouched []string         `json:"tables_touched,omitempty"`
+	// Effects is the handler's transitive effect closure (#2811): any of
+	// db_read/db_write/http_out/fs_read/fs_write/mutation/env. Lets the Paths
+	// panel filter "which endpoints write to the DB / touch the filesystem".
+	Effects []string `json:"effects,omitempty"`
 
 	// process_flow fields.
 	Steps           []string `json:"steps,omitempty"`
@@ -256,6 +260,8 @@ func appendListField(fm *EnrichmentFrontmatter, key, item string) {
 		fm.Gaps = append(fm.Gaps, item)
 	case "tables_touched":
 		fm.TablesTouched = append(fm.TablesTouched, item)
+	case "effects":
+		fm.Effects = append(fm.Effects, item)
 	case "steps":
 		fm.Steps = append(fm.Steps, item)
 	case "expected_consumers":

--- a/internal/dashboard/enrichment_frontmatter_test.go
+++ b/internal/dashboard/enrichment_frontmatter_test.go
@@ -42,6 +42,7 @@ method: GET
 path: /api/orders
 auth: Bearer required
 tables_touched: [orders, users]
+effects: [db_write, mutation]
 ---
 
 ## Description
@@ -73,6 +74,12 @@ Free-form prose.
 	}
 	assertStr(t, "tables_touched[0]", fm.TablesTouched[0], "orders")
 	assertStr(t, "tables_touched[1]", fm.TablesTouched[1], "users")
+	// #2811 — effects list.
+	if len(fm.Effects) != 2 {
+		t.Errorf("effects: expected 2, got %d: %v", len(fm.Effects), fm.Effects)
+	}
+	assertStr(t, "effects[0]", fm.Effects[0], "db_write")
+	assertStr(t, "effects[1]", fm.Effects[1], "mutation")
 }
 
 func TestParseFrontmatterBytes_disqualified(t *testing.T) {

--- a/internal/links/effect_propagation.go
+++ b/internal/links/effect_propagation.go
@@ -210,6 +210,17 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 		}
 	}
 
+	// #2811 — propagate handler effect closures onto http_endpoint entities.
+	// Each http_endpoint synthetic carries an IMPLEMENTS edge from its handler
+	// (handler → endpoint). The handler's transitive effect set (already
+	// computed in `effects` above via the CALLS fixed-point) is the answer to
+	// "does this endpoint write to the DB / touch the filesystem / mutate
+	// state". We union every handler's set onto the endpoint so a route served
+	// by several handler methods reports the combined surface. Endpoints
+	// resolved this way are tagged source="endpoint" so MCP/docs can tell an
+	// endpoint annotation apart from a function's own direct/transitive set.
+	endpointDerived := propagateEndpointEffects(graphs, effects)
+
 	// Stamp results back onto entity.Properties so MCP/dashboard can read
 	// them without re-running the pass.
 	stamped := 0
@@ -225,7 +236,7 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 			if e.Properties == nil {
 				e.Properties = map[string]string{}
 			}
-			stampEffectProperties(e.Properties, *set, directByEntity[fullID] != nil)
+			stampEffectProperties(e.Properties, *set, directByEntity[fullID] != nil, endpointDerived[fullID])
 			stamped++
 		}
 	}
@@ -234,18 +245,87 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 
 	if paths.Links != "" {
 		sidecar := strings.TrimSuffix(paths.Links, ".json") + "-effects.json"
-		if err := writeEffectsDoc(sidecar, effects, directByEntity); err != nil {
+		if err := writeEffectsDoc(sidecar, effects, directByEntity, endpointDerived); err != nil {
 			return res, fmt.Errorf("write effects doc: %w", err)
 		}
 	}
 	return res, nil
 }
 
+// propagateEndpointEffects unions each http_endpoint synthetic's handler
+// effect closure onto the endpoint itself (#2811). The handler is resolved
+// via the IMPLEMENTS edge (handler → endpoint) that the HTTP synthesis pass
+// emits on the producer side; the handler's transitive effect set is already
+// present in `effects` (computed by the CALLS fixed-point above). The endpoint
+// inherits the union of all its handlers' sets so a route served by multiple
+// handler methods reports the combined surface.
+//
+// Returns the set of endpoint entity keys (repo::id) that received an
+// inherited annotation so the caller can tag them source="endpoint". Mutates
+// the shared `effects` map in place. Idempotent: re-running over the same
+// graph produces the same union; delta-aware because it derives purely from
+// the current in-memory edge set and handler effects with no persisted state.
+func propagateEndpointEffects(graphs []repoGraph, effects map[string]*substrate.EffectSet) map[string]bool {
+	derived := map[string]bool{}
+
+	for _, g := range graphs {
+		// handlersByEndpoint[endpointLocalID] = []handlerLocalID, from the
+		// producer-side IMPLEMENTS edge (handler → endpoint).
+		handlersByEndpoint := map[string][]string{}
+		for _, e := range g.Edges {
+			if !strings.EqualFold(e.Kind, "IMPLEMENTS") {
+				continue
+			}
+			handlersByEndpoint[e.ToID] = append(handlersByEndpoint[e.ToID], e.FromID)
+		}
+		if len(handlersByEndpoint) == 0 {
+			continue
+		}
+		for _, e := range g.Entities {
+			if !isHTTPEndpointLink(e.Kind) {
+				continue
+			}
+			handlers := handlersByEndpoint[e.ID]
+			if len(handlers) == 0 {
+				continue
+			}
+			var merged substrate.EffectSet
+			got := false
+			for _, hID := range handlers {
+				hs := effects[entityKey(g.Repo, hID)]
+				if hs == nil || hs.IsEmpty() {
+					continue
+				}
+				merged.Union(*hs)
+				got = true
+			}
+			if !got {
+				continue
+			}
+			epKey := entityKey(g.Repo, e.ID)
+			// Union onto any set the endpoint may already carry (e.g. when an
+			// endpoint entity is itself function-like and was annotated above);
+			// in practice synthetic endpoints have no direct effects of their own.
+			if existing := effects[epKey]; existing != nil {
+				existing.Union(merged)
+			} else {
+				cp := merged
+				effects[epKey] = &cp
+			}
+			derived[epKey] = true
+		}
+	}
+	return derived
+}
+
 // stampEffectProperties writes the effect annotation onto props using the
-// canonical key set documented above. effectsDirect indicates whether
-// the entity owns at least one direct sink (used to populate the
-// effect_source key).
-func stampEffectProperties(props map[string]string, set substrate.EffectSet, direct bool) {
+// canonical key set documented above. direct indicates whether the entity
+// owns at least one direct sink; endpoint indicates the set was inherited
+// from a handler closure via the IMPLEMENTS edge (#2811). Both feed the
+// effect_source key, with endpoint taking precedence so an http_endpoint
+// reads as source="endpoint" rather than the underlying direct/transitive
+// shape of its handler.
+func stampEffectProperties(props map[string]string, set substrate.EffectSet, direct, endpoint bool) {
 	effs := set.AsList()
 	if len(effs) == 0 {
 		return
@@ -265,9 +345,12 @@ func stampEffectProperties(props map[string]string, set substrate.EffectSet, dir
 	if len(sinks) > 0 {
 		props[EffectPropertyKeySinks] = strings.Join(sinks, ",")
 	}
-	if direct {
+	switch {
+	case endpoint:
+		props[EffectPropertyKeySource] = "endpoint"
+	case direct:
 		props[EffectPropertyKeySource] = "direct"
-	} else {
+	default:
 		props[EffectPropertyKeySource] = "transitive"
 	}
 }
@@ -409,7 +492,7 @@ type effectEntry struct {
 	Source      string             `json:"source"` // "direct" | "transitive"
 }
 
-func writeEffectsDoc(path string, effects, direct map[string]*substrate.EffectSet) error {
+func writeEffectsDoc(path string, effects, direct map[string]*substrate.EffectSet, endpointDerived map[string]bool) error {
 	ids := make([]string, 0, len(effects))
 	for id := range effects {
 		ids = append(ids, id)
@@ -433,7 +516,10 @@ func writeEffectsDoc(path string, effects, direct map[string]*substrate.EffectSe
 			}
 		}
 		src := "transitive"
-		if direct[id] != nil {
+		switch {
+		case endpointDerived[id]:
+			src = "endpoint"
+		case direct[id] != nil:
 			src = "direct"
 		}
 		entries = append(entries, effectEntry{

--- a/internal/links/effect_propagation_test.go
+++ b/internal/links/effect_propagation_test.go
@@ -254,6 +254,85 @@ def process_job(self, payload):
 	}
 }
 
+// TestEffectPropagation_EndpointInheritsHandlerEffects verifies #2811: an
+// http_endpoint synthetic inherits its handler's transitive effect closure via
+// the IMPLEMENTS edge (handler → endpoint), and is tagged source="endpoint".
+func TestEffectPropagation_EndpointInheritsHandlerEffects(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "views.py", `
+class BuildingViewSet:
+    def create(self, request):
+        b = Building(**request.data)
+        b.save()
+        return b
+`)
+	graphs := []repoGraph{{
+		Repo:     "upvate-core",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "h1", Name: "create", Kind: "SCOPE.Function", SourceFile: "views.py"},
+			{ID: "ep1", Name: "http:POST:/buildings", Kind: "http_endpoint", SourceFile: "views.py",
+				Properties: map[string]string{"verb": "POST", "path": "/buildings", "pattern_type": "http_endpoint_synthesis"}},
+		},
+		Edges: []edgeRef{
+			// handler → endpoint (producer-side IMPLEMENTS).
+			{FromID: "h1", ToID: "ep1", Kind: "IMPLEMENTS"},
+		},
+	}}
+	paths := Paths{Links: filepath.Join(root, "out", "links.json")}
+	if _, err := runEffectPropagationPass(graphs, paths, nil); err != nil {
+		t.Fatal(err)
+	}
+	ep := graphs[0].Entities[1]
+	effs := ep.Properties[EffectPropertyKeyList]
+	if !strings.Contains(effs, "db_write") {
+		t.Fatalf("endpoint effects=%q; want db_write inherited from handler", effs)
+	}
+	if got := ep.Properties[EffectPropertyKeySource]; got != "endpoint" {
+		t.Errorf("endpoint effect_source=%q; want endpoint", got)
+	}
+	// Sidecar entry for the endpoint should also carry source=endpoint.
+	buf, err := os.ReadFile(filepath.Join(root, "out", "links-effects.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(buf), `"upvate-core::ep1"`) {
+		t.Errorf("sidecar missing endpoint entry; got:\n%s", buf)
+	}
+	if !strings.Contains(string(buf), `"endpoint"`) {
+		t.Errorf("sidecar missing endpoint source tag; got:\n%s", buf)
+	}
+}
+
+// TestEffectPropagation_EndpointPureHandlerUnstamped verifies an endpoint
+// whose handler has no detected effects is left unstamped (no noise).
+func TestEffectPropagation_EndpointPureHandlerUnstamped(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "ping.py", `
+class HealthView:
+    def get(self, request):
+        return "ok"
+`)
+	graphs := []repoGraph{{
+		Repo:     "upvate-core",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "h1", Name: "get", Kind: "SCOPE.Function", SourceFile: "ping.py"},
+			{ID: "ep1", Name: "http:GET:/health", Kind: "http_endpoint", SourceFile: "ping.py",
+				Properties: map[string]string{"verb": "GET", "path": "/health"}},
+		},
+		Edges: []edgeRef{
+			{FromID: "h1", ToID: "ep1", Kind: "IMPLEMENTS"},
+		},
+	}}
+	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := graphs[0].Entities[1].Properties[EffectPropertyKeyList]; ok {
+		t.Errorf("endpoint with pure handler carries effects=%q; want unstamped", v)
+	}
+}
+
 func confFromProps(props map[string]string, effect string) float64 {
 	if props == nil {
 		return 0

--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -126,6 +126,12 @@ type endpointDefItem struct {
 	StartLine  int               `json:"start_line,omitempty"`
 	Method     string            `json:"method,omitempty"`
 	Path       string            `json:"path,omitempty"`
+	// Effects is the transitive effect closure of this endpoint's handler
+	// (#2811): db_read/db_write/http_out/fs_read/fs_write/mutation/env. Sourced
+	// from the on-disk effects sidecar (written by the effect-propagation pass),
+	// surfaced in both terse and verbose modes so reviewers can filter "which
+	// endpoints write to the DB / touch the filesystem / mutate state".
+	Effects    []string          `json:"effects,omitempty"`
 	Properties map[string]string `json:"properties,omitempty"`
 }
 
@@ -669,7 +675,7 @@ func (s *Server) handleEndpointDefinitionsWithNavigation(ctx context.Context, re
 //
 // Tool name: archigraph_endpoint_definitions
 func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	_, lg, errRes := s.resolveAndGroup(req)
+	groupName, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil
 	}
@@ -679,6 +685,11 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 	method := pOpts.Method
 	verbose := pOpts.Verbose
 	orphanOnly := argBool(req, "orphan_only", false)
+	// #2811 — optional effect filter: keep only endpoints whose handler effect
+	// closure contains the named effect (e.g. effect="db_write"). The effect
+	// set is read from the on-disk effects sidecar, keyed by prefixed entity id.
+	effectFilter := strings.ToLower(strings.TrimSpace(argString(req, "effect", "")))
+	effectsSidecar, _ := loadEffectsSidecar(groupName)
 
 	// #2292: orphan_only=true filters to endpoint definitions with no inbound
 	// client-call edges. In this graph the edge kind from a call-site to its
@@ -720,6 +731,14 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 			if orphanOnly && !isOrphanDefinition(r, e.ID, res) {
 				continue
 			}
+			// #2811 — endpoint effect closure from the sidecar.
+			var effs []string
+			if entry, ok := effectsSidecar[prefixedID(r.Repo, e.ID)]; ok {
+				effs = entry.Effects
+			}
+			if effectFilter != "" && !containsFold(effs, effectFilter) {
+				continue
+			}
 			it := endpointDefItem{
 				EntityID:   prefixedID(r.Repo, e.ID),
 				Repo:       r.Repo,
@@ -727,6 +746,7 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 				StartLine:  e.StartLine,
 				Method:     m,
 				Path:       p,
+				Effects:    effs,
 			}
 			if verbose {
 				it.Kind = e.Kind
@@ -766,6 +786,7 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 		"path_contains": env.PathContains,
 		"method":        env.Method,
 		"orphan_only":   orphanOnly,
+		"effect":        effectFilter,
 		"token_budget":  env.TokenBudget,
 		// #2317: "note" field removed — schema lives in the tool description,
 		// not in runtime responses (reduces wire bytes on every call).
@@ -789,7 +810,8 @@ type terseLine struct {
 	SourceFile string
 	StartLine  int
 	Repo       string
-	Name       string // for calls: caller symbol name
+	Name       string   // for calls: caller symbol name
+	Effects    []string // #2811: endpoint handler effect closure
 }
 
 func renderTerseLines(lines []terseLine) []string {
@@ -820,6 +842,11 @@ func renderTerseLines(lines []terseLine) []string {
 			b.WriteString(it.Repo)
 			b.WriteString(")")
 		}
+		if len(it.Effects) > 0 {
+			b.WriteString("  [")
+			b.WriteString(strings.Join(it.Effects, ","))
+			b.WriteString("]")
+		}
 		out = append(out, b.String())
 	}
 	return out
@@ -836,9 +863,21 @@ func renderTerseDefinitions(items []endpointDefItem) []string {
 			StartLine:  it.StartLine,
 			Repo:       it.Repo,
 			Name:       it.Name,
+			Effects:    it.Effects,
 		})
 	}
 	return renderTerseLines(lines)
+}
+
+// containsFold reports whether want (already lower-cased) is present in the
+// slice, comparing case-insensitively. Used for the endpoint effect filter.
+func containsFold(haystack []string, want string) bool {
+	for _, h := range haystack {
+		if strings.EqualFold(h, want) {
+			return true
+		}
+	}
+	return false
 }
 
 // rendered/capByRenderedBytes operate on item via its terse-line size; we use

--- a/internal/mcp/endpoint_tools_test.go
+++ b/internal/mcp/endpoint_tools_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -279,6 +281,53 @@ func TestEndpointDefinitions_ReturnsDefinitionsOnly(t *testing.T) {
 	if !kinds["http_endpoint_definition"] {
 		t.Error("expected http_endpoint_definition kind in definitions")
 	}
+}
+
+// TestEndpointDefinitions_SurfacesEffects verifies #2811: endpoint definitions
+// carry the handler effect closure from the on-disk effects sidecar, and the
+// `effect` filter narrows to endpoints touching a given effect.
+func TestEndpointDefinitions_SurfacesEffects(t *testing.T) {
+	srv := newEndpointServer(t)
+	// Redirect HOME so effectsSidecarPath resolves into the temp dir.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".archigraph", "groups")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// ep_legacy (repo1) → [db_write, mutation]; ep_def stays pure.
+	sidecar := `{"version":1,"method":"effect_propagation","entries":[` +
+		`{"entity_id":"repo1::ep_legacy","effects":["db_write","mutation"],"confidences":{"db_write":0.9,"mutation":0.8},"source":"endpoint"}` +
+		`]}`
+	if err := os.WriteFile(filepath.Join(dir, "test-links-effects.json"), []byte(sidecar), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without filter: ep_legacy carries the effects field.
+	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{"group": "test", "verbose": true})
+	defs := getSlice(t, res, "definitions")
+	var found bool
+	for _, d := range defs {
+		obj := d.(map[string]any)
+		if obj["kind"] == "http_endpoint" {
+			effs := obj["effects"].([]any)
+			if len(effs) != 2 || effs[0].(string) != "db_write" {
+				t.Errorf("ep_legacy effects=%v; want [db_write mutation]", effs)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("ep_legacy definition not found")
+	}
+
+	// With effect=db_write filter: only ep_legacy survives.
+	resF := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{"group": "test", "effect": "db_write"})
+	assertEndpointCount(t, resF, 1)
+
+	// With effect=fs_write filter: none survive.
+	resNone := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{"group": "test", "effect": "fs_write"})
+	assertEndpointCount(t, resNone, 0)
 }
 
 func TestEndpointDefinitions_ExcludesClientSynthesis(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -726,9 +726,10 @@ func (s *Server) registerTools() {
 	// format="terse" (default) returns one-line "lines" entries; "full" returns
 	// per-record structs with kind + deduplicated properties (path/verb stripped).
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_endpoints",
-		mcpapi.WithDescription("HTTP endpoints: definitions|calls|stats. kind=navigation: NAVIGATES_TO."),
+		mcpapi.WithDescription("HTTP endpoints: definitions|calls|stats. kind=navigation. effect= filter."),
 		mcpapi.WithString("action", mcpapi.Required()),
 		mcpapi.WithBoolean("orphan_only", mcpapi.DefaultBool(false)),
+		mcpapi.WithAny("effect"), // #2811 — filter definitions by handler effect closure
 		mcpapi.WithBoolean("include_navigation", mcpapi.DefaultBool(false)), // #2665
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(20)),
 		mcpapi.WithNumber("offset", mcpapi.DefaultNumber(0)),

--- a/skills/archigraph-graph-enrich/prompts/13-enrichment.md
+++ b/skills/archigraph-graph-enrich/prompts/13-enrichment.md
@@ -140,6 +140,12 @@ confident data for:
 - `responses` — document at least `200` and the most likely error codes.
   Shape is a compact inline TypeScript-style type string.
 - `auth` — one-sentence description of the auth requirement.
+- `effects` — the handler's transitive effect closure (#2811): any of
+  `db_read`, `db_write`, `http_out`, `fs_read`, `fs_write`, `mutation`, `env`.
+  Copy verbatim from `archigraph_endpoints(action=definitions)` (the `effects`
+  field) or `archigraph_effects(entity_id=<endpoint id>)` — both read it from
+  the effects sidecar, so you do not need to re-derive it. Lets the Paths panel
+  answer "which endpoints write to the DB / touch the filesystem / mutate state".
 - `tables_touched` — list DB tables or ORM models that this handler reads or writes.
 - `parameters_explained` — prose expanding on non-obvious parameter semantics.
 - `response_shapes_explained` — prose describing nested object structures,

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -460,8 +460,8 @@ records:
             - file: internal/substrate/effect_sinks_python.go
               functions: [sniffEffectsPython, appendPyMatches]
             - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2764"]
+              functions: [runEffectPropagationPass, stampEffectProperties, propagateEndpointEffects]
+          issues_implemented: ["2764", "2811"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -469,8 +469,8 @@ records:
             - file: internal/substrate/effect_sinks_python.go
               functions: [sniffEffectsPython]
             - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass]
-          issues_implemented: ["2764"]
+              functions: [runEffectPropagationPass, propagateEndpointEffects]
+          issues_implemented: ["2764", "2811"]
           verified_at: "2026-05-28"
         fs_effect:
           status: partial
@@ -478,8 +478,8 @@ records:
             - file: internal/substrate/effect_sinks_python.go
               functions: [sniffEffectsPython]
             - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass]
-          issues_implemented: ["2764"]
+              functions: [runEffectPropagationPass, propagateEndpointEffects]
+          issues_implemented: ["2764", "2811"]
           verified_at: "2026-05-28"
         mutation_effect:
           status: partial
@@ -487,8 +487,8 @@ records:
             - file: internal/substrate/effect_sinks_python.go
               functions: [sniffEffectsPython]
             - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass]
-          issues_implemented: ["2764"]
+              functions: [runEffectPropagationPass, propagateEndpointEffects]
+          issues_implemented: ["2764", "2811"]
         taint_source_detection:
           status: partial
           symbols:


### PR DESCRIPTION
## Summary
Surfaces the Phase 1A effect classification on HTTP endpoints. Each `http_endpoint` synthetic now inherits the **transitive effect closure of its handler** (resolved via the `IMPLEMENTS` edge handler → endpoint), so the dashboard and docs can answer *"which endpoints write to the DB / touch the filesystem / mutate state"*. Builds on #2804 (effects classifier fix) and #2807 (DB-engine).

Closes #2811.

## What changed
- **`internal/links/effect_propagation.go`** — `propagateEndpointEffects()` unions each handler's effect set onto its endpoint after the existing CALLS fixed-point. Endpoints are tagged `effect_source="endpoint"` in both `entity.Properties` and the `<group>-links-effects.json` sidecar. Idempotent + delta-aware: derives purely from the current in-memory edge set + handler effects, no persisted state.
- **`internal/mcp/endpoint_tools.go`** — `archigraph_endpoints(action=definitions)` now surfaces an `effects[]` field (terse `[db_write,…]` suffix + verbose JSON) joined from the effects sidecar, plus an `effect=` filter param ("which endpoints write to the DB").
- **`internal/dashboard/enrichment_frontmatter.go`** — parse `effects: [...]` on `http_endpoint` frontmatter for the Paths panel.
- **`skills/archigraph-graph-enrich/prompts/13-enrichment.md`** — document the `effects` frontmatter field for endpoints.
- **`tools/coverage/capability-map.yaml`** — cite `propagateEndpointEffects` on the python `db_effect`/`http_effect`/`fs_effect`/`mutation_effect` cells (`implements-capability: db_effect, http_effect, fs_effect, mutation_effect`).

## Verified on real data (upvate, 3-repo fresh index, isolated home — shared :47274 daemon untouched)
273 endpoints annotated. Histogram: `db_read:243 db_write:132 http_out:55 fs_write:7 mutation:7 env_read:5 fs_read:3`.

| Endpoint | Effects |
|---|---|
| `POST /api/v1/buildings` (BuildingViewSet.create) | `[db_read, db_write, http_out]` |
| `GET /api/v1/buildings` (list) | `[db_read]` |
| `PATCH /api/v1/groups/{pk}/send_test_email` | `[http_out]` |
| `POST /api/v1/elv3/send-notification` | `[db_read, http_out]` |
| `PATCH /api/v1/groups/{pk}/email_template` | `[db_read, db_write, mutation]` |

## Test plan
- [x] `go test ./internal/links/ ./internal/substrate/ ./internal/mcp/ ./tools/coverage/` — all pass
- [x] `go run ./tools/coverage validate` — mapping resolves, no new errors
- [x] New tests: `TestEffectPropagation_EndpointInheritsHandlerEffects`, `TestEffectPropagation_EndpointPureHandlerUnstamped`, `TestEndpointDefinitions_SurfacesEffects` (effects field + `effect=` filter), frontmatter `effects` parse
- [x] Self-rebased on origin/main (clean, no conflicts); the prior `TestNoSessionMetaInNonWhoamiHandlers` (#2780) failure is resolved by #2827 now in main

🤖 Generated with [Claude Code](https://claude.com/claude-code)