### PR TITLE
fix(coverage): reconcile capability-map vs registry validator errors to 0 (#2799)

### DIFF
--- a/tools/coverage/AGENTS.md
+++ b/tools/coverage/AGENTS.md
@@ -35,6 +35,38 @@ Because the taxonomy is data-driven:
 - Templates live in `templates/` and use Go's `text/template`.
 - Keep them deterministic: sort every map / slice before iterating. The `gen_test.go` snapshot test will catch nondeterministic ordering.
 
+## Errors vs warnings — the validate gate policy
+
+`go run ./tools/coverage validate` distinguishes two severities, and the CI
+gate (`.github/workflows/coverage-docs.yml`) treats them differently:
+
+- **Errors fail the build** (`main.go` returns non-zero when `totalErrors > 0`).
+  These are hard consistency violations: a capability-map citation pointing at a
+  registry cell that doesn't exist (or whose shape/group doesn't match), a cited
+  source file or function missing on disk, an invalid status enum, a stale
+  dictionary key, a duplicate capability key. **Errors must stay at 0.**
+- **Warnings never fail the build.** They are advisory nudges and are expected
+  to number in the thousands at the group's current breadth. Do not "fix" them
+  by deleting registry rows or capability-map content — that would silence
+  reality rather than reflect it. The two dominant warning classes are
+  structural and intentional:
+  1. *"capability has no mapping entry"* (`validate_map.go`, the
+     mapping-coverage nudge) — every registry cell with status `full`/`partial`
+     ideally has a `capability-map.yaml` symbol/function mapping. The mapping
+     section only enumerates archigraph's own code-delivering records (~18); the
+     hundreds of framework/language records (e.g. `lang.jsts.framework.*`,
+     `test.pytest`) are descriptive coverage entries served by *shared*
+     extractors, so per-record symbol mappings are deliberately absent. Adding
+     mapping is incremental, never required.
+  2. *"capability has no tracking issue"* (`validate.go`,
+     `validateCapabilityCell`) — `partial`/`missing` cells without an `issue:`
+     link get a nudge to file a ticket. These mark known framework-support gaps
+     and are advisory, not blocking.
+
+  If a warning is ever genuinely wrong (cell status misrepresents what the code
+  does), fix it at the source — flip the registry cell or correct the citation —
+  rather than suppressing the warning. (Ref: #2799.)
+
 ## Coverage matrix update rule
 
 The root `AGENTS.md` "Coverage matrix update" section is **the** rule for capability-changing PRs across the repo. Tooling changes inside this directory generally do NOT require a matrix update unless they alter the schema (in which case the schema PR + record migration must ship together).


### PR DESCRIPTION
## Summary

Closes the audit in #2799. Re-baselined `go run ./tools/coverage validate` against current `main` (post Wave-8): the **45 hard errors** the issue cited are **stale** — the parallel capability-mapping, dictionary, and subcategory PRs that have since landed already flipped/added the registry cells and corrected citations.

**BEFORE (current main):** 0 errors, 4694 warnings, exit 0.
**AFTER:** 0 errors (unchanged — no errors to fix), 4694 warnings.

No registry cells or capability-map citations were added or removed in this PR, because reality already matches the map — there were no unsupported citations and no missing cells left to reconcile. Silencing-by-deletion would have been the wrong move.

## Warning verdict

All 4694 warnings are **advisory and non-gate-blocking** (`main.go` fails the build only on `totalErrors > 0`). Two structural-and-expected classes:

1. **"capability has no mapping entry" (2421)** — `validate_map.go` mapping-coverage nudge. The `capability-map.yaml` mapping section enumerates archigraph's own ~18 code-delivering records; the hundreds of framework/language records (`lang.jsts.framework.*`, `test.pytest`, …) are descriptive coverage entries served by *shared* extractors, so per-record symbol mappings are intentionally absent. Mapping is incremental, never required.
2. **"capability has no tracking issue" (2231)** — `validate.go`/`validateCapabilityCell`, nudging a ticket for `partial`/`missing` cells. Advisory framework-gap markers.

Audited the differing System/Flow/test samples too — none are genuinely wrong.

## CI gate

The gate #2799 asks for **already exists**: `.github/workflows/coverage-docs.yml` runs `go run ./tools/coverage validate` (non-zero on errors) on every PR touching `docs/coverage/**` or `tools/coverage/**`, then regenerates and diffs the docs. No new workflow needed.

## Change

Documented the error-vs-warning gate policy in `tools/coverage/AGENTS.md` so the warnings aren't re-opened as tech debt, with the source-fix discipline (flip cell / fix citation, never suppress).

## Test plan

- [x] `go run ./tools/coverage validate` → `ok: 541 record(s), 4694 warning(s)`, exit 0
- [x] `go run ./tools/coverage gen` → no drift (`git diff` empty)
- [x] `go test ./tools/coverage/` → ok
- [x] Rebased on origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)