### PR TITLE
[JS/TS coverage] Mobile structure + data-flow + lifecycle — Ionic, NativeScript (+ finish Expo/RN state partials)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -189,10 +189,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 | [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -52,10 +52,10 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [Ionic](../detail/lang.jsts.framework.ionic.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 3/3 | |
-| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 3/3 | |
-| [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/lang.jsts.framework.expo.md
+++ b/docs/coverage/detail/lang.jsts.framework.expo.md
@@ -43,7 +43,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `branch_conditions` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/discriminator.go` | — |
-| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` | — |
+| `state_management` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_expo/ProfileScreen.tsx`<br>`internal/extractors/javascript/zustand_store.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.jsts.framework.ionic.md
+++ b/docs/coverage/detail/lang.jsts.framework.ionic.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `context_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `context_extraction` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | `internal/extractors/javascript/extractor.go` | — |
+| `hoc_wrapper_recognition` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx` | — |
 
 ### Navigation
 
@@ -42,8 +42,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
-| `state_management` | ❌ `missing` | — | — | — | — | — |
+| `branch_conditions` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/discriminator.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx` | — |
+| `state_management` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx`<br>`internal/extractors/javascript/zustand_store.go` | — |
 
 ### Type System
 
@@ -57,7 +57,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `state_setter_emission` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.jsts.framework.nativescript.md
+++ b/docs/coverage/detail/lang.jsts.framework.nativescript.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `context_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `context_extraction` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx` | — |
+| `hoc_wrapper_recognition` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx` | — |
 
 ### Navigation
 
@@ -42,8 +42,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
-| `state_management` | ❌ `missing` | — | — | — | — | — |
+| `branch_conditions` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/discriminator.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts` | — |
+| `state_management` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts` | — |
 
 ### Type System
 
@@ -57,7 +57,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `state_setter_emission` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
+| `state_setter_emission` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.jsts.framework.react-native.md
+++ b/docs/coverage/detail/lang.jsts.framework.react-native.md
@@ -43,7 +43,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `branch_conditions` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/discriminator.go` | — |
-| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` | — |
+| `state_management` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_react_native/CartScreen.tsx`<br>`internal/extractors/javascript/zustand_store.go` | — |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14707,11 +14707,9 @@
             "verified_at": "2026-05-28"
           },
           "state_management": {
-            "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/expo.yaml"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_expo/ProfileScreen.tsx","internal/extractors/javascript/zustand_store.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859",
             "verified_at": "2026-05-28"
           }
         },
@@ -15394,12 +15392,14 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing",
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2751"
           },
           "hoc_wrapper_recognition": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         },
         "Navigation": {
@@ -15425,11 +15425,14 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/discriminator.go","internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           },
           "state_management": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx","internal/extractors/javascript/zustand_store.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         },
         "Type System": {
@@ -15457,8 +15460,9 @@
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         },
         "Testing": {
@@ -15725,12 +15729,14 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           },
           "hoc_wrapper_recognition": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         },
         "Navigation": {
@@ -15756,11 +15762,14 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/discriminator.go","internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           },
           "state_management": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         },
         "Type System": {
@@ -15788,8 +15797,9 @@
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         },
         "Testing": {
@@ -16589,11 +16599,9 @@
             "verified_at": "2026-05-28"
           },
           "state_management": {
-            "status": "partial",
-            "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/react_native.yaml"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_react_native/CartScreen.tsx","internal/extractors/javascript/zustand_store.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859",
             "verified_at": "2026-05-28"
           }
         },

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -796,9 +796,86 @@ func (x *extractor) handleMethodDefinition(n *sitter.Node, _ string, cb *classBi
 	params := n.ChildByFieldName("parameters")
 	frame := x.functionParamFrame(params, cb)
 	rels := x.extractCallRelationships(body, name, frame)
-	x.emitWithRels(name, "SCOPE.Operation", n, "method", fmt.Sprintf("method %s", name), rels)
+	subtype := "method"
+	// Issue #2859 — NativeScript Observable view-models expose state mutation
+	// through their own component model, NOT React's [value, setter] hook
+	// tuple. The two idioms are:
+	//   1. a TypeScript `set` accessor whose body notifies observers, e.g.
+	//        set count(v) { this._count = v; this.notifyPropertyChange('count', v); }
+	//   2. an imperative method that calls this.set("prop", v) or
+	//      this.notifyPropertyChange("prop", v) (Observable.set / notify).
+	// Both are the NativeScript analogue of a React state setter, so we tag
+	// them subtype="state_setter" — the same subtype the resolver already
+	// understands for React setters (#513) — to make Lifecycle/state_setter
+	// queries framework-uniform across the mobile family.
+	if x.isNativeScriptStateSetter(body) {
+		subtype = "state_setter"
+	}
+	x.emitWithRels(name, "SCOPE.Operation", n, subtype, fmt.Sprintf("method %s", name), rels)
 	// Issue #2654 — stamp discriminator comparisons found in the body.
 	x.stampDiscriminators(body)
+}
+
+// isNativeScriptStateSetter recognises the NativeScript Observable
+// state-mutation idiom on a class method (#2859). It returns true when EITHER:
+//   - the method_definition is a `set` accessor whose body notifies observers
+//     (calls notifyPropertyChange or this.set), OR
+//   - any method body issues a this.set("prop", v) / this.notifyPropertyChange
+//     call (the imperative Observable setter).
+//
+// The match is conservative: a plain `set` accessor that does not notify is
+// NOT tagged (it is an ordinary property writer, not an observable state
+// setter), and the notify-call form must target a string-keyed property to
+// avoid catching unrelated set() calls (e.g. Set#add aliased to set).
+func (x *extractor) isNativeScriptStateSetter(body *sitter.Node) bool {
+	if body == nil {
+		return false
+	}
+	return x.bodyNotifiesObservable(body)
+}
+
+// bodyNotifiesObservable returns true when the statement block contains a
+// call to notifyPropertyChange(...) or this.set("<prop>", ...) — the two
+// NativeScript Observable mutation primitives.
+func (x *extractor) bodyNotifiesObservable(n *sitter.Node) bool {
+	if n == nil {
+		return false
+	}
+	if n.Type() == "call_expression" {
+		fn := n.ChildByFieldName("function")
+		if fn != nil && fn.Type() == "member_expression" {
+			prop := fn.ChildByFieldName("property")
+			obj := fn.ChildByFieldName("object")
+			leaf := x.nodeText(prop)
+			switch leaf {
+			case "notifyPropertyChange":
+				return true
+			case "set":
+				// Require this.set("prop", value): receiver `this`,
+				// first argument a string literal (the property key).
+				if obj != nil && obj.Type() == "this" {
+					if args := n.ChildByFieldName("arguments"); args != nil {
+						for i := 0; i < int(args.ChildCount()); i++ {
+							c := args.Child(i)
+							if c != nil && (c.Type() == "string" || c.Type() == "template_string") {
+								return true
+							}
+							if c != nil && c.IsNamed() {
+								// first named arg decides
+								return c.Type() == "string" || c.Type() == "template_string"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if x.bodyNotifiesObservable(n.Child(i)) {
+			return true
+		}
+	}
+	return false
 }
 
 // handlePublicFieldDefinition handles class-body field assignments whose RHS
@@ -889,7 +966,13 @@ func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass stri
 	}
 	sig := fmt.Sprintf("%s%s = (...) =>", sigParts, name)
 
-	x.emitWithRels(name, "SCOPE.Operation", valueNode, "method", sig, rels)
+	// Issue #2859 — NativeScript class-field arrow methods that notify
+	// observers are state setters, same as their method_definition twins.
+	fieldSubtype := "method"
+	if x.isNativeScriptStateSetter(body) {
+		fieldSubtype = "state_setter"
+	}
+	x.emitWithRels(name, "SCOPE.Operation", valueNode, fieldSubtype, sig, rels)
 	// Issue #2654 — stamp discriminator comparisons found in the body.
 	x.stampDiscriminators(body)
 
@@ -1415,6 +1498,9 @@ func (x *extractor) isFunctionWrapperCall(n *sitter.Node) bool {
 		"styled", "css", "keyframes",
 		// React Router HOCs
 		"withRouter", "withTranslation", "withTheme", "withStyles",
+		// Ionic React lifecycle HOC (#2859) — wraps a page component to
+		// receive Ionic's ionViewWillEnter/ionViewDidLeave lifecycle events.
+		"withIonLifeCycle",
 		// Redux / Recoil / Zustand selectors
 		"connect", "createSelector", "createStructuredSelector",
 		// React Native Animated
@@ -1447,7 +1533,42 @@ func (x *extractor) isFunctionWrapperCall(n *sitter.Node) bool {
 		"useCallback", "useMemo":
 		return true
 	}
+	// Issue #2859 — generic Higher-Order Component naming convention.
+	// `withFoo(Component)` is the dominant React/Ionic HOC shape (withAuth,
+	// withIonLifeCycle, withTheme, …). When the callee is `with<Capital>…`
+	// and it is invoked with a single argument (the wrapped component), the
+	// bound name IS the wrapped component (a function), so SCOPE.Operation is
+	// correct. Single-arg gate keeps this conservative — multi-arg `with*`
+	// helpers (rare) are not component wrappers.
+	if isHOCName(leaf) && callArgCount(n) == 1 {
+		return true
+	}
 	return false
+}
+
+// isHOCName reports whether leaf matches the `with<Capital>` HOC naming
+// convention (e.g. withAuth, withRouter, withIonLifeCycle).
+func isHOCName(leaf string) bool {
+	if len(leaf) <= 4 || leaf[:4] != "with" {
+		return false
+	}
+	c := leaf[4]
+	return c >= 'A' && c <= 'Z'
+}
+
+// callArgCount returns the number of named argument nodes in a call_expression.
+func callArgCount(n *sitter.Node) int {
+	args := n.ChildByFieldName("arguments")
+	if args == nil {
+		return 0
+	}
+	count := 0
+	for i := 0; i < int(args.ChildCount()); i++ {
+		if c := args.Child(i); c != nil && c.IsNamed() {
+			count++
+		}
+	}
+	return count
 }
 
 // isContextFactory returns true when valueNode is a call_expression whose

--- a/internal/extractors/javascript/issue2859_mobile_test.go
+++ b/internal/extractors/javascript/issue2859_mobile_test.go
@@ -1,0 +1,224 @@
+// Package javascript_test — issue #2859 mobile coverage greening.
+//
+// Proves the Structure / Data Flow / Lifecycle capabilities for the mobile
+// framework family (Ionic, NativeScript, Expo, React Native) against small
+// hand-written fixtures under testdata/mobile_*. Each fixture is the proving
+// artifact for a coverage cell flipped to `full` in docs/coverage/registry.json.
+//
+// The JS/TS extractor is framework-agnostic: Ionic (React under the hood),
+// React-NativeScript, Expo and React Native all reuse React's
+// createContext / HOC / useState primitives, so the existing extraction
+// (#611 context, #513 state setters, HOC wrapper recognition, #2654
+// discriminators, #2590 zustand stores) covers them. NativeScript core adds
+// its own Observable state-setter idiom (this.set / notifyPropertyChange),
+// recognised by isNativeScriptStateSetter (#2859).
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractFixture parses and extracts a testdata file with the TypeScript grammar.
+func extractFixture(t *testing.T, relPath string) []types.EntityRecord {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join("testdata", relPath))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", relPath, err)
+	}
+	tree := parseTS(t, content)
+	e := javascript.New()
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     relPath,
+		Content:  content,
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", relPath, err)
+	}
+	return ents
+}
+
+func entityWithSubtype(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func assertContext(t *testing.T, ents []types.EntityRecord, name string) {
+	t.Helper()
+	e := entityWithSubtype(ents, name)
+	if e == nil {
+		t.Fatalf("context entity %q not found; names: %v", name, entityNames(ents))
+	}
+	if e.Subtype != "context" {
+		t.Errorf("context %q: subtype=%q, want \"context\"", name, e.Subtype)
+	}
+}
+
+func assertHOC(t *testing.T, ents []types.EntityRecord, name string) {
+	t.Helper()
+	e := entityWithSubtype(ents, name)
+	if e == nil {
+		t.Fatalf("HOC entity %q not found; names: %v", name, entityNames(ents))
+	}
+	if e.Kind != "SCOPE.Operation" {
+		t.Errorf("HOC %q: kind=%q, want SCOPE.Operation", name, e.Kind)
+	}
+}
+
+func assertStateSetter(t *testing.T, ents []types.EntityRecord, name string) {
+	t.Helper()
+	e := entityWithSubtype(ents, name)
+	if e == nil {
+		t.Fatalf("state-setter entity %q not found; names: %v", name, entityNames(ents))
+	}
+	if e.Subtype != "state_setter" {
+		t.Errorf("state setter %q: subtype=%q, want \"state_setter\"", name, e.Subtype)
+	}
+	if e.Kind != "SCOPE.Operation" {
+		t.Errorf("state setter %q: kind=%q, want SCOPE.Operation", name, e.Kind)
+	}
+}
+
+func assertDiscriminator(t *testing.T, ents []types.EntityRecord, entityName, wantContains string) {
+	t.Helper()
+	for i := range ents {
+		if ents[i].Name == entityName {
+			got := ents[i].Properties["discriminators"]
+			if got == "" {
+				t.Errorf("%q: no discriminators stamped", entityName)
+			}
+			if wantContains != "" && !contains(got, wantContains) {
+				t.Errorf("%q: discriminators=%q, want to contain %q", entityName, got, wantContains)
+			}
+			return
+		}
+	}
+	t.Errorf("entity %q not found for discriminator check; names: %v", entityName, entityNames(ents))
+}
+
+func assertZustandAction(t *testing.T, ents []types.EntityRecord, name string) {
+	t.Helper()
+	e := entityWithSubtype(ents, name)
+	if e == nil {
+		t.Fatalf("zustand action %q not found; names: %v", name, entityNames(ents))
+	}
+	if e.Kind != "SCOPE.Operation" {
+		t.Errorf("zustand action %q: kind=%q, want SCOPE.Operation", name, e.Kind)
+	}
+	if e.Properties["via"] != "zustand_store" {
+		t.Errorf("zustand action %q: via=%q, want \"zustand_store\"", name, e.Properties["via"])
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// ── Ionic (React under the hood) ─────────────────────────────────────────────
+
+func TestMobile_Ionic_StructureDataFlowLifecycle(t *testing.T) {
+	ents := extractFixture(t, "mobile_ionic/SessionContext.tsx")
+
+	// Structure/context_extraction
+	assertContext(t, ents, "SessionContext")
+	// Structure/hoc_wrapper_recognition — Ionic lifecycle HOC + React memo
+	assertHOC(t, ents, "LifecyclePanel")
+	assertHOC(t, ents, "MemoPanel")
+	// Data Flow/state_management + Lifecycle/state_setter_emission
+	assertStateSetter(t, ents, "setAuthState")
+	assertStateSetter(t, ents, "setRetries")
+	// Data Flow/branch_conditions
+	assertDiscriminator(t, ents, "classify", "authState=authenticated")
+}
+
+// ── NativeScript (Observable core + React flavor) ────────────────────────────
+
+func TestMobile_NativeScript_ObservableStateSetters(t *testing.T) {
+	ents := extractFixture(t, "mobile_nativescript/main-view-model.ts")
+
+	// Data Flow/state_management + Lifecycle/state_setter_emission via the
+	// NativeScript Observable idiom (set accessor, this.set, notifyPropertyChange).
+	assertStateSetter(t, ents, "counter")        // set accessor that notifies
+	assertStateSetter(t, ents, "incrementCounter") // this.set("counter", ...)
+	assertStateSetter(t, ents, "reset")          // notifyPropertyChange
+
+	// Regression: a plain method that does not notify is NOT a state setter.
+	if e := entityWithSubtype(ents, "classify"); e == nil {
+		t.Fatal("classify method not found")
+	} else if e.Subtype == "state_setter" {
+		t.Errorf("classify: should NOT be state_setter (no observable notify)")
+	}
+
+	// Data Flow/branch_conditions
+	assertDiscriminator(t, ents, "classify", "status=idle")
+}
+
+func TestMobile_NativeScript_ReactFlavorContextHOC(t *testing.T) {
+	ents := extractFixture(t, "mobile_nativescript/AppShell.tsx")
+
+	// Structure/context_extraction
+	assertContext(t, ents, "DeviceContext")
+	// Structure/hoc_wrapper_recognition — NativeScript orientation HOC + memo
+	assertHOC(t, ents, "OrientationShell")
+	assertHOC(t, ents, "MemoShell")
+}
+
+// ── React Native (FLAGSHIP) ──────────────────────────────────────────────────
+
+func TestMobile_ReactNative_StateManagementFull(t *testing.T) {
+	ents := extractFixture(t, "mobile_react_native/CartScreen.tsx")
+
+	// Data Flow/state_management + Lifecycle/state_setter_emission
+	assertStateSetter(t, ents, "setQuantity")
+	assertStateSetter(t, ents, "setCoupon")
+	assertStateSetter(t, ents, "dispatch") // useReducer dispatch
+
+	// Structure/context_extraction + hoc_wrapper_recognition
+	assertContext(t, ents, "CartContext")
+
+	// zustand store actions are recognised store members (#2590) — emitted as
+	// SCOPE.Operation with Properties["via"]="zustand_store".
+	assertZustandAction(t, ents, "useCartStore::addItem")
+	assertZustandAction(t, ents, "useCartStore::clear")
+
+	// Data Flow/branch_conditions
+	assertDiscriminator(t, ents, "checkout", "coupon=FREESHIP")
+}
+
+// ── Expo ─────────────────────────────────────────────────────────────────────
+
+func TestMobile_Expo_StateManagementFull(t *testing.T) {
+	ents := extractFixture(t, "mobile_expo/ProfileScreen.tsx")
+
+	assertStateSetter(t, ents, "setName")
+	assertStateSetter(t, ents, "setTheme")
+	assertStateSetter(t, ents, "dispatchPrefs")
+
+	assertContext(t, ents, "ThemeContext")
+
+	assertZustandAction(t, ents, "useSessionStore::setToken")
+	assertZustandAction(t, ents, "useSessionStore::logout")
+
+	assertDiscriminator(t, ents, "save", "theme=dark")
+}

--- a/internal/extractors/javascript/testdata/mobile_expo/ProfileScreen.tsx
+++ b/internal/extractors/javascript/testdata/mobile_expo/ProfileScreen.tsx
@@ -1,0 +1,46 @@
+// Expo fixture (#2859) — proves Expo's full Data Flow/state_management surface
+// (was partial). Expo apps are React Native apps; state management is handled
+// by the same extractor (#513 setters + #2590 zustand store actions). Proves:
+//   - state_management   → useState setter, useReducer dispatch, zustand action
+//   - state_setter_emission → subtype="state_setter"
+//   - context_extraction → createContext()
+//   - hoc_wrapper_recognition → memo()
+import React, { createContext, useState, useReducer, memo } from 'react';
+import { View } from 'react-native';
+import { create } from 'zustand';
+
+// context_extraction
+export const ThemeContext = createContext('light');
+
+// zustand store
+export const useSessionStore = create((set) => ({
+  token: null,
+  setToken: (t) => set({ token: t }),
+  logout: () => set({ token: null }),
+}));
+
+function prefsReducer(state, action) {
+  return state;
+}
+
+function ProfileScreen() {
+  // state_management + state_setter_emission
+  const [name, setName] = useState('');
+  const [theme, setTheme] = useState('light');
+  const [prefs, dispatchPrefs] = useReducer(prefsReducer, {});
+
+  const logout = useSessionStore((s) => s.logout);
+
+  // branch_conditions
+  function save() {
+    if (theme === 'dark') {
+      setName(name);
+    }
+    dispatchPrefs({ type: 'save' });
+    logout();
+  }
+
+  return <View onLayout={save} />;
+}
+
+export default memo(ProfileScreen);

--- a/internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx
+++ b/internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx
@@ -1,0 +1,44 @@
+// Ionic React fixture (#2859) — Ionic builds on React under the hood, so the
+// framework-agnostic JS/TS extractor already covers its Structure / Data Flow /
+// Lifecycle capabilities. This fixture proves:
+//   - Structure/context_extraction      → createContext() → SCOPE.Component subtype="context"
+//   - Structure/hoc_wrapper_recognition → withIonLifeCycle() / memo() HOC → SCOPE.Operation
+//   - Data Flow/state_management        → useState [value, setter] tuple
+//   - Data Flow/branch_conditions       → discriminator comparisons in a body
+//   - Lifecycle/state_setter_emission   → setter element subtype="state_setter"
+import { createContext, useState, memo } from 'react';
+import { IonPage, IonContent } from '@ionic/react';
+import { withIonLifeCycle } from '@ionic/react';
+
+// context_extraction
+export const SessionContext = createContext(null);
+
+// state_management + state_setter_emission
+function SessionPanel() {
+  const [authState, setAuthState] = useState('anonymous');
+  const [retries, setRetries] = useState(0);
+
+  // branch_conditions — discriminator comparisons on a bare identifier
+  function classify() {
+    if (authState === 'authenticated') {
+      return 1;
+    }
+    if (retries === 3) {
+      setAuthState('locked');
+    }
+    return 0;
+  }
+
+  return (
+    <IonPage>
+      <IonContent onClick={() => setRetries(retries + 1)}>{classify()}</IonContent>
+    </IonPage>
+  );
+}
+
+// hoc_wrapper_recognition — Ionic lifecycle HOC and React memo both produce
+// a wrapped component bound to a name.
+const LifecyclePanel = withIonLifeCycle(SessionPanel);
+export const MemoPanel = memo(SessionPanel);
+
+export default LifecyclePanel;

--- a/internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx
+++ b/internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx
@@ -1,0 +1,18 @@
+// React-NativeScript fixture (#2859) — the React flavor of NativeScript
+// (`react-nativescript`) reuses React's context + HOC primitives, which the
+// framework-agnostic extractor already covers. Proves for NativeScript:
+//   - Structure/context_extraction      → createContext()
+//   - Structure/hoc_wrapper_recognition → withOrientation() HOC + memo()
+import { createContext, memo } from 'react';
+import { withOrientation } from 'react-nativescript';
+
+// context_extraction
+export const DeviceContext = createContext({ orientation: 'portrait' });
+
+function ShellRoot() {
+  return null;
+}
+
+// hoc_wrapper_recognition — NativeScript orientation HOC + React memo.
+export const OrientationShell = withOrientation(ShellRoot);
+export const MemoShell = memo(ShellRoot);

--- a/internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts
+++ b/internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts
@@ -1,0 +1,47 @@
+// NativeScript core fixture (#2859) — vanilla NativeScript uses its OWN
+// component model: a view-model class extends Observable and mutates state via
+// `set` accessors / this.set("prop", v) / notifyPropertyChange, which the
+// extractor recognises as state setters (subtype="state_setter"). Proves:
+//   - Data Flow/state_management      → Observable setter methods
+//   - Lifecycle/state_setter_emission → subtype="state_setter" on those methods
+//   - Data Flow/branch_conditions     → discriminator comparisons in a body
+import { Observable } from '@nativescript/core';
+
+export class MainViewModel extends Observable {
+  private _counter = 0;
+  private _status = 'idle';
+
+  // state setter — `set` accessor that notifies observers
+  set counter(value: number) {
+    this._counter = value;
+    this.notifyPropertyChange('counter', value);
+  }
+
+  get counter(): number {
+    return this._counter;
+  }
+
+  // state setter — imperative this.set("prop", v)
+  incrementCounter() {
+    this.set('counter', this._counter + 1);
+  }
+
+  // state setter — direct notifyPropertyChange
+  reset() {
+    this._counter = 0;
+    this.notifyPropertyChange('counter', 0);
+  }
+
+  // NOT a state setter — plain method, no observable notification.
+  // branch_conditions: discriminator comparisons on bare identifiers.
+  classify() {
+    const status = this._status;
+    if (status === 'idle') {
+      return 0;
+    }
+    if (this._counter === 10) {
+      return 2;
+    }
+    return 1;
+  }
+}

--- a/internal/extractors/javascript/testdata/mobile_react_native/CartScreen.tsx
+++ b/internal/extractors/javascript/testdata/mobile_react_native/CartScreen.tsx
@@ -1,0 +1,57 @@
+// React Native fixture (#2859) — FLAGSHIP. Proves React Native's full
+// Data Flow/state_management surface (was partial, citing only the detection
+// yaml). The state-management extraction lives in the framework-agnostic
+// extractor (#513 state setters) + zustand_store.go (#2590 store actions), and
+// applies to React Native verbatim. Proves:
+//   - state_management   → useState [value, setter], useReducer dispatch, zustand store actions
+//   - state_setter_emission → setter / dispatch subtype="state_setter"
+//   - context_extraction → createContext()
+//   - hoc_wrapper_recognition → memo()
+//   - branch_conditions  → discriminator comparisons
+import React, { createContext, useState, useReducer, memo } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { create } from 'zustand';
+
+// context_extraction
+export const CartContext = createContext(null);
+
+// zustand store — actions inside the closure are CALLS targets (#2590)
+export const useCartStore = create((set, get) => ({
+  items: [],
+  addItem: (item) => set((s) => ({ items: [...s.items, item] })),
+  clear: () => set({ items: [] }),
+}));
+
+function cartReducer(state, action) {
+  return state;
+}
+
+function CartScreen() {
+  // state_management + state_setter_emission
+  const [quantity, setQuantity] = useState(1);
+  const [coupon, setCoupon] = useState('');
+  const [state, dispatch] = useReducer(cartReducer, { items: [] });
+
+  // zustand selector usage
+  const addItem = useCartStore((s) => s.addItem);
+
+  // branch_conditions — discriminator comparisons
+  function checkout() {
+    if (coupon === 'FREESHIP') {
+      setQuantity(quantity);
+    }
+    if (quantity === 0) {
+      dispatch({ type: 'reset' });
+    }
+    addItem({ id: 1 });
+  }
+
+  return (
+    <View>
+      <Text>{quantity}</Text>
+      <Pressable onPress={checkout} />
+    </View>
+  );
+}
+
+export default memo(CartScreen);


### PR DESCRIPTION
_Closes #2859. Part of epic #2847._

## Summary
Greens 12 JS/TS **mobile** coverage cells (Structure / Data Flow / Lifecycle) for Ionic, NativeScript, Expo and React Native. The JS/TS extractor is framework-agnostic, so Ionic (React under the hood), Expo, React Native, and React-NativeScript reuse the existing `createContext` (#611), HOC-wrapper, `useState`/`useReducer` state-setter (#513), discriminator (#2654) and zustand-store (#2590) extraction. New work:

- **Generic `with<Capital>(Component)` HOC recognition** (single-arg gate) + explicit `withIonLifeCycle` — covers the dominant React/Ionic HOC naming convention beyond the prior fixed list.
- **NativeScript Observable state-setter detection** — recognises NativeScript's own component model (`set` accessor that notifies, `this.set("prop", v)`, `notifyPropertyChange`) and tags those methods `subtype="state_setter"`, the same subtype the resolver already understands for React setters.

Each flipped cell has a proving fixture under `internal/extractors/javascript/testdata/mobile_{ionic,nativescript,expo,react_native}/` with assertions in `issue2859_mobile_test.go`. **No new entity/edge Kind** — `state_setter` is a subtype of the existing `SCOPE.Operation` Kind, so `internal/types/` is unaffected (verified: `go test ./internal/types/` passes).

React Native (flagship) reaches full state_management with fixtures proving useState setters, useReducer dispatch, and zustand store actions.

## implements-capability
```
implements-capability: lang.jsts.framework.ionic/Structure/context_extraction:missing→full
implements-capability: lang.jsts.framework.ionic/Structure/hoc_wrapper_recognition:missing→full
implements-capability: lang.jsts.framework.nativescript/Structure/context_extraction:missing→full
implements-capability: lang.jsts.framework.nativescript/Structure/hoc_wrapper_recognition:missing→full
implements-capability: lang.jsts.framework.expo/Data Flow/state_management:partial→full
implements-capability: lang.jsts.framework.react-native/Data Flow/state_management:partial→full
implements-capability: lang.jsts.framework.ionic/Data Flow/state_management:missing→full
implements-capability: lang.jsts.framework.ionic/Data Flow/branch_conditions:missing→full
implements-capability: lang.jsts.framework.nativescript/Data Flow/state_management:missing→full
implements-capability: lang.jsts.framework.nativescript/Data Flow/branch_conditions:missing→full
implements-capability: lang.jsts.framework.ionic/Lifecycle/state_setter_emission:missing→full
implements-capability: lang.jsts.framework.nativescript/Lifecycle/state_setter_emission:missing→full
```

## Test plan
- [x] `go test ./internal/extractors/javascript/` — new `TestMobile_*` + no regressions
- [x] `go test ./internal/types/` — no new Kind, registry exhaustive
- [x] `go test ./internal/substrate/ ./internal/links/ ./internal/engine/ ./tools/coverage/`
- [x] `go run ./tools/coverage validate` exits 0; `gen` byte-stable
- [x] Real-data: extractor run over real React/TS files (nextjs-commerce corpus) — 5 state_setters + 1 context, no crashes from the generic HOC convention
- [x] Self-rebased onto origin/main (picked up #2868/#2870)

🤖 Generated with [Claude Code](https://claude.com/claude-code)