### PR TITLE
feat(coverage): assembly toolchain/dialect records — first-class in summary (#2744)

### DIFF
--- a/docs/coverage/by-category/language.md
+++ b/docs/coverage/by-category/language.md
@@ -1,12 +1,16 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # language
 
-**Total**: 4 records · **COBOL**: 4
+**Total**: 8 records · **assembly**: 4 · **COBOL**: 4
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
 | Language | Name | Call Line Precision | Core Extraction | Db Effect | Discriminates On | Fs Effect | HTTP Effect | Import Resolution Quality | Navigates To | Status | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
+| [assembly](../by-language/assembly.md) | [ARM armasm](../detail/lang.assembly.toolchain.armasm.md) | ✅ | ⚠️ | — | — | — | — | ⚠️ | — | ⚠️ | |
+| [assembly](../by-language/assembly.md) | [GNU as (gas)](../detail/lang.assembly.toolchain.gnu-as.md) | ✅ | ✅ | — | — | — | — | ✅ | — | ✅ | |
+| [assembly](../by-language/assembly.md) | [MASM](../detail/lang.assembly.toolchain.masm.md) | ✅ | ⚠️ | — | — | — | — | ⚠️ | — | ⚠️ | |
+| [assembly](../by-language/assembly.md) | [NASM](../detail/lang.assembly.toolchain.nasm.md) | ✅ | ✅ | — | — | — | — | ✅ | — | ✅ | |
 | [COBOL](../by-language/cobol.md) | [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | — | — | — | — | ✅ | ✅ | — | — | ✅ | |
 | [COBOL](../by-language/cobol.md) | [COBOL Embedded DB2 SQL](../detail/lang.cobol.embedded.db2-sql.md) | — | — | ✅ | — | — | — | — | — | ✅ | |
 | [COBOL](../by-language/cobol.md) | [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | ✅ | ✅ | — | — | — | — | ✅ | — | ✅ | |

--- a/docs/coverage/by-language/assembly.md
+++ b/docs/coverage/by-language/assembly.md
@@ -1,12 +1,15 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Assembly
+# assembly
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 4
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** archigraph has extractor support for
-> this language (see `internal/extractors/assembly/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.assembly.framework.<name>`).
+## Other
+
+| Name | Category | Status | Notes |
+|---|---|---|---|
+| [ARM armasm](../detail/lang.assembly.toolchain.armasm.md) | [language](../by-category/language.md) | ⚠️ | |
+| [GNU as (gas)](../detail/lang.assembly.toolchain.gnu-as.md) | [language](../by-category/language.md) | ✅ | |
+| [MASM](../detail/lang.assembly.toolchain.masm.md) | [language](../by-category/language.md) | ⚠️ | |
+| [NASM](../detail/lang.assembly.toolchain.nasm.md) | [language](../by-category/language.md) | ✅ | |

--- a/docs/coverage/detail/lang.assembly.toolchain.armasm.md
+++ b/docs/coverage/detail/lang.assembly.toolchain.armasm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.assembly.toolchain.armasm` — ARM armasm
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [assembly](../by-language/assembly.md)
+- **Category:** [language](../by-category/language.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `call_line_precision` | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| `core_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.assembly.toolchain.armasm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.assembly.toolchain.gnu-as.md
+++ b/docs/coverage/detail/lang.assembly.toolchain.gnu-as.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.assembly.toolchain.gnu-as` — GNU as (gas)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [assembly](../by-language/assembly.md)
+- **Category:** [language](../by-category/language.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `call_line_precision` | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| `core_extraction` | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| `import_resolution_quality` | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.assembly.toolchain.gnu-as ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.assembly.toolchain.masm.md
+++ b/docs/coverage/detail/lang.assembly.toolchain.masm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.assembly.toolchain.masm` — MASM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [assembly](../by-language/assembly.md)
+- **Category:** [language](../by-category/language.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `call_line_precision` | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| `core_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go` | — |
+| `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.assembly.toolchain.masm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.assembly.toolchain.nasm.md
+++ b/docs/coverage/detail/lang.assembly.toolchain.nasm.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.assembly.toolchain.nasm` — NASM
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [assembly](../by-language/assembly.md)
+- **Category:** [language](../by-category/language.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `call_line_precision` | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| `core_extraction` | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| `import_resolution_quality` | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.assembly.toolchain.nasm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1799,6 +1799,142 @@
       }
     },
     {
+      "id": "lang.assembly.toolchain.armasm",
+      "category": "language",
+      "language": "assembly",
+      "label": "ARM armasm",
+      "capabilities": {
+        "call_line_precision": {
+          "status": "full",
+          "cites": [
+            "internal/extractors/assembly/extractor.go",
+            "internal/extractors/assembly/extractor_test.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        },
+        "core_extraction": {
+          "status": "partial",
+          "cites": [
+            "internal/extractors/assembly/extractor.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        },
+        "import_resolution_quality": {
+          "status": "partial",
+          "cites": [
+            "internal/extractors/assembly/extractor.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.assembly.toolchain.gnu-as",
+      "category": "language",
+      "language": "assembly",
+      "label": "GNU as (gas)",
+      "capabilities": {
+        "call_line_precision": {
+          "status": "full",
+          "cites": [
+            "internal/extractors/assembly/extractor.go",
+            "internal/extractors/assembly/extractor_test.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        },
+        "core_extraction": {
+          "status": "full",
+          "cites": [
+            "internal/extractors/assembly/extractor.go",
+            "internal/extractors/assembly/extractor_test.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        },
+        "import_resolution_quality": {
+          "status": "full",
+          "cites": [
+            "internal/extractors/assembly/extractor.go",
+            "internal/extractors/assembly/extractor_test.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.assembly.toolchain.masm",
+      "category": "language",
+      "language": "assembly",
+      "label": "MASM",
+      "capabilities": {
+        "call_line_precision": {
+          "status": "full",
+          "cites": [
+            "internal/extractors/assembly/extractor.go",
+            "internal/extractors/assembly/extractor_test.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        },
+        "core_extraction": {
+          "status": "partial",
+          "cites": [
+            "internal/extractors/assembly/extractor.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        },
+        "import_resolution_quality": {
+          "status": "partial",
+          "cites": [
+            "internal/extractors/assembly/extractor.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
+      "id": "lang.assembly.toolchain.nasm",
+      "category": "language",
+      "language": "assembly",
+      "label": "NASM",
+      "capabilities": {
+        "call_line_precision": {
+          "status": "full",
+          "cites": [
+            "internal/extractors/assembly/extractor.go",
+            "internal/extractors/assembly/extractor_test.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        },
+        "core_extraction": {
+          "status": "full",
+          "cites": [
+            "internal/extractors/assembly/extractor.go",
+            "internal/extractors/assembly/extractor_test.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        },
+        "import_resolution_quality": {
+          "status": "full",
+          "cites": [
+            "internal/extractors/assembly/extractor.go",
+            "internal/extractors/assembly/extractor_test.go"
+          ],
+          "issue": "2744",
+          "verified_at": "2026-05-28"
+        }
+      }
+    },
+    {
       "id": "lang.c-cpp.driver.libpqxx",
       "category": "orm",
       "language": "c-cpp",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 36 (17 active · 19 placeholder) · **Frameworks**: 182 · **ORMs**: 150 · **Tools**: 110 · **Other**: 103
+**Languages**: 36 (18 active · 18 placeholder) · **Frameworks**: 182 · **ORMs**: 150 · **Tools**: 110 · **Other**: 107
 
 ## Coverage by language
 
@@ -21,6 +21,7 @@
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
+| [assembly](by-language/assembly.md) | 0 | 0 | 0 | 4 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 4 |
 | [dart](by-language/dart.md) | 0 | 1 | 0 | 0 |
 | [groovy](by-language/groovy.md) | 0 | 1 | 0 | 0 |
@@ -45,7 +46,6 @@
 
 | Language |
 |---|
-| [Assembly](by-language/assembly.md) |
 | [Clojure](by-language/clojure.md) |
 | [Crystal](by-language/crystal.md) |
 | [Elm](by-language/elm.md) |
@@ -65,4 +65,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 182 frameworks · 110 tools · 150 ORMs · 103 other
+Total: 182 frameworks · 110 tools · 150 ORMs · 107 other

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -166,6 +166,80 @@ records:
         issues_implemented: ["2743", "2838"]
         verified_at: "2026-05-28"
 
+  lang.assembly.toolchain.gnu-as:
+    capabilities:
+      core_extraction:
+        # gas/AT&T: procedures, .text/.data/.bss/.rodata sections,
+        # .equ/.set constants, and local-label anchors. Exercised by the
+        # x86-64 gas + ARM64 + m68k fixtures (#2744, #2835/#2836 via #2844).
+        status: full
+        symbols:
+          - file: internal/extractors/assembly/extractor.go
+            functions: [extractAssembly, buildProcedureEntities, buildSectionEntities, buildConstantEntities, collectLocalLabels]
+        tests:
+          - file: internal/extractors/assembly/extractor_test.go
+        issues_implemented: ["2744"]
+        verified_at: "2026-05-28"
+      call_line_precision:
+        # call/callq, bl/blx/blr, jsr/bsr, jal CALLS plus jmp/jXX/b/bXX
+        # branch edges, each attached to the enclosing procedure with its
+        # source line; self-recursion/tail-call classification (#2836).
+        status: full
+        symbols:
+          - file: internal/extractors/assembly/extractor.go
+            functions: [buildProcedureEntities, callTarget, mnemonicAndOperand, normalizeMnemonic]
+        tests:
+          - file: internal/extractors/assembly/extractor_test.go
+        issues_implemented: ["2744"]
+        verified_at: "2026-05-28"
+      import_resolution_quality:
+        # .include "file" IMPORTS, .globl/.global exported + .extern external
+        # symbol classification, and intra-file branch-target / cross-file
+        # label resolution (#2836).
+        status: full
+        symbols:
+          - file: internal/extractors/assembly/extractor.go
+            functions: [buildIncludeEntities, collectExported, collectExternal, localLabelStub]
+        tests:
+          - file: internal/extractors/assembly/extractor_test.go
+        issues_implemented: ["2744"]
+        verified_at: "2026-05-28"
+
+  lang.assembly.toolchain.nasm:
+    capabilities:
+      core_extraction:
+        # NASM/Intel: procedures, `section` directives, %define / EQU
+        # constants, and label anchors. Exercised by the x86-64 NASM fixture.
+        status: full
+        symbols:
+          - file: internal/extractors/assembly/extractor.go
+            functions: [extractAssembly, buildProcedureEntities, buildSectionEntities, buildConstantEntities]
+        tests:
+          - file: internal/extractors/assembly/extractor_test.go
+        issues_implemented: ["2744"]
+        verified_at: "2026-05-28"
+      call_line_precision:
+        # Intel-syntax call/jmp target extraction is syntax-agnostic with
+        # gas (callTarget handles `[rax]`, `near`/`short`, PLT relocs) — #2835.
+        status: full
+        symbols:
+          - file: internal/extractors/assembly/extractor.go
+            functions: [buildProcedureEntities, callTarget, splitOperandTokens, cleanTargetToken]
+        tests:
+          - file: internal/extractors/assembly/extractor_test.go
+        issues_implemented: ["2744"]
+        verified_at: "2026-05-28"
+      import_resolution_quality:
+        # %include "file" IMPORTS + NASM `extern` external-symbol resolution.
+        status: full
+        symbols:
+          - file: internal/extractors/assembly/extractor.go
+            functions: [buildIncludeEntities, collectExternal]
+        tests:
+          - file: internal/extractors/assembly/extractor_test.go
+        issues_implemented: ["2744"]
+        verified_at: "2026-05-28"
+
   lang.jsts.framework.react:
     capabilities:
       Structure:


### PR DESCRIPTION
## Summary

Assembly was shipped by the #2834/#2841/#2844 extractor PRs with **zero registry records** (over-conservatively mirroring verilog/vhdl), so it sat in summary.md's "Languages with extractor support, no records yet" placeholder while same-wave COBOL got first-class rows. This adds genuine `language=assembly` records keyed on the real toolchains, mirroring COBOL's record model (#2840), so Assembly graduates to the main coverage table.

Records added (honest cells against `internal/extractors/assembly/extractor.go`):

| Record | core_extraction | call_line_precision | import_resolution_quality |
|---|---|---|---|
| `lang.assembly.toolchain.gnu-as` (GNU as/gas) | full | full | full |
| `lang.assembly.toolchain.nasm` (NASM) | full | full | full |
| `lang.assembly.toolchain.masm` (MASM) | partial | full | partial |
| `lang.assembly.toolchain.armasm` (ARM armasm) | partial | full | partial |

- **gas/nasm full**: gas covers x86-64 AT&T + ARM64 + m68k; NASM covers x86-64 Intel + `%define`/`%include`. Both exercised by the merged extractor fixtures (x86-64 gas/NASM/Intel, ARM64, m68k, cross-file resolution).
- **masm/armasm partial**: call/branch target extraction is syntax-agnostic (full), but MASM `.CODE`/`.DATA`/`INCLUDE` and armasm `AREA`/`IMPORT`/`GET` section & include directives are not parsed — only `.text`/`.data`/`.section` + `.include`/`%include` are. Instructions, labels, and EQU constants still extract.
- The **syscall effect** is delivered as a `CALLS` edge to the synthetic `__syscall` target (captured under the core/call cells), not a db/fs/http effect — assembly performs none of those, so those language-category effect cells are honestly omitted.
- **No new capability-dictionary keys**: the `language` allow-list already carries `core_extraction`/`call_line_precision`/`import_resolution_quality` post-#2840. `capability-map.yaml` gains gas/nasm traceability entries citing `extractor.go` functions.

## Verification

- summary.md header: **17 active / 19 placeholder -> 18 active / 18 placeholder**.
- Assembly now in the main "## Coverage by language" table (`| [assembly](by-language/assembly.md) | 0 | 0 | 0 | 4 |`), removed from the placeholder section.
- by-language/assembly.md shows the four records, no "No ecosystem records tracked yet" placeholder.
- `go run ./tools/coverage gen` + `validate` clean (0 errors).
- `go test ./tools/coverage/ ./internal/types/` green.

## Test plan

- [ ] `go run ./tools/coverage validate` -> 0 errors
- [ ] `go run ./tools/coverage gen` -> docs in sync (CI gate)
- [ ] `go test ./tools/coverage/ ./internal/types/`
- [ ] summary.md shows Assembly in main table + header 18/18

🤖 Generated with [Claude Code](https://claude.com/claude-code)