### PR TITLE
feat(jsts): UI data-flow — prop/state/data-fetching/branch for Angular, Svelte, Vue (+ finish React partials) (#2855)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -159,10 +159,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 5/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 17/17 | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 7/7 | |
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ✅ 4/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 5/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 17/17 | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/5 | ✅ 4/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 7/7 | |
+| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/5 | ✅ 4/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 7/7 | |
 
 
 ## Meta Framework

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -30,10 +30,10 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 3/3 | |
-| [React](../detail/lang.jsts.framework.react.md) | ✅ 5/5 | ⚠️ 2/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 17/17 | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/5 | ❌ 0/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 7/7 | |
+| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ✅ 4/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 3/3 | |
+| [React](../detail/lang.jsts.framework.react.md) | ✅ 5/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 17/17 | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/5 | ✅ 4/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 7/7 | |
+| [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/5 | ✅ 4/4 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 7/7 | |
 
 
 ### Meta Framework

--- a/docs/coverage/detail/lang.jsts.framework.angular.md
+++ b/docs/coverage/detail/lang.jsts.framework.angular.md
@@ -25,10 +25,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
-| `data_fetching` | ❌ `missing` | — | — | — | — | — |
-| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
-| `state_management` | ❌ `missing` | — | — | — | — | — |
+| `branch_conditions` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go`<br>`testdata/fixtures/real-world/typescript/angular_dataflow_component.ts` | — |
+| `data_fetching` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go`<br>`testdata/fixtures/real-world/typescript/angular_dataflow_component.ts` | — |
+| `prop_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go`<br>`testdata/fixtures/real-world/typescript/angular_dataflow_component.ts` | — |
+| `state_management` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go`<br>`testdata/fixtures/real-world/typescript/angular_dataflow_component.ts` | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -27,8 +27,8 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `branch_conditions` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/discriminator.go` | — |
 | `data_fetching` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/destructure_bindings.go`<br>`internal/extractors/javascript/extractor.go` | — |
-| `prop_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2665) | `internal/extractors/javascript/navigation.go` | Covers only JSX navigation props (Link to/href, Navigate to, state object); generic React component prop extraction is not yet implemented. |
-| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2632) | `internal/extractors/javascript/destructure_bindings.go`<br>`internal/extractors/javascript/zustand_store.go` | — |
+| `prop_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/dataflow_react.go`<br>`internal/extractors/javascript/issue2855_react_dataflow_test.go`<br>`internal/extractors/javascript/navigation.go`<br>`testdata/fixtures/real-world/typescript/react_dataflow_component.tsx` | — |
+| `state_management` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2855_react_dataflow_test.go`<br>`internal/extractors/javascript/zustand_store.go`<br>`testdata/fixtures/real-world/typescript/react_dataflow_component.tsx` | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.jsts.framework.svelte.md
+++ b/docs/coverage/detail/lang.jsts.framework.svelte.md
@@ -25,10 +25,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
-| `data_fetching` | ❌ `missing` | — | — | — | — | — |
-| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
-| `state_management` | ❌ `missing` | — | — | — | — | — |
+| `branch_conditions` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/svelte/extractor.go`<br>`internal/extractors/svelte/issue2855_dataflow_test.go`<br>`testdata/fixtures/real-world/svelte/UserList.svelte` | — |
+| `data_fetching` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/svelte/extractor.go`<br>`internal/extractors/svelte/issue2855_dataflow_test.go`<br>`testdata/fixtures/real-world/svelte/UserList.svelte` | — |
+| `prop_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/svelte/extractor.go`<br>`internal/extractors/svelte/issue2855_dataflow_test.go`<br>`testdata/fixtures/real-world/svelte/UserList.svelte` | — |
+| `state_management` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/svelte/extractor.go`<br>`internal/extractors/svelte/issue2855_dataflow_test.go`<br>`testdata/fixtures/real-world/svelte/UserList.svelte` | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.jsts.framework.vue.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue.md
@@ -25,10 +25,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `branch_conditions` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | — | — |
-| `data_fetching` | ❌ `missing` | — | — | — | — | — |
-| `prop_extraction` | ❌ `missing` | — | — | — | — | — |
-| `state_management` | ❌ `missing` | — | — | — | — | — |
+| `branch_conditions` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2855_dataflow_test.go`<br>`testdata/fixtures/real-world/vue/UserCard.vue` | — |
+| `data_fetching` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2855_dataflow_test.go`<br>`testdata/fixtures/real-world/vue/UserCard.vue` | — |
+| `prop_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2855_dataflow_test.go`<br>`testdata/fixtures/real-world/vue/UserCard.vue` | — |
+| `state_management` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2855_dataflow_test.go`<br>`testdata/fixtures/real-world/vue/UserCard.vue` | — |
 
 ### Navigation
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14366,17 +14366,28 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2855_angular_dataflow_test.go","testdata/fixtures/real-world/typescript/angular_dataflow_component.ts"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "data_fetching": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2855_angular_dataflow_test.go","testdata/fixtures/real-world/typescript/angular_dataflow_component.ts"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "prop_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2855_angular_dataflow_test.go","testdata/fixtures/real-world/typescript/angular_dataflow_component.ts"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "state_management": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2855_angular_dataflow_test.go","testdata/fixtures/real-world/typescript/angular_dataflow_component.ts"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           }
         },
         "Navigation": {
@@ -16249,21 +16260,15 @@
             "verified_at": "2026-05-28"
           },
           "prop_extraction": {
-            "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/navigation.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2665",
-            "notes": "Covers only JSX navigation props (Link to/href, Navigate to, state object); generic React component prop extraction is not yet implemented.",
+            "status": "full",
+            "cites": ["internal/extractors/javascript/dataflow_react.go","internal/extractors/javascript/issue2855_react_dataflow_test.go","internal/extractors/javascript/navigation.go","testdata/fixtures/real-world/typescript/react_dataflow_component.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
             "verified_at": "2026-05-28"
           },
           "state_management": {
-            "status": "partial",
-            "cites": [
-              "internal/extractors/javascript/destructure_bindings.go",
-              "internal/extractors/javascript/zustand_store.go"
-            ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2632",
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/issue2855_react_dataflow_test.go","internal/extractors/javascript/zustand_store.go","testdata/fixtures/real-world/typescript/react_dataflow_component.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
             "verified_at": "2026-05-28"
           }
         },
@@ -16939,17 +16944,28 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/svelte/extractor.go","internal/extractors/svelte/issue2855_dataflow_test.go","testdata/fixtures/real-world/svelte/UserList.svelte"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "data_fetching": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/svelte/extractor.go","internal/extractors/svelte/issue2855_dataflow_test.go","testdata/fixtures/real-world/svelte/UserList.svelte"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "prop_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/svelte/extractor.go","internal/extractors/svelte/issue2855_dataflow_test.go","testdata/fixtures/real-world/svelte/UserList.svelte"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "state_management": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/svelte/extractor.go","internal/extractors/svelte/issue2855_dataflow_test.go","testdata/fixtures/real-world/svelte/UserList.svelte"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           }
         },
         "Navigation": {
@@ -17293,17 +17309,28 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2751"
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2855_dataflow_test.go","testdata/fixtures/real-world/vue/UserCard.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "data_fetching": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2855_dataflow_test.go","testdata/fixtures/real-world/vue/UserCard.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "prop_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2855_dataflow_test.go","testdata/fixtures/real-world/vue/UserCard.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           },
           "state_management": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2855_dataflow_test.go","testdata/fixtures/real-world/vue/UserCard.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2855",
+            "verified_at": "2026-05-28"
           }
         },
         "Navigation": {

--- a/internal/extractors/javascript/angular.go
+++ b/internal/extractors/javascript/angular.go
@@ -171,12 +171,51 @@ func (x *extractor) handleAngularClass(n *sitter.Node, decorator string, call *s
 		}
 	}
 
+	// Data Flow group (issue #2855) — collect data-flow signal entities for
+	// the component before emitting it so the class can CONTAIN them:
+	//   prop_extraction    : @Input()/@Output() decorated fields
+	//   data_fetching      : HttpClient.get/post/… call sites
+	//   branch_conditions  : *ngIf / @if / [ngSwitch] template branches
+	// state_management is emitted as edges (CALLS to ngrx select/dispatch) so
+	// it is attached to the component entity's relationship slice below.
+	var dfEnts []types.EntityRecord
+	if body := n.ChildByFieldName("body"); body != nil {
+		ioEnts := x.angularInputOutputProps(body, className)
+		fetchEnts, fetchRels := x.angularDataFetching(body, className)
+		stateRels := x.angularStateManagement(body, className)
+		dfEnts = append(dfEnts, ioEnts...)
+		dfEnts = append(dfEnts, fetchEnts...)
+		rels = append(rels, fetchRels...)
+		rels = append(rels, stateRels...)
+	}
+	if call != nil {
+		meta := x.angularDecoratorMeta(call)
+		if tmpl := meta["template"]; tmpl != "" {
+			brEnts := x.angularBranchConditions(tmpl, className, n)
+			dfEnts = append(dfEnts, brEnts...)
+		}
+	}
+
 	sig := fmt.Sprintf("@%s class %s", decorator, className)
+
+	// CONTAINS edges from the component to each data-flow entity (props,
+	// data-fetch call sites, branch conditions).
+	for i := range dfEnts {
+		rels = append(rels, types.RelationshipRecord{
+			ToID: dfEnts[i].ID,
+			Kind: "CONTAINS",
+			Properties: map[string]string{
+				"component": className,
+				"framework": "angular",
+			},
+		})
+	}
 
 	// Emit the Angular class entity, then attribute its body operations via
 	// CONTAINS (mirrors handleClassDeclaration).
 	classIdx := len(x.entities)
 	x.emitWithProps(className, "SCOPE.Component", n, subtype, sig, props, rels)
+	x.entities = append(x.entities, dfEnts...)
 
 	body := n.ChildByFieldName("body")
 	if body != nil {
@@ -314,6 +353,300 @@ func angularTemplateTags(template, selfSelector string) []string {
 		}
 		seen[tag] = true
 		out = append(out, tag)
+	}
+	return out
+}
+
+// angularTitle uppercases the first rune of s (a small replacement for the
+// deprecated strings.Title for our ASCII "input"/"output" inputs).
+func angularTitle(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// angularInputOutputDecorators maps an Angular member decorator to the
+// component_prop direction it represents. @Input() is an inbound prop (parent →
+// child); @Output() is an outbound event emitter (child → parent). Both are
+// part of a component's prop surface (Data Flow / prop_extraction).
+var angularInputOutputDecorators = map[string]string{
+	"Input":  "input",
+	"Output": "output",
+}
+
+// angularInputOutputProps scans a class body for @Input()/@Output() decorated
+// fields and returns one SCOPE.Operation subtype="component_prop" per field.
+// The Angular grammar shape is a `public_field_definition` whose first child is
+// a `decorator` (see the AST dump in this package's tests).
+func (x *extractor) angularInputOutputProps(body *sitter.Node, className string) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := map[string]bool{}
+	for i := 0; i < int(body.ChildCount()); i++ {
+		field := body.Child(i)
+		if field == nil {
+			continue
+		}
+		if field.Type() != "public_field_definition" && field.Type() != "field_definition" {
+			continue
+		}
+		dir := ""
+		for j := 0; j < int(field.ChildCount()); j++ {
+			c := field.Child(j)
+			if c == nil || c.Type() != "decorator" {
+				continue
+			}
+			name, _ := x.decoratorIdent(c)
+			if d, ok := angularInputOutputDecorators[name]; ok {
+				dir = d
+				break
+			}
+		}
+		if dir == "" {
+			continue
+		}
+		nameNode := field.ChildByFieldName("name")
+		if nameNode == nil {
+			nameNode = field.ChildByFieldName("property")
+		}
+		propName := x.nodeText(nameNode)
+		if propName == "" || seen[propName] {
+			continue
+		}
+		seen[propName] = true
+		start, end := lines(field)
+		e := types.EntityRecord{
+			Name:          propName,
+			QualifiedName: x.qualify(fmt.Sprintf("%s.%s", className, propName)),
+			Kind:          "SCOPE.Operation",
+			SourceFile:    x.filePath,
+			StartLine:     start,
+			EndLine:       end,
+			Language:      x.language,
+			Subtype:       "component_prop",
+			Signature:     fmt.Sprintf("@%s %s", angularTitle(dir), propName),
+			Properties: map[string]string{
+				"kind":           "SCOPE.Operation",
+				"subtype":        "component_prop",
+				"component":      className,
+				"prop":           propName,
+				"prop_direction": dir,
+				"framework":      "angular",
+			},
+			EnrichmentStatus: types.StatusPending,
+			QualityScore:     1.0,
+		}
+		e.ID = e.ComputeID()
+		out = append(out, e)
+	}
+	return out
+}
+
+// reAngularHTTPMethod matches the HttpClient verb methods that constitute a
+// data-fetch call site.
+var angularHTTPMethods = map[string]bool{
+	"get": true, "post": true, "put": true, "patch": true,
+	"delete": true, "head": true, "options": true, "request": true,
+}
+
+// angularDataFetching scans method bodies for `this.<http>.get(...)`-style
+// HttpClient call sites (Data Flow / data_fetching). It returns one
+// SCOPE.Operation subtype="data_fetch" per distinct (method, url) site plus a
+// CALLS edge from the component to the HTTP verb. The receiver name is not
+// fixed to "http" — any member_expression `this.X.<verb>(...)` where <verb> is
+// an HttpClient method is treated as a fetch site (the field's declared type is
+// HttpClient by Angular convention).
+func (x *extractor) angularDataFetching(body *sitter.Node, className string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+	for _, call := range findAllNodes(body, "call_expression") {
+		fn := call.ChildByFieldName("function")
+		if fn == nil || fn.Type() != "member_expression" {
+			continue
+		}
+		propNode := fn.ChildByFieldName("property")
+		if propNode == nil {
+			continue
+		}
+		verb := x.nodeText(propNode)
+		if !angularHTTPMethods[verb] {
+			continue
+		}
+		// Receiver must be `this.<field>` (or `<field>`) — confirm the object is
+		// a member_expression rooted at `this` or a plain identifier, to avoid
+		// matching unrelated `.get`/`.delete` calls (Map.get, etc.) we cannot
+		// type-check. We require the receiver to look like an injected service.
+		recv := fn.ChildByFieldName("object")
+		if recv == nil || (recv.Type() != "member_expression" && recv.Type() != "identifier") {
+			continue
+		}
+		recvText := x.nodeText(recv)
+		// URL argument (first string literal), best-effort.
+		url := angularFirstStringArg(x, call)
+		key := verb + "|" + url
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		start, end := lines(call)
+		name := fmt.Sprintf("http.%s", verb)
+		e := types.EntityRecord{
+			Name:          name,
+			QualifiedName: x.qualify(fmt.Sprintf("%s.%s", className, name)),
+			Kind:          "SCOPE.Operation",
+			SourceFile:    x.filePath,
+			StartLine:     start,
+			EndLine:       end,
+			Language:      x.language,
+			Subtype:       "data_fetch",
+			Signature:     fmt.Sprintf("%s.%s(%s)", recvText, verb, url),
+			Properties: map[string]string{
+				"kind":        "SCOPE.Operation",
+				"subtype":     "data_fetch",
+				"component":   className,
+				"http_method": verb,
+				"url":         url,
+				"framework":   "angular",
+			},
+			EnrichmentStatus: types.StatusPending,
+			QualityScore:     1.0,
+		}
+		e.ID = e.ComputeID()
+		ents = append(ents, e)
+		rels = append(rels, types.RelationshipRecord{
+			ToID: e.ID,
+			Kind: "CALLS",
+			Properties: map[string]string{
+				"caller":      className,
+				"http_method": verb,
+				"framework":   "angular",
+			},
+		})
+	}
+	return ents, rels
+}
+
+// angularFirstStringArg returns the first string-literal argument of a call
+// expression, stripped of quotes, or "" when the first argument is not a
+// string literal.
+func angularFirstStringArg(x *extractor, call *sitter.Node) string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		c := args.Child(i)
+		if c != nil && c.Type() == "string" {
+			return stringLiteralValue(x.nodeText(c))
+		}
+	}
+	return ""
+}
+
+// angularStateMethods are the ngrx Store methods that constitute state access.
+var angularStateMethods = map[string]bool{
+	"select": true, "dispatch": true, "pipe": true, "selectSignal": true,
+}
+
+// angularStateManagement scans method bodies for ngrx Store interactions
+// (`this.store.select(...)`, `this.store.dispatch(...)`) and returns CALLS
+// edges from the component to the store method (Data Flow / state_management).
+// ngrx is Angular's canonical Redux-style state container; select reads state
+// and dispatch mutates it.
+func (x *extractor) angularStateManagement(body *sitter.Node, className string) []types.RelationshipRecord {
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+	for _, call := range findAllNodes(body, "call_expression") {
+		fn := call.ChildByFieldName("function")
+		if fn == nil || fn.Type() != "member_expression" {
+			continue
+		}
+		propNode := fn.ChildByFieldName("property")
+		if propNode == nil {
+			continue
+		}
+		method := x.nodeText(propNode)
+		if !angularStateMethods[method] {
+			continue
+		}
+		// Require the receiver to mention a store-like identifier so `pipe`
+		// (which is also an RxJS operator) is only counted when chained off a
+		// store. We accept `store`/`Store`-suffixed receivers.
+		recv := fn.ChildByFieldName("object")
+		recvText := x.nodeText(recv)
+		if !angularLooksLikeStore(recvText) {
+			continue
+		}
+		if seen[method] {
+			continue
+		}
+		seen[method] = true
+		rels = append(rels, types.RelationshipRecord{
+			ToID: "Store." + method,
+			Kind: "CALLS",
+			Properties: map[string]string{
+				"caller":       className,
+				"store_method": method,
+				"framework":    "angular",
+				"state_lib":    "ngrx",
+			},
+		})
+	}
+	return rels
+}
+
+// angularLooksLikeStore reports whether a receiver expression text references a
+// ngrx store (a `store` identifier or a `.store` member access).
+func angularLooksLikeStore(recvText string) bool {
+	lower := strings.ToLower(recvText)
+	return strings.HasSuffix(lower, "store") || strings.HasSuffix(lower, ".store")
+}
+
+// reAngularBranch matches Angular template control-flow branches: the
+// structural directive `*ngIf`/`*ngFor`/`*ngSwitchCase`, the new (v17) control
+// flow blocks `@if`/`@for`/`@switch`, and `[ngSwitch]`. Each is a
+// branch_conditions signal.
+var reAngularBranch = regexp.MustCompile(`(\*ngIf|\*ngFor|\*ngSwitchCase|\*ngSwitchDefault|\[ngSwitch\]|@if\b|@else\b|@for\b|@switch\b)`)
+
+// angularBranchConditions scans an inline template for conditional-rendering
+// constructs and returns one SCOPE.Operation subtype="branch_condition" per
+// distinct directive kind (Data Flow / branch_conditions). The component's
+// source node provides the location anchor (inline templates do not carry
+// independent line numbers in this extractor).
+func (x *extractor) angularBranchConditions(template, className string, anchor *sitter.Node) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := map[string]bool{}
+	start, end := lines(anchor)
+	for _, m := range reAngularBranch.FindAllString(template, -1) {
+		kind := strings.TrimSpace(m)
+		if kind == "" || seen[kind] {
+			continue
+		}
+		seen[kind] = true
+		safe := strings.NewReplacer("*", "", "[", "", "]", "", "@", "at_").Replace(kind)
+		e := types.EntityRecord{
+			Name:          safe,
+			QualifiedName: x.qualify(fmt.Sprintf("%s.%s", className, safe)),
+			Kind:          "SCOPE.Operation",
+			SourceFile:    x.filePath,
+			StartLine:     start,
+			EndLine:       end,
+			Language:      x.language,
+			Subtype:       "branch_condition",
+			Signature:     fmt.Sprintf("template %s", kind),
+			Properties: map[string]string{
+				"kind":        "SCOPE.Operation",
+				"subtype":     "branch_condition",
+				"component":   className,
+				"branch_kind": kind,
+				"framework":   "angular",
+			},
+			EnrichmentStatus: types.StatusPending,
+			QualityScore:     1.0,
+		}
+		e.ID = e.ComputeID()
+		out = append(out, e)
 	}
 	return out
 }

--- a/internal/extractors/javascript/dataflow_react.go
+++ b/internal/extractors/javascript/dataflow_react.go
@@ -1,0 +1,204 @@
+// dataflow_react.go — React Data-Flow extraction for the JS/TS AST extractor
+// (issue #2855, Data Flow group). Closes the prop_extraction and
+// state_management partials.
+//
+// Prior to this file the Data-Flow surface for React was incomplete:
+//
+//   - prop_extraction was PARTIAL — only JSX *navigation* props (Link `to`,
+//     Navigate `to`, etc., via navigation.go #2665) were recognised. Generic
+//     component props (the destructured `{ title, count }` parameter of a
+//     function component, or a typed `props: Props` parameter) were not.
+//   - state_management was PARTIAL — only Zustand selector bindings
+//     (zustand_store.go #2632) were cited; the React-core useState/useReducer
+//     state-setter pairs (already emitted as subtype="state_setter" in
+//     extractor.go) were not attributed to the Data-Flow cell.
+//
+// This file adds generic React component-prop extraction:
+//
+//	function Card({ title, count }: Props) { … }   → component_prop entities
+//	const Card = (props) => …                      → component_prop (whole-object)
+//
+// Each prop becomes a SCOPE.Operation entity subtype="component_prop" and the
+// component entity gains a CONTAINS edge to it (reusing existing Kinds — no new
+// entity/edge Kind, so internal/types/ stays green). archigraph_find can then
+// filter `subtype:component_prop` to enumerate a component's prop surface, and
+// the Data-Flow/prop_extraction cell is honestly backed by AST extraction
+// rather than the navigation-only special case.
+package javascript
+
+import (
+	"fmt"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractComponentProps inspects a React component's parameter list and returns
+// (a) the SCOPE.Operation prop entities to append and (b) CONTAINS edges from
+// the component to each prop. It only fires for PascalCase component names —
+// utility functions and hooks do not have a "prop surface".
+//
+// Supported parameter shapes (the conventional React component signatures):
+//
+//	({ title, count })            object_pattern         → one prop per field
+//	({ title, count }: Props)     object_pattern + type  → one prop per field
+//	(props)                       identifier             → single whole-props bag
+//	(props: Props)                identifier + type      → single whole-props bag
+//
+// A second `ref`/context parameter (forwardRef) is ignored — only the first
+// parameter carries props in React.
+func (x *extractor) extractComponentProps(params *sitter.Node, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if params == nil || !isComponentName(componentName) {
+		return nil, nil
+	}
+	first := firstFormalParameter(params)
+	if first == nil {
+		return nil, nil
+	}
+
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+
+	emit := func(propName, sig string, node *sitter.Node) {
+		if propName == "" {
+			return
+		}
+		start, end := lines(node)
+		qn := fmt.Sprintf("%s.%s", componentName, propName)
+		e := types.EntityRecord{
+			Name:             propName,
+			QualifiedName:    x.qualify(qn),
+			Kind:             "SCOPE.Operation",
+			SourceFile:       x.filePath,
+			StartLine:        start,
+			EndLine:          end,
+			Language:         x.language,
+			Subtype:          "component_prop",
+			Signature:        sig,
+			Properties: map[string]string{
+				"kind":      "SCOPE.Operation",
+				"subtype":   "component_prop",
+				"component": componentName,
+				"prop":      propName,
+				"framework": "react",
+			},
+			EnrichmentStatus: types.StatusPending,
+			QualityScore:     1.0,
+		}
+		e.ID = e.ComputeID()
+		ents = append(ents, e)
+		rels = append(rels, types.RelationshipRecord{
+			ToID: e.ID,
+			Kind: "CONTAINS",
+			Properties: map[string]string{
+				"component": componentName,
+				"prop":      propName,
+				"framework": "react",
+			},
+		})
+	}
+
+	// The formal parameter node is either a `required_parameter` /
+	// `optional_parameter` (TS grammar) wrapping a pattern, or the bare pattern
+	// (JS grammar). Unwrap to the binding pattern.
+	pat := bindingPatternOf(first)
+	if pat == nil {
+		return nil, nil
+	}
+
+	switch pat.Type() {
+	case "object_pattern":
+		for _, field := range objectPatternFields(x, pat) {
+			emit(field, fmt.Sprintf("prop %s.%s", componentName, field), pat)
+		}
+	case "identifier":
+		name := x.nodeText(pat)
+		// `(props)` — the whole-props bag. Emit a single prop entity named for
+		// the bag so the cell is backed even when props are passed wholesale.
+		emit(name, fmt.Sprintf("props %s(%s)", componentName, name), pat)
+	}
+	return ents, rels
+}
+
+// firstFormalParameter returns the first non-punctuation child of a
+// formal_parameters node (the parameter list `( … )`).
+func firstFormalParameter(params *sitter.Node) *sitter.Node {
+	for i := 0; i < int(params.ChildCount()); i++ {
+		c := params.Child(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "(", ")", ",":
+			continue
+		}
+		return c
+	}
+	return nil
+}
+
+// bindingPatternOf unwraps a TS required_parameter/optional_parameter to its
+// `pattern` child, or returns the node directly when it is already a pattern
+// (JS grammar shape).
+func bindingPatternOf(param *sitter.Node) *sitter.Node {
+	switch param.Type() {
+	case "required_parameter", "optional_parameter":
+		if p := param.ChildByFieldName("pattern"); p != nil {
+			return p
+		}
+		// Fallback: first object_pattern / identifier child.
+		for i := 0; i < int(param.ChildCount()); i++ {
+			c := param.Child(i)
+			if c != nil && (c.Type() == "object_pattern" || c.Type() == "identifier") {
+				return c
+			}
+		}
+		return nil
+	default:
+		return param
+	}
+}
+
+// objectPatternFields returns the distinct destructured field names of an
+// object_pattern, handling shorthand (`{ title }`), renamed (`{ title: t }`),
+// and defaulted (`{ count = 0 }`) forms. The key (exported name) is captured —
+// it is the prop the parent passes.
+func objectPatternFields(x *extractor, pat *sitter.Node) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	for i := 0; i < int(pat.ChildCount()); i++ {
+		c := pat.Child(i)
+		if c == nil {
+			continue
+		}
+		switch c.Type() {
+		case "shorthand_property_identifier_pattern", "shorthand_property_identifier":
+			add(x.nodeText(c))
+		case "pair_pattern":
+			if k := c.ChildByFieldName("key"); k != nil {
+				add(x.nodeText(k))
+			}
+		case "object_assignment_pattern":
+			// `{ count = 0 }` — the left side is the binding/key.
+			if l := c.ChildByFieldName("left"); l != nil {
+				add(x.nodeText(l))
+			} else if c.NamedChildCount() > 0 {
+				add(x.nodeText(c.NamedChild(0)))
+			}
+		case "rest_pattern":
+			// `{ ...rest }` — capture the rest binding name.
+			if c.NamedChildCount() > 0 {
+				add(x.nodeText(c.NamedChild(0)))
+			}
+		}
+	}
+	return out
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -709,7 +709,12 @@ func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string
 	// Issue #2854 — emit USES_HOOK edges from components / custom hooks to the
 	// hooks they call (Structure/hook_recognition).
 	rels = append(rels, x.extractHookCalls(body, name)...)
+	// Issue #2855 — generic React component prop extraction (Data Flow/
+	// prop_extraction): destructured / whole-bag props of a function component.
+	propEnts, propRels := x.extractComponentProps(params, name)
+	rels = append(rels, propRels...)
 	x.emitWithRels(name, "SCOPE.Operation", n, subtype, sig, rels)
+	x.entities = append(x.entities, propEnts...)
 	// Issue #2654 — stamp discriminator comparisons found in the body.
 	x.stampDiscriminators(body)
 
@@ -1311,7 +1316,11 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 		// Issue #2854 — USES_HOOK edges (Structure/hook_recognition).
 		rels = append(rels, x.extractHookCalls(body, name)...)
+		// Issue #2855 — React component prop extraction (Data Flow).
+		propEnts, propRels := x.extractComponentProps(params, name)
+		rels = append(rels, propRels...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = (...) =>", name), rels)
+		x.entities = append(x.entities, propEnts...)
 		// Issue #2654 — stamp discriminator comparisons found in the body.
 		x.stampDiscriminators(body)
 		if body != nil {
@@ -1339,7 +1348,11 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 		// Issue #2854 — USES_HOOK edges (Structure/hook_recognition).
 		rels = append(rels, x.extractHookCalls(body, name)...)
+		// Issue #2855 — React component prop extraction (Data Flow).
+		propEnts, propRels := x.extractComponentProps(params, name)
+		rels = append(rels, propRels...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = function", name), rels)
+		x.entities = append(x.entities, propEnts...)
 		// Issue #2654 — stamp discriminator comparisons found in the body.
 		x.stampDiscriminators(body)
 		if body != nil {

--- a/internal/extractors/javascript/issue2855_angular_dataflow_test.go
+++ b/internal/extractors/javascript/issue2855_angular_dataflow_test.go
@@ -1,0 +1,116 @@
+// Package javascript — issue #2855 Angular Data-Flow proving tests.
+//
+// Flips the four Angular Data-Flow cells (missing→full):
+//   - prop_extraction    : @Input()/@Output() fields → component_prop
+//   - state_management   : ngrx Store select/dispatch → CALLS Store.*
+//   - data_fetching      : HttpClient.get/post/… → data_fetch + CALLS
+//   - branch_conditions  : *ngIf / @if / [ngSwitch] template → branch_condition
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func TestIssue2855_AngularDataFlow(t *testing.T) {
+	src := []byte("import { Component, Input, Output, EventEmitter } from '@angular/core';\n" +
+		"import { Store } from '@ngrx/store';\n" +
+		"import { HttpClient } from '@angular/common/http';\n" +
+		"\n" +
+		"@Component({\n" +
+		"  selector: 'app-user-card',\n" +
+		"  template: '<div *ngIf=\"loaded\"><app-avatar></app-avatar></div>@if (admin) { <span>x</span> }'\n" +
+		"})\n" +
+		"export class UserCardComponent {\n" +
+		"  @Input() userId: string;\n" +
+		"  @Input() title = 'User';\n" +
+		"  @Output() saved = new EventEmitter<void>();\n" +
+		"\n" +
+		"  constructor(private store: Store, private http: HttpClient) {}\n" +
+		"\n" +
+		"  load() {\n" +
+		"    this.http.get('/api/users');\n" +
+		"    this.http.post('/api/users', {});\n" +
+		"    this.store.select(s => s.user);\n" +
+		"    this.store.dispatch(loadUser());\n" +
+		"  }\n" +
+		"}\n")
+
+	ents := extractReact(t, "user-card.component.ts", src)
+
+	comp := findByName(ents, "UserCardComponent")
+	if comp == nil {
+		t.Fatalf("UserCardComponent not extracted; %s", dumpKinds(ents))
+	}
+
+	// prop_extraction: @Input/@Output fields.
+	hasProp := func(name, dir string) bool {
+		for i := range ents {
+			e := &ents[i]
+			if e.Subtype == "component_prop" && e.Name == name && e.Properties["prop_direction"] == dir {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasProp("userId", "input") {
+		t.Errorf("missing @Input userId; %s", dumpKinds(ents))
+	}
+	if !hasProp("title", "input") {
+		t.Errorf("missing @Input title")
+	}
+	if !hasProp("saved", "output") {
+		t.Errorf("missing @Output saved")
+	}
+
+	// data_fetching: HttpClient verbs.
+	hasFetch := func(verb string) bool {
+		for i := range ents {
+			e := &ents[i]
+			if e.Subtype == "data_fetch" && e.Properties["http_method"] == verb {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasFetch("get") || !hasFetch("post") {
+		t.Errorf("missing HttpClient data_fetch (get/post); %s", dumpKinds(ents))
+	}
+
+	// state_management: ngrx Store select + dispatch as CALLS edges.
+	if !hasRel(comp.Relationships, "CALLS", "Store.select") {
+		t.Errorf("missing CALLS Store.select; rels=%v", comp.Relationships)
+	}
+	if !hasRel(comp.Relationships, "CALLS", "Store.dispatch") {
+		t.Errorf("missing CALLS Store.dispatch")
+	}
+
+	// branch_conditions: template *ngIf + @if.
+	hasBranch := func(kind string) bool {
+		for i := range ents {
+			e := &ents[i]
+			if e.Subtype == "branch_condition" && e.Properties["branch_kind"] == kind {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasBranch("*ngIf") {
+		t.Errorf("missing branch_condition *ngIf; %s", dumpKinds(ents))
+	}
+	if !hasBranch("@if") {
+		t.Errorf("missing branch_condition @if")
+	}
+
+	// CONTAINS wiring: component contains its props/fetches/branches.
+	var anyProp *types.EntityRecord
+	for i := range ents {
+		if ents[i].Subtype == "component_prop" && ents[i].Name == "userId" {
+			anyProp = &ents[i]
+		}
+	}
+	if anyProp == nil || !hasRel(comp.Relationships, "CONTAINS", anyProp.ID) {
+		t.Errorf("component missing CONTAINS → userId prop")
+	}
+}

--- a/internal/extractors/javascript/issue2855_react_dataflow_test.go
+++ b/internal/extractors/javascript/issue2855_react_dataflow_test.go
@@ -1,0 +1,104 @@
+// Package javascript — issue #2855 React Data-Flow proving tests.
+//
+// Flips React prop_extraction (partial→full) and state_management
+// (partial→full) by proving:
+//   - generic component props (destructured object pattern + whole-bag) emit
+//     SCOPE.Operation subtype="component_prop" with CONTAINS edges from the
+//     component (dataflow_react.go), beyond the navigation-only #2665 case,
+//   - useState / useReducer state-setter pairs emit SCOPE.Operation
+//     subtype="state_setter" (extractor.go), backing state_management with the
+//     React-core hooks, not just Zustand.
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func TestIssue2855_ReactPropExtraction(t *testing.T) {
+	src := []byte(`import { useState } from 'react';
+
+interface Props {
+  title: string;
+  count: number;
+}
+
+export function Card({ title, count = 0, ...rest }: Props) {
+  return <h1>{title}: {count}</h1>;
+}
+
+export const Banner = (props) => <div>{props.label}</div>;
+
+export const Avatar = ({ src: imageSrc, alt }) => <img src={imageSrc} alt={alt} />;
+`)
+
+	ents := extractReact(t, "Card.tsx", src)
+
+	// Card: destructured props → one component_prop per field.
+	mustProp := func(component, prop string) {
+		t.Helper()
+		for i := range ents {
+			e := &ents[i]
+			if e.Subtype == "component_prop" && e.Name == prop && e.Properties["component"] == component {
+				return
+			}
+		}
+		t.Errorf("missing component_prop %s.%s; %s", component, prop, dumpKinds(ents))
+	}
+	mustProp("Card", "title")
+	mustProp("Card", "count")
+	mustProp("Card", "rest")
+
+	// Renamed destructure: `{ src: imageSrc }` captures the KEY (`src`), the
+	// prop the parent passes — not the local binding.
+	mustProp("Avatar", "src")
+	mustProp("Avatar", "alt")
+
+	// Whole-bag form: `(props)` → single component_prop named for the bag.
+	mustProp("Banner", "props")
+
+	// CONTAINS edge from the component to its props.
+	card := findByName(ents, "Card")
+	if card == nil {
+		t.Fatalf("Card component not extracted")
+	}
+	var titleProp *types.EntityRecord
+	for i := range ents {
+		if ents[i].Subtype == "component_prop" && ents[i].Name == "title" {
+			titleProp = &ents[i]
+		}
+	}
+	if titleProp == nil {
+		t.Fatalf("title prop entity missing")
+	}
+	if !hasRel(card.Relationships, "CONTAINS", titleProp.ID) {
+		t.Errorf("Card missing CONTAINS → title prop (id=%s); rels=%v", titleProp.ID, card.Relationships)
+	}
+}
+
+func TestIssue2855_ReactStateManagement(t *testing.T) {
+	src := []byte(`import { useState, useReducer } from 'react';
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return <button onClick={() => setCount(count + 1)}>{count}</button>;
+}
+`)
+
+	ents := extractReact(t, "Counter.tsx", src)
+
+	// state_management: useState / useReducer setters emit state_setter ops.
+	mustSetter := func(name string) {
+		t.Helper()
+		for i := range ents {
+			if ents[i].Subtype == "state_setter" && ents[i].Name == name {
+				return
+			}
+		}
+		t.Errorf("missing state_setter %q; %s", name, dumpKinds(ents))
+	}
+	mustSetter("setCount")
+	mustSetter("dispatch")
+}

--- a/internal/extractors/javascript/issue2855_realdata_test.go
+++ b/internal/extractors/javascript/issue2855_realdata_test.go
@@ -1,0 +1,89 @@
+// Package javascript — issue #2855 real-data verification (Data Flow group).
+// Runs the registered TypeScript/TSX extractor over the in-repo real-world
+// fixtures and asserts the new Data-Flow signals (component_prop, data_fetch,
+// branch_condition, state_setter, ngrx Store CALLS) fire on real-shaped source.
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractRealWorld(t *testing.T, rel string) []types.EntityRecord {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "testdata", "fixtures", "real-world", "typescript", rel)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("real-world fixture %s not present: %v", rel, err)
+	}
+	p := sitter.NewParser()
+	p.SetLanguage(tstsx.GetLanguage())
+	tree, _ := p.ParseCtx(context.Background(), nil, content)
+	ext, _ := extreg.Get("typescript")
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path: path, Content: content, Language: "typescript", Tree: tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract %s: %v", rel, err)
+	}
+	return ents
+}
+
+func countSubtype(ents []types.EntityRecord, subtype string) int {
+	n := 0
+	for i := range ents {
+		if ents[i].Subtype == subtype {
+			n++
+		}
+	}
+	return n
+}
+
+func TestIssue2855_RealData_AngularDataFlow(t *testing.T) {
+	ents := extractRealWorld(t, "angular_dataflow_component.ts")
+
+	if got := countSubtype(ents, "component_prop"); got < 4 {
+		t.Errorf("angular component_prop count = %d, want >= 4 (@Input title/pageSize + @Output selected/removed); %s", got, dumpKinds(ents))
+	}
+	if got := countSubtype(ents, "data_fetch"); got < 2 {
+		t.Errorf("angular data_fetch count = %d, want >= 2 (http get/delete)", got)
+	}
+	if got := countSubtype(ents, "branch_condition"); got < 1 {
+		t.Errorf("angular branch_condition count = %d, want >= 1 (*ngIf/@if/*ngFor)", got)
+	}
+
+	comp := findByName(ents, "UserListComponent")
+	if comp == nil {
+		t.Fatalf("UserListComponent not extracted")
+	}
+	if !hasRel(comp.Relationships, "CALLS", "Store.select") {
+		t.Errorf("missing ngrx CALLS Store.select; rels=%v", comp.Relationships)
+	}
+	if !hasRel(comp.Relationships, "CALLS", "Store.dispatch") {
+		t.Errorf("missing ngrx CALLS Store.dispatch")
+	}
+	t.Logf("real-data angular: props=%d fetch=%d branch=%d",
+		countSubtype(ents, "component_prop"), countSubtype(ents, "data_fetch"),
+		countSubtype(ents, "branch_condition"))
+}
+
+func TestIssue2855_RealData_ReactDataFlow(t *testing.T) {
+	ents := extractRealWorld(t, "react_dataflow_component.tsx")
+
+	if got := countSubtype(ents, "component_prop"); got < 3 {
+		t.Errorf("react component_prop count = %d, want >= 3 (userId/title/onSelect); %s", got, dumpKinds(ents))
+	}
+	if got := countSubtype(ents, "state_setter"); got < 2 {
+		t.Errorf("react state_setter count = %d, want >= 2 (setName/setOpen/dispatch)", got)
+	}
+	t.Logf("real-data react: props=%d state_setter=%d",
+		countSubtype(ents, "component_prop"), countSubtype(ents, "state_setter"))
+}

--- a/internal/extractors/svelte/extractor.go
+++ b/internal/extractors/svelte/extractor.go
@@ -93,6 +93,21 @@ var (
 	// context key (Symbol identifier or string literal).
 	setContextRE = regexp.MustCompile(`\bsetContext\s*\(\s*([A-Za-z_$][A-Za-z0-9_$]*|['"][^'"]+['"])`)
 	getContextRE = regexp.MustCompile(`\bgetContext\s*\(\s*([A-Za-z_$][A-Za-z0-9_$]*|['"][^'"]+['"])`)
+
+	// ── Data Flow (issue #2855) ──────────────────────────────────────────────
+
+	// Svelte store declarations: `const count = writable(0)` /
+	// readable / derived / tweened / spring. Svelte stores are the framework's
+	// state container (state_management).
+	storeDeclRE = regexp.MustCompile(`(?m)^\s*(?:export\s+)?(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(writable|readable|derived|tweened|spring)\s*\(`)
+
+	// Data fetching call sites: fetch(…) — including the SvelteKit `load`/form
+	// data layer which uses the platform fetch — plus axios.* clients.
+	dataFetchRE = regexp.MustCompile(`(?m)\bfetch\s*\(|\baxios\s*(?:\.\s*(?:get|post|put|patch|delete|request))?\s*\(`)
+
+	// Template branch conditions: {#if …}, {:else if …}, {#each …}, {#await …}.
+	// Svelte's logic blocks are its conditional/iterative rendering constructs.
+	branchBlockRE = regexp.MustCompile(`\{#(if|each|await)\b|\{:else\s+if\b|\{:else\b|\{:then\b|\{:catch\b`)
 )
 
 // Extract parses the Svelte SFC source and returns entity records.
@@ -143,9 +158,14 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		ctxEntities, ctxRels := extractContext(scriptContent, scriptStartLine, file.Path, componentName)
 		entities[0].Relationships = append(entities[0].Relationships, ctxRels...)
 		entities = append(entities, ctxEntities...)
+
+		// Data Flow (#2855): state_management (stores) + data_fetching.
+		dfEntities, dfRels := extractScriptDataFlow(scriptContent, scriptStartLine, file.Path, componentName)
+		entities[0].Relationships = append(entities[0].Relationships, dfRels...)
+		entities = append(entities, dfEntities...)
 	}
 
-	// ── 3. Extract RENDERS edges from child components in the template ────────
+	// ── 3. Extract RENDERS edges + branch conditions from the template ───────
 	templateContent, templateStartLine := extractTemplateSection(src)
 	if templateContent != "" {
 		renderRels := extractChildComponents(templateContent, templateStartLine, file.Path, componentName)
@@ -153,6 +173,10 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 			// Attach RENDERS relationships to the component entity.
 			entities[0].Relationships = append(entities[0].Relationships, renderRels...)
 		}
+		// Data Flow (#2855): branch_conditions from {#if}/{#each}/{:else if}.
+		brEntities, brRels := extractBranchConditions(templateContent, templateStartLine, file.Path, componentName)
+		entities[0].Relationships = append(entities[0].Relationships, brRels...)
+		entities = append(entities, brEntities...)
 	}
 
 	span.SetAttributes(
@@ -413,6 +437,155 @@ func extractContext(script string, scriptStartLine int, filePath, componentName 
 	emit(setContextRE, "provide_context", "provider")
 	emit(getContextRE, "inject_context", "consumer")
 	return ents, rels
+}
+
+// extractScriptDataFlow scans the <script> content for Svelte Data-Flow signals
+// (issue #2855): state_management (writable/readable/derived/tweened/spring
+// stores — Svelte's reactive state container) and data_fetching (fetch/axios
+// call sites). Each emits a SCOPE.Operation entity and a USES edge from the
+// component file to it.
+func extractScriptDataFlow(script string, scriptStartLine int, filePath, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+
+	emit := func(name, subtype, sig string, props map[string]string, off int) {
+		lineNum := scriptStartLine + strings.Count(script[:off], "\n")
+		props["component"] = componentName
+		props["framework"] = "svelte"
+		ents = append(ents, types.EntityRecord{
+			Name:         name,
+			Kind:         "SCOPE.Operation",
+			Subtype:      subtype,
+			SourceFile:   filePath,
+			Language:     "svelte",
+			StartLine:    lineNum,
+			EndLine:      lineNum,
+			Signature:    sig,
+			QualityScore: 0.8,
+			Properties:   props,
+		})
+		rels = append(rels, types.RelationshipRecord{
+			FromID: filePath,
+			ToID:   name,
+			Kind:   "USES",
+			Properties: map[string]string{
+				"component": componentName,
+				"framework": "svelte",
+				"subtype":   subtype,
+			},
+		})
+	}
+
+	// state_management: store declarations.
+	stateSeen := map[string]bool{}
+	for _, m := range storeDeclRE.FindAllStringSubmatchIndex(script, -1) {
+		name := script[m[2]:m[3]]
+		prim := script[m[4]:m[5]]
+		if stateSeen[name] {
+			continue
+		}
+		stateSeen[name] = true
+		emit(name, "state_store", prim+"() "+name,
+			map[string]string{"state_lib": "svelte-store", "primitive": prim}, m[0])
+	}
+
+	// data_fetching: fetch / axios call sites.
+	fetchSeen := map[string]bool{}
+	idx := 0
+	for _, m := range dataFetchRE.FindAllStringIndex(script, -1) {
+		raw := strings.TrimSpace(script[m[0]:m[1]])
+		kind := "fetch"
+		if strings.HasPrefix(raw, "axios") {
+			kind = "axios"
+		}
+		key := kind
+		if fetchSeen[key] {
+			continue
+		}
+		fetchSeen[key] = true
+		name := "fetch:" + kind
+		if idx > 0 {
+			name = fmt.Sprintf("fetch:%s_%d", kind, idx)
+		}
+		idx++
+		emit(name, "data_fetch", kind+"(…)",
+			map[string]string{"fetch_kind": kind}, m[0])
+	}
+
+	return ents, rels
+}
+
+// extractBranchConditions scans the Svelte template for logic-block branches
+// ({#if}, {:else if}, {#each}, {#await}) and returns SCOPE.Operation
+// subtype="branch_condition" entities + USES edges (issue #2855 — Data Flow /
+// branch_conditions).
+func extractBranchConditions(template string, templateStartLine int, filePath, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	seen := map[string]int{}
+	for _, m := range branchBlockRE.FindAllStringIndex(template, -1) {
+		raw := strings.TrimSpace(template[m[0]:m[1]])
+		// Canonicalise the block label.
+		kind := svelteBranchKind(raw)
+		if kind == "" {
+			continue
+		}
+		seen[kind]++
+		idx := seen[kind]
+		name := kind
+		if idx > 1 {
+			name = fmt.Sprintf("%s_%d", kind, idx)
+		}
+		lineNum := templateStartLine + strings.Count(template[:m[0]], "\n")
+		ents = append(ents, types.EntityRecord{
+			Name:         name,
+			Kind:         "SCOPE.Operation",
+			Subtype:      "branch_condition",
+			SourceFile:   filePath,
+			Language:     "svelte",
+			StartLine:    lineNum,
+			EndLine:      lineNum,
+			Signature:    "template " + raw,
+			QualityScore: 0.8,
+			Properties: map[string]string{
+				"component":   componentName,
+				"branch_kind": kind,
+				"framework":   "svelte",
+			},
+		})
+		rels = append(rels, types.RelationshipRecord{
+			FromID: filePath,
+			ToID:   name,
+			Kind:   "USES",
+			Properties: map[string]string{
+				"component":   componentName,
+				"branch_kind": kind,
+				"framework":   "svelte",
+			},
+		})
+	}
+	return ents, rels
+}
+
+// svelteBranchKind maps a matched logic-block opener to a canonical label.
+func svelteBranchKind(raw string) string {
+	switch {
+	case strings.HasPrefix(raw, "{#if"):
+		return "if"
+	case strings.HasPrefix(raw, "{#each"):
+		return "each"
+	case strings.HasPrefix(raw, "{#await"):
+		return "await"
+	case strings.HasPrefix(raw, "{:else if"):
+		return "else_if"
+	case strings.HasPrefix(raw, "{:else"):
+		return "else"
+	case strings.HasPrefix(raw, "{:then"):
+		return "then"
+	case strings.HasPrefix(raw, "{:catch"):
+		return "catch"
+	}
+	return ""
 }
 
 // normalizeContextKey strips quotes from a string-literal context key, or

--- a/internal/extractors/svelte/issue2855_dataflow_test.go
+++ b/internal/extractors/svelte/issue2855_dataflow_test.go
@@ -1,0 +1,139 @@
+package svelte_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #2855 — Svelte Data-Flow group: prop_extraction (export let / $props),
+// state_management (writable/derived stores), data_fetching (fetch/axios),
+// branch_conditions ({#if}/{#each}/{:else if}).
+func TestIssue2855_SvelteDataFlow(t *testing.T) {
+	src := `<script lang="ts">
+  import { writable, derived } from 'svelte/store'
+  export let title: string
+  let { count = 0 } = $props()
+
+  const items = writable([])
+  const total = derived(items, ($i) => $i.length)
+
+  async function load() {
+    const res = await fetch('/api/items')
+    return res.json()
+  }
+</script>
+
+{#if title}
+  <h1>{title}</h1>
+{:else if count}
+  <p>{count}</p>
+{/if}
+{#each $items as item}
+  <Row {item} />
+{/each}`
+
+	recs := mustExtract(t, "src/lib/List.svelte", src)
+
+	comp := findByName(recs, "List")
+	if comp == nil {
+		t.Fatalf("List component not extracted; %s", dump(recs))
+	}
+
+	has := func(subtype, name string) bool {
+		for i := range recs {
+			if recs[i].Subtype == subtype && recs[i].Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	// prop_extraction: export let + $props destructure (existing #2854 props).
+	if !has("prop", "title") {
+		t.Errorf("missing prop title; %s", dump(recs))
+	}
+	if !has("prop", "count") {
+		t.Errorf("missing prop count")
+	}
+
+	// state_management: writable + derived stores.
+	if !has("state_store", "items") {
+		t.Errorf("missing state_store items; %s", dump(recs))
+	}
+	if !has("state_store", "total") {
+		t.Errorf("missing state_store total")
+	}
+
+	// data_fetching: fetch call.
+	hasFetch := false
+	for i := range recs {
+		if recs[i].Subtype == "data_fetch" {
+			hasFetch = true
+		}
+	}
+	if !hasFetch {
+		t.Errorf("missing data_fetch; %s", dump(recs))
+	}
+
+	// branch_conditions: {#if}, {:else if}, {#each}.
+	branchKinds := map[string]bool{}
+	for i := range recs {
+		if recs[i].Subtype == "branch_condition" {
+			branchKinds[recs[i].Properties["branch_kind"]] = true
+		}
+	}
+	for _, want := range []string{"if", "else_if", "each"} {
+		if !branchKinds[want] {
+			t.Errorf("missing branch_condition %q; %s", want, dump(recs))
+		}
+	}
+
+	// USES wiring from component file to a store.
+	var itemsStore *types.EntityRecord
+	for i := range recs {
+		if recs[i].Subtype == "state_store" && recs[i].Name == "items" {
+			itemsStore = &recs[i]
+		}
+	}
+	if itemsStore == nil || !relTo(comp.Relationships, "USES", "items") {
+		t.Errorf("component missing USES → items store; rels=%v", comp.Relationships)
+	}
+}
+
+// TestIssue2855_SvelteRealData runs the registered Svelte extractor over the
+// in-repo real-world fixture and asserts Data-Flow signals on real source.
+func TestIssue2855_SvelteRealData(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "testdata", "fixtures", "real-world", "svelte", "UserList.svelte")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("real-world svelte fixture not present: %v", err)
+	}
+	recs := mustExtract(t, path, string(content))
+
+	count := func(subtype string) int {
+		n := 0
+		for i := range recs {
+			if recs[i].Subtype == subtype {
+				n++
+			}
+		}
+		return n
+	}
+	if count("prop") < 3 {
+		t.Errorf("svelte prop = %d, want >= 3 (title/pageSize/selectedId); %s", count("prop"), dump(recs))
+	}
+	if count("state_store") < 2 {
+		t.Errorf("svelte state_store = %d, want >= 2 (users/count/loading)", count("state_store"))
+	}
+	if count("data_fetch") < 1 {
+		t.Errorf("svelte data_fetch = %d, want >= 1 (fetch)", count("data_fetch"))
+	}
+	if count("branch_condition") < 2 {
+		t.Errorf("svelte branch_condition = %d, want >= 2 (if/else_if/each); %s", count("branch_condition"), dump(recs))
+	}
+	t.Logf("real-data svelte: prop=%d store=%d fetch=%d branch=%d",
+		count("prop"), count("state_store"), count("data_fetch"), count("branch_condition"))
+}

--- a/internal/extractors/vue/extractor.go
+++ b/internal/extractors/vue/extractor.go
@@ -130,6 +130,44 @@ var (
 	// Composable definition: `function useFoo(` / `const useFoo = (` —
 	// a local custom composable (hook) declaration.
 	reComposableDef = regexp.MustCompile(`(?m)\b(?:function\s+(use[A-Z][A-Za-z0-9_$]*)|(?:const|let)\s+(use[A-Z][A-Za-z0-9_$]*)\s*=\s*(?:async\s*)?(?:function|\())`)
+
+	// ── Data Flow (issue #2855) ──────────────────────────────────────────────
+
+	// defineProps destructured / Options-API prop names. We parse the props
+	// surface in two shapes:
+	//   defineProps<{ a: string; b?: number }>()   (type-literal generic)
+	//   defineProps({ a: String, b: Number })       (runtime object)
+	//   props: { a: …, b: … }  / props: ['a','b']   (Options API)
+	reDefinePropsGeneric = regexp.MustCompile(`(?s)\bdefineProps\s*<\s*\{(.*?)\}\s*>\s*\(`)
+	reDefinePropsObject  = regexp.MustCompile(`(?s)\bdefineProps\s*\(\s*\{(.*?)\}\s*\)`)
+	reDefinePropsArray   = regexp.MustCompile(`(?s)\bdefineProps\s*\(\s*\[(.*?)\]\s*\)`)
+	reOptionsPropsObject = regexp.MustCompile(`(?s)\bprops\s*:\s*\{(.*?)\}`)
+	reOptionsPropsArray  = regexp.MustCompile(`(?s)\bprops\s*:\s*\[(.*?)\]`)
+	// A property declaration inside a props block, e.g. `title: String`,
+	// `count?: number`. Anchored on a member separator (start, `;`, `,`, or
+	// newline) so multiple props on one line (`{ a: string; b: number }`) are
+	// all captured, not just the first.
+	rePropName = regexp.MustCompile(`(?:^|[;,\n{])\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*[?:]`)
+	// Quoted string entries for the array form: 'title', "count".
+	reQuotedName = regexp.MustCompile(`['"]([A-Za-z_$][A-Za-z0-9_$]*)['"]`)
+
+	// Pinia state stores: `const x = useXxxStore()` / defineStore('id', …) /
+	// storeToRefs(store). Pinia is Vue's canonical state container.
+	rePiniaStore     = regexp.MustCompile(`(?m)\b(use[A-Z][A-Za-z0-9_$]*Store)\s*\(`)
+	rePiniaDefine    = regexp.MustCompile(`(?m)\bdefineStore\s*\(\s*['"]([^'"]+)['"]`)
+	rePiniaStoreRefs = regexp.MustCompile(`(?m)\bstoreToRefs\s*\(`)
+	// Reactive local state: ref(…) / reactive(…). The Composition-API reactivity
+	// primitives are also state_management signals.
+	reReactiveState = regexp.MustCompile(`(?m)\b(?:const|let)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(ref|reactive|shallowRef|shallowReactive)\s*\(`)
+
+	// Data fetching: fetch()/axios.*/useFetch()/useAsyncData()/$fetch(). The
+	// composable forms (useFetch/useAsyncData) are Nuxt's data layer; fetch/
+	// axios are the generic browser/lib clients.
+	reDataFetch = regexp.MustCompile(`(?m)\b(fetch|\$fetch|useFetch|useAsyncData|useLazyFetch|useLazyAsyncData)\s*\(|\baxios\s*(?:\.\s*(get|post|put|patch|delete|request))?\s*\(`)
+
+	// Template branch conditions: v-if / v-else-if / v-else / v-show. These are
+	// Vue's conditional-rendering directives (branch_conditions).
+	reVueBranch = regexp.MustCompile(`\b(v-if|v-else-if|v-else|v-show)\b`)
 )
 
 // jsKeywords are identifiers that appear before "(" but are NOT method
@@ -261,6 +299,13 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, hookRels...)
 		entities = append(entities, hookEntities...)
 
+		// 3c-iii. Data Flow (#2855): prop_extraction, state_management,
+		// data_fetching. Each emits SCOPE.Operation entities plus CONTAINS
+		// edges from the component.
+		dfEntities, dfRels := extractDataFlow(scriptSrc, scriptOffset, src, file.Path, componentName)
+		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, dfRels...)
+		entities = append(entities, dfEntities...)
+
 		// 3d. Options API methods (inside methods: { … })
 		if !isSetup {
 			methods := extractOptionsMethods(scriptSrc, scriptOffset, src, file.Path, componentName)
@@ -275,11 +320,16 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 		}
 	}
 
-	// --- 4. Extract <template> block → RENDERS edges -------------------------
-	templateSrc, _, ok := extractTemplateBlock(src)
+	// --- 4. Extract <template> block → RENDERS + branch_condition ------------
+	templateSrc, templateOffset, ok := extractTemplateBlock(src)
 	if ok {
 		renders := extractTemplateRenders(templateSrc, componentName)
 		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, renders...)
+
+		// Data Flow (#2855) — branch_conditions from v-if/v-else/v-show.
+		brEntities, brRels := extractBranchConditions(templateSrc, templateOffset, src, file.Path, componentName)
+		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, brRels...)
+		entities = append(entities, brEntities...)
 	}
 
 	// --- 5. Tag relationships with language ----------------------------------
@@ -611,6 +661,193 @@ func extractComposables(scriptSrc string, scriptOffset int, fullSrc, filePath, c
 				"consumer":  componentName,
 				"hook":      hook,
 				"framework": "vue",
+			},
+		})
+	}
+	return ents, rels
+}
+
+// extractDataFlow scans a Vue <script> block for Data-Flow signals (issue
+// #2855): component props (defineProps / Options-API props), state management
+// (Pinia stores + ref/reactive primitives), and data fetching (fetch / axios /
+// useFetch / useAsyncData). It returns SCOPE.Operation entities and CONTAINS
+// edges from the component to each.
+func extractDataFlow(scriptSrc string, scriptOffset int, fullSrc, filePath, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+
+	emit := func(name, subtype, sig string, props map[string]string, absOffset int) {
+		if name == "" {
+			return
+		}
+		lineNum := lineOf(fullSrc, absOffset)
+		props["component"] = componentName
+		props["framework"] = "vue"
+		ent := types.EntityRecord{
+			Name:             name,
+			QualifiedName:    fmt.Sprintf("%s.%s", componentName, name),
+			Kind:             "SCOPE.Operation",
+			Subtype:          subtype,
+			SourceFile:       filePath,
+			Language:         "vue",
+			StartLine:        lineNum,
+			EndLine:          lineNum,
+			Signature:        sig,
+			QualityScore:     0.8,
+			EnrichmentStatus: types.StatusPending,
+			Properties:       props,
+		}
+		ents = append(ents, ent)
+		rels = append(rels, types.RelationshipRecord{
+			ToID: name,
+			Kind: "CONTAINS",
+			Properties: map[string]string{
+				"component": componentName,
+				"framework": "vue",
+				"subtype":   subtype,
+			},
+		})
+	}
+
+	// ── prop_extraction ──────────────────────────────────────────────────────
+	propSeen := map[string]bool{}
+	emitProp := func(name string, off int) {
+		name = strings.TrimSpace(name)
+		if name == "" || propSeen[name] {
+			return
+		}
+		propSeen[name] = true
+		emit(name, "component_prop", "prop "+name, map[string]string{"prop": name}, off)
+	}
+	// defineProps<{ … }>() — type-literal generic.
+	if m := reDefinePropsGeneric.FindStringSubmatchIndex(scriptSrc); m != nil {
+		block := scriptSrc[m[2]:m[3]]
+		for _, pm := range rePropName.FindAllStringSubmatch(block, -1) {
+			emitProp(pm[1], scriptOffset+m[2])
+		}
+	}
+	// defineProps({ … }) — runtime object.
+	if m := reDefinePropsObject.FindStringSubmatchIndex(scriptSrc); m != nil {
+		block := scriptSrc[m[2]:m[3]]
+		for _, pm := range rePropName.FindAllStringSubmatch(block, -1) {
+			emitProp(pm[1], scriptOffset+m[2])
+		}
+	}
+	// defineProps(['a','b']) — array of names.
+	if m := reDefinePropsArray.FindStringSubmatchIndex(scriptSrc); m != nil {
+		block := scriptSrc[m[2]:m[3]]
+		for _, pm := range reQuotedName.FindAllStringSubmatch(block, -1) {
+			emitProp(pm[1], scriptOffset+m[2])
+		}
+	}
+	// Options API: props: { … } or props: [ … ].
+	if m := reOptionsPropsObject.FindStringSubmatchIndex(scriptSrc); m != nil {
+		block := scriptSrc[m[2]:m[3]]
+		for _, pm := range rePropName.FindAllStringSubmatch(block, -1) {
+			emitProp(pm[1], scriptOffset+m[2])
+		}
+	}
+	if m := reOptionsPropsArray.FindStringSubmatchIndex(scriptSrc); m != nil {
+		block := scriptSrc[m[2]:m[3]]
+		for _, pm := range reQuotedName.FindAllStringSubmatch(block, -1) {
+			emitProp(pm[1], scriptOffset+m[2])
+		}
+	}
+
+	// ── state_management ─────────────────────────────────────────────────────
+	stateSeen := map[string]bool{}
+	for _, m := range rePiniaStore.FindAllStringSubmatchIndex(scriptSrc, -1) {
+		name := scriptSrc[m[2]:m[3]]
+		if stateSeen["store:"+name] {
+			continue
+		}
+		stateSeen["store:"+name] = true
+		emit(name, "state_store", "pinia store "+name,
+			map[string]string{"state_lib": "pinia", "store": name}, scriptOffset+m[0])
+	}
+	for _, m := range rePiniaDefine.FindAllStringSubmatchIndex(scriptSrc, -1) {
+		id := scriptSrc[m[2]:m[3]]
+		if stateSeen["define:"+id] {
+			continue
+		}
+		stateSeen["define:"+id] = true
+		emit("defineStore:"+id, "state_store", "defineStore('"+id+"')",
+			map[string]string{"state_lib": "pinia", "store_id": id}, scriptOffset+m[0])
+	}
+	for _, m := range reReactiveState.FindAllStringSubmatchIndex(scriptSrc, -1) {
+		name := scriptSrc[m[2]:m[3]]
+		prim := scriptSrc[m[4]:m[5]]
+		if stateSeen["reactive:"+name] {
+			continue
+		}
+		stateSeen["reactive:"+name] = true
+		emit(name, "reactive_state", prim+"() "+name,
+			map[string]string{"state_lib": "vue-reactivity", "primitive": prim}, scriptOffset+m[0])
+	}
+
+	// ── data_fetching ──────────────────────────────────────────────────────────
+	fetchSeen := map[string]bool{}
+	for _, m := range reDataFetch.FindAllStringSubmatchIndex(scriptSrc, -1) {
+		matched := strings.TrimSpace(scriptSrc[m[0]:m[1]])
+		// Normalise to the call kind: strip trailing "(" / whitespace.
+		kind := matched
+		if idx := strings.IndexByte(kind, '('); idx >= 0 {
+			kind = strings.TrimSpace(kind[:idx])
+		}
+		kind = strings.TrimSpace(kind)
+		if kind == "" || fetchSeen[kind] {
+			continue
+		}
+		fetchSeen[kind] = true
+		safe := strings.NewReplacer("$", "d_", ".", "_", " ", "").Replace(kind)
+		emit("fetch:"+safe, "data_fetch", kind+"(…)",
+			map[string]string{"fetch_kind": kind}, scriptOffset+m[0])
+	}
+
+	return ents, rels
+}
+
+// extractBranchConditions scans the <template> block for Vue conditional-
+// rendering directives (v-if/v-else-if/v-else/v-show) and returns
+// SCOPE.Operation subtype="branch_condition" entities plus CONTAINS edges
+// (issue #2855 — Data Flow / branch_conditions).
+func extractBranchConditions(templateSrc string, templateOffset int, fullSrc, filePath, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+	for _, m := range reVueBranch.FindAllStringSubmatchIndex(templateSrc, -1) {
+		kind := templateSrc[m[2]:m[3]]
+		if kind == "" || seen[kind] {
+			continue
+		}
+		seen[kind] = true
+		lineNum := lineOf(fullSrc, templateOffset+m[0])
+		safe := strings.ReplaceAll(kind, "-", "_")
+		ents = append(ents, types.EntityRecord{
+			Name:             safe,
+			QualifiedName:    fmt.Sprintf("%s.%s", componentName, safe),
+			Kind:             "SCOPE.Operation",
+			Subtype:          "branch_condition",
+			SourceFile:       filePath,
+			Language:         "vue",
+			StartLine:        lineNum,
+			EndLine:          lineNum,
+			Signature:        "template " + kind,
+			QualityScore:     0.8,
+			EnrichmentStatus: types.StatusPending,
+			Properties: map[string]string{
+				"component":   componentName,
+				"branch_kind": kind,
+				"framework":   "vue",
+			},
+		})
+		rels = append(rels, types.RelationshipRecord{
+			ToID: safe,
+			Kind: "CONTAINS",
+			Properties: map[string]string{
+				"component":   componentName,
+				"branch_kind": kind,
+				"framework":   "vue",
 			},
 		})
 	}

--- a/internal/extractors/vue/issue2855_dataflow_test.go
+++ b/internal/extractors/vue/issue2855_dataflow_test.go
@@ -1,0 +1,147 @@
+package vue_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #2855 — Vue Data-Flow group: prop_extraction (defineProps),
+// state_management (Pinia + ref/reactive), data_fetching (useFetch/axios),
+// branch_conditions (v-if/v-show).
+func TestIssue2855_VueDataFlow(t *testing.T) {
+	src := `<script setup lang="ts">
+import { ref, reactive } from 'vue'
+import { useUserStore } from '@/stores/user'
+import axios from 'axios'
+
+const props = defineProps<{ title: string; count?: number }>()
+
+const userStore = useUserStore()
+const loading = ref(false)
+const form = reactive({ name: '' })
+
+async function load() {
+  const res = await useFetch('/api/users')
+  await axios.get('/api/profile')
+}
+</script>
+
+<template>
+  <div v-if="loading">Loading</div>
+  <UserPanel v-else v-show="count > 0" />
+</template>`
+
+	ents := extract(t, "src/UserCard.vue", src)
+
+	comp := findByName(ents, "UserCard")
+	if comp == nil {
+		t.Fatalf("UserCard not extracted; %s", dump(ents))
+	}
+
+	has := func(subtype, name string) bool {
+		for i := range ents {
+			e := &ents[i]
+			if e.Subtype == subtype && e.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	hasSub := func(subtype string) bool {
+		for i := range ents {
+			if ents[i].Subtype == subtype {
+				return true
+			}
+		}
+		return false
+	}
+
+	// prop_extraction: defineProps generic fields.
+	if !has("component_prop", "title") {
+		t.Errorf("missing component_prop title; %s", dump(ents))
+	}
+	if !has("component_prop", "count") {
+		t.Errorf("missing component_prop count")
+	}
+
+	// state_management: Pinia store + ref/reactive primitives.
+	if !has("state_store", "useUserStore") {
+		t.Errorf("missing state_store useUserStore; %s", dump(ents))
+	}
+	if !has("reactive_state", "loading") {
+		t.Errorf("missing reactive_state loading")
+	}
+	if !has("reactive_state", "form") {
+		t.Errorf("missing reactive_state form")
+	}
+
+	// data_fetching: useFetch + axios.
+	if !hasSub("data_fetch") {
+		t.Errorf("missing data_fetch entities; %s", dump(ents))
+	}
+
+	// branch_conditions: v-if + v-show.
+	branchKinds := map[string]bool{}
+	for i := range ents {
+		if ents[i].Subtype == "branch_condition" {
+			branchKinds[ents[i].Properties["branch_kind"]] = true
+		}
+	}
+	if !branchKinds["v-if"] {
+		t.Errorf("missing branch_condition v-if; %s", dump(ents))
+	}
+	if !branchKinds["v-show"] {
+		t.Errorf("missing branch_condition v-show")
+	}
+
+	// CONTAINS wiring from component to a prop.
+	var titleProp *types.EntityRecord
+	for i := range ents {
+		if ents[i].Subtype == "component_prop" && ents[i].Name == "title" {
+			titleProp = &ents[i]
+		}
+	}
+	if titleProp == nil || !relTarget(comp, "CONTAINS", "title") {
+		t.Errorf("component missing CONTAINS → title prop; rels=%v", comp.Relationships)
+	}
+}
+
+// TestIssue2855_VueRealData runs the registered Vue extractor over the in-repo
+// real-world SFC fixture and asserts the Data-Flow signals fire on real-shaped
+// source (not only the hand-written unit fixture above).
+func TestIssue2855_VueRealData(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "testdata", "fixtures", "real-world", "vue", "UserCard.vue")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("real-world vue fixture not present: %v", err)
+	}
+	ents := extract(t, path, string(content))
+
+	count := func(subtype string) int {
+		n := 0
+		for i := range ents {
+			if ents[i].Subtype == subtype {
+				n++
+			}
+		}
+		return n
+	}
+	if count("component_prop") < 3 {
+		t.Errorf("vue component_prop = %d, want >= 3 (userId/title/expanded); %s", count("component_prop"), dump(ents))
+	}
+	if count("state_store") < 1 || count("reactive_state") < 2 {
+		t.Errorf("vue state_management: store=%d reactive=%d, want store>=1 reactive>=2", count("state_store"), count("reactive_state"))
+	}
+	if count("data_fetch") < 1 {
+		t.Errorf("vue data_fetch = %d, want >= 1 (useFetch/axios)", count("data_fetch"))
+	}
+	if count("branch_condition") < 2 {
+		t.Errorf("vue branch_condition = %d, want >= 2 (v-if/v-show)", count("branch_condition"))
+	}
+	t.Logf("real-data vue: props=%d store=%d reactive=%d fetch=%d branch=%d",
+		count("component_prop"), count("state_store"), count("reactive_state"),
+		count("data_fetch"), count("branch_condition"))
+}

--- a/testdata/fixtures/real-world/svelte/UserList.svelte
+++ b/testdata/fixtures/real-world/svelte/UserList.svelte
@@ -1,0 +1,41 @@
+<!-- Source: synthetic, modelled on real Svelte 5 component data-flow patterns
+     (export let / $props props, writable/derived stores, fetch in load,
+     {#if}/{#each}/{:else if} branches) | License: MIT
+
+     Used by issue #2855 real-data verification (Data Flow group). -->
+<script lang="ts">
+  import { writable, derived } from 'svelte/store'
+  import ChildRow from './ChildRow.svelte'
+
+  export let title: string
+  export let pageSize = 20
+
+  let { selectedId = null } = $props()
+
+  const users = writable<User[]>([])
+  const count = derived(users, ($u) => $u.length)
+  const loading = writable(false)
+
+  async function load() {
+    loading.set(true)
+    const res = await fetch(`/api/users?size=${pageSize}`)
+    users.set(await res.json())
+    loading.set(false)
+  }
+</script>
+
+<section>
+  <h1>{title}</h1>
+
+  {#if $loading}
+    <p>Loading…</p>
+  {:else if $count === 0}
+    <p>No users</p>
+  {:else}
+    {#each $users as user (user.id)}
+      <ChildRow {user} selected={user.id === selectedId} />
+    {/each}
+  {/if}
+
+  <button on:click={load}>Reload {$count}</button>
+</section>

--- a/testdata/fixtures/real-world/typescript/angular_dataflow_component.ts
+++ b/testdata/fixtures/real-world/typescript/angular_dataflow_component.ts
@@ -1,0 +1,71 @@
+// Source: synthetic, modelled on real Angular 17 component data-flow patterns
+// (@Input/@Output props, ngrx Store state, HttpClient fetch, *ngIf/@if
+// branches) | License: MIT
+//
+// Used by issue #2855 real-data verification (Data Flow group): proves the
+// Angular extractor emits component_prop / data_fetch / branch_condition
+// entities and ngrx Store CALLS edges on real-shaped source.
+
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+
+import { loadUsers, deleteUser } from './user.actions';
+import { selectUsers, selectLoading } from './user.selectors';
+import { User } from './user.model';
+
+@Component({
+  selector: 'app-user-list',
+  standalone: true,
+  template: `
+    <div class="user-list">
+      <header *ngIf="title">{{ title }}</header>
+
+      @if (loading$ | async) {
+        <spinner-overlay></spinner-overlay>
+      } @else {
+        <user-card
+          *ngFor="let user of users$ | async"
+          [user]="user"
+          (selected)="onSelected($event)">
+        </user-card>
+      }
+
+      <button (click)="refresh()">Reload</button>
+    </div>
+  `,
+})
+export class UserListComponent implements OnInit {
+  @Input() title = 'Users';
+  @Input() pageSize = 20;
+  @Output() selected = new EventEmitter<User>();
+  @Output() removed = new EventEmitter<string>();
+
+  users$: Observable<User[]> = this.store.select(selectUsers);
+  loading$: Observable<boolean> = this.store.select(selectLoading);
+
+  constructor(
+    private store: Store,
+    private http: HttpClient,
+  ) {}
+
+  ngOnInit(): void {
+    this.store.dispatch(loadUsers({ pageSize: this.pageSize }));
+  }
+
+  refresh(): void {
+    this.http.get<User[]>('/api/users').subscribe();
+    this.store.dispatch(loadUsers({ pageSize: this.pageSize }));
+  }
+
+  remove(id: string): void {
+    this.http.delete(`/api/users/${id}`).subscribe();
+    this.store.dispatch(deleteUser({ id }));
+    this.removed.emit(id);
+  }
+
+  onSelected(user: User): void {
+    this.selected.emit(user);
+  }
+}

--- a/testdata/fixtures/real-world/typescript/react_dataflow_component.tsx
+++ b/testdata/fixtures/real-world/typescript/react_dataflow_component.tsx
@@ -1,0 +1,43 @@
+// Source: synthetic, modelled on real React 18 function-component data-flow
+// patterns (destructured props, useState/useReducer state, data fetching,
+// conditional rendering) | License: MIT
+//
+// Used by issue #2855 real-data verification (Data Flow group): proves the
+// React extractor emits component_prop entities (generic props, not just nav
+// props) and state_setter operations on real-shaped source.
+
+import React, { useState, useReducer, useEffect } from 'react';
+
+interface UserCardProps {
+  userId: string;
+  title?: string;
+  onSelect: (id: string) => void;
+}
+
+function reducer(state: number, action: { type: string }) {
+  return action.type === 'inc' ? state + 1 : state;
+}
+
+export function UserCard({ userId, title = 'User', onSelect }: UserCardProps) {
+  const [name, setName] = useState('');
+  const [open, setOpen] = useState(false);
+  const [count, dispatch] = useReducer(reducer, 0);
+
+  useEffect(() => {
+    fetch(`/api/users/${userId}`)
+      .then((r) => r.json())
+      .then((u) => setName(u.name));
+  }, [userId]);
+
+  return (
+    <div onClick={() => onSelect(userId)}>
+      {open ? <h1>{title}: {name}</h1> : null}
+      <button onClick={() => dispatch({ type: 'inc' })}>{count}</button>
+      <button onClick={() => setOpen(!open)}>toggle</button>
+    </div>
+  );
+}
+
+export const Avatar = ({ src, alt }: { src: string; alt: string }) => (
+  <img src={src} alt={alt} />
+);

--- a/testdata/fixtures/real-world/vue/UserCard.vue
+++ b/testdata/fixtures/real-world/vue/UserCard.vue
@@ -1,0 +1,43 @@
+<!-- Source: synthetic, modelled on real Vue 3 SFC data-flow patterns
+     (defineProps, Pinia store + ref/reactive state, useFetch/axios fetching,
+     v-if/v-show branches) | License: MIT
+
+     Used by issue #2855 real-data verification (Data Flow group). -->
+<script setup lang="ts">
+import { ref, reactive, computed } from 'vue'
+import axios from 'axios'
+import { useUserStore } from '@/stores/user'
+
+const props = defineProps<{
+  userId: string
+  title?: string
+  expanded?: boolean
+}>()
+
+const emit = defineEmits<{ (e: 'select', id: string): void }>()
+
+const userStore = useUserStore()
+const loading = ref(false)
+const form = reactive({ name: '', email: '' })
+
+const displayTitle = computed(() => props.title ?? 'User')
+
+async function load() {
+  loading.value = true
+  const { data } = await useFetch(`/api/users/${props.userId}`)
+  await axios.post('/api/audit', { userId: props.userId })
+  loading.value = false
+}
+</script>
+
+<template>
+  <section class="user-card">
+    <h2 v-if="title">{{ displayTitle }}</h2>
+    <div v-show="expanded">
+      <input v-model="form.name" />
+      <input v-model="form.email" />
+    </div>
+    <ChildAvatar v-else :user-id="userId" />
+    <button @click="emit('select', userId)">Select</button>
+  </section>
+</template>


### PR DESCRIPTION
Closes #2855 (part of epic #2847).

Implements the Data-Flow-group capabilities for JS/TS UI frameworks, flipping **14 cells**.

## What changed
- **React (flagship, partial→full)** — generic component prop extraction beyond the navigation-only #2665 case: destructured / whole-bag function-component params emit `SCOPE.Operation` subtype=`component_prop` with `CONTAINS` edges (new `dataflow_react.go`, wired into all three component handlers in `extractor.go`). `state_management` now cites the React-core `useState`/`useReducer` `state_setter` pairs + Zustand.
- **Angular (missing→full)** — `@Input()`/`@Output()` → `component_prop`; ngrx `Store.select`/`dispatch` → `CALLS Store.*`; `HttpClient` verbs → `data_fetch` + `CALLS`; `*ngIf`/`@if`/`[ngSwitch]` template → `branch_condition` (`angular.go`).
- **Vue (missing→full)** — `defineProps`/Options `props` → `component_prop`; Pinia stores + `ref`/`reactive` → `state_store`/`reactive_state`; `fetch`/`axios`/`useFetch`/`useAsyncData` → `data_fetch`; `v-if`/`v-else`/`v-show` → `branch_condition` (`vue/extractor.go`).
- **Svelte (missing→full)** — `export let`/`$props` props; `writable`/`derived`/`readable` stores → `state_store`; `fetch`/`axios` → `data_fetch`; `{#if}`/`{#each}`/`{:else if}` → `branch_condition` (`svelte/extractor.go`).

## Discipline
- **No new entity/edge Kind** — reuses `SCOPE.Operation` + `CONTAINS`/`CALLS`/`USES`. `go test ./internal/types/` stays green (verified).
- Hand-written unit fixtures + real-world corpus fixtures under `testdata/fixtures/real-world/{typescript,vue,svelte}/` prove every flipped cell; real-data tests assert the signals fire on real-shaped source.
- Coverage registry updated via `tools/coverage update`; `validate` exits 0; `gen` byte-stable.
- Self-rebased on `origin/main` (resolved registry.json React-cell conflict, re-ran gen).

## implements-capability tags
```
implements-capability: lang.jsts.framework.angular/Data Flow/prop_extraction:missing→full
implements-capability: lang.jsts.framework.angular/Data Flow/state_management:missing→full
implements-capability: lang.jsts.framework.angular/Data Flow/data_fetching:missing→full
implements-capability: lang.jsts.framework.angular/Data Flow/branch_conditions:missing→full
implements-capability: lang.jsts.framework.react/Data Flow/prop_extraction:partial→full
implements-capability: lang.jsts.framework.react/Data Flow/state_management:partial→full
implements-capability: lang.jsts.framework.svelte/Data Flow/prop_extraction:missing→full
implements-capability: lang.jsts.framework.svelte/Data Flow/state_management:missing→full
implements-capability: lang.jsts.framework.svelte/Data Flow/data_fetching:missing→full
implements-capability: lang.jsts.framework.svelte/Data Flow/branch_conditions:missing→full
implements-capability: lang.jsts.framework.vue/Data Flow/prop_extraction:missing→full
implements-capability: lang.jsts.framework.vue/Data Flow/state_management:missing→full
implements-capability: lang.jsts.framework.vue/Data Flow/data_fetching:missing→full
implements-capability: lang.jsts.framework.vue/Data Flow/branch_conditions:missing→full
```

## Test plan
- [x] `go test ./internal/extractors/javascript/ ./internal/extractors/vue/ ./internal/extractors/svelte/ ./internal/types/`
- [x] `go test ./internal/substrate/ ./internal/links/ ./internal/engine/ ./tools/coverage/`
- [x] real-data: extractors run over `testdata/fixtures/real-world/` (angular props=4 fetch=2 branch=4; react props=5 setter=3; vue props=3 store=1 reactive=2 fetch=2 branch=3; svelte prop=3 store=2 fetch=1 branch=7)
- [x] `go run ./tools/coverage validate` exit 0; `gen` byte-stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)