### PR TITLE
fix(types): register/remap assembly SCOPE.Constant kind (#2839)

### DIFF
--- a/internal/extractors/assembly/extractor.go
+++ b/internal/extractors/assembly/extractor.go
@@ -403,7 +403,7 @@ func buildConstantEntities(scrubbed, filePath, lang string) []types.EntityRecord
 		seen[name] = true
 		out = append(out, types.EntityRecord{
 			Name:       name,
-			Kind:       "SCOPE.Constant",
+			Kind:       string(types.EntityKindConstant),
 			Subtype:    "equate",
 			SourceFile: filePath,
 			Language:   lang,

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -41,6 +41,14 @@ const (
 	EntityKindProject  EntityKind = "SCOPE.Project"
 	EntityKindConfig   EntityKind = "SCOPE.Config"
 	EntityKindModel    EntityKind = "SCOPE.Model"
+
+	// #2839: Named constant declarations (e.g. assembly equ/const directives).
+	// Registered as a first-class kind so producers across all low-level
+	// languages can emit constant symbols without reusing SCOPE.Schema (which
+	// carries "data type / field" semantics). Subtype "equate" is used by the
+	// assembly extractor; future producers may use other subtypes (e.g. "define"
+	// for C preprocessor macros, "const" for Zig/Rust compile-time constants).
+	EntityKindConstant EntityKind = "SCOPE.Constant"
 	// AgentPattern is the kind for agent-learned Pattern entities introduced
 	// in ADR-0018. Stored as "AgentPattern" (no SCOPE. prefix) to distinguish
 	// from the structural SCOPE.Pattern kind used by static-analysis extractors.
@@ -157,6 +165,8 @@ func AllEntityKinds() []EntityKind {
 		EntityKindProject,
 		EntityKindConfig,
 		EntityKindModel,
+		// #2839:
+		EntityKindConstant,
 		EntityKindAgentPattern,
 		// #1884:
 		EntityKindModule,


### PR DESCRIPTION
## Summary

- Adds `EntityKindConstant EntityKind = "SCOPE.Constant"` to `internal/types/kinds.go` and `AllEntityKinds`, registering it as a first-class kind.
- Updates `internal/extractors/assembly/extractor.go:406` to reference the typed `types.EntityKindConstant` constant instead of the free-form string literal `"SCOPE.Constant"`.
- Fixes `TestProducerKindLiterals_AreValid` which was failing on `origin/main` because the assembly extractor emitted an unregistered kind.

**Option chosen: Register (Option B)** — `SCOPE.Constant` is a semantically distinct concept from `SCOPE.Schema` (which covers data types/fields). Assembly `equ`/`const` directives are named symbolic constants, not type schemas. The extractor test fixture already asserted `Kind == "SCOPE.Constant"`, and the kind is useful corpus-wide for future producers (C `#define`, Zig/Rust `const`, etc.).

## Test plan

- [x] `go test ./internal/types/` — GREEN (`TestProducerKindLiterals_AreValid` passes)
- [x] `go test ./internal/extractors/assembly/` — GREEN (fixtures still extract correctly)
- [x] `go build ./...` — clean
- [x] `go run ./tools/coverage gen` — no unexpected diff (545 records generated)

Closes #2839.

🤖 Generated with [Claude Code](https://claude.com/claude-code)