### PR TITLE
feat(security): promote taint findings to SecurityFinding entities + security doc tier (#2810)

### DIFF
--- a/internal/mcp/findings.go
+++ b/internal/mcp/findings.go
@@ -131,6 +131,27 @@ func findingsSince(all []Finding, since time.Time) []Finding {
 	return out
 }
 
+// findingsOfType filters findings by their Type field (#2810). An empty
+// stored Type is normalised to "note" to match save_finding's default, so
+// list_findings(type="note") returns un-typed legacy findings too. A blank
+// `typ` argument is a no-op (caller-side guarded, but defensive here).
+func findingsOfType(all []Finding, typ string) []Finding {
+	if typ == "" {
+		return all
+	}
+	out := []Finding{}
+	for _, f := range all {
+		ft := f.Type
+		if ft == "" {
+			ft = "note"
+		}
+		if ft == typ {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // findingsToJSON renders a slice of findings as the wire shape (drops the
 // internal SavedAtFile field).
 func findingsToJSON(in []Finding, limit int) []map[string]any {

--- a/internal/mcp/schema_contract_ast_test.go
+++ b/internal/mcp/schema_contract_ast_test.go
@@ -145,6 +145,7 @@ var intentionalGaps = []intentionalGap{
 	{"archigraph_list_findings", "since", "#2426 token ceiling pattern — optional RFC3339 filter"},
 	{"archigraph_list_findings", "entity_id", "#2426 token ceiling pattern — optional entity filter"},
 	{"archigraph_list_findings", "limit", "#2426 token ceiling pattern — optional result limit"},
+	{"archigraph_list_findings", "type", "#2810 token ceiling pattern — optional finding-type filter (e.g. security_finding)"},
 
 	// archigraph_cross_links: per-action args undeclared for token budget (#2424 / #1639 pattern).
 	{"archigraph_cross_links", "channel", "#2424 token ceiling pattern — list filter"},

--- a/internal/mcp/security_finding_promotion_test.go
+++ b/internal/mcp/security_finding_promotion_test.go
@@ -1,0 +1,160 @@
+package mcp
+
+// security_finding_promotion_test.go — proves the Phase-2 promotion pipeline
+// for the archigraph-security-audit skill (#2810).
+//
+// The skill's Phase 2 confirms a taint finding and then PROMOTES it into the
+// group memory store as a first-class, queryable record via
+// archigraph_save_finding(type="security_finding", nodes=[entity_id], ...).
+// This test injects a SYNTHETIC confirmed finding (request.body -> os.remove
+// path-traversal), saves it through the real handler, and then verifies it is
+// queryable in isolation via archigraph_list_findings(type="security_finding")
+// — without dragging along co-resident note findings.
+//
+// It is the unit-test stand-in for the manual "inject a real taint into a
+// scratch fixture" check: it exercises save -> list -> type-filter end to end
+// against the live handlers, with the memory dir pointed at a t.TempDir() so
+// nothing touches the user's ~/.archigraph store.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// callRawTool invokes a handler and returns the raw JSON text (handles both
+// object and array result bodies — list_findings returns a JSON array).
+func callRawTool(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) string {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("handler returned nil result")
+	}
+	if res.IsError {
+		t.Fatalf("handler returned tool error: %v", res.Content)
+	}
+	return extractResultText(t, res)
+}
+
+func TestSecurityFindingPromotionRoundtrip(t *testing.T) {
+	// A tiny graph with the entity the synthetic finding points at, so the
+	// nodes reference is a real ID the skill could resolve later.
+	doc := minDoc([]graph.Entity{
+		{ID: "ent_send_proposals", Name: "send_proposals", Kind: "function"},
+	}, nil)
+	srv := newTestServer(t, doc)
+
+	// Point the memory store at a temp dir so we never touch ~/.archigraph.
+	memDir := t.TempDir()
+	srv.State.Group("test").MemoryDir = memDir
+
+	// 1) Save a benign note first — it must NOT show up in the security query.
+	noteOut := callRawTool(t, srv.handleSaveResult, map[string]any{
+		"group":    "test",
+		"question": "Why does the inspector card fail to navigate?",
+		"answer":   "Stale buildingId from a persisted-store migration.",
+		// no type => defaults to "note"
+	})
+	if !json.Valid([]byte(noteOut)) {
+		t.Fatalf("save note: invalid JSON result: %s", noteOut)
+	}
+
+	// 2) PROMOTE a confirmed taint finding as a first-class security_finding.
+	//    This is exactly the call the skill's Phase-2 prompt should make.
+	secOut := callRawTool(t, srv.handleSaveResult, map[string]any{
+		"group":    "test",
+		"question": "path_traversal on send_proposals",
+		"answer":   "SEVERITY=high. Tainted input from request.body reaches os.remove without a sanitizer.",
+		"type":     "security_finding",
+		"nodes":    []any{"ent_send_proposals"},
+	})
+	var saved map[string]any
+	if err := json.Unmarshal([]byte(secOut), &saved); err != nil {
+		t.Fatalf("save security_finding: unmarshal failed: %v\nraw: %s", err, secOut)
+	}
+	if saved["path"] == nil || saved["path"] == "" {
+		t.Fatalf("save security_finding: expected a non-empty path, got %v", saved["path"])
+	}
+
+	// 3) Query ONLY the security findings. The note must be excluded.
+	listOut := callRawTool(t, srv.handleListFindings, map[string]any{
+		"group": "test",
+		"type":  "security_finding",
+	})
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(listOut), &items); err != nil {
+		t.Fatalf("list_findings(type=security_finding): unmarshal failed: %v\nraw: %s", err, listOut)
+	}
+	if len(items) != 1 {
+		t.Fatalf("type-filtered list: got %d findings, want exactly 1 (the promoted finding)\nraw: %s", len(items), listOut)
+	}
+	got := items[0]
+	if got["type"] != "security_finding" {
+		t.Errorf("promoted finding type: got %v, want security_finding", got["type"])
+	}
+	if got["question"] != "path_traversal on send_proposals" {
+		t.Errorf("promoted finding question: got %v", got["question"])
+	}
+	// The entity reference must survive the roundtrip so the finding is
+	// graph-queryable by entity (archigraph_list_findings entity_id=...).
+	nodes, ok := got["nodes"].([]any)
+	if !ok || len(nodes) != 1 || nodes[0] != "ent_send_proposals" {
+		t.Errorf("promoted finding nodes: got %v, want [ent_send_proposals]", got["nodes"])
+	}
+
+	// 4) Sanity: the unfiltered list contains BOTH records, proving the type
+	//    filter is what isolated the security finding (not an empty store).
+	allOut := callRawTool(t, srv.handleListFindings, map[string]any{"group": "test"})
+	var all []map[string]any
+	if err := json.Unmarshal([]byte(allOut), &all); err != nil {
+		t.Fatalf("list_findings(all): unmarshal failed: %v\nraw: %s", err, allOut)
+	}
+	if len(all) != 2 {
+		t.Fatalf("unfiltered list: got %d findings, want 2 (note + security_finding)", len(all))
+	}
+
+	// 5) The promoted finding is also reachable by entity_id — the acceptance
+	//    criterion "queryable via archigraph_list_findings".
+	byEntOut := callRawTool(t, srv.handleListFindings, map[string]any{
+		"group":     "test",
+		"entity_id": "ent_send_proposals",
+	})
+	var byEnt []map[string]any
+	if err := json.Unmarshal([]byte(byEntOut), &byEnt); err != nil {
+		t.Fatalf("list_findings(entity_id): unmarshal failed: %v\nraw: %s", err, byEntOut)
+	}
+	if len(byEnt) != 1 || byEnt[0]["question"] != "path_traversal on send_proposals" {
+		t.Fatalf("entity_id query: got %v, want the promoted security finding", byEnt)
+	}
+}
+
+// TestFindingsOfTypeNoteFallback documents the normalisation: a stored finding
+// with an empty Type is treated as "note", so legacy un-typed findings remain
+// queryable via list_findings(type="note") and never leak into a
+// security_finding query.
+func TestFindingsOfTypeNoteFallback(t *testing.T) {
+	in := []Finding{
+		{Question: "legacy", Type: ""},
+		{Question: "explicit-note", Type: "note"},
+		{Question: "sec", Type: "security_finding"},
+	}
+	notes := findingsOfType(in, "note")
+	if len(notes) != 2 {
+		t.Fatalf("findingsOfType(note): got %d, want 2 (empty-type normalises to note)", len(notes))
+	}
+	sec := findingsOfType(in, "security_finding")
+	if len(sec) != 1 || sec[0].Question != "sec" {
+		t.Fatalf("findingsOfType(security_finding): got %v, want the one sec finding", sec)
+	}
+	if got := findingsOfType(in, ""); len(got) != 3 {
+		t.Fatalf("findingsOfType(empty): got %d, want all 3 (no-op)", len(got))
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1760,6 +1760,12 @@ func (s *Server) handleListFindings(ctx context.Context, req mcpapi.CallToolRequ
 		}
 		all = findingsForEntity(all, ids...)
 	}
+	// type filter (#2810): isolate a single finding kind, e.g.
+	// "security_finding" so the security-audit skill can query just the
+	// promoted SecurityFinding records without re-scanning notes.
+	if typ := argString(req, "type", ""); typ != "" {
+		all = findingsOfType(all, typ)
+	}
 	limit := argInt(req, "limit", 50)
 	return jsonResult(findingsToJSON(all, limit)), nil
 }

--- a/skills/archigraph-security-audit/SKILL.md
+++ b/skills/archigraph-security-audit/SKILL.md
@@ -91,8 +91,8 @@ Output: per-finding markdown pages at `~/.archigraph/docs/<group>/security/`.
 - `archigraph_security_findings` — Phase 2B taint-flow source→sink findings (#2772). Args: `category`, `min_confidence` (default 0.7), `limit`, `source_repo`. Returns deterministic SecurityFinding records ranked by confidence.
 - `archigraph_repairs` — check for residual edges on security-sensitive paths
 - `archigraph_enrichments` — read enriched endpoint metadata
-- `archigraph_save_finding` — persist confirmed security findings
-- `archigraph_list_findings` — load prior findings to avoid duplicates
+- `archigraph_save_finding` — promote a confirmed finding to a first-class `security_finding` record. Args: `question`, `answer` (required); `type="security_finding"`, `nodes=["<entity_id>"]`, `repo_filter` (optional). It does NOT accept `entity_id`/`severity` top-level — carry the entity in `nodes` and severity in the question/answer text.
+- `archigraph_list_findings` — load prior findings to avoid duplicates. Pass `type="security_finding"` to query only promoted security findings, or `entity_id=<id>` to find findings touching a specific entity.
 
 ## Related
 

--- a/skills/archigraph-security-audit/prompts/02-semantic-confirmation.md
+++ b/skills/archigraph-security-audit/prompts/02-semantic-confirmation.md
@@ -6,7 +6,8 @@ Reads `phase1-findings.json`, confirms or dismisses each finding with LLM reason
 
 - Load `phase1-findings.json` from `~/.archigraph/groups/<group>/archigraph-security-audit/`.
 - Load prior `~/.archigraph/groups/<group>/archigraph-security-audit/state.json` (if exists) to skip already-confirmed findings by fingerprint.
-- If no findings remain after deduplication: print "No new findings to confirm." and exit.
+- Also call `archigraph_list_findings(type="security_finding")` to load findings already promoted to the graph (the `fingerprint=` trailer in each `answer` is the dedup key) so a re-run does not double-promote.
+- If no findings remain after deduplication: print "No new findings to confirm." and exit. An EMPTY finding set is the expected, correct outcome on a clean codebase — still write the index (Step 4) with all-zero counts; do not error or fabricate findings.
 
 ## Step 1 — Cost estimate
 
@@ -39,16 +40,27 @@ For each finding in priority order (critical first, then high, medium, low, info
 
 ## Step 3 — Persist confirmed findings
 
-For each confirmed finding, call:
+For each confirmed finding, call `archigraph_save_finding` to promote it into
+the group memory store as a first-class, queryable `security_finding` record:
 ```
 archigraph_save_finding(
   type="security_finding",
-  question="<check_name> on <entity_name>",
-  answer="<explanation>",
-  entity_id="<entity_id>",
-  severity="<severity>"
+  question="[<SEVERITY>] <check_name> on <entity_name>",
+  answer="<explanation>\n\nseverity=<severity>; fingerprint=<fingerprint>; check=<check_name>",
+  nodes=["<entity_id>"]
 )
 ```
+
+Field mapping (the tool persists `type`, `nodes`, and `repo_filter` alongside
+`question`/`answer`):
+- `type="security_finding"` — promotes the record so it is queryable in
+  isolation via `archigraph_list_findings(type="security_finding")`, separate
+  from ordinary `note` findings.
+- `nodes=["<entity_id>"]` — the entity reference. This is what makes the
+  finding graph-queryable by entity:
+  `archigraph_list_findings(entity_id="<entity_id>")`. Do NOT pass `entity_id`
+  or `severity` as top-level args — the tool ignores them; carry severity in
+  the `question` prefix and the `answer` trailer instead.
 
 Write a per-finding markdown page to `~/.archigraph/docs/<group>/security/findings/<fingerprint>.md`:
 


### PR DESCRIPTION
Closes #2810

## Summary

Wires and verifies the **archigraph-security-audit Phase-2 promotion pipeline** (#2810). Confirmed taint findings now persist as first-class, queryable `security_finding` records in the group memory store — distinct from ordinary notes — and the skill's `save_finding`/`list_findings` contract is corrected to match the real tool.

- `archigraph_list_findings` gains an optional `type` filter so the skill can query only promoted security findings (`type=security_finding`) without re-scanning notes. Empty-type records normalise to `note` (legacy findings stay queryable). Added to the schema-contract intentional-gaps allowlist per the #2426/#1639 token-ceiling pattern.
- **Skill fix:** the Phase-2 prompt and SKILL.md told the agent to call `save_finding(entity_id=..., severity=...)` — but the tool ignores those args. Corrected to `nodes=[entity_id]` with severity folded into question/answer. Documented the empty-finding-set as the expected **clean** outcome (write a zero-count index, never error/fabricate).
- **Synthetic-finding proof:** new roundtrip test injects a `request.body -> os.remove` path_traversal finding, promotes it via `save_finding(type=security_finding, nodes=[...])`, and verifies it is queryable in isolation via `list_findings(type=security_finding)` and by `entity_id`, while a co-resident note is excluded.

## Context

- Depends on #2805 (merged) — generated-path FP filter. On upvate, taint findings dropped to **0** at confidence floor 0.5, so there is nothing to promote there; this PR is about WIRING + VERIFYING, with the synthetic test as the proof the pipeline works when findings exist.

## Test plan

- [x] `go test ./internal/mcp/` — passes incl. `TestSecurityFindingPromotionRoundtrip`, `TestFindingsOfTypeNoteFallback`, schema-contract AST test
- [x] `go test ./tools/coverage/` — passes
- [x] `go build ./...` + `go vet ./internal/mcp/`
- [x] `go run ./tools/coverage gen` — no coverage-cell diff (change doesn't touch a capability cell)
- [x] rebased on origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)