### PR TITLE
fix(security): auth_coverage detects DRF class-level + default permission_classes (#2816)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -105,7 +105,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/20 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/20 | |
 | [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md).
 | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/20 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ⚠️ 7/20 | |
 | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 5/6 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go` | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | [link](2816) | `internal/extractors/python/config_module.go`<br>`internal/extractors/python/django_drf_permissions.go`<br>`internal/mcp/auth_coverage.go` | — |
 
 ### Validation
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -16454,8 +16454,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/engine/django_drf_actions.go"],
+            "status": "full",
+            "cites": ["internal/extractors/python/config_module.go","internal/extractors/python/django_drf_permissions.go","internal/mcp/auth_coverage.go"],
+            "issue": "2816",
             "verified_at": "2026-05-28"
           }
         },

--- a/internal/extractors/python/config_module.go
+++ b/internal/extractors/python/config_module.go
@@ -131,6 +131,22 @@ func emitConfigModuleEntity(root *sitter.Node, file extractor.FileInput, out *[]
 		props["top_level_symbols"] = strings.Join(symbolNames, ",")
 	}
 
+	// Issue #2816 — capture the DRF global default permission policy so the
+	// auth_coverage detector knows whether endpoints with no explicit perms
+	// are protected by default. We stamp two properties:
+	//
+	//	drf_default_permission_classes — comma-joined leaf names from
+	//	    REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"] (empty when the key is
+	//	    absent — DRF's built-in default is then AllowAny, i.e. open).
+	//	drf_default_permission_present — "true" when the key is present at all
+	//	    (so "" can be distinguished from "explicit empty tuple").
+	if configType == "django_settings" || configType == "generic_config" {
+		if perms, present := extractDRFDefaultPermissionClasses(root, file.Content); present {
+			props["drf_default_permission_present"] = "true"
+			props["drf_default_permission_classes"] = strings.Join(perms, ",")
+		}
+	}
+
 	// Issue #1964 — emit the real file end line so the docgen
 	// source_window helper can excerpt the entire settings/manage/celery
 	// module body instead of clipping at line 1. The config_module entity
@@ -258,4 +274,104 @@ func collectTopLevelAssignmentNames(root *sitter.Node, src []byte) []string {
 		}
 	}
 	return names
+}
+
+// extractDRFDefaultPermissionClasses scans a Django settings module for
+//
+//	REST_FRAMEWORK = {
+//	    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated", ...),
+//	}
+//
+// and returns (leafPermissionNames, present). `present` is true when the
+// DEFAULT_PERMISSION_CLASSES key exists at all — a present-but-empty value
+// means the project explicitly opted into an open default. When the key is
+// absent the caller should treat the global default as AllowAny (DRF's
+// built-in), i.e. NOT auth coverage.
+//
+// Values may be string literals ("rest_framework.permissions.IsAuthenticated")
+// or bare identifiers (IsAuthenticated); both are reduced to their leaf class
+// name (IsAuthenticated). Only the top-level REST_FRAMEWORK assignment is
+// examined.
+func extractDRFDefaultPermissionClasses(root *sitter.Node, src []byte) ([]string, bool) {
+	if root == nil {
+		return nil, false
+	}
+	for i := 0; i < int(root.ChildCount()); i++ {
+		child := root.Child(i)
+		if child == nil || child.Type() != "expression_statement" {
+			continue
+		}
+		for j := 0; j < int(child.NamedChildCount()); j++ {
+			expr := child.NamedChild(j)
+			if expr == nil || expr.Type() != "assignment" {
+				continue
+			}
+			lhs := expr.ChildByFieldName("left")
+			if lhs == nil || lhs.Type() != "identifier" || nodeText(lhs, src) != "REST_FRAMEWORK" {
+				continue
+			}
+			rhs := expr.ChildByFieldName("right")
+			if rhs == nil || rhs.Type() != "dictionary" {
+				continue
+			}
+			return dictDefaultPermissionClasses(rhs, src)
+		}
+	}
+	return nil, false
+}
+
+// dictDefaultPermissionClasses reads a `dictionary` node and, if it has a
+// "DEFAULT_PERMISSION_CLASSES" key, returns the leaf names of its value list
+// plus present=true.
+func dictDefaultPermissionClasses(dict *sitter.Node, src []byte) ([]string, bool) {
+	for i := 0; i < int(dict.NamedChildCount()); i++ {
+		pair := dict.NamedChild(i)
+		if pair == nil || pair.Type() != "pair" {
+			continue
+		}
+		keyNode := pair.ChildByFieldName("key")
+		valNode := pair.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		if stripQuotes(strings.TrimSpace(nodeText(keyNode, src))) != "DEFAULT_PERMISSION_CLASSES" {
+			continue
+		}
+		raw := parseListLiteralStringsOrIdents(valNode, src)
+		out := make([]string, 0, len(raw))
+		for _, r := range raw {
+			if leaf := permissionLeafName(stripQuotes(r)); leaf != "" {
+				out = append(out, leaf)
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+// parseListLiteralStringsOrIdents reads a list/tuple/set literal and returns
+// the raw source text of each element (string literal or identifier/attribute),
+// tolerating the mixed string-or-symbol forms common in DRF settings.
+func parseListLiteralStringsOrIdents(n *sitter.Node, src []byte) []string {
+	if n == nil {
+		return nil
+	}
+	switch n.Type() {
+	case "list", "tuple", "set":
+		var out []string
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			ch := n.NamedChild(i)
+			if ch == nil {
+				continue
+			}
+			switch ch.Type() {
+			case "string", "identifier", "attribute", "dotted_name":
+				out = append(out, strings.TrimSpace(nodeText(ch, src)))
+			}
+		}
+		return out
+	case "string", "identifier", "attribute", "dotted_name":
+		return []string{strings.TrimSpace(nodeText(n, src))}
+	}
+	return nil
 }

--- a/internal/extractors/python/django_drf_permissions.go
+++ b/internal/extractors/python/django_drf_permissions.go
@@ -1,0 +1,198 @@
+// django_drf_permissions.go — class-level DRF authorisation surface (#2816).
+//
+// # Why this exists
+//
+// archigraph_auth_coverage previously detected auth only via per-method /
+// per-decorator signals (e.g. `@permission_classes(...)`, `@login_required`).
+// Real DRF apps overwhelmingly declare authorisation at the *class* level:
+//
+//	class BuildingViewSet(viewsets.ModelViewSet):
+//	    permission_classes = [IsAuthenticated]      # class attribute
+//
+//	    def get_permissions(self):                  # dynamic override
+//	        return [IsAuthenticated(), ...]
+//
+// On a mature DRF codebase (upvate-core) this meant 0 % coverage / hundreds of
+// false-positive "unprotected endpoint" findings — a security surface that
+// cried wolf.  This pass stamps the class-level authorisation surface onto the
+// ViewSet/APIView class entity so the auth_coverage detector can read it
+// without re-parsing source:
+//
+//	permission_classes      → comma-joined identifier list of the class
+//	                          attribute RHS (e.g. "IsAuthenticated" or
+//	                          "AllowAny"). Empty list → "" (explicit
+//	                          permission-less, i.e. open).
+//	has_permission_classes  → "true" when the class attribute is present
+//	                          (even if its value is `[]` / AllowAny) so the
+//	                          detector can distinguish "explicitly open" from
+//	                          "no signal at all".
+//	has_get_permissions     → "true" when the class defines get_permissions().
+//	get_permissions_classes → comma-joined identifier list of permission
+//	                          classes referenced anywhere in the get_permissions
+//	                          body (best-effort; covers the common pattern of
+//	                          `permission_classes = [IsAuthenticated, ...]`).
+//
+// The detector treats a non-AllowAny class attribute, or a get_permissions()
+// that references a non-AllowAny permission class, as auth coverage.  An
+// explicit `permission_classes = [AllowAny]` (or `[]`) is recognised as
+// genuinely public.
+//
+// This pass runs AFTER walkNode has emitted the class entity and its method /
+// field children, mirroring applyFrameworkInnerClassProperties (#757).
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// applyDRFPermissionProperties inspects classBody for a class-level
+// `permission_classes = [...]` assignment and a `get_permissions()` method,
+// and stamps the corresponding properties onto parent in-place.
+//
+// Safe to call on any class body — non-DRF classes simply have neither shape
+// and the function is a no-op.
+func applyDRFPermissionProperties(parent *types.EntityRecord, classBody *sitter.Node, src []byte) {
+	if parent == nil || classBody == nil {
+		return
+	}
+
+	var (
+		setProp = func(k, v string) {
+			if parent.Properties == nil {
+				parent.Properties = make(map[string]string)
+			}
+			parent.Properties[k] = v
+		}
+	)
+
+	for i := 0; i < int(classBody.ChildCount()); i++ {
+		stmt := classBody.Child(i)
+		if stmt == nil {
+			continue
+		}
+		switch stmt.Type() {
+		case "expression_statement":
+			// Look for `permission_classes = [...]` at class-body scope.
+			for j := 0; j < int(stmt.NamedChildCount()); j++ {
+				expr := stmt.NamedChild(j)
+				if expr == nil || expr.Type() != "assignment" {
+					continue
+				}
+				lhs := expr.ChildByFieldName("left")
+				if lhs == nil || lhs.Type() != "identifier" {
+					continue
+				}
+				if nodeText(lhs, src) != "permission_classes" {
+					continue
+				}
+				rhs := expr.ChildByFieldName("right")
+				raw := parseListLiteralIdentifiers(rhs, src)
+				perms := make([]string, 0, len(raw))
+				for _, p := range raw {
+					if leaf := permissionLeafName(p); leaf != "" {
+						perms = append(perms, leaf)
+					}
+				}
+				setProp("has_permission_classes", "true")
+				setProp("permission_classes", strings.Join(perms, ","))
+			}
+		case "function_definition":
+			if isGetPermissionsDef(stmt, src) {
+				setProp("has_get_permissions", "true")
+				if cls := getPermissionsReferencedClasses(stmt, src); len(cls) > 0 {
+					setProp("get_permissions_classes", strings.Join(cls, ","))
+				}
+			}
+		case "decorated_definition":
+			// get_permissions is occasionally decorated (rare). Unwrap.
+			if inner := stmt.ChildByFieldName("definition"); inner != nil &&
+				inner.Type() == "function_definition" && isGetPermissionsDef(inner, src) {
+				setProp("has_get_permissions", "true")
+				if cls := getPermissionsReferencedClasses(inner, src); len(cls) > 0 {
+					setProp("get_permissions_classes", strings.Join(cls, ","))
+				}
+			}
+		}
+	}
+}
+
+// isGetPermissionsDef reports whether fnDef is `def get_permissions(self):`.
+func isGetPermissionsDef(fnDef *sitter.Node, src []byte) bool {
+	if fnDef == nil {
+		return false
+	}
+	nameNode := fnDef.ChildByFieldName("name")
+	return nameNode != nil && nodeText(nameNode, src) == "get_permissions"
+}
+
+// getPermissionsReferencedClasses collects identifier names referenced inside a
+// get_permissions() body that look like DRF permission classes.  It walks the
+// body for any `permission_classes = [...]` assignments (the canonical pattern)
+// and, failing that, falls back to identifiers in the returned expression.
+//
+// The result is a best-effort, deduplicated list of the bare identifier names
+// (e.g. "IsAuthenticated", "AllowAny", "CustomActionPermissionCheck"). The
+// auth_coverage detector decides which of those constitute real protection.
+func getPermissionsReferencedClasses(fnDef *sitter.Node, src []byte) []string {
+	body := fnDef.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	collectPermissionAssignments(body, src, add)
+	return out
+}
+
+// collectPermissionAssignments recursively walks a statement subtree and, for
+// every `permission_classes = [...]` assignment (regardless of nesting depth —
+// these typically live inside if/elif branches), feeds the list-literal
+// identifiers to add. Falls through to `return [...]` expressions too.
+func collectPermissionAssignments(n *sitter.Node, src []byte, add func(string)) {
+	if n == nil {
+		return
+	}
+	switch n.Type() {
+	case "assignment":
+		lhs := n.ChildByFieldName("left")
+		if lhs != nil && lhs.Type() == "identifier" && nodeText(lhs, src) == "permission_classes" {
+			rhs := n.ChildByFieldName("right")
+			for _, id := range parseListLiteralIdentifiers(rhs, src) {
+				add(permissionLeafName(id))
+			}
+		}
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		collectPermissionAssignments(n.Child(i), src, add)
+	}
+}
+
+// permissionLeafName reduces a possibly-dotted or called permission reference
+// to its leaf class name so the detector matches against a stable token:
+//
+//	IsAuthenticated                     → IsAuthenticated
+//	permissions.IsAdminUser             → IsAdminUser
+//	CustomPagePermissionCheck(PAGES[X]) → CustomPagePermissionCheck
+func permissionLeafName(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if paren := strings.IndexByte(ref, '('); paren >= 0 {
+		ref = ref[:paren]
+	}
+	if dot := strings.LastIndexByte(ref, '.'); dot >= 0 {
+		ref = ref[dot+1:]
+	}
+	return strings.TrimSpace(ref)
+}

--- a/internal/extractors/python/django_drf_permissions_test.go
+++ b/internal/extractors/python/django_drf_permissions_test.go
@@ -1,0 +1,192 @@
+package python_test
+
+// django_drf_permissions_test.go — issue #2816.
+//
+// Verifies the python extractor stamps the DRF class-level authorisation
+// surface (permission_classes attribute + get_permissions override) onto the
+// ViewSet class entity, and harvests the global REST_FRAMEWORK
+// DEFAULT_PERMISSION_CLASSES from a settings module.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// drfPermClass looks up a class entity by name (reusing the shared
+// findClassEntity helper which returns a value) and returns a pointer to its
+// properties via a fresh local copy is insufficient, so we re-resolve the
+// pointer here for in-place property assertions.
+func drfPermClass(t *testing.T, entities []types.EntityRecord, name string) *types.EntityRecord {
+	t.Helper()
+	for i := range entities {
+		e := &entities[i]
+		if e.Name == name && e.Kind == "SCOPE.Component" && e.Subtype == "class" {
+			return e
+		}
+	}
+	return nil
+}
+
+func TestDRFPermissions_ClassAttribute(t *testing.T) {
+	src := `from rest_framework.permissions import IsAuthenticated
+
+class BuildingViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+    serializer_class = BuildingSerializer
+`
+	out := extractPy(t, src, "core/views/building.py")
+	cls := drfPermClass(t, out, "BuildingViewSet")
+	if cls == nil {
+		t.Fatalf("BuildingViewSet class entity not found")
+	}
+	if cls.Properties["has_permission_classes"] != "true" {
+		t.Errorf("has_permission_classes = %q, want true", cls.Properties["has_permission_classes"])
+	}
+	if cls.Properties["permission_classes"] != "IsAuthenticated" {
+		t.Errorf("permission_classes = %q, want IsAuthenticated", cls.Properties["permission_classes"])
+	}
+}
+
+func TestDRFPermissions_AllowAnyTuple(t *testing.T) {
+	src := `from rest_framework.permissions import AllowAny
+
+class LoginViewSet(viewsets.ModelViewSet):
+    permission_classes = (AllowAny,)
+`
+	out := extractPy(t, src, "core/views/auth.py")
+	cls := drfPermClass(t, out, "LoginViewSet")
+	if cls == nil {
+		t.Fatalf("LoginViewSet class entity not found")
+	}
+	if cls.Properties["permission_classes"] != "AllowAny" {
+		t.Errorf("permission_classes = %q, want AllowAny", cls.Properties["permission_classes"])
+	}
+}
+
+func TestDRFPermissions_DottedPermission(t *testing.T) {
+	src := `class AdminViewSet(viewsets.ModelViewSet):
+    permission_classes = [permissions.IsAdminUser]
+`
+	out := extractPy(t, src, "core/views/admin.py")
+	cls := drfPermClass(t, out, "AdminViewSet")
+	if cls == nil {
+		t.Fatalf("AdminViewSet class entity not found")
+	}
+	if cls.Properties["permission_classes"] != "IsAdminUser" {
+		t.Errorf("permission_classes = %q, want IsAdminUser (leaf of permissions.IsAdminUser)", cls.Properties["permission_classes"])
+	}
+}
+
+func TestDRFPermissions_GetPermissionsOverride(t *testing.T) {
+	src := `from rest_framework.permissions import IsAuthenticated
+
+class UserViewSet(viewsets.ModelViewSet):
+    serializer_class = UserSerializer
+
+    def get_permissions(self):
+        if self.action in ["list", "retrieve"]:
+            permission_classes = [IsAuthenticated]
+        else:
+            permission_classes = [IsAuthenticated, CustomActionPermissionCheck]
+        return [permission() for permission in permission_classes]
+`
+	out := extractPy(t, src, "core/views/user.py")
+	cls := drfPermClass(t, out, "UserViewSet")
+	if cls == nil {
+		t.Fatalf("UserViewSet class entity not found")
+	}
+	if cls.Properties["has_get_permissions"] != "true" {
+		t.Errorf("has_get_permissions = %q, want true", cls.Properties["has_get_permissions"])
+	}
+	gp := cls.Properties["get_permissions_classes"]
+	if gp == "" || !containsAll(gp, "IsAuthenticated", "CustomActionPermissionCheck") {
+		t.Errorf("get_permissions_classes = %q, want it to include IsAuthenticated + CustomActionPermissionCheck", gp)
+	}
+}
+
+func TestDRFPermissions_NonViewClassUntouched(t *testing.T) {
+	src := `class PlainModel(models.Model):
+    name = models.CharField(max_length=10)
+`
+	out := extractPy(t, src, "core/models/plain.py")
+	cls := drfPermClass(t, out, "PlainModel")
+	if cls == nil {
+		t.Fatalf("PlainModel class entity not found")
+	}
+	if _, ok := cls.Properties["has_permission_classes"]; ok {
+		t.Errorf("non-DRF class should not carry has_permission_classes")
+	}
+	if _, ok := cls.Properties["has_get_permissions"]; ok {
+		t.Errorf("non-DRF class should not carry has_get_permissions")
+	}
+}
+
+func TestDRFPermissions_SettingsDefaultPermissionClasses(t *testing.T) {
+	src := `REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework.authentication.TokenAuthentication",),
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+}
+`
+	out := extractPy(t, src, "proj/settings.py")
+	cm := findConfigModule(out)
+	if cm == nil {
+		t.Fatalf("settings config_module entity not found")
+	}
+	if cm.Properties["drf_default_permission_present"] != "true" {
+		t.Errorf("drf_default_permission_present = %q, want true", cm.Properties["drf_default_permission_present"])
+	}
+	if cm.Properties["drf_default_permission_classes"] != "IsAuthenticated" {
+		t.Errorf("drf_default_permission_classes = %q, want IsAuthenticated", cm.Properties["drf_default_permission_classes"])
+	}
+}
+
+func TestDRFPermissions_SettingsNoDefaultPermission(t *testing.T) {
+	// upvate-core's real shape: DEFAULT_AUTHENTICATION_CLASSES set, but no
+	// DEFAULT_PERMISSION_CLASSES → DRF's built-in default (AllowAny) applies,
+	// so the harvested property must be absent.
+	src := `REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework.authentication.TokenAuthentication",),
+    "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
+}
+`
+	out := extractPy(t, src, "proj/settings.py")
+	cm := findConfigModule(out)
+	if cm == nil {
+		t.Fatalf("settings config_module entity not found")
+	}
+	if _, ok := cm.Properties["drf_default_permission_present"]; ok {
+		t.Errorf("drf_default_permission_present must be absent when DEFAULT_PERMISSION_CLASSES is not set")
+	}
+}
+
+func containsAll(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		found := false
+		for _, part := range splitComma(haystack) {
+			if part == n {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func splitComma(s string) []string {
+	var out []string
+	cur := ""
+	for _, r := range s {
+		if r == ',' {
+			out = append(out, cur)
+			cur = ""
+			continue
+		}
+		cur += string(r)
+	}
+	out = append(out, cur)
+	return out
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -681,6 +681,11 @@ func walkNode(
 				// binding. Runs AFTER applyFrameworkInnerClassProperties so
 				// the parent's `meta_model` property is already stamped.
 				emitDRFSerializerFieldRefs(body, file, childParent, classIdx, before, after, out)
+				// Issue #2816 — stamp the DRF class-level authorisation surface
+				// (permission_classes attribute + get_permissions override) onto
+				// the ViewSet/APIView entity so archigraph_auth_coverage can
+				// recognise class-level auth, not just per-method decorators.
+				applyDRFPermissionProperties(&(*out)[classIdx], body, file.Content)
 			}
 		}
 		return // body handled above — do not recurse further
@@ -804,6 +809,10 @@ func walkNode(
 					// Issue #2061 — DRF serializer field REFERENCES (decorated
 					// class branch). See bare branch above for rationale.
 					emitDRFSerializerFieldRefs(body, file, childParent, classIdx, before, after, out)
+					// Issue #2816 — DRF class-level authorisation surface
+					// (decorated class branch, e.g. @method_decorator-wrapped
+					// ViewSets). See bare branch above for rationale.
+					applyDRFPermissionProperties(&(*out)[classIdx], body, file.Content)
 				}
 			}
 		}

--- a/internal/mcp/auth_coverage.go
+++ b/internal/mcp/auth_coverage.go
@@ -120,6 +120,89 @@ var authPropertyKeys = []string{
 	"annotation_name", // set by decorator_extractor
 }
 
+// openPermissionNames are DRF permission classes that grant access to ALL
+// callers (authenticated or not) — their presence does NOT constitute auth
+// coverage. Lookup is case-insensitive on the leaf class name.
+var openPermissionNames = map[string]bool{
+	"allowany": true,
+}
+
+// isProtectivePermissionList reports whether a comma-joined list of DRF
+// permission-class leaf names (as stamped by the python extractor in the
+// `permission_classes` / `get_permissions_classes` properties) represents real
+// protection.
+//
+// Rules:
+//   - empty list                       → not protective (permission-less; DRF
+//     treats an empty permission_classes as open)
+//   - every entry is AllowAny          → not protective (explicitly public)
+//   - at least one non-AllowAny entry  → protective (e.g. IsAuthenticated, a
+//     custom permission check, IsAdminUser)
+//
+// Returns (protective, evidenceName) where evidenceName is the first
+// non-AllowAny permission class found (for the auth_evidence string).
+func isProtectivePermissionList(joined string) (bool, string) {
+	parts := strings.Split(joined, ",")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if openPermissionNames[strings.ToLower(p)] {
+			continue
+		}
+		return true, p
+	}
+	return false, ""
+}
+
+// drfClassAuth captures the class-level DRF authorisation posture of a single
+// ViewSet / APIView, keyed by its source-line range so an endpoint can be
+// attributed to its enclosing class.
+type drfClassAuth struct {
+	startLine int
+	endLine   int
+	// hasPermAttr is true when the class declares `permission_classes = [...]`
+	// (even if the value is AllowAny / empty).
+	hasPermAttr bool
+	// permClasses is the comma-joined leaf names of the class-level attribute.
+	permClasses string
+	// hasGetPermissions is true when the class defines get_permissions().
+	hasGetPermissions bool
+	// getPermClasses is the comma-joined leaf names referenced in
+	// get_permissions().
+	getPermClasses string
+}
+
+// evaluate returns (decided, hasAuth, evidence) for this class. decided=false
+// means the class carries no explicit DRF permission signal at all, so the
+// caller should fall back to the repo-level default policy.
+func (c drfClassAuth) evaluate() (decided, hasAuth bool, evidence string) {
+	// A dynamic get_permissions() override is the strongest class-level signal.
+	if c.hasGetPermissions {
+		if prot, name := isProtectivePermissionList(c.getPermClasses); prot {
+			return true, true, "DRF get_permissions: " + name
+		}
+		// get_permissions present but we could not extract a protective class
+		// (e.g. it returns AllowAny, or the body is too dynamic to parse). If
+		// the only thing we saw was AllowAny, treat as open; otherwise treat
+		// the mere presence of get_permissions as a (weak) protective signal —
+		// hand-written get_permissions almost always gates access.
+		if c.getPermClasses != "" {
+			return true, false, ""
+		}
+		return true, true, "DRF get_permissions override"
+	}
+	if c.hasPermAttr {
+		if prot, name := isProtectivePermissionList(c.permClasses); prot {
+			return true, true, "DRF permission_classes: " + name
+		}
+		// Explicit AllowAny / empty permission_classes → genuinely open.
+		return true, false, ""
+	}
+	return false, false, ""
+}
+
 // authPropertyValues — for annotation_name property, these values signal auth.
 var authPropertyValues = authAnnotationNames
 
@@ -201,6 +284,13 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 		// Build set of entity IDs reachable via TAGGED_AS edges to auth_policy.
 		taggedAuthIDs := buildTaggedAuthIDs(r.Doc)
 
+		// Issue #2816 — DRF class-level authorisation index: per source file,
+		// the line-range posture of every ViewSet/APIView carrying
+		// permission_classes / get_permissions, plus the repo-wide DRF default
+		// permission policy harvested from the settings REST_FRAMEWORK dict.
+		drfAuthByFile := buildDRFClassAuthByFile(r.Doc)
+		drfDefaultProtected, drfDefaultEvidence := repoDRFDefaultPolicy(r.Doc)
+
 		repoTotal := 0
 		repoCovered := 0
 		repoErrors := 0
@@ -218,7 +308,10 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 
 			repoTotal++
 
-			hasAuth, evidence := determineAuthCoverage(e, authPoliciesByFile, taggedAuthIDs)
+			hasAuth, evidence := determineAuthCoverage(
+				e, authPoliciesByFile, taggedAuthIDs,
+				drfAuthByFile, drfDefaultProtected, drfDefaultEvidence,
+			)
 
 			method := e.Properties["verb"]
 			path := e.Properties["path"]
@@ -417,12 +510,21 @@ func buildTaggedAuthIDs(doc *graph.Document) map[string]bool {
 	return tagged
 }
 
-// determineAuthCoverage checks three signals (in priority order) and returns
-// (hasAuth, evidenceDescription).
+// determineAuthCoverage checks the available signals (in priority order) and
+// returns (hasAuth, evidenceDescription).
+//
+// DRF class-level signals (issue #2816) take precedence over the coarse
+// file-level auth_policy match because they can both PROVE protection
+// (permission_classes=[IsAuthenticated], get_permissions()) AND prove that an
+// endpoint is genuinely public (permission_classes=[AllowAny]) — the latter is
+// essential to avoid mislabelling intentional login/public endpoints.
 func determineAuthCoverage(
 	e *graph.Entity,
 	authByFile map[string][]string,
 	taggedAuthIDs map[string]bool,
+	drfAuthByFile map[string][]drfClassAuth,
+	drfDefaultProtected bool,
+	drfDefaultEvidence string,
 ) (bool, string) {
 	// Signal 1: entity property directly on the endpoint.
 	for _, k := range authPropertyKeys {
@@ -436,16 +538,193 @@ func determineAuthCoverage(
 		}
 	}
 
-	// Signal 2: TAGGED_AS edge to auth_policy entity.
+	// Signal 2: DRF class-level authorisation. Attribute the endpoint to its
+	// enclosing ViewSet/APIView by source-line range and read that class's
+	// permission_classes / get_permissions posture. A decisive class verdict
+	// (protected OR explicitly-open) wins over the weaker file/edge signals.
+	fileClasses := drfAuthByFile[e.SourceFile]
+	if cls, ok := enclosingDRFClass(fileClasses, e.StartLine); ok {
+		if decided, hasAuth, evidence := cls.evaluate(); decided {
+			if hasAuth {
+				return true, evidence
+			}
+			// Class explicitly opts into AllowAny / empty perms → genuinely
+			// open. Do NOT fall through to weaker signals or the global
+			// default; an explicit class-level AllowAny overrides the default.
+			return false, ""
+		}
+		// Class present but carried no explicit permission signal → fall
+		// through to the repo-level DRF default below.
+	} else if len(fileClasses) > 0 {
+		// Router-synthesised endpoints (standard CRUD verbs) frequently carry
+		// no source line, so they cannot be attributed to an enclosing class by
+		// range. Fall back to a file-level aggregate verdict: when every DRF
+		// class in the file agrees on a posture we can apply it confidently.
+		if decided, hasAuth, evidence := fileDRFVerdict(fileClasses); decided {
+			if hasAuth {
+				return true, evidence
+			}
+			return false, ""
+		}
+	}
+
+	// Signal 3: TAGGED_AS edge to auth_policy entity.
 	if taggedAuthIDs[e.ID] {
 		return true, "TAGGED_AS auth_policy"
 	}
 
-	// Signal 3: an auth_policy entity shares the same source file.
+	// Signal 4: an auth_policy entity shares the same source file.
 	if evidences, ok := authByFile[e.SourceFile]; ok && len(evidences) > 0 {
 		return true, "file-level: " + strings.Join(deduplicateStrings(evidences), ", ")
 	}
 
+	// Signal 5: repo-wide DRF default permission policy. An endpoint with no
+	// explicit per-method/class permission inherits REST_FRAMEWORK's
+	// DEFAULT_PERMISSION_CLASSES; when that default is protective every
+	// otherwise-unmarked DRF endpoint is covered. Only applied to Python DRF
+	// endpoints (those whose enclosing source file participates in the DRF
+	// class index, or where the repo declares a protective default).
+	if drfDefaultProtected && isLikelyDRFEndpoint(e) {
+		return true, drfDefaultEvidence
+	}
+
+	return false, ""
+}
+
+// isLikelyDRFEndpoint reports whether an http endpoint entity originates from a
+// Python DRF view (so the repo-wide DEFAULT_PERMISSION_CLASSES applies to it).
+// We gate on the .py source suffix to avoid leaking a Python global default
+// onto endpoints from other languages/frameworks in a polyglot repo.
+func isLikelyDRFEndpoint(e *graph.Entity) bool {
+	if e.Language == "python" {
+		return true
+	}
+	return strings.HasSuffix(e.SourceFile, ".py")
+}
+
+// enclosingDRFClass returns the DRF class whose [startLine, endLine] range
+// contains line, preferring the innermost (smallest) range when nested. The
+// boolean is false when no class in classes contains line.
+func enclosingDRFClass(classes []drfClassAuth, line int) (drfClassAuth, bool) {
+	var best drfClassAuth
+	found := false
+	for _, c := range classes {
+		if c.startLine == 0 || line == 0 {
+			continue
+		}
+		// endLine may be 0 for malformed/partial entities — treat as unbounded.
+		within := line >= c.startLine && (c.endLine == 0 || line <= c.endLine)
+		if !within {
+			continue
+		}
+		if !found || (c.startLine >= best.startLine && rangeSize(c) <= rangeSize(best)) {
+			best = c
+			found = true
+		}
+	}
+	return best, found
+}
+
+// fileDRFVerdict computes an aggregate authorisation verdict for a source file
+// from the postures of all DRF classes it declares. Used for endpoints that
+// carry no source line (router-synthesised CRUD verbs) and therefore cannot be
+// attributed to a single enclosing class by range.
+//
+// Verdict rules:
+//   - at least one class is decisively protected AND none is decisively open →
+//     protected (the common single-ViewSet-per-file case, and files where all
+//     ViewSets gate access).
+//   - at least one class is decisively open AND none is decisively protected →
+//     open (e.g. auth_viewset.py: all AllowAny login/register endpoints).
+//   - mixed (some open, some protected) → undecided (decided=false): the file
+//     hosts both public and protected ViewSets, so a line-less endpoint cannot
+//     be safely attributed; the caller falls back to the repo default.
+//   - no class carries a decisive posture → undecided.
+func fileDRFVerdict(classes []drfClassAuth) (decided, hasAuth bool, evidence string) {
+	var anyProtected, anyOpen bool
+	var protectedEvidence string
+	for _, c := range classes {
+		d, ha, ev := c.evaluate()
+		if !d {
+			continue
+		}
+		if ha {
+			anyProtected = true
+			if protectedEvidence == "" {
+				protectedEvidence = ev
+			}
+		} else {
+			anyOpen = true
+		}
+	}
+	switch {
+	case anyProtected && !anyOpen:
+		return true, true, protectedEvidence
+	case anyOpen && !anyProtected:
+		return true, false, ""
+	default:
+		// mixed or no decisive posture
+		return false, false, ""
+	}
+}
+
+// rangeSize returns the line span of a class (large when unbounded).
+func rangeSize(c drfClassAuth) int {
+	if c.endLine == 0 {
+		return 1 << 30
+	}
+	return c.endLine - c.startLine
+}
+
+// buildDRFClassAuthByFile indexes every Python class entity that carries a
+// DRF class-level authorisation property, grouped by source file. These
+// properties are stamped by the python extractor's applyDRFPermissionProperties
+// pass (issue #2816).
+func buildDRFClassAuthByFile(doc *graph.Document) map[string][]drfClassAuth {
+	out := make(map[string][]drfClassAuth)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Properties == nil {
+			continue
+		}
+		_, hasAttr := e.Properties["has_permission_classes"]
+		_, hasGet := e.Properties["has_get_permissions"]
+		if !hasAttr && !hasGet {
+			continue
+		}
+		out[e.SourceFile] = append(out[e.SourceFile], drfClassAuth{
+			startLine:         e.StartLine,
+			endLine:           e.EndLine,
+			hasPermAttr:       hasAttr,
+			permClasses:       e.Properties["permission_classes"],
+			hasGetPermissions: hasGet,
+			getPermClasses:    e.Properties["get_permissions_classes"],
+		})
+	}
+	return out
+}
+
+// repoDRFDefaultPolicy inspects the repo's Django settings config_module entity
+// for the harvested REST_FRAMEWORK DEFAULT_PERMISSION_CLASSES (stamped by the
+// python config_module extractor, issue #2816) and reports whether the global
+// default protects endpoints. When the key is absent DRF's built-in default is
+// AllowAny → not protected.
+func repoDRFDefaultPolicy(doc *graph.Document) (protected bool, evidence string) {
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Properties == nil {
+			continue
+		}
+		if e.Properties["drf_default_permission_present"] != "true" {
+			continue
+		}
+		if prot, name := isProtectivePermissionList(e.Properties["drf_default_permission_classes"]); prot {
+			return true, "DRF default permission: " + name
+		}
+		// Present but AllowAny/empty default → explicitly open. A later
+		// settings module won't override an explicit open default, so keep
+		// scanning only for a protective one.
+	}
 	return false, ""
 }
 

--- a/internal/mcp/auth_coverage_test.go
+++ b/internal/mcp/auth_coverage_test.go
@@ -468,6 +468,204 @@ func TestAuthCoverage_IDORRiskDetection(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// DRF class-level / default-permission detection (#2816)
+// ---------------------------------------------------------------------------
+
+// drfViewClass builds a View entity carrying the permission properties stamped
+// by the python extractor's applyDRFPermissionProperties pass.
+func drfViewClass(id, name, file string, start, end int, props map[string]string) graph.Entity {
+	return graph.Entity{
+		ID: id, Name: name, Kind: "View", Subtype: "class",
+		SourceFile: file, StartLine: start, EndLine: end,
+		Language: "python", Properties: props,
+	}
+}
+
+func drfEndpoint(id, name, file, verb, path string, line int) graph.Entity {
+	return graph.Entity{
+		ID: id, Name: name, Kind: "http_endpoint_definition",
+		SourceFile: file, StartLine: line, Language: "python",
+		Properties: map[string]string{"verb": verb, "path": path},
+	}
+}
+
+func TestAuthCoverage_DRFClassPermissionClasses_Protected(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Entities: []graph.Entity{
+		drfViewClass("cls", "BuildingViewSet", "views/building.py", 10, 100,
+			map[string]string{"has_permission_classes": "true", "permission_classes": "IsAuthenticated"}),
+		drfEndpoint("ep", "list", "views/building.py", "GET", "/buildings", 20),
+	}}
+	s := newTestServer(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	ep := endpointsByID(t, out)["ep"]
+	if hasAuth, _ := ep["has_auth"].(bool); !hasAuth {
+		t.Errorf("class-level permission_classes=[IsAuthenticated] should yield has_auth=true; evidence=%v", ep["auth_evidence"])
+	}
+}
+
+func TestAuthCoverage_DRFClassPermissionClasses_AllowAnyOpen(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Entities: []graph.Entity{
+		drfViewClass("cls", "LoginViewSet", "views/auth.py", 10, 50,
+			map[string]string{"has_permission_classes": "true", "permission_classes": "AllowAny"}),
+		// register is a sensitive op so it would be error severity if uncovered.
+		drfEndpoint("ep", "register", "views/auth.py", "POST", "/auth/register", 20),
+	}}
+	s := newTestServer(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	ep := endpointsByID(t, out)["ep"]
+	if hasAuth, _ := ep["has_auth"].(bool); hasAuth {
+		t.Errorf("permission_classes=[AllowAny] should be recognised as genuinely public (has_auth=false)")
+	}
+}
+
+func TestAuthCoverage_DRFGetPermissions_Protected(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Entities: []graph.Entity{
+		drfViewClass("cls", "UserViewSet", "views/user.py", 10, 200,
+			map[string]string{"has_get_permissions": "true", "get_permissions_classes": "IsAuthenticated,CustomActionPermissionCheck"}),
+		drfEndpoint("ep", "list", "views/user.py", "GET", "/users", 30),
+	}}
+	s := newTestServer(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	ep := endpointsByID(t, out)["ep"]
+	if hasAuth, _ := ep["has_auth"].(bool); !hasAuth {
+		t.Errorf("get_permissions referencing IsAuthenticated should yield has_auth=true")
+	}
+}
+
+// Router-synthesised endpoints carry no source line (StartLine==0); they must
+// be covered via the file-level aggregate verdict when the file's sole ViewSet
+// is protected.
+func TestAuthCoverage_DRFLineLessEndpoint_FileLevelFallback(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Entities: []graph.Entity{
+		drfViewClass("cls", "UserViewSet", "views/user.py", 10, 200,
+			map[string]string{"has_get_permissions": "true", "get_permissions_classes": "IsAuthenticated"}),
+		drfEndpoint("ep", "http:PUT:/users/{pk}", "views/user.py", "PUT", "/users/{pk}", 0),
+	}}
+	s := newTestServer(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	ep := endpointsByID(t, out)["ep"]
+	if hasAuth, _ := ep["has_auth"].(bool); !hasAuth {
+		t.Errorf("line-less router endpoint should inherit the file's sole protected ViewSet verdict")
+	}
+}
+
+// A file with BOTH an open and a protected ViewSet cannot attribute a line-less
+// endpoint, so the file-level fallback must NOT decide (undecided → falls
+// through to the repo default, which is open here).
+func TestAuthCoverage_DRFLineLessEndpoint_MixedFileUndecided(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Entities: []graph.Entity{
+		drfViewClass("cls_open", "PublicViewSet", "views/mixed.py", 10, 100,
+			map[string]string{"has_permission_classes": "true", "permission_classes": "AllowAny"}),
+		drfViewClass("cls_prot", "PrivateViewSet", "views/mixed.py", 110, 200,
+			map[string]string{"has_permission_classes": "true", "permission_classes": "IsAuthenticated"}),
+		drfEndpoint("ep", "http:PUT:/thing/{pk}", "views/mixed.py", "PUT", "/thing/{pk}", 0),
+	}}
+	s := newTestServer(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	ep := endpointsByID(t, out)["ep"]
+	if hasAuth, _ := ep["has_auth"].(bool); hasAuth {
+		t.Errorf("mixed-file line-less endpoint must remain undecided (no protective repo default), got has_auth=true")
+	}
+}
+
+// An endpoint inside the protected ViewSet's range is covered even when the
+// same file also hosts an AllowAny ViewSet (range attribution beats the
+// undecided file aggregate).
+func TestAuthCoverage_DRFMixedFile_RangeAttribution(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Entities: []graph.Entity{
+		drfViewClass("cls_open", "PublicViewSet", "views/mixed.py", 10, 100,
+			map[string]string{"has_permission_classes": "true", "permission_classes": "AllowAny"}),
+		drfViewClass("cls_prot", "PrivateViewSet", "views/mixed.py", 110, 200,
+			map[string]string{"has_permission_classes": "true", "permission_classes": "IsAuthenticated"}),
+		drfEndpoint("ep_open", "open", "views/mixed.py", "POST", "/public", 30),
+		drfEndpoint("ep_prot", "prot", "views/mixed.py", "GET", "/private", 130),
+	}}
+	s := newTestServer(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps := endpointsByID(t, out)
+	if hasAuth, _ := eps["ep_open"]["has_auth"].(bool); hasAuth {
+		t.Errorf("ep_open (inside AllowAny ViewSet range) should be open")
+	}
+	if hasAuth, _ := eps["ep_prot"]["has_auth"].(bool); !hasAuth {
+		t.Errorf("ep_prot (inside IsAuthenticated ViewSet range) should be covered")
+	}
+}
+
+// Global REST_FRAMEWORK DEFAULT_PERMISSION_CLASSES covers endpoints with no
+// explicit class/method auth signal.
+func TestAuthCoverage_DRFGlobalDefault_Protected(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Entities: []graph.Entity{
+		{
+			ID: "settings", Name: "settings", Kind: "SCOPE.Config", Subtype: "config_module",
+			SourceFile: "proj/settings.py", Language: "python",
+			Properties: map[string]string{
+				"config_type":                    "django_settings",
+				"drf_default_permission_present": "true",
+				"drf_default_permission_classes": "IsAuthenticated",
+			},
+		},
+		// No View entity / no permission props → relies purely on the global default.
+		drfEndpoint("ep", "list", "views/plain.py", "GET", "/plain", 10),
+	}}
+	s := newTestServer(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	ep := endpointsByID(t, out)["ep"]
+	if hasAuth, _ := ep["has_auth"].(bool); !hasAuth {
+		t.Errorf("global DEFAULT_PERMISSION_CLASSES=[IsAuthenticated] should cover unmarked DRF endpoints; evidence=%v", ep["auth_evidence"])
+	}
+}
+
+func TestAuthCoverage_DRFGlobalDefault_AllowAnyOpen(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Entities: []graph.Entity{
+		{
+			ID: "settings", Name: "settings", Kind: "SCOPE.Config", Subtype: "config_module",
+			SourceFile: "proj/settings.py", Language: "python",
+			Properties: map[string]string{
+				"config_type":                    "django_settings",
+				"drf_default_permission_present": "true",
+				"drf_default_permission_classes": "AllowAny",
+			},
+		},
+		drfEndpoint("ep", "list", "views/plain.py", "GET", "/plain", 10),
+	}}
+	s := newTestServer(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	ep := endpointsByID(t, out)["ep"]
+	if hasAuth, _ := ep["has_auth"].(bool); hasAuth {
+		t.Errorf("AllowAny global default should not cover unmarked endpoints")
+	}
+}
+
+func TestIsProtectivePermissionList(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in       string
+		wantProt bool
+	}{
+		{"IsAuthenticated", true},
+		{"AllowAny", false},
+		{"", false},
+		{"AllowAny,IsAuthenticated", true},
+		{"IsAuthenticated,CustomActionPermissionCheck", true},
+		{"AllowAny,AllowAny", false},
+	}
+	for _, tc := range cases {
+		got, _ := isProtectivePermissionList(tc.in)
+		if got != tc.wantProt {
+			t.Errorf("isProtectivePermissionList(%q) = %v, want %v", tc.in, got, tc.wantProt)
+		}
+	}
+}
+
 func TestAuthCoverage_SeverityOrdering(t *testing.T) {
 	t.Parallel()
 	// Errors must appear before warns, warns before infos.

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -402,11 +402,30 @@ records:
           verified_at: "2026-05-28"
       Security:
         auth_coverage:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/python/django_drf_actions.go
               functions: [parseActionKwargs, scanClassBodyForActions]
-          issues_implemented: []
+            - file: internal/extractors/python/django_drf_permissions.go
+              functions:
+                - applyDRFPermissionProperties
+                - getPermissionsReferencedClasses
+                - collectPermissionAssignments
+                - permissionLeafName
+            - file: internal/extractors/python/config_module.go
+              functions: [extractDRFDefaultPermissionClasses, dictDefaultPermissionClasses]
+            - file: internal/mcp/auth_coverage.go
+              functions:
+                - determineAuthCoverage
+                - buildDRFClassAuthByFile
+                - repoDRFDefaultPolicy
+                - enclosingDRFClass
+                - fileDRFVerdict
+                - isProtectivePermissionList
+          tests:
+            - file: internal/extractors/python/django_drf_permissions_test.go
+            - file: internal/mcp/auth_coverage_test.go
+          issues_implemented: ["2816"]
           verified_at: "2026-05-28"
       Substrate:
         constant_propagation:


### PR DESCRIPTION
## Summary
`archigraph_auth_coverage` detected DRF auth only via per-method
`@action(permission_classes=...)` decorators, so a mature DRF app
(upvate-core) reported **0% coverage / 499 uncovered / 79 error-severity** — a
detection bug, not 499 open endpoints. A security surface that cries wolf at
100% is worse than none.

This change recognises DRF authorisation at every level and distinguishes
genuinely-public endpoints from inherited-default-protected ones:

- **Class-level** `permission_classes = [...]` on the ViewSet/APIView
- **`get_permissions()`** dynamic overrides
- **Global** `REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES']` from settings
- **AllowAny / empty perms** → recognised as genuinely public (login/register
  stay correctly flagged as the truly-open endpoints), so the default does not
  mask intentional public surface.

### How
- **Extractor** (`internal/extractors/python/django_drf_permissions.go`): stamps
  `has_permission_classes` / `permission_classes` / `has_get_permissions` /
  `get_permissions_classes` onto the ViewSet entity. `config_module.go` harvests
  `DEFAULT_PERMISSION_CLASSES` from the settings `REST_FRAMEWORK` dict
  (`drf_default_permission_present` / `drf_default_permission_classes`).
- **Detector** (`internal/mcp/auth_coverage.go`): attributes each endpoint to
  its enclosing ViewSet by source-line range; explicit class verdict (protected
  OR AllowAny) wins over weaker file/edge signals. Router-synthesised CRUD
  endpoints (no source line) use a file-level aggregate verdict; mixed-posture
  files stay undecided and fall back to the repo default.

implements-capability: lang.python.framework.django-drf/auth_coverage (full, #2816)

## Verification (real data — upvate-core, isolated daemon)
| metric | before | after |
|---|---|---|
| overall coverage | 0% | **85.2%** (425/499) |
| default policy | default-allow | **default-deny** |
| error-severity | 79 | **9** |

Spot-checks:
- **Protected** — `BuildingViewSet`, `UserViewSet`, `ContractingCompanyViewSet`
  → covered via `DRF get_permissions: IsAuthenticated`.
- **Public** — `LoginViewSet` / register / reset_password / update_password
  (`permission_classes = (AllowAny,)`) → correctly NOT covered (the truly-open
  endpoints, not all 499). `SyncGroupsViewSet` (AllowAny) → open.
- Remaining 74 uncovered are ViewSets with no DRF-level auth (upvate has no
  `DEFAULT_PERMISSION_CLASSES`; they rely on a WSGI middleware) — accurate gaps.

Daemon discipline: shared :47274 daemon untouched; verified against a local
build on an isolated `ARCHIGRAPH_DAEMON_ROOT` + port 47999, queried via
`mcp-bridge`.

## Test plan
- [x] `go test ./internal/extractors/python/` (new `django_drf_permissions_test.go`)
- [x] `go test ./internal/mcp/` (new DRF cases in `auth_coverage_test.go`)
- [x] `go test ./tools/coverage/`
- [x] `go run ./tools/coverage gen` + `validate` clean; coverage matrix updated
- [x] self-rebased on origin/main (clean), gofmt + go vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)