### PR TITLE
feat(cobol): copybook resolution + embedded-SQL/CICS depth (#2838 Phase 2)

### DIFF
--- a/docs/coverage/by-category/language.md
+++ b/docs/coverage/by-category/language.md
@@ -7,7 +7,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 
 | Language | Name | Call Line Precision | Core Extraction | Db Effect | Discriminates On | Fs Effect | HTTP Effect | Import Resolution Quality | Navigates To | Status | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| [COBOL](../by-language/cobol.md) | [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | — | — | — | — | — | ⚠️ | — | — | ⚠️ | |
+| [COBOL](../by-language/cobol.md) | [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | — | — | — | — | ✅ | ✅ | — | — | ✅ | |
 | [COBOL](../by-language/cobol.md) | [COBOL Embedded DB2 SQL](../detail/lang.cobol.embedded.db2-sql.md) | — | — | ✅ | — | — | — | — | — | ✅ | |
-| [COBOL](../by-language/cobol.md) | [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | ✅ | ✅ | — | — | — | — | ⚠️ | — | ⚠️ | |
-| [COBOL](../by-language/cobol.md) | [IBM Enterprise COBOL](../detail/lang.cobol.runtime.ibm-enterprise.md) | ✅ | ✅ | ⚠️ | — | ⚠️ | — | ⚠️ | — | ⚠️ | |
+| [COBOL](../by-language/cobol.md) | [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | ✅ | ✅ | — | — | — | — | ✅ | — | ✅ | |
+| [COBOL](../by-language/cobol.md) | [IBM Enterprise COBOL](../detail/lang.cobol.runtime.ibm-enterprise.md) | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ | — | ✅ | |

--- a/docs/coverage/by-language/cobol.md
+++ b/docs/coverage/by-language/cobol.md
@@ -9,7 +9,7 @@ Back to [summary](../summary.md).
 
 | Name | Category | Status | Notes |
 |---|---|---|---|
-| [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | [language](../by-category/language.md) | ⚠️ | |
+| [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | [language](../by-category/language.md) | ✅ | |
 | [COBOL Embedded DB2 SQL](../detail/lang.cobol.embedded.db2-sql.md) | [language](../by-category/language.md) | ✅ | |
-| [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | [language](../by-category/language.md) | ⚠️ | |
-| [IBM Enterprise COBOL](../detail/lang.cobol.runtime.ibm-enterprise.md) | [language](../by-category/language.md) | ⚠️ | |
+| [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | [language](../by-category/language.md) | ✅ | |
+| [IBM Enterprise COBOL](../detail/lang.cobol.runtime.ibm-enterprise.md) | [language](../by-category/language.md) | ✅ | |

--- a/docs/coverage/detail/lang.cobol.embedded.cics.md
+++ b/docs/coverage/detail/lang.cobol.embedded.cics.md
@@ -5,13 +5,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [COBOL](../by-language/cobol.md)
 - **Category:** [language](../by-category/language.md)
-- **Capability cells:** 1
+- **Capability cells:** 2
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `http_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](2743) | `internal/substrate/effect_sinks_cobol.go` | — |
+| `fs_effect` | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/substrate/effect_sinks_cobol.go` | — |
+| `http_effect` | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/substrate/effect_sinks_cobol.go`<br>`internal/extractors/cobol/depth.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.cobol.embedded.db2-sql.md
+++ b/docs/coverage/detail/lang.cobol.embedded.db2-sql.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `db_effect` | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/substrate/effect_sinks_cobol.go` | — |
+| `db_effect` | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/substrate/effect_sinks_cobol.go`<br>`internal/extractors/cobol/depth.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.cobol.runtime.gnucobol.md
+++ b/docs/coverage/detail/lang.cobol.runtime.gnucobol.md
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `call_line_precision` | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/extractors/cobol/extractor.go` | — |
 | `core_extraction` | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/classifier/classifier.go`<br>`internal/extractors/cobol/extractor.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | [link](2743) | `internal/extractors/cobol/extractor.go` | — |
+| `import_resolution_quality` | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/extractors/cobol/extractor.go`<br>`internal/extractors/cobol/depth.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.cobol.runtime.ibm-enterprise.md
+++ b/docs/coverage/detail/lang.cobol.runtime.ibm-enterprise.md
@@ -5,7 +5,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [COBOL](../by-language/cobol.md)
 - **Category:** [language](../by-category/language.md)
-- **Capability cells:** 5
+- **Capability cells:** 6
 
 ## Capabilities
 
@@ -13,9 +13,10 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `call_line_precision` | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/extractors/cobol/extractor.go` | — |
 | `core_extraction` | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/classifier/classifier.go`<br>`internal/extractors/cobol/extractor.go` | — |
-| `db_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](2743) | `internal/substrate/effect_sinks_cobol.go` | — |
-| `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | [link](2743) | `internal/substrate/effect_sinks_cobol.go` | — |
-| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | [link](2743) | `internal/extractors/cobol/extractor.go` | — |
+| `db_effect` | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/substrate/effect_sinks_cobol.go`<br>`internal/extractors/cobol/depth.go` | — |
+| `fs_effect` | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/substrate/effect_sinks_cobol.go` | — |
+| `http_effect` | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/substrate/effect_sinks_cobol.go`<br>`internal/extractors/cobol/depth.go` | — |
+| `import_resolution_quality` | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/extractors/cobol/extractor.go`<br>`internal/extractors/cobol/depth.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -4950,11 +4950,20 @@
       "label": "COBOL CICS",
       "capabilities": {
         "http_effect": {
-          "status": "partial",
+          "status": "full",
+          "cites": [
+            "internal/substrate/effect_sinks_cobol.go",
+            "internal/extractors/cobol/depth.go"
+          ],
+          "issue": "2838",
+          "verified_at": "2026-05-28"
+        },
+        "fs_effect": {
+          "status": "full",
           "cites": [
             "internal/substrate/effect_sinks_cobol.go"
           ],
-          "issue": "2743",
+          "issue": "2838",
           "verified_at": "2026-05-28"
         }
       }
@@ -4968,9 +4977,10 @@
         "db_effect": {
           "status": "full",
           "cites": [
-            "internal/substrate/effect_sinks_cobol.go"
+            "internal/substrate/effect_sinks_cobol.go",
+            "internal/extractors/cobol/depth.go"
           ],
-          "issue": "2743",
+          "issue": "2838",
           "verified_at": "2026-05-28"
         }
       }
@@ -4999,11 +5009,12 @@
           "verified_at": "2026-05-28"
         },
         "import_resolution_quality": {
-          "status": "partial",
+          "status": "full",
           "cites": [
-            "internal/extractors/cobol/extractor.go"
+            "internal/extractors/cobol/extractor.go",
+            "internal/extractors/cobol/depth.go"
           ],
-          "issue": "2743",
+          "issue": "2838",
           "verified_at": "2026-05-28"
         }
       }
@@ -5032,27 +5043,38 @@
           "verified_at": "2026-05-28"
         },
         "db_effect": {
-          "status": "partial",
+          "status": "full",
           "cites": [
-            "internal/substrate/effect_sinks_cobol.go"
+            "internal/substrate/effect_sinks_cobol.go",
+            "internal/extractors/cobol/depth.go"
           ],
-          "issue": "2743",
+          "issue": "2838",
           "verified_at": "2026-05-28"
         },
         "fs_effect": {
-          "status": "partial",
+          "status": "full",
           "cites": [
             "internal/substrate/effect_sinks_cobol.go"
           ],
-          "issue": "2743",
+          "issue": "2838",
           "verified_at": "2026-05-28"
         },
         "import_resolution_quality": {
-          "status": "partial",
+          "status": "full",
           "cites": [
-            "internal/extractors/cobol/extractor.go"
+            "internal/extractors/cobol/extractor.go",
+            "internal/extractors/cobol/depth.go"
           ],
-          "issue": "2743",
+          "issue": "2838",
+          "verified_at": "2026-05-28"
+        },
+        "http_effect": {
+          "status": "full",
+          "cites": [
+            "internal/substrate/effect_sinks_cobol.go",
+            "internal/extractors/cobol/depth.go"
+          ],
+          "issue": "2838",
           "verified_at": "2026-05-28"
         }
       }

--- a/internal/extractors/cobol/depth.go
+++ b/internal/extractors/cobol/depth.go
@@ -1,0 +1,447 @@
+// Phase-2 depth extraction for COBOL (#2838): copybook (COPY) resolution
+// against on-disk .cpy files, embedded-SQL entity extraction (tables +
+// cursors as SCOPE.DataAccess with ACCESSES_TABLE edges), EXEC CICS depth
+// (program-transfer LINK/XCTL/START as CALLS, file/queue I/O surfaced through
+// the effect sniffer), and the 01/05/10 data hierarchy with REDEFINES /
+// OCCURS as structured-field metadata.
+//
+// This file builds on extractor.go (Phase 1, #2743). Phase 1 already emits the
+// program / division / section / paragraph entities and PERFORM/CALL/COPY
+// edges; the helpers here are invoked from extractCOBOL to deepen those into
+// resolvable, drift-detectable entities.
+package cobol
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Copybook (COPY) resolution — #2838 Phase 2 item 1
+// ---------------------------------------------------------------------------
+
+// copyDirectiveRe captures a full COPY directive including an optional
+// REPLACING clause. Group 1: copybook name. The remainder (REPLACING ...) is
+// parsed separately so the bare-name copyRe in extractor.go keeps working for
+// the common case.
+//
+// Examples handled:
+//
+//	COPY EMPREC.
+//	COPY EMPREC REPLACING ==:PFX:== BY ==WS==.
+//	COPY EMPREC OF MYLIB.
+var copyDirectiveRe = regexp.MustCompile(
+	`(?i)\bCOPY\s+([A-Za-z0-9][A-Za-z0-9-]*)` +
+		`(?:\s+(?:OF|IN)\s+[A-Za-z0-9][A-Za-z0-9-]*)?` +
+		`(\s+REPLACING\b[^.]*)?`,
+)
+
+// replacingPairRe extracts ==pseudo-text== BY ==pseudo-text== pairs from a
+// REPLACING clause (also supports bare-word operands).
+var replacingPairRe = regexp.MustCompile(
+	`(?i)(==[^=]*==|[A-Za-z0-9:#$@-]+)\s+BY\s+(==[^=]*==|[A-Za-z0-9:#$@-]+)`,
+)
+
+// copybookExtensions are the conventional on-disk suffixes a COPY name may
+// resolve to, in priority order.
+var copybookExtensions = []string{".cpy", ".CPY", ".cbl", ".CBL", ".cob", ".COB", ".cobol", ""}
+
+// copyResolution is the outcome of resolving a COPY directive against disk.
+type copyResolution struct {
+	book      string // copybook name as written
+	resolved  bool   // a matching file was found on disk
+	path      string // repo-relative resolved path (when resolved)
+	replacing string // normalized REPLACING clause text (when present)
+}
+
+// resolveCopybook tries to resolve a COPY name to an on-disk copybook file,
+// searching the directory of the using program and common copybook
+// sub-directories under repoRoot. Returns resolved=false when no candidate
+// exists (the IMPORTS edge is still emitted, but as an unresolved reference).
+func resolveCopybook(repoRoot, usingFile, book string) (string, bool) {
+	if repoRoot == "" {
+		return "", false
+	}
+	// Directories to probe, relative to repoRoot, most-specific first.
+	dirs := []string{}
+	if usingFile != "" {
+		dirs = append(dirs, filepath.Dir(usingFile))
+	}
+	dirs = append(dirs,
+		"", "copybook", "copybooks", "copylib", "cpy", "include", "copy",
+	)
+	// COBOL COPY names are case-insensitive; probe both as-written and the
+	// upper-cased form (the IBM convention).
+	names := []string{book, strings.ToUpper(book), strings.ToLower(book)}
+	seen := map[string]bool{}
+	for _, d := range dirs {
+		for _, n := range names {
+			for _, ext := range copybookExtensions {
+				rel := filepath.Join(d, n+ext)
+				if seen[rel] {
+					continue
+				}
+				seen[rel] = true
+				abs := filepath.Join(repoRoot, rel)
+				if fi, err := os.Stat(abs); err == nil && !fi.IsDir() {
+					return filepath.ToSlash(rel), true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+// parseCopyDirective extracts the copybook name + a normalized REPLACING
+// clause from a COPY line. Returns ok=false when the line is not a COPY.
+func parseCopyDirective(code string) (book, replacing string, ok bool) {
+	m := copyDirectiveRe.FindStringSubmatch(code)
+	if m == nil {
+		return "", "", false
+	}
+	book = m[1]
+	if rep := strings.TrimSpace(m[2]); rep != "" {
+		// Collapse whitespace and drop the leading REPLACING keyword for a
+		// compact, comparable property value.
+		rep = strings.Join(strings.Fields(rep), " ")
+		rep = strings.TrimPrefix(rep, "REPLACING ")
+		rep = strings.TrimPrefix(rep, "replacing ")
+		replacing = rep
+	}
+	return book, replacing, true
+}
+
+// buildCopyImportEdge constructs the IMPORTS relationship for a resolved (or
+// unresolved) COPY. When the copybook resolves on disk, ToID is the resolved
+// file path so the edge binds to the copybook's file/component entity; the
+// per-name placeholder entity emitted alongside keeps the bare-name resolution
+// path working for unresolved books.
+func buildCopyImportEdge(usingFile string, cr copyResolution, line int) types.RelationshipRecord {
+	toID := cr.book
+	if cr.resolved {
+		toID = cr.path
+	}
+	props := map[string]string{
+		"line":     strconv.Itoa(line),
+		"copybook": cr.book,
+		"resolved": strconv.FormatBool(cr.resolved),
+	}
+	if cr.resolved {
+		props["copybook_path"] = cr.path
+	}
+	if cr.replacing != "" {
+		props["replacing"] = cr.replacing
+		// Record the REPLACING pairs in a structured form for drift analysis.
+		if pairs := parseReplacingPairs(cr.replacing); pairs != "" {
+			props["replacing_pairs"] = pairs
+		}
+	}
+	return types.RelationshipRecord{
+		FromID:     usingFile,
+		ToID:       toID,
+		Kind:       "IMPORTS",
+		Properties: props,
+	}
+}
+
+// parseReplacingPairs renders the REPLACING operand pairs as a compact
+// "from=>to;from=>to" string.
+func parseReplacingPairs(clause string) string {
+	var b strings.Builder
+	for _, m := range replacingPairRe.FindAllStringSubmatch(clause, -1) {
+		if b.Len() > 0 {
+			b.WriteByte(';')
+		}
+		b.WriteString(trimPseudo(m[1]))
+		b.WriteString("=>")
+		b.WriteString(trimPseudo(m[2]))
+	}
+	return b.String()
+}
+
+// trimPseudo strips the ==...== pseudo-text delimiters from a REPLACING
+// operand, leaving the inner text trimmed.
+func trimPseudo(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "==") && strings.HasSuffix(s, "==") && len(s) >= 4 {
+		return strings.TrimSpace(s[2 : len(s)-2])
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Embedded SQL (EXEC SQL ... END-EXEC) — #2838 Phase 2 item 2
+// ---------------------------------------------------------------------------
+
+// execBlock is one EXEC SQL / EXEC CICS block accumulated across lines.
+type execBlock struct {
+	kind      string // "SQL" or "CICS"
+	startLine int
+	text      string // joined block body (between EXEC <kind> and END-EXEC)
+}
+
+var (
+	execStartRe = regexp.MustCompile(`(?i)\bEXEC\s+(SQL|CICS)\b`)
+	execEndRe   = regexp.MustCompile(`(?i)\bEND-EXEC\b`)
+
+	// SQL DML / cursor patterns. Table names follow FROM / INTO / UPDATE /
+	// JOIN / DELETE FROM. Host-variable colons and schema-qualified names are
+	// tolerated.
+	sqlSelectFromRe = regexp.MustCompile(`(?is)\bFROM\s+([A-Za-z][A-Za-z0-9_$.]*)`)
+	sqlInsertIntoRe = regexp.MustCompile(`(?is)\bINSERT\s+INTO\s+([A-Za-z][A-Za-z0-9_$.]*)`)
+	sqlUpdateRe     = regexp.MustCompile(`(?is)\bUPDATE\s+([A-Za-z][A-Za-z0-9_$.]*)`)
+	sqlDeleteFromRe = regexp.MustCompile(`(?is)\bDELETE\s+FROM\s+([A-Za-z][A-Za-z0-9_$.]*)`)
+	sqlJoinRe       = regexp.MustCompile(`(?is)\bJOIN\s+([A-Za-z][A-Za-z0-9_$.]*)`)
+
+	// DECLARE <name> CURSOR FOR ... — captures the cursor name.
+	sqlDeclareCursorRe = regexp.MustCompile(`(?is)\bDECLARE\s+([A-Za-z][A-Za-z0-9_-]*)\s+CURSOR\b`)
+	// OPEN / FETCH / CLOSE <cursor> — cursor traffic.
+	sqlCursorOpRe = regexp.MustCompile(`(?is)\b(OPEN|FETCH|CLOSE)\s+([A-Za-z][A-Za-z0-9_-]*)`)
+)
+
+const (
+	// kindDataAccess mirrors the cross/dbmap extractor so embedded-SQL access
+	// entities resolve through the same ACCESSES_TABLE pipeline.
+	kindDataAccess = "SCOPE.DataAccess"
+	relAccessesTab = "ACCESSES_TABLE"
+	ormEmbeddedSQL = "embedded-sql"
+)
+
+// cursorOpReserved are keywords that OPEN/FETCH/CLOSE may be followed by but
+// which are not cursor names (so they are not turned into cursor references).
+var cursorOpReserved = map[string]bool{
+	"FOR": true, "INTO": true, "ALL": true, "CURSOR": true,
+}
+
+// sqlOpFor classifies an EXEC SQL block body into a primary DML operation.
+func sqlOpFor(body string) string {
+	up := strings.ToUpper(body)
+	switch {
+	case strings.Contains(up, "INSERT"):
+		return "INSERT"
+	case strings.Contains(up, "UPDATE"):
+		return "UPDATE"
+	case strings.Contains(up, "DELETE"):
+		return "DELETE"
+	case strings.Contains(up, "MERGE"):
+		return "UPSERT"
+	case strings.Contains(up, "SELECT"), strings.Contains(up, "FETCH"):
+		return "SELECT"
+	default:
+		return "EXEC"
+	}
+}
+
+// dataAccessRef builds a stable identity string for an embedded-SQL
+// SCOPE.DataAccess entity, matching the shape cross/dbmap uses so the resolver
+// binds the ACCESSES_TABLE edge toID to this entity.
+func dataAccessRef(filePath, op, table string) string {
+	return "scope:dataaccess:" + filepath.ToSlash(filePath) + "#" + ormEmbeddedSQL + ":" + op + ":" + table
+}
+
+// extractSQLEntities turns one EXEC SQL block into SCOPE.DataAccess entities:
+// one per referenced table, plus a cursor entity for DECLARE CURSOR. The
+// enclosing paragraph (fnRef) is the FromID of each ACCESSES_TABLE edge.
+func extractSQLEntities(filePath, fnQName string, blk execBlock) []types.EntityRecord {
+	var out []types.EntityRecord
+	op := sqlOpFor(blk.text)
+
+	// Collect referenced tables (dedup).
+	tables := map[string]bool{}
+	collect := func(re *regexp.Regexp) {
+		for _, m := range re.FindAllStringSubmatch(blk.text, -1) {
+			t := strings.TrimSuffix(m[1], ".")
+			if t != "" {
+				tables[t] = true
+			}
+		}
+	}
+	collect(sqlSelectFromRe)
+	collect(sqlInsertIntoRe)
+	collect(sqlUpdateRe)
+	collect(sqlDeleteFromRe)
+	collect(sqlJoinRe)
+
+	fnRef := sqlFunctionRef(filePath, fnQName)
+	for table := range tables {
+		ref := dataAccessRef(filePath, op, table)
+		rec := types.EntityRecord{
+			Name:          op + " " + table,
+			Kind:          kindDataAccess,
+			QualifiedName: ref,
+			SourceFile:    filePath,
+			Language:      "cobol",
+			Subtype:       ormEmbeddedSQL,
+			StartLine:     blk.startLine,
+			EndLine:       blk.startLine,
+			Properties: map[string]string{
+				"table":        table,
+				"operation":    op,
+				"orm":          ormEmbeddedSQL,
+				"ref":          ref,
+				"function_ref": fnQName,
+				"provenance":   "INFERRED_FROM_EXEC_SQL",
+			},
+			QualityScore: 0.8,
+		}
+		rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+			FromID: fnRef,
+			ToID:   ref,
+			Kind:   relAccessesTab,
+			Properties: map[string]string{
+				"function_qname": fnQName,
+				"orm":            ormEmbeddedSQL,
+				"operation":      op,
+				"table":          table,
+			},
+		})
+		out = append(out, rec)
+	}
+
+	// DECLARE CURSOR — emit a cursor SCOPE.DataAccess entity.
+	declared := map[string]bool{}
+	for _, m := range sqlDeclareCursorRe.FindAllStringSubmatch(blk.text, -1) {
+		cursor := m[1]
+		declared[strings.ToUpper(cursor)] = true
+		ref := cursorRef(filePath, cursor)
+		out = append(out, types.EntityRecord{
+			Name:          cursor,
+			Kind:          kindDataAccess,
+			QualifiedName: ref,
+			SourceFile:    filePath,
+			Language:      "cobol",
+			Subtype:       "cursor",
+			StartLine:     blk.startLine,
+			EndLine:       blk.startLine,
+			Properties: map[string]string{
+				"cursor":     cursor,
+				"operation":  "DECLARE_CURSOR",
+				"orm":        ormEmbeddedSQL,
+				"ref":        ref,
+				"provenance": "INFERRED_FROM_EXEC_SQL",
+			},
+			QualityScore: 0.8,
+		})
+	}
+
+	// OPEN / FETCH / CLOSE <cursor> — emit a REFERENCES edge from the
+	// enclosing paragraph to the cursor entity so cursor traffic is part of
+	// the data-access graph (deduped per cursor+op).
+	seenCursorOp := map[string]bool{}
+	for _, m := range sqlCursorOpRe.FindAllStringSubmatch(blk.text, -1) {
+		verb := strings.ToUpper(m[1])
+		cursor := m[2]
+		if cursorOpReserved[strings.ToUpper(cursor)] {
+			continue
+		}
+		// DECLARE itself is handled above; skip the DECLARE-line OPEN noise.
+		key := verb + ":" + strings.ToUpper(cursor)
+		if seenCursorOp[key] {
+			continue
+		}
+		seenCursorOp[key] = true
+		out = append(out, types.EntityRecord{
+			Name:          verb + " " + cursor,
+			Kind:          kindDataAccess,
+			QualifiedName: cursorRef(filePath, cursor) + ":" + verb,
+			SourceFile:    filePath,
+			Language:      "cobol",
+			Subtype:       "cursor",
+			StartLine:     blk.startLine,
+			EndLine:       blk.startLine,
+			Properties: map[string]string{
+				"cursor":       cursor,
+				"operation":    verb,
+				"orm":          ormEmbeddedSQL,
+				"function_ref": fnQName,
+				"provenance":   "INFERRED_FROM_EXEC_SQL",
+			},
+			Relationships: []types.RelationshipRecord{{
+				FromID:     fnRef,
+				ToID:       cursorRef(filePath, cursor),
+				Kind:       "REFERENCES",
+				Properties: map[string]string{"cursor": cursor, "operation": verb},
+			}},
+			QualityScore: 0.75,
+		})
+	}
+
+	return out
+}
+
+// cursorRef builds a stable identity for a cursor SCOPE.DataAccess entity.
+func cursorRef(filePath, cursor string) string {
+	return "scope:dataaccess:" + filepath.ToSlash(filePath) + "#cursor:" + cursor
+}
+
+// sqlFunctionRef builds the Format A operation ref for the enclosing paragraph
+// so the ACCESSES_TABLE edge resolves to the paragraph entity.
+func sqlFunctionRef(filePath, fnQName string) string {
+	if fnQName == "" {
+		return "scope:operation:" + filepath.ToSlash(filePath) + "#_file_scope"
+	}
+	return extractor.BuildOperationStructuralRef("cobol", filePath, fnQName)
+}
+
+// ---------------------------------------------------------------------------
+// EXEC CICS depth — #2838 Phase 2 item 3
+// ---------------------------------------------------------------------------
+
+// cicsXferRe matches CICS program-transfer verbs and captures the target
+// program name from the PROGRAM('NAME') operand. LINK / XCTL transfer control
+// to another program; START schedules a transaction.
+var cicsXferRe = regexp.MustCompile(
+	`(?is)\b(LINK|XCTL)\b[^.]*?\bPROGRAM\s*\(\s*'?([A-Za-z0-9$#@][A-Za-z0-9$#@_-]*)'?\s*\)`,
+)
+
+// cicsStartRe matches CICS START TRANSID('TRAN') — schedules a transaction.
+var cicsStartRe = regexp.MustCompile(
+	`(?is)\bSTART\b[^.]*?\bTRANSID\s*\(\s*'?([A-Za-z0-9$#@][A-Za-z0-9$#@_-]*)'?\s*\)`,
+)
+
+// cicsCmd is a detected CICS command with its transfer target (if any).
+type cicsCmd struct {
+	verb    string // LINK | XCTL | START
+	target  string // program (LINK/XCTL) or transid (START)
+	transid bool   // true when target is a TRANSID rather than a program
+}
+
+// extractCICSTransfers scans a CICS block body for program-transfer commands
+// and returns CALLS targets. LINK/XCTL → external program CALLS; START
+// TRANSID → external transaction CALLS.
+func extractCICSTransfers(body string) []cicsCmd {
+	var out []cicsCmd
+	for _, m := range cicsXferRe.FindAllStringSubmatch(body, -1) {
+		out = append(out, cicsCmd{verb: strings.ToUpper(m[1]), target: m[2]})
+	}
+	for _, m := range cicsStartRe.FindAllStringSubmatch(body, -1) {
+		out = append(out, cicsCmd{verb: "START", target: m[1], transid: true})
+	}
+	return out
+}
+
+// cicsCallEdge builds the CALLS relationship for a CICS program/transaction
+// transfer. external=true (cross-program); via=EXEC-CICS-<VERB>.
+func cicsCallEdge(c cicsCmd, line int) types.RelationshipRecord {
+	props := map[string]string{
+		"line":     strconv.Itoa(line),
+		"via":      "EXEC-CICS-" + c.verb,
+		"external": "true",
+	}
+	if c.transid {
+		props["transid"] = c.target
+	} else {
+		props["program"] = c.target
+	}
+	return types.RelationshipRecord{
+		ToID:       c.target,
+		Kind:       "CALLS",
+		Properties: props,
+	}
+}

--- a/internal/extractors/cobol/extractor.go
+++ b/internal/extractors/cobol/extractor.go
@@ -23,7 +23,7 @@
 //   - CALLS    — PERFORM <paragraph> (intra-program control flow)
 //   - CALLS    — CALL '<program>' (inter-program dynamic call; external=true)
 //   - IMPORTS  — COPY <copybook> (.cpy copybook inclusion — the COBOL analog
-//                of #include / import)
+//     of #include / import)
 //   - CONTAINS — program → its paragraphs (Format A structural ref)
 //
 // COBOL column sensitivity is respected for fixed-format source: columns
@@ -92,13 +92,16 @@ var (
 	// variable holding the program name). Group 1: identifier.
 	callIdentRe = regexp.MustCompile(`(?i)\bCALL\s+([A-Za-z][A-Za-z0-9-]*)`)
 
-	// copyRe matches `COPY <copybook>` directives (optionally `COPY name.`).
-	// Group 1: copybook name.
-	copyRe = regexp.MustCompile(`(?i)\bCOPY\s+([A-Za-z0-9][A-Za-z0-9-]*)`)
-
 	// dataItemRe matches level-numbered data items, e.g. `01 CUSTOMER-REC.`
 	// or `05 CUST-ID PIC X(10).`. Group 1: level number; Group 2: item name.
 	dataItemRe = regexp.MustCompile(`(?i)^\s*(0[1-9]|[1-4][0-9]|66|77|88)\s+([A-Za-z0-9][A-Za-z0-9-]*)`)
+
+	// dataRedefinesRe captures the REDEFINES target on a data item.
+	dataRedefinesRe = regexp.MustCompile(`\bREDEFINES\s+([A-Za-z][A-Za-z0-9-]*)`)
+	// dataOccursRe captures the OCCURS count (array dimension).
+	dataOccursRe = regexp.MustCompile(`\bOCCURS\s+([0-9]+)`)
+	// dataPicRe captures the PICTURE clause string (PIC / PICTURE).
+	dataPicRe = regexp.MustCompile(`\bPIC(?:TURE)?\s+(?:IS\s+)?([A-Z0-9()VSX$.,/+\-]+)`)
 
 	// paragraphRe matches a PROCEDURE DIVISION paragraph header: an
 	// identifier in Area A terminated by a period, alone on the line.
@@ -141,7 +144,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	if len(file.Content) == 0 {
 		return nil, nil
 	}
-	out := extractCOBOL(string(file.Content), file.Path)
+	out := extractCOBOL(string(file.Content), file.Path, file.RepoRoot)
 	extractor.TagRelationshipsLanguage(out, "cobol")
 	extractor.TagEntitiesLanguage(out, "cobol")
 	return out, nil
@@ -228,7 +231,7 @@ func splitLines(src string) []codeLine {
 // Core extraction
 // ---------------------------------------------------------------------------
 
-func extractCOBOL(src, filePath string) []types.EntityRecord {
+func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 	lines := splitLines(src)
 	var entities []types.EntityRecord
 
@@ -250,9 +253,53 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 	// edges discovered while scanning paragraph bodies.
 	currentParagraphIdx := -1
 
+	// currentParagraphName tracks the open paragraph's name so embedded-SQL
+	// access entities can be attributed to it (the ACCESSES_TABLE FromID).
+	currentParagraphName := ""
+
+	// EXEC SQL / EXEC CICS block accumulation (#2838 Phase 2). A block may
+	// span many lines; we buffer its body until END-EXEC, then extract.
+	var execBuf *execBlock
+
+	// Data-hierarchy tracking: a stack of (level, entity index) so 05/10 items
+	// can record their parent group via a CONTAINS edge and a parent property.
+	type dataScope struct {
+		level int
+		idx   int
+	}
+	var dataStack []dataScope
+
 	addProgramRel := func(rel types.RelationshipRecord) {
 		if programIdx >= 0 {
 			entities[programIdx].Relationships = append(entities[programIdx].Relationships, rel)
+		}
+	}
+
+	// fnRefName returns the qualified name used to attribute embedded-SQL /
+	// CICS effects: the open paragraph, else the program name.
+	fnRefName := func() string {
+		if currentParagraphName != "" {
+			return currentParagraphName
+		}
+		return programName
+	}
+
+	// flushExecBlock processes a completed EXEC SQL / CICS block: SQL blocks
+	// yield SCOPE.DataAccess table/cursor entities; CICS blocks yield CALLS
+	// edges for program/transaction transfers.
+	flushExecBlock := func() {
+		if execBuf == nil {
+			return
+		}
+		blk := *execBuf
+		execBuf = nil
+		switch blk.kind {
+		case "SQL":
+			entities = append(entities, extractSQLEntities(filePath, fnRefName(), blk)...)
+		case "CICS":
+			for _, c := range extractCICSTransfers(blk.text) {
+				attachCall(entities, currentParagraphIdx, programIdx, cicsCallEdge(c, blk.startLine))
+			}
 		}
 	}
 
@@ -261,11 +308,37 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 			continue
 		}
 
+		// ── EXEC SQL / EXEC CICS block accumulation ──────────────────────
+		// Buffer the body of an EXEC block across lines until END-EXEC so the
+		// full statement (multi-line in practice) is available for table /
+		// cursor / program-transfer extraction.
+		if execBuf != nil {
+			execBuf.text += " " + ln.code
+			if execEndRe.MatchString(ln.upper) {
+				flushExecBlock()
+			}
+			continue
+		}
+		if m := execStartRe.FindStringSubmatch(ln.upper); m != nil {
+			execBuf = &execBlock{
+				kind:      strings.ToUpper(m[1]),
+				startLine: ln.num,
+				text:      ln.code,
+			}
+			// A single-line EXEC ... END-EXEC closes immediately.
+			if execEndRe.MatchString(ln.upper) {
+				flushExecBlock()
+			}
+			continue
+		}
+
 		// ── PROGRAM-ID ────────────────────────────────────────────────────
 		if m := programIDRe.FindStringSubmatch(ln.code); m != nil {
 			programName = m[1]
 			programIdx = len(entities)
 			currentParagraphIdx = -1
+			currentParagraphName = ""
+			dataStack = dataStack[:0]
 			entities = append(entities, types.EntityRecord{
 				Name:       programName,
 				Kind:       "SCOPE.Component",
@@ -285,6 +358,8 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 			inProcedureDivision = div == "PROCEDURE"
 			inDataItemArea = false
 			currentParagraphIdx = -1
+			currentParagraphName = ""
+			dataStack = dataStack[:0]
 			entities = append(entities, types.EntityRecord{
 				Name:       div + " DIVISION",
 				Kind:       "SCOPE.Component",
@@ -328,27 +403,25 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 				Signature:  strings.TrimSpace(ln.code),
 			})
 			currentParagraphIdx = -1
+			currentParagraphName = ""
+			dataStack = dataStack[:0]
 			continue
 		}
 
 		// ── COPY (IMPORTS) — valid anywhere ──────────────────────────────
-		if m := copyRe.FindStringSubmatch(ln.code); m != nil {
-			book := m[1]
+		// Resolve the copybook name against on-disk .cpy files (#2838): when
+		// resolved, the IMPORTS edge binds to the actual copybook file path
+		// and REPLACING clauses are captured for drift analysis.
+		if book, replacing, ok := parseCopyDirective(ln.code); ok {
 			if !seenCopy[strings.ToUpper(book)] {
 				seenCopy[strings.ToUpper(book)] = true
-				rel := types.RelationshipRecord{
-					FromID: filePath,
-					ToID:   book,
-					Kind:   "IMPORTS",
-					Properties: map[string]string{
-						"line":     strconv.Itoa(ln.num),
-						"copybook": book,
-					},
-				}
-				addProgramRel(rel)
-				// Also emit a placeholder entity for the copybook so the
-				// import target is resolvable (mirrors crystal's require).
-				entities = append(entities, types.EntityRecord{
+				path, resolved := resolveCopybook(repoRoot, filePath, book)
+				cr := copyResolution{book: book, resolved: resolved, path: path, replacing: replacing}
+				addProgramRel(buildCopyImportEdge(filePath, cr, ln.num))
+				// Emit a placeholder entity for the copybook so the bare-name
+				// import target is resolvable even when the file is absent
+				// (mirrors crystal's require). When resolved, record the path.
+				placeholder := types.EntityRecord{
 					Name:       book,
 					Kind:       "SCOPE.Component",
 					Subtype:    "copybook",
@@ -356,7 +429,15 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 					Language:   "cobol",
 					StartLine:  ln.num,
 					EndLine:    ln.num,
-				})
+					Properties: map[string]string{"resolved": strconv.FormatBool(resolved)},
+				}
+				if resolved {
+					placeholder.Properties["copybook_path"] = path
+				}
+				if replacing != "" {
+					placeholder.Properties["replacing"] = replacing
+				}
+				entities = append(entities, placeholder)
 			}
 			// COPY may share a line with other code in rare cases; fall
 			// through so PERFORM/CALL on the same line are still scanned.
@@ -377,6 +458,38 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 				if strings.EqualFold(fieldName, "FILLER") {
 					continue
 				}
+				levelNum, _ := strconv.Atoi(level)
+				props := map[string]string{"level": level}
+				// REDEFINES / OCCURS structured-field metadata (#2838).
+				if rm := dataRedefinesRe.FindStringSubmatch(ln.upper); rm != nil {
+					props["redefines"] = rm[1]
+				}
+				if om := dataOccursRe.FindStringSubmatch(ln.upper); om != nil {
+					props["occurs"] = om[1]
+				}
+				if pm := dataPicRe.FindStringSubmatch(ln.upper); pm != nil {
+					props["pic"] = pm[1]
+				} else if levelNum != 88 && levelNum != 66 {
+					// No PICTURE clause on an ordinary item ⇒ group item.
+					props["group"] = "true"
+				}
+				// Maintain the level stack and bind this item to its parent
+				// group (the nearest enclosing item with a lower level number).
+				// Levels 88 (condition) / 66 (renames) attach to the current
+				// top without becoming parents themselves.
+				for len(dataStack) > 0 && dataStack[len(dataStack)-1].level >= levelNum {
+					dataStack = dataStack[:len(dataStack)-1]
+				}
+				thisIdx := len(entities)
+				if len(dataStack) > 0 {
+					parent := dataStack[len(dataStack)-1]
+					props["parent"] = entities[parent.idx].Name
+					// CONTAINS edge: parent group → this field.
+					toID := extractor.BuildSchemaFieldStructuralRef("cobol", filePath, fieldName)
+					entities[parent.idx].Relationships = append(entities[parent.idx].Relationships,
+						types.RelationshipRecord{ToID: toID, Kind: "CONTAINS",
+							Properties: map[string]string{"child": fieldName}})
+				}
 				entities = append(entities, types.EntityRecord{
 					Name:       fieldName,
 					Kind:       "SCOPE.Schema",
@@ -386,8 +499,11 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 					StartLine:  ln.num,
 					EndLine:    ln.num,
 					Signature:  strings.TrimSpace(ln.code),
-					Properties: map[string]string{"level": level},
+					Properties: props,
 				})
+				if levelNum != 88 && levelNum != 66 {
+					dataStack = append(dataStack, dataScope{level: levelNum, idx: thisIdx})
+				}
 				continue
 			}
 		}
@@ -400,6 +516,7 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 				up := strings.ToUpper(name)
 				if !cobolReservedHeads[up] && !isAllDigits(name) {
 					currentParagraphIdx = len(entities)
+					currentParagraphName = name
 					rec := types.EntityRecord{
 						Name:       name,
 						Kind:       "SCOPE.Operation",
@@ -481,6 +598,10 @@ func extractCOBOL(src, filePath string) []types.EntityRecord {
 			}
 		}
 	}
+
+	// Flush a trailing EXEC block that lacked a closing END-EXEC (tolerant of
+	// malformed / truncated source).
+	flushExecBlock()
 
 	_ = programName
 	return entities

--- a/internal/extractors/cobol/extractor_test.go
+++ b/internal/extractors/cobol/extractor_test.go
@@ -13,16 +13,35 @@ import (
 // run is a small helper that extracts entities from a source string.
 func run(t *testing.T, path, src string) []types.EntityRecord {
 	t.Helper()
+	return runWithRoot(t, path, src, "")
+}
+
+// runWithRoot extracts with an explicit RepoRoot so the COPY resolver can
+// bind copybook references to on-disk .cpy files (#2838).
+func runWithRoot(t *testing.T, path, src, repoRoot string) []types.EntityRecord {
+	t.Helper()
 	e := &Extractor{}
 	recs, err := e.Extract(context.Background(), extractor.FileInput{
 		Path:     path,
 		Content:  []byte(src),
 		Language: "cobol",
+		RepoRoot: repoRoot,
 	})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
 	}
 	return recs
+}
+
+// importEdge returns the first IMPORTS relationship whose copybook property
+// matches book, or false.
+func importEdge(recs []types.EntityRecord, book string) (types.RelationshipRecord, bool) {
+	for _, rel := range relationsByKind(recs, "IMPORTS") {
+		if rel.Properties["copybook"] == book {
+			return rel, true
+		}
+	}
+	return types.RelationshipRecord{}, false
 }
 
 // findByKind returns entities matching kind (and optional subtype).
@@ -263,6 +282,238 @@ func TestExtractor_LanguageTagging(t *testing.T) {
 				t.Fatalf("relationship %s->%s language not tagged cobol", rel.FromID, rel.ToID)
 			}
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #2838 Phase 2 — copybook resolution, embedded SQL, CICS depth, data hierarchy
+// ---------------------------------------------------------------------------
+
+// findDataAccess returns SCOPE.DataAccess entities (optionally by subtype).
+func findDataAccess(recs []types.EntityRecord, subtype string) []types.EntityRecord {
+	return findByKind(recs, "SCOPE.DataAccess", subtype)
+}
+
+func dataAccessFor(recs []types.EntityRecord, op, table string) bool {
+	for _, r := range findDataAccess(recs, "embedded-sql") {
+		if r.Properties["operation"] == op && r.Properties["table"] == table {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExtractor_CopybookResolution proves COPY resolves against on-disk .cpy
+// files: with RepoRoot=testdata, COPY EMPREC / COPY TAXRULES bind to the real
+// files and the IMPORTS edge carries resolved=true + copybook_path. This is
+// the import_resolution_quality partial→full move.
+func TestExtractor_CopybookResolution(t *testing.T) {
+	src := loadFixture(t, "ledger.cbl")
+	recs := runWithRoot(t, "ledger.cbl", src, "testdata")
+
+	for _, book := range []string{"EMPREC", "TAXRULES"} {
+		rel, ok := importEdge(recs, book)
+		if !ok {
+			t.Fatalf("expected IMPORTS edge for %q", book)
+		}
+		if rel.Properties["resolved"] != "true" {
+			t.Errorf("COPY %s expected resolved=true, got %q", book, rel.Properties["resolved"])
+		}
+		if rel.Properties["copybook_path"] == "" {
+			t.Errorf("COPY %s expected copybook_path, got empty", book)
+		}
+		// A resolved COPY binds the edge ToID to the resolved file path.
+		if rel.ToID != rel.Properties["copybook_path"] {
+			t.Errorf("COPY %s ToID=%q should equal copybook_path=%q", book, rel.ToID, rel.Properties["copybook_path"])
+		}
+	}
+}
+
+// TestExtractor_CopybookUnresolvedStaysPartial proves that without a RepoRoot
+// (no disk to resolve against) the edge is still emitted but marked
+// resolved=false — honest degradation, no false "full".
+func TestExtractor_CopybookUnresolved(t *testing.T) {
+	src := loadFixture(t, "ledger.cbl")
+	recs := run(t, "ledger.cbl", src) // no RepoRoot
+
+	rel, ok := importEdge(recs, "EMPREC")
+	if !ok {
+		t.Fatal("expected IMPORTS edge for EMPREC even when unresolved")
+	}
+	if rel.Properties["resolved"] != "false" {
+		t.Errorf("unresolved COPY expected resolved=false, got %q", rel.Properties["resolved"])
+	}
+	if rel.ToID != "EMPREC" {
+		t.Errorf("unresolved COPY ToID should be bare name EMPREC, got %q", rel.ToID)
+	}
+}
+
+// TestExtractor_CopybookReplacing proves the REPLACING clause is captured and
+// its operand pairs normalized.
+func TestExtractor_CopybookReplacing(t *testing.T) {
+	src := loadFixture(t, "ledger.cbl")
+	recs := runWithRoot(t, "ledger.cbl", src, "testdata")
+
+	rel, ok := importEdge(recs, "EMPREC")
+	if !ok {
+		t.Fatal("expected IMPORTS edge for EMPREC")
+	}
+	if rel.Properties["replacing"] == "" {
+		t.Error("expected REPLACING clause to be captured on COPY EMPREC")
+	}
+	if pairs := rel.Properties["replacing_pairs"]; pairs != "EM=>WS-EM" {
+		t.Errorf("expected replacing_pairs=EM=>WS-EM, got %q", pairs)
+	}
+}
+
+// TestExtractor_EmbeddedSQLTables proves EXEC SQL table references become
+// SCOPE.DataAccess entities with ACCESSES_TABLE edges (db_effect precision).
+func TestExtractor_EmbeddedSQLTables(t *testing.T) {
+	src := loadFixture(t, "ledger.cbl")
+	recs := runWithRoot(t, "ledger.cbl", src, "testdata")
+
+	want := []struct{ op, table string }{
+		{"SELECT", "LEDGER_ENTRY"},
+		{"INSERT", "PAYROLL_LEDGER"},
+		{"UPDATE", "ACCOUNT_BALANCE"},
+		{"DELETE", "LEDGER_ENTRY"},
+	}
+	for _, w := range want {
+		if !dataAccessFor(recs, w.op, w.table) {
+			t.Errorf("expected SCOPE.DataAccess %s %s", w.op, w.table)
+		}
+	}
+	// Every table access carries an ACCESSES_TABLE edge.
+	if len(relationsByKind(recs, "ACCESSES_TABLE")) == 0 {
+		t.Error("expected ACCESSES_TABLE edges for embedded SQL")
+	}
+}
+
+// TestExtractor_EmbeddedSQLCursor proves DECLARE CURSOR yields a cursor
+// SCOPE.DataAccess entity and OPEN/FETCH/CLOSE emit REFERENCES edges.
+func TestExtractor_EmbeddedSQLCursor(t *testing.T) {
+	src := loadFixture(t, "ledger.cbl")
+	recs := runWithRoot(t, "ledger.cbl", src, "testdata")
+
+	cursors := findDataAccess(recs, "cursor")
+	var declared bool
+	for _, c := range cursors {
+		if c.Properties["operation"] == "DECLARE_CURSOR" && c.Properties["cursor"] == "LEDGER-CUR" {
+			declared = true
+		}
+	}
+	if !declared {
+		t.Error("expected DECLARE_CURSOR SCOPE.DataAccess entity for LEDGER-CUR")
+	}
+	// OPEN / FETCH / CLOSE reference the cursor.
+	ops := map[string]bool{}
+	for _, rel := range relationsByKind(recs, "REFERENCES") {
+		if rel.Properties["cursor"] == "LEDGER-CUR" {
+			ops[rel.Properties["operation"]] = true
+		}
+	}
+	for _, op := range []string{"OPEN", "FETCH", "CLOSE"} {
+		if !ops[op] {
+			t.Errorf("expected cursor REFERENCES edge for %s LEDGER-CUR", op)
+		}
+	}
+}
+
+// TestExtractor_CICSProgramTransfer proves EXEC CICS LINK/XCTL/START become
+// external CALLS edges (CICS transaction-graph depth).
+func TestExtractor_CICSProgramTransfer(t *testing.T) {
+	src := loadFixture(t, "orderui.cbl")
+	recs := run(t, "orderui.cbl", src)
+
+	for _, prog := range []string{"PRICESVC", "ORDMENU"} {
+		if !hasCallTo(recs, prog) {
+			t.Errorf("expected CICS program-transfer CALLS edge to %q", prog)
+		}
+	}
+	// START TRANSID('AUDT') schedules a transaction.
+	var foundTransid bool
+	for _, rel := range relationsByKind(recs, "CALLS") {
+		if rel.ToID == "AUDT" && rel.Properties["transid"] == "AUDT" {
+			foundTransid = true
+		}
+	}
+	if !foundTransid {
+		t.Error("expected CICS START TRANSID CALLS edge for AUDT")
+	}
+	// LINK edge carries via=EXEC-CICS-LINK + external.
+	var linkTagged bool
+	for _, rel := range relationsByKind(recs, "CALLS") {
+		if rel.ToID == "PRICESVC" {
+			if rel.Properties["via"] != "EXEC-CICS-LINK" || rel.Properties["external"] != "true" {
+				t.Errorf("CICS LINK edge to PRICESVC missing via/external: %v", rel.Properties)
+			}
+			linkTagged = true
+		}
+	}
+	if !linkTagged {
+		t.Error("expected EXEC-CICS-LINK edge to PRICESVC")
+	}
+}
+
+// TestExtractor_DataHierarchy proves 01/05 nesting binds child fields to their
+// parent group (parent property + CONTAINS edge) and captures REDEFINES/OCCURS.
+func TestExtractor_DataHierarchy(t *testing.T) {
+	src := loadFixture(t, "payroll.cbl")
+	recs := run(t, "payroll.cbl", src)
+
+	// EMP-ID (05) is nested under EMP-RECORD (01).
+	var found bool
+	for _, r := range findByKind(recs, "SCOPE.Schema", "field") {
+		if r.Name == "EMP-ID" {
+			found = true
+			if r.Properties["parent"] != "EMP-RECORD" {
+				t.Errorf("EMP-ID parent = %q, want EMP-RECORD", r.Properties["parent"])
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected field EMP-ID")
+	}
+	// The 01 group records the CONTAINS edge to its children.
+	var contains bool
+	for _, r := range findByKind(recs, "SCOPE.Schema", "field") {
+		if r.Name == "EMP-RECORD" {
+			for _, rel := range r.Relationships {
+				if rel.Kind == "CONTAINS" && rel.Properties["child"] == "EMP-ID" {
+					contains = true
+				}
+			}
+		}
+	}
+	if !contains {
+		t.Error("expected CONTAINS edge EMP-RECORD -> EMP-ID")
+	}
+}
+
+// TestExtractor_DataRedefinesOccurs proves REDEFINES/OCCURS structured-field
+// metadata is captured.
+func TestExtractor_DataRedefinesOccurs(t *testing.T) {
+	src := "       DATA DIVISION.\n" +
+		"       WORKING-STORAGE SECTION.\n" +
+		"       01  WS-BUFFER.\n" +
+		"           05  WS-LINES OCCURS 10 TIMES PIC X(80).\n" +
+		"       01  WS-ALIAS REDEFINES WS-BUFFER PIC X(800).\n"
+	recs := run(t, "redef.cbl", src)
+
+	var occursOK, redefOK bool
+	for _, r := range findByKind(recs, "SCOPE.Schema", "field") {
+		if r.Name == "WS-LINES" && r.Properties["occurs"] == "10" {
+			occursOK = true
+		}
+		if r.Name == "WS-ALIAS" && r.Properties["redefines"] == "WS-BUFFER" {
+			redefOK = true
+		}
+	}
+	if !occursOK {
+		t.Error("expected OCCURS 10 on WS-LINES")
+	}
+	if !redefOK {
+		t.Error("expected REDEFINES WS-BUFFER on WS-ALIAS")
 	}
 }
 

--- a/internal/extractors/cobol/testdata/ledger.cbl
+++ b/internal/extractors/cobol/testdata/ledger.cbl
@@ -1,0 +1,52 @@
+      ******************************************************************
+      * LEDGER.CBL — embedded-SQL cursor program fixture (#2838).       *
+      * Proves: COPY ... REPLACING resolution against an on-disk .cpy,  *
+      * EXEC SQL DECLARE CURSOR + OPEN/FETCH/CLOSE, and SELECT/INSERT/   *
+      * UPDATE/DELETE table REFERENCES as SCOPE.DataAccess entities.     *
+      ******************************************************************
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. LEDGER.
+
+       ENVIRONMENT DIVISION.
+
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-AMT                PIC 9(09)V99.
+       01  WS-DEPT               PIC X(04).
+       COPY EMPREC REPLACING ==EM== BY ==WS-EM==.
+       COPY TAXRULES.
+
+       PROCEDURE DIVISION.
+       OPEN-LEDGER.
+           EXEC SQL
+               DECLARE LEDGER-CUR CURSOR FOR
+                   SELECT AMOUNT, DEPT_CODE
+                       FROM LEDGER_ENTRY
+                       WHERE POSTED = 'Y'
+           END-EXEC
+           EXEC SQL OPEN LEDGER-CUR END-EXEC.
+
+       READ-NEXT.
+           EXEC SQL
+               FETCH LEDGER-CUR INTO :WS-AMT, :WS-DEPT
+           END-EXEC.
+
+       POST-ENTRY.
+           EXEC SQL
+               INSERT INTO PAYROLL_LEDGER (EMP_ID, AMOUNT)
+                   VALUES (:WS-EM-ID, :WS-AMT)
+           END-EXEC
+           EXEC SQL
+               UPDATE ACCOUNT_BALANCE
+                   SET BALANCE = BALANCE + :WS-AMT
+                   WHERE DEPT_CODE = :WS-DEPT
+           END-EXEC.
+
+       PURGE-OLD.
+           EXEC SQL
+               DELETE FROM LEDGER_ENTRY
+                   WHERE POSTED = 'Y'
+           END-EXEC.
+
+       CLOSE-LEDGER.
+           EXEC SQL CLOSE LEDGER-CUR END-EXEC.

--- a/internal/extractors/cobol/testdata/orderui.cbl
+++ b/internal/extractors/cobol/testdata/orderui.cbl
@@ -1,0 +1,53 @@
+      ******************************************************************
+      * ORDERUI.CBL — CICS online transaction program fixture (#2838).  *
+      * Proves: EXEC CICS LINK/XCTL program transfer as external CALLS,  *
+      * START TRANSID transaction scheduling, and CICS file/queue I/O    *
+      * (READ/WRITE/READQ/WRITEQ) surfaced as fs effects.                *
+      ******************************************************************
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ORDERUI.
+
+       ENVIRONMENT DIVISION.
+
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-ORDER-REC.
+           05  WS-ORDER-ID       PIC X(10).
+           05  WS-CUST-ID        PIC X(08).
+       01  WS-MSG-QUEUE          PIC X(08) VALUE 'ORDERQ'.
+
+       PROCEDURE DIVISION.
+       MAIN-TRANS.
+           EXEC CICS RECEIVE MAP('ORDMAP') END-EXEC
+           PERFORM LOAD-ORDER
+           PERFORM CALL-PRICING
+           PERFORM PERSIST-ORDER
+           EXEC CICS XCTL PROGRAM('ORDMENU') END-EXEC.
+
+       LOAD-ORDER.
+           EXEC CICS READ FILE('ORDFILE')
+               INTO(WS-ORDER-REC)
+               RIDFLD(WS-ORDER-ID)
+           END-EXEC
+           EXEC CICS READQ TS QUEUE(WS-MSG-QUEUE)
+               INTO(WS-ORDER-REC)
+           END-EXEC.
+
+       CALL-PRICING.
+           EXEC CICS LINK PROGRAM('PRICESVC')
+               COMMAREA(WS-ORDER-REC)
+           END-EXEC.
+
+       PERSIST-ORDER.
+           EXEC CICS WRITE FILE('ORDFILE')
+               FROM(WS-ORDER-REC)
+               RIDFLD(WS-ORDER-ID)
+           END-EXEC
+           EXEC CICS WRITEQ TS QUEUE(WS-MSG-QUEUE)
+               FROM(WS-ORDER-REC)
+           END-EXEC.
+
+       SCHEDULE-AUDIT.
+           EXEC CICS START TRANSID('AUDT')
+               INTERVAL(0)
+           END-EXEC.

--- a/internal/extractors/cobol/testdata/taxrules.cpy
+++ b/internal/extractors/cobol/testdata/taxrules.cpy
@@ -1,0 +1,10 @@
+      ******************************************************************
+      * TAXRULES.CPY — shared tax-bracket copybook (data only).        *
+      * Resolved on disk by the COPY resolver (#2838) so the IMPORTS    *
+      * edge from a using program binds to this file, raising           *
+      * import_resolution_quality from partial to full.                 *
+      ******************************************************************
+       01  TAX-RULES.
+           05  TR-BRACKET        PIC 9(02).
+           05  TR-RATE           PIC 9V9(04).
+           05  TR-CAP            PIC 9(07)V99.

--- a/internal/substrate/effect_sinks_cobol.go
+++ b/internal/substrate/effect_sinks_cobol.go
@@ -4,18 +4,18 @@
 // them unusually clean to detect:
 //
 //   - fs_read  : READ <file> / OPEN INPUT / OPEN I-O / START / RETURN
-//                (sequential / indexed / relative file I/O on an FD record)
+//     (sequential / indexed / relative file I/O on an FD record)
 //   - fs_write : WRITE <rec> / REWRITE <rec> / DELETE <file> / OPEN OUTPUT /
-//                OPEN EXTEND / RELEASE
+//     OPEN EXTEND / RELEASE
 //   - db_read  : EXEC SQL SELECT / OPEN <cursor> / FETCH (embedded DB2)
 //   - db_write : EXEC SQL INSERT|UPDATE|DELETE|MERGE (embedded DB2)
 //   - http_out : EXEC CICS LINK / XCTL / WEB / INVOKE — outbound transaction
-//                / service calls treated as the COBOL analog of an outbound
-//                request (the closest effect in the lattice for CICS
-//                inter-program / service control transfers)
+//     / service calls treated as the COBOL analog of an outbound
+//     request (the closest effect in the lattice for CICS
+//     inter-program / service control transfers)
 //   - mutation : MOVE ... TO <ident> / SET <ident> / COMPUTE <ident> — an
-//                observable working-storage state write (low confidence; the
-//                most common COBOL statement so it is intentionally weak)
+//     observable working-storage state write (low confidence; the
+//     most common COBOL statement so it is intentionally weak)
 //
 // Function attribution binds each sink to the nearest preceding PARAGRAPH
 // header (a lone identifier + period in Area A inside PROCEDURE DIVISION).
@@ -66,9 +66,26 @@ var cobolDBWriteRe = regexp.MustCompile(
 	`(?is)EXEC\s+SQL\b[^.]*?\b(?:INSERT|UPDATE|DELETE|MERGE|CREATE|DROP|ALTER)\b`,
 )
 
-// cobolCICSRe matches EXEC CICS outbound transaction / service primitives.
+// cobolCICSRe matches EXEC CICS outbound transaction / service primitives:
+// program transfer (LINK/XCTL), transaction scheduling (START), and terminal
+// / web service traffic (SEND/RECEIVE/WEB/INVOKE) — all modelled as the COBOL
+// analog of an outbound request (#2838 Phase 2 deepens this from a flag into
+// the EXEC-CICS verb set).
 var cobolCICSRe = regexp.MustCompile(
 	`(?is)EXEC\s+CICS\b[^.]*?\b(?:LINK|XCTL|START|INVOKE|WEB|SEND|RECEIVE)\b`,
+)
+
+// cobolCICSFSReadRe matches EXEC CICS READ / READQ (file or transient/temp
+// storage queue read) — a filesystem-class read effect on the CICS region's
+// VSAM files and queues.
+var cobolCICSFSReadRe = regexp.MustCompile(
+	`(?is)EXEC\s+CICS\b[^.]*?\b(?:READQ|READ)\b`,
+)
+
+// cobolCICSFSWriteRe matches EXEC CICS WRITE / WRITEQ / REWRITE / DELETE /
+// DELETEQ — a filesystem-class write effect on CICS files and queues.
+var cobolCICSFSWriteRe = regexp.MustCompile(
+	`(?is)EXEC\s+CICS\b[^.]*?\b(?:WRITEQ|WRITE|REWRITE|DELETEQ|DELETE)\b`,
 )
 
 // cobolMutationRe matches working-storage state writes.
@@ -89,6 +106,8 @@ func sniffEffectsCobol(content string) []EffectMatch {
 	out = appendCobolMatches(out, content, headers, cobolDBReadRe, EffectDBRead, "EXEC-SQL.SELECT/FETCH", 1.0)
 	out = appendCobolMatches(out, content, headers, cobolDBWriteRe, EffectDBWrite, "EXEC-SQL.INSERT/UPDATE/DELETE", 1.0)
 	out = appendCobolMatches(out, content, headers, cobolCICSRe, EffectHTTPOut, "EXEC-CICS.LINK/XCTL/WEB", 0.85)
+	out = appendCobolMatches(out, content, headers, cobolCICSFSReadRe, EffectFSRead, "EXEC-CICS.READ/READQ", 0.9)
+	out = appendCobolMatches(out, content, headers, cobolCICSFSWriteRe, EffectFSWrite, "EXEC-CICS.WRITE/WRITEQ/REWRITE", 0.9)
 	out = appendCobolMatches(out, content, headers, cobolMutationRe, EffectMutation, "MOVE...TO/SET/COMPUTE", 0.6)
 	return out
 }

--- a/internal/substrate/effect_sinks_cobol_test.go
+++ b/internal/substrate/effect_sinks_cobol_test.go
@@ -74,6 +74,33 @@ func TestSniffEffectsCobol_Mutation(t *testing.T) {
 	}
 }
 
+// TestSniffEffectsCobol_CICSFileIO proves EXEC CICS file/queue I/O
+// (READ/READQ → fs_read, WRITE/WRITEQ/REWRITE → fs_write) is surfaced as
+// filesystem effects, deepening CICS beyond the http_out flag (#2838).
+func TestSniffEffectsCobol_CICSFileIO(t *testing.T) {
+	src := `       PROCEDURE DIVISION.
+       LOAD-ORDER.
+           EXEC CICS READ FILE('ORDFILE') INTO(WS-REC) END-EXEC
+           EXEC CICS READQ TS QUEUE(WS-Q) INTO(WS-REC) END-EXEC.
+       PERSIST-ORDER.
+           EXEC CICS WRITE FILE('ORDFILE') FROM(WS-REC) END-EXEC
+           EXEC CICS WRITEQ TS QUEUE(WS-Q) FROM(WS-REC) END-EXEC.
+       CALL-SVC.
+           EXEC CICS LINK PROGRAM('PRICESVC') END-EXEC.
+`
+	got := cobolEffectsByFn(src)
+	if !got["LOAD-ORDER"][EffectFSRead] {
+		t.Errorf("LOAD-ORDER expected fs_read (CICS READ/READQ), got %v", got["LOAD-ORDER"])
+	}
+	if !got["PERSIST-ORDER"][EffectFSWrite] {
+		t.Errorf("PERSIST-ORDER expected fs_write (CICS WRITE/WRITEQ), got %v", got["PERSIST-ORDER"])
+	}
+	// LINK still registers as http_out (transaction/service transfer).
+	if !got["CALL-SVC"][EffectHTTPOut] {
+		t.Errorf("CALL-SVC expected http_out (CICS LINK), got %v", got["CALL-SVC"])
+	}
+}
+
 func TestSniffEffectsCobol_Registered(t *testing.T) {
 	if EffectSnifferFor("cobol") == nil {
 		t.Fatal("cobol effect sniffer not registered")

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -41,29 +41,55 @@ records:
         issues_implemented: ["2743"]
         verified_at: "2026-05-28"
       import_resolution_quality:
-        status: partial
+        # #2838: COPY resolves against on-disk .cpy files (resolveCopybook)
+        # and REPLACING clauses are captured — partial→full.
+        status: full
         symbols:
           - file: internal/extractors/cobol/extractor.go
             functions: [extractCOBOL]
-        issues_implemented: ["2743"]
+          - file: internal/extractors/cobol/depth.go
+            functions: [resolveCopybook, parseCopyDirective, buildCopyImportEdge]
+        tests:
+          - file: internal/extractors/cobol/extractor_test.go
+        issues_implemented: ["2743", "2838"]
         verified_at: "2026-05-28"
       fs_effect:
-        status: partial
+        # #2838: CICS file/queue I/O (READ/READQ/WRITE/WRITEQ) deepened.
+        status: full
         symbols:
           - file: internal/substrate/effect_sinks_cobol.go
             functions: [sniffEffectsCobol, scanCobolParagraphHeaders]
         tests:
           - file: internal/substrate/effect_sinks_cobol_test.go
-        issues_implemented: ["2743"]
+        issues_implemented: ["2743", "2838"]
         verified_at: "2026-05-28"
       db_effect:
-        status: partial
+        # #2838: embedded SQL tables/cursors extracted as SCOPE.DataAccess
+        # entities + ACCESSES_TABLE edges — not just a flag — partial→full.
+        status: full
         symbols:
           - file: internal/substrate/effect_sinks_cobol.go
             functions: [sniffEffectsCobol]
+          - file: internal/extractors/cobol/depth.go
+            functions: [extractSQLEntities, sqlOpFor]
         tests:
           - file: internal/substrate/effect_sinks_cobol_test.go
-        issues_implemented: ["2743"]
+          - file: internal/extractors/cobol/extractor_test.go
+        issues_implemented: ["2743", "2838"]
+        verified_at: "2026-05-28"
+      http_effect:
+        # #2838: EXEC CICS LINK/XCTL/START surfaced as external CALLS +
+        # http_out effect (transaction depth) — partial→full.
+        status: full
+        symbols:
+          - file: internal/substrate/effect_sinks_cobol.go
+            functions: [sniffEffectsCobol]
+          - file: internal/extractors/cobol/depth.go
+            functions: [extractCICSTransfers, cicsCallEdge]
+        tests:
+          - file: internal/substrate/effect_sinks_cobol_test.go
+          - file: internal/extractors/cobol/extractor_test.go
+        issues_implemented: ["2743", "2838"]
         verified_at: "2026-05-28"
 
   lang.cobol.runtime.gnucobol:
@@ -85,35 +111,59 @@ records:
         issues_implemented: ["2743"]
         verified_at: "2026-05-28"
       import_resolution_quality:
-        status: partial
+        # #2838: COPY disk resolution applies to GnuCOBOL too (same extractor).
+        status: full
         symbols:
           - file: internal/extractors/cobol/extractor.go
             functions: [extractCOBOL]
-        issues_implemented: ["2743"]
+          - file: internal/extractors/cobol/depth.go
+            functions: [resolveCopybook, parseCopyDirective]
+        tests:
+          - file: internal/extractors/cobol/extractor_test.go
+        issues_implemented: ["2743", "2838"]
         verified_at: "2026-05-28"
 
   lang.cobol.embedded.db2-sql:
     capabilities:
       db_effect:
+        # #2838: tables + cursors extracted as SCOPE.DataAccess entities.
+        status: full
+        symbols:
+          - file: internal/substrate/effect_sinks_cobol.go
+            functions: [sniffEffectsCobol]
+          - file: internal/extractors/cobol/depth.go
+            functions: [extractSQLEntities, sqlOpFor]
+        tests:
+          - file: internal/substrate/effect_sinks_cobol_test.go
+          - file: internal/extractors/cobol/extractor_test.go
+        issues_implemented: ["2743", "2838"]
+        verified_at: "2026-05-28"
+
+  lang.cobol.embedded.cics:
+    capabilities:
+      http_effect:
+        # #2838: EXEC CICS LINK/XCTL/START program-transfer + transaction
+        # scheduling as external CALLS — partial→full.
+        status: full
+        symbols:
+          - file: internal/substrate/effect_sinks_cobol.go
+            functions: [sniffEffectsCobol]
+          - file: internal/extractors/cobol/depth.go
+            functions: [extractCICSTransfers, cicsCallEdge]
+        tests:
+          - file: internal/substrate/effect_sinks_cobol_test.go
+          - file: internal/extractors/cobol/extractor_test.go
+        issues_implemented: ["2743", "2838"]
+        verified_at: "2026-05-28"
+      fs_effect:
+        # #2838: CICS file/queue I/O (READ/READQ/WRITE/WRITEQ) as fs effects.
         status: full
         symbols:
           - file: internal/substrate/effect_sinks_cobol.go
             functions: [sniffEffectsCobol]
         tests:
           - file: internal/substrate/effect_sinks_cobol_test.go
-        issues_implemented: ["2743"]
-        verified_at: "2026-05-28"
-
-  lang.cobol.embedded.cics:
-    capabilities:
-      http_effect:
-        status: partial
-        symbols:
-          - file: internal/substrate/effect_sinks_cobol.go
-            functions: [sniffEffectsCobol]
-        tests:
-          - file: internal/substrate/effect_sinks_cobol_test.go
-        issues_implemented: ["2743"]
+        issues_implemented: ["2743", "2838"]
         verified_at: "2026-05-28"
 
   lang.jsts.framework.react:


### PR DESCRIPTION
## Summary

Deepens the Phase-1 COBOL extractor (#2840) toward maximal honest coverage, implementing #2838 Phase 2. No new entity `Kind` is emitted — embedded-SQL access reuses `SCOPE.DataAccess` (the cross/dbmap pipeline), so `internal/types` stays green.

- **Copybook (COPY) resolution** — `resolveCopybook` binds `COPY <name>` to on-disk `.cpy`/`.cbl` files under `RepoRoot` (program dir + common copybook dirs, case-insensitive). `REPLACING` clauses are captured and normalized into `replacing_pairs`. IMPORTS edges carry `resolved=true` + `copybook_path` when found, and degrade honestly to `resolved=false` (bare-name ToID) otherwise.
- **Embedded SQL entities** — multi-line `EXEC SQL ... END-EXEC` blocks are accumulated and parsed: each referenced table becomes a `SCOPE.DataAccess` entity + `ACCESSES_TABLE` edge (SELECT/INSERT/UPDATE/DELETE/JOIN), and `DECLARE CURSOR` plus `OPEN/FETCH/CLOSE` yield cursor entities + `REFERENCES` edges. `db_effect` is now precise, not just a flag.
- **EXEC CICS depth** — `LINK`/`XCTL` program transfer and `START TRANSID` scheduling become external `CALLS` edges (`via=EXEC-CICS-<verb>`); CICS file/queue I/O (`READ`/`READQ`/`WRITE`/`WRITEQ`/`REWRITE`) is surfaced as `fs_read`/`fs_write` effects.
- **Data hierarchy** — `01/05/10` level nesting binds child fields to their parent group (`parent` property + `CONTAINS` edge) and records `REDEFINES`/`OCCURS`/`PIC` metadata.

### Coverage cells moved partial→full (each proven by a passing fixture)

| Record | Cell | Fixture proving it |
|---|---|---|
| ibm-enterprise, gnucobol | `import_resolution_quality` | `ledger.cbl` COPY EMPREC/TAXRULES resolve to `testdata/*.cpy` |
| ibm-enterprise, db2-sql | `db_effect` | `ledger.cbl` SELECT/INSERT/UPDATE/DELETE tables + LEDGER-CUR cursor |
| ibm-enterprise, cics | `http_effect` | `orderui.cbl` CICS LINK/XCTL → CALLS, START TRANSID |
| ibm-enterprise, cics | `fs_effect` | `orderui.cbl` CICS READ/READQ/WRITE/WRITEQ → fs effects |

New fixtures: `ledger.cbl` (cursor + COPY REPLACING), `orderui.cbl` (CICS), `taxrules.cpy`.

## Test plan

- [x] `go test ./internal/extractors/cobol/` — copybook resolution (resolved + unresolved + REPLACING), embedded-SQL tables, cursor, CICS transfer, data hierarchy, REDEFINES/OCCURS
- [x] `go test ./internal/substrate/` — CICS file/queue I/O effect sniffing
- [x] `go test ./internal/types/` — `TestProducerKindLiterals_AreValid` green (no new Kind)
- [x] `go test ./tools/coverage/` + `go run ./tools/coverage validate` (rc=0, no cobol warnings) + `gen` regenerated docs
- [x] `go build ./...` + `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #2838
