### PR TITLE
feat(jsts): meta-framework Structure + Routing — Next/Remix/Gatsby + Astro (#2857)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -171,11 +171,11 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 | [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 4/4 | |
-| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 1/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 4/4 | |
 | [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 3/14 | |
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -40,11 +40,11 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 4/4 | |
-| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 1/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 4/4 | |
+| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/2 | ✅ 2/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | — | |
 | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 1/2 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ✅ 1/1 | ✅ 4/4 | |
 
 

--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/extractors/astro/extractor.go`<br>`internal/extractors/astro/issue2857_routing_test.go` | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` | — |
-| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+| `router_pattern` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/extractors/astro/extractor.go`<br>`internal/extractors/astro/issue2857_routing_test.go` | — |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.gatsby.md
+++ b/docs/coverage/detail/lang.jsts.framework.gatsby.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/gatsby.go`<br>`internal/custom/javascript/react_shared.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
+| `hook_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/gatsby.go`<br>`internal/custom/javascript/react_shared.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
 
 ### Data Flow
 
@@ -35,8 +35,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `route_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml` | — |
-| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+| `route_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/gatsby.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
+| `router_pattern` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/gatsby.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
-| `hook_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | — | — |
+| `component_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/nextjs.go`<br>`internal/custom/javascript/react_shared.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
+| `hook_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/nextjs.go`<br>`internal/custom/javascript/react_shared.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hook_recognition` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/remix.go`<br>`internal/custom/javascript/react_shared.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
+| `hook_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/remix.go`<br>`internal/custom/javascript/react_shared.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
 
 ### Data Flow
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` | — |
-| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+| `router_pattern` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2857) | `internal/custom/javascript/remix.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
 
 ### Build
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14496,7 +14496,13 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": [
+              "internal/extractors/astro/extractor.go",
+              "internal/extractors/astro/issue2857_routing_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           },
           "hook_recognition": {
             "status": "not_applicable"
@@ -14524,7 +14530,13 @@
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
-            "status": "missing"
+            "status": "full",
+            "cites": [
+              "internal/extractors/astro/extractor.go",
+              "internal/extractors/astro/issue2857_routing_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           }
         },
         "Build": {
@@ -15089,10 +15101,24 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": [
+              "internal/custom/javascript/gatsby.go",
+              "internal/custom/javascript/react_shared.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           },
           "hook_recognition": {
-            "status": "missing"
+            "status": "full",
+            "cites": [
+              "internal/custom/javascript/gatsby.go",
+              "internal/custom/javascript/react_shared.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
@@ -15110,15 +15136,22 @@
         },
         "Routing": {
           "route_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": [
-              "internal/engine/rules/javascript_typescript/frameworks/gatsby.yaml"
+              "internal/custom/javascript/gatsby.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
             ],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
-            "status": "missing"
+            "status": "full",
+            "cites": [
+              "internal/custom/javascript/gatsby.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           }
         },
         "Build": {
@@ -15930,12 +15963,24 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+            "status": "full",
+            "cites": [
+              "internal/custom/javascript/nextjs.go",
+              "internal/custom/javascript/react_shared.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           },
           "hook_recognition": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+            "status": "full",
+            "cites": [
+              "internal/custom/javascript/nextjs.go",
+              "internal/custom/javascript/react_shared.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
@@ -16665,10 +16710,24 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": [
+              "internal/custom/javascript/remix.go",
+              "internal/custom/javascript/react_shared.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           },
           "hook_recognition": {
-            "status": "missing"
+            "status": "full",
+            "cites": [
+              "internal/custom/javascript/remix.go",
+              "internal/custom/javascript/react_shared.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
@@ -16693,7 +16752,13 @@
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
-            "status": "missing"
+            "status": "full",
+            "cites": [
+              "internal/custom/javascript/remix.go",
+              "internal/custom/javascript/issue2857_meta_structure_test.go"
+            ],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2857",
+            "verified_at": "2026-05-28"
           }
         },
         "Build": {

--- a/internal/custom/javascript/gatsby.go
+++ b/internal/custom/javascript/gatsby.go
@@ -1,0 +1,157 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// gatsby.go — Gatsby meta-framework extractor (issue #2857).
+//
+// Gatsby is React-based. It discovers routes from the file-system convention
+// `src/pages/**` (each component file under src/pages/ becomes a route) and
+// supports programmatic routes via `createPage({ path, component })` calls in
+// gatsby-node.js plus client-only routes via the `@reach/router`-style
+// matchPath. Page components are React components and Gatsby ships hooks
+// (useStaticQuery) on top of React's own — so component + hook recognition
+// reuse the shared React detection (react_shared.go).
+//
+// Emitted entities:
+//
+//	src/pages/**.{js,jsx,tsx}      → SCOPE.Operation   subtype="page_route"      (router_pattern / route_extraction)
+//	createPage({path,component})   → SCOPE.Operation   subtype="programmatic_route"
+//	React function/arrow/class     → SCOPE.UIComponent subtype="component"       (component_extraction, shared)
+//	useStaticQuery / useXxx        → SCOPE.Operation   subtype="hook"/"hook_call" (hook_recognition, shared)
+
+func init() {
+	extreg.Register("custom_js_gatsby", &gatsbyExtractor{})
+}
+
+type gatsbyExtractor struct{}
+
+func (e *gatsbyExtractor) Language() string { return "custom_js_gatsby" }
+
+var (
+	// createPage({ path: '/foo', component: ... }) in gatsby-node.js.
+	reGatsbyCreatePage = regexp.MustCompile(
+		`createPage\s*\(\s*\{[^}]*?\bpath\s*:\s*['"` + "`" + `]([^'"` + "`" + `]+)['"` + "`" + `]`,
+	)
+	// Gatsby dynamic page params use [param] like Next pages router.
+	reGatsbyDynParam = regexp.MustCompile(`\[([^\]]+)\]`)
+	// Import from the 'gatsby' package — marks a file as Gatsby context even
+	// when it lives outside src/pages or src/templates.
+	reGatsbyImport = regexp.MustCompile(`(?m)(?:from\s+['"]gatsby['"]|require\(\s*['"]gatsby['"]\s*\))`)
+)
+
+func normalizeGatsbyPath(fp string) string {
+	result := reGatsbyDynParam.ReplaceAllStringFunc(fp, func(s string) string {
+		inner := s[1 : len(s)-1]
+		if strings.HasPrefix(inner, "...") {
+			return "{" + inner[3:] + "*}"
+		}
+		return "{" + inner + "}"
+	})
+	for strings.Contains(result, "//") {
+		result = strings.ReplaceAll(result, "//", "/")
+	}
+	return result
+}
+
+func (e *gatsbyExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.gatsby_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "gatsby"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	fp := filepath.ToSlash(file.Path)
+	stem := filepath.Base(fp)
+	ext := filepath.Ext(stem)
+	stem = strings.TrimSuffix(stem, ext)
+
+	// File-convention routing: src/pages/**.
+	isPagesFile := strings.Contains(fp, "/src/pages/") || strings.HasPrefix(fp, "src/pages/")
+	isJSX := strings.HasSuffix(fp, ".tsx") || strings.HasSuffix(fp, ".jsx") ||
+		strings.HasSuffix(fp, ".ts") || strings.HasSuffix(fp, ".js")
+
+	if isPagesFile && isJSX {
+		routePath := normalizeGatsbyPath(fp)
+		if idx := strings.Index(routePath, "/src/pages/"); idx >= 0 {
+			routePath = routePath[idx+len("/src/pages"):]
+		} else if strings.HasPrefix(routePath, "src/pages/") {
+			routePath = routePath[len("src/pages"):]
+		}
+		if ext2 := filepath.Ext(routePath); ext2 != "" {
+			routePath = strings.TrimSuffix(routePath, ext2)
+		}
+		routePath = strings.TrimSuffix(routePath, "/index")
+		if routePath == "" {
+			routePath = "/"
+		}
+		if !strings.HasPrefix(routePath, "/") {
+			routePath = "/" + routePath
+		}
+		ent := makeEntity(routePath, "SCOPE.Operation", "page_route", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "gatsby", "route_path", routePath, "stem", stem,
+			"router", "file_system", "provenance", "INFERRED_FROM_GATSBY_FILE_PATH")
+		addEntity(ent)
+	}
+
+	// Programmatic routing: createPage({ path, component }) in gatsby-node.
+	for _, m := range reGatsbyCreatePage.FindAllStringSubmatchIndex(src, -1) {
+		routePath := src[m[2]:m[3]]
+		name := fmt.Sprintf("createPage:%s", routePath)
+		ent := makeEntity(name, "SCOPE.Operation", "programmatic_route", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "gatsby", "route_path", routePath,
+			"router", "create_pages_api", "provenance", "INFERRED_FROM_GATSBY_CREATE_PAGE")
+		addEntity(ent)
+	}
+
+	// React structure: page/template components + custom hooks + hook calls
+	// (useStaticQuery and friends). Reuses the shared React detection. Gated to
+	// genuine Gatsby context — a page/template file, or a file that imports from
+	// 'gatsby' — so non-Gatsby React projects don't get gatsby-tagged duplicate
+	// component entities (custom_js_react already covers generic React).
+	isTemplate := strings.Contains(fp, "/src/templates/") || strings.HasPrefix(fp, "src/templates/")
+	isGatsbyContext := isPagesFile || isTemplate || reGatsbyImport.MatchString(src)
+	isJSXFile := strings.HasSuffix(fp, ".tsx") || strings.HasSuffix(fp, ".jsx")
+	if isJSXFile && isGatsbyContext {
+		extractReactStructure(src, file.Path, file.Language, "gatsby", addEntity)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/javascript/issue2857_meta_structure_test.go
+++ b/internal/custom/javascript/issue2857_meta_structure_test.go
@@ -1,0 +1,165 @@
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// rawHasProp runs the named extractor and reports whether an entity with the
+// given Name carries Properties[key]==want — used for route_path / router
+// convention assertions that the Kind/Subtype/Name-only extract() helper can't
+// see.
+func rawHasProp(t *testing.T, extractor, path, lang, src, name, key, want string) bool {
+	t.Helper()
+	e, ok := extreg.Get(extractor)
+	if !ok {
+		t.Fatalf("extractor %q not registered", extractor)
+	}
+	ents, err := e.Extract(context.Background(), fi(path, lang, src))
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	for _, ent := range ents {
+		if ent.Name == name && ent.Properties[key] == want {
+			return true
+		}
+	}
+	return false
+}
+
+// issue2857_meta_structure_test.go — proving fixtures for the meta-framework
+// Structure (component_extraction, hook_recognition) + Routing (router_pattern,
+// route_extraction) coverage cells closed by issue #2857. These are
+// hand-written, dependency-manifest-free source snippets exercised through the
+// registered custom extractors.
+
+// ── Next.js (React-based): component + hook recognition ───────────────────────
+
+func TestNextjs2857PageComponentAndHooks(t *testing.T) {
+	src := `
+import { useState, useEffect } from 'react'
+import { useMyData } from '../hooks/useMyData'
+
+export default function ProfilePage() {
+  const [count, setCount] = useState(0)
+  useEffect(() => {}, [])
+  const data = useMyData()
+  return <div>{count}{data}</div>
+}
+`
+	ents := extract(t, "custom_js_nextjs", fi("app/profile/page.tsx", "typescript", src))
+	if !containsEntity(ents, "SCOPE.UIComponent", "ProfilePage") {
+		t.Error("expected ProfilePage React component (component_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "call:useState") {
+		t.Error("expected useState hook call (hook_recognition)")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "call:useMyData") {
+		t.Error("expected custom useMyData hook call (hook_recognition)")
+	}
+}
+
+func TestNextjs2857CustomHookDefinition(t *testing.T) {
+	src := `
+import { useState } from 'react'
+export function useToggle() {
+  const [on, setOn] = useState(false)
+  return [on, () => setOn(!on)]
+}
+`
+	ents := extract(t, "custom_js_nextjs", fi("app/dashboard/page.tsx", "typescript", src))
+	if !containsEntity(ents, "SCOPE.Operation", "useToggle") {
+		t.Error("expected useToggle custom hook definition (hook_recognition)")
+	}
+}
+
+func TestNextjs2857ApiRouteNoComponent(t *testing.T) {
+	// .ts API route handlers must NOT pick up React component/hook entities.
+	src := `export async function GET() { return Response.json({}) }`
+	ents := extract(t, "custom_js_nextjs", fi("app/api/users/route.ts", "typescript", src))
+	for _, e := range ents {
+		if e.Kind == "SCOPE.UIComponent" {
+			t.Errorf("API route .ts should not emit UIComponent, got %q", e.Name)
+		}
+	}
+}
+
+// ── Remix (React-based): component + hook recognition + router pattern ────────
+
+func TestRemix2857ComponentHooksRouter(t *testing.T) {
+	src := `
+import { useState } from 'react'
+export function loader() { return {} }
+export default function PostRoute() {
+  const [n] = useState(0)
+  return <article>{n}</article>
+}
+`
+	ents := extract(t, "custom_js_remix", fi("app/routes/posts.$id.tsx", "typescript", src))
+	if !containsSubtype(ents, "route_component") {
+		t.Error("expected Remix route_component (component_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "call:useState") {
+		t.Error("expected useState hook call (hook_recognition)")
+	}
+	// route_path derived from routes/ file convention proves router_pattern.
+	if !rawHasProp(t, "custom_js_remix", "app/routes/posts.$id.tsx", "typescript", src,
+		"loader:/posts/{id}", "route_path", "/posts/{id}") {
+		t.Error("expected loader route_path /posts/{id} (router_pattern)")
+	}
+}
+
+// ── Gatsby (React-based): file route + programmatic route + component + hook ──
+
+func TestGatsby2857PageRouteAndComponent(t *testing.T) {
+	src := `
+import { useStaticQuery, graphql } from 'gatsby'
+export default function AboutPage() {
+  const data = useStaticQuery(graphql` + "`" + `query { site { id } }` + "`" + `)
+  return <main>{data}</main>
+}
+`
+	ents := extract(t, "custom_js_gatsby", fi("src/pages/about.tsx", "typescript", src))
+	if !containsEntity(ents, "SCOPE.Operation", "/about") {
+		t.Error("expected /about file-system route (route_extraction + router_pattern)")
+	}
+	if !containsSubtype(ents, "page_route") {
+		t.Error("expected page_route subtype (router_pattern)")
+	}
+	if !containsEntity(ents, "SCOPE.UIComponent", "AboutPage") {
+		t.Error("expected AboutPage React component (component_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "call:useStaticQuery") {
+		t.Error("expected useStaticQuery hook call (hook_recognition)")
+	}
+}
+
+func TestGatsby2857IndexRoute(t *testing.T) {
+	src := `export default function Home() { return <div /> }`
+	ents := extract(t, "custom_js_gatsby", fi("src/pages/index.tsx", "typescript", src))
+	if !containsEntity(ents, "SCOPE.Operation", "/") {
+		t.Error("expected index → / route")
+	}
+}
+
+func TestGatsby2857DynamicRoute(t *testing.T) {
+	src := `export default function Post() { return <article /> }`
+	if !rawHasProp(t, "custom_js_gatsby", "src/pages/blog/[slug].tsx", "typescript", src,
+		"/blog/{slug}", "route_path", "/blog/{slug}") {
+		t.Error("expected dynamic /blog/{slug} route (router_pattern)")
+	}
+}
+
+func TestGatsby2857ProgrammaticRoute(t *testing.T) {
+	src := `
+exports.createPages = async ({ actions }) => {
+  actions.createPage({ path: '/products/widget', component: require.resolve('./tpl.tsx') })
+}
+`
+	ents := extract(t, "custom_js_gatsby", fi("gatsby-node.js", "javascript", src))
+	if !containsSubtype(ents, "programmatic_route") {
+		t.Errorf("expected programmatic_route from createPage (router_pattern), got %#v", ents)
+	}
+}

--- a/internal/custom/javascript/nextjs.go
+++ b/internal/custom/javascript/nextjs.go
@@ -202,6 +202,17 @@ func (e *nextjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 		addEntity(ent)
 	}
 
+	// React structure: page/layout components + custom hooks + hook calls.
+	// Next.js pages are React components, so reuse the shared React component /
+	// hook recognition (issue #2857, Structure group). Gated to Next router
+	// context (app/ or pages/) AND JSX files, so neither API route .ts handlers
+	// nor non-Next React projects pick up nextjs-tagged duplicate components
+	// (custom_js_react covers generic React).
+	isJSXFile := strings.HasSuffix(fp, ".tsx") || strings.HasSuffix(fp, ".jsx")
+	if isJSXFile && (isAppRouter || isPagesRouter) {
+		extractReactStructure(src, file.Path, file.Language, "nextjs", addEntity)
+	}
+
 	// Server actions ("use server" + exported async functions)
 	if reNextjsServerAction.MatchString(src) {
 		for _, m := range reNextjsServerActionFn.FindAllStringSubmatchIndex(src, -1) {

--- a/internal/custom/javascript/react.go
+++ b/internal/custom/javascript/react.go
@@ -51,6 +51,12 @@ var (
 	reReactUseContext = regexp.MustCompile(
 		`useContext\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)`,
 	)
+	// Hook call sites: useState(...), useEffect(...), useMyHook(...). The
+	// `use` + Uppercase-4th-rune convention is the Rules-of-Hooks naming the
+	// React linter enforces. Anchored so `used(`/`user(` do not match.
+	reReactUseHookCall = regexp.MustCompile(
+		`\b(use[A-Z][A-Za-z0-9_]*)\s*\(`,
+	)
 	// JSX guard: presence of JSX in file
 	// JSX guard: presence of JSX in file (matches component tags <Foo, HTML tags <div, or createElement).
 	reReactJSXPresence = regexp.MustCompile(

--- a/internal/custom/javascript/react_shared.go
+++ b/internal/custom/javascript/react_shared.go
@@ -1,0 +1,109 @@
+package javascript
+
+import (
+	"fmt"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// react_shared.go — shared React component + hook recognition used by the
+// React-based meta-frameworks (Next.js, Remix, Gatsby) so they extract page
+// components and custom/builtin hook usage with the same fidelity as the
+// standalone React extractor (issue #2857, Structure group).
+//
+// The regexes themselves live in react.go (reReactExportFunction,
+// reReactExportConst, reReactClassComponent, reReactHook,
+// reReactCreateContext, reReactUseContext, reReactJSXPresence,
+// reReactUseHookCall). These helpers wrap them so each meta-framework
+// extractor can tag the framework name + provenance while reusing the exact
+// same detection logic — no duplicated patterns.
+
+// reactComponentSink receives an extracted entity. Each meta-framework passes
+// its own dedup-aware adder.
+type reactComponentSink func(ent types.EntityRecord)
+
+// extractReactStructure runs the shared React component + hook recognition over
+// src and feeds every entity to add. framework tags the emitted entities so
+// downstream queries can attribute them to the host meta-framework
+// (react/next/remix/gatsby). It covers:
+//
+//   - function / arrow / class components (PascalCase, JSX-guarded)        → SCOPE.UIComponent subtype="component"
+//   - custom hook definitions (export const/function useXxx)               → SCOPE.Operation   subtype="hook"
+//   - hook call sites (useState, useEffect, useMyHook, ...)                → SCOPE.Operation   subtype="hook_call"
+//   - createContext + useContext                                          → SCOPE.Component/Operation
+//
+// It returns the set of component / hook-definition names it emitted so the
+// caller can decide route-component attribution.
+func extractReactStructure(src, filePath, language, framework string, add reactComponentSink) {
+	hasJSX := reReactJSXPresence.MatchString(src)
+
+	if hasJSX {
+		for _, m := range reReactExportFunction.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity(name, "SCOPE.UIComponent", "component", filePath, language, lineOf(src, m[0]))
+			setProps(&ent, "framework", framework, "component_type", "function",
+				"provenance", "INFERRED_FROM_REACT_COMPONENT")
+			add(ent)
+		}
+		for _, m := range reReactExportConst.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity(name, "SCOPE.UIComponent", "component", filePath, language, lineOf(src, m[0]))
+			setProps(&ent, "framework", framework, "component_type", "arrow",
+				"provenance", "INFERRED_FROM_REACT_COMPONENT")
+			add(ent)
+		}
+	}
+
+	for _, m := range reReactClassComponent.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.UIComponent", "component", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", framework, "component_type", "class",
+			"provenance", "INFERRED_FROM_REACT_CLASS_COMPONENT")
+		add(ent)
+	}
+
+	// Custom hook definitions.
+	for _, m := range reReactHook.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Operation", "hook", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", framework, "provenance", "INFERRED_FROM_REACT_HOOK")
+		add(ent)
+	}
+
+	// Hook call sites (useXxx(...)). Proves hook_recognition for components that
+	// only *consume* hooks (the common case for a page component).
+	for _, m := range reReactUseHookCall.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity("call:"+name, "SCOPE.Operation", "hook_call", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", framework, "hook", name,
+			"builtin", fmt.Sprintf("%t", reactBuiltinHooks[name]),
+			"provenance", "INFERRED_FROM_REACT_HOOK_CALL")
+		add(ent)
+	}
+
+	// createContext / useContext.
+	for _, m := range reReactCreateContext.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Component", "context", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", framework, "provenance", "INFERRED_FROM_REACT_CONTEXT")
+		add(ent)
+	}
+	for _, m := range reReactUseContext.FindAllStringSubmatchIndex(src, -1) {
+		ctxName := src[m[2]:m[3]]
+		ent := makeEntity("useContext:"+ctxName, "SCOPE.Operation", "context_use", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", framework, "context_name", ctxName,
+			"provenance", "INFERRED_FROM_REACT_USE_CONTEXT")
+		add(ent)
+	}
+}
+
+// reactBuiltinHooks is the set of React-core hooks; a call to one proves the
+// enclosing file is a React component / custom hook.
+var reactBuiltinHooks = map[string]bool{
+	"useState": true, "useEffect": true, "useContext": true, "useReducer": true,
+	"useCallback": true, "useMemo": true, "useRef": true, "useImperativeHandle": true,
+	"useLayoutEffect": true, "useDebugValue": true, "useTransition": true,
+	"useDeferredValue": true, "useId": true, "useSyncExternalStore": true,
+	"useInsertionEffect": true, "useOptimistic": true, "useActionState": true,
+	"useFormStatus": true,
+}

--- a/internal/custom/javascript/remix.go
+++ b/internal/custom/javascript/remix.go
@@ -188,6 +188,17 @@ func (e *remixExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]
 		addEntity(ent)
 	}
 
+	// React structure: custom hooks + hook call sites in the route module.
+	// Remix routes are React components (the default export is captured above
+	// as route_component); this adds hook_recognition (issue #2857) by reusing
+	// the shared React detection. Gated to Remix routes/ context so non-Remix
+	// React projects don't get remix-tagged duplicate component entities.
+	isRoutesFile := strings.Contains(fp, "/routes/") || strings.HasPrefix(fp, "routes/") ||
+		strings.Contains(fp, "/app/root.") || strings.HasPrefix(fp, "app/root.")
+	if isRoutesFile {
+		extractReactStructure(src, file.Path, file.Language, "remix", addEntity)
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
 }

--- a/internal/extractors/astro/extractor.go
+++ b/internal/extractors/astro/extractor.go
@@ -123,6 +123,15 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		EndLine:      lineCount,
 		Signature:    componentName + ".astro",
 		QualityScore: 0.85,
+		Properties:   map[string]string{"framework": "astro"},
+	}
+	// Astro file-system routing (issue #2857, router_pattern): a file under
+	// pages/ maps to a route by its path. Record the derived route_path and the
+	// router convention on the page entity so route discovery is provable.
+	if subtype == "astro_page" {
+		routePath := routePathFromAstroPage(file.Path)
+		componentEntity.Properties["route_path"] = routePath
+		componentEntity.Properties["router"] = "file_system"
 	}
 	entities = append(entities, componentEntity)
 
@@ -165,6 +174,43 @@ func componentNameFromPath(path string) string {
 		return "Component"
 	}
 	return name
+}
+
+// astroDynParamRE matches Astro dynamic-route segments: [slug], [...path],
+// [[...optional]]. Used to normalize the route path of a page file.
+var astroDynParamRE = regexp.MustCompile(`\[+\.?\.?\.?([^\]]+)\]+`)
+
+// routePathFromAstroPage derives the URL route for an Astro page from its file
+// path under pages/. Astro's file-system router maps:
+//
+//	src/pages/index.astro        → /
+//	src/pages/about.astro        → /about
+//	src/pages/blog/[slug].astro  → /blog/{slug}
+//	src/pages/[...path].astro    → /{path*}
+func routePathFromAstroPage(path string) string {
+	norm := filepath.ToSlash(path)
+	idx := strings.Index(norm, "/pages/")
+	rel := norm
+	switch {
+	case idx >= 0:
+		rel = norm[idx+len("/pages/"):]
+	case strings.HasPrefix(norm, "pages/"):
+		rel = norm[len("pages/"):]
+	}
+	rel = strings.TrimSuffix(rel, ".astro")
+	rel = strings.TrimSuffix(rel, "/index")
+	if rel == "index" {
+		rel = ""
+	}
+	rel = astroDynParamRE.ReplaceAllStringFunc(rel, func(s string) string {
+		inner := strings.Trim(s, "[]")
+		if strings.HasPrefix(inner, "...") {
+			return "{" + strings.TrimPrefix(inner, "...") + "*}"
+		}
+		return "{" + inner + "}"
+	})
+	route := "/" + strings.TrimPrefix(rel, "/")
+	return route
 }
 
 // pageSubtype returns "astro_page" if the file is under a pages/ directory,

--- a/internal/extractors/astro/issue2857_routing_test.go
+++ b/internal/extractors/astro/issue2857_routing_test.go
@@ -1,0 +1,76 @@
+package astro_test
+
+import "testing"
+
+// issue2857_routing_test.go — proving fixtures for Astro Structure
+// (component_extraction) + Routing (router_pattern) coverage cells closed by
+// issue #2857. Astro uses file-system routing under pages/.
+
+func TestAstro2857PageRouterPattern(t *testing.T) {
+	src := `---
+const { title } = Astro.props
+---
+<h1>{title}</h1>`
+	recs := mustExtract(t, "src/pages/about.astro", src)
+	page := findByName(recs, "about")
+	if page == nil {
+		t.Fatal("expected page component entity (component_extraction)")
+	}
+	if page.Subtype != "astro_page" {
+		t.Errorf("expected astro_page subtype, got %q", page.Subtype)
+	}
+	if page.Properties["route_path"] != "/about" {
+		t.Errorf("expected route_path /about (router_pattern), got %q", page.Properties["route_path"])
+	}
+	if page.Properties["router"] != "file_system" {
+		t.Errorf("expected router=file_system, got %q", page.Properties["router"])
+	}
+}
+
+func TestAstro2857IndexRoute(t *testing.T) {
+	recs := mustExtract(t, "src/pages/index.astro", `<h1>Home</h1>`)
+	page := findByName(recs, "index")
+	if page == nil {
+		t.Fatal("expected index page entity")
+	}
+	if page.Properties["route_path"] != "/" {
+		t.Errorf("expected index → /, got %q", page.Properties["route_path"])
+	}
+}
+
+func TestAstro2857DynamicRoute(t *testing.T) {
+	recs := mustExtract(t, "src/pages/blog/[slug].astro", `<article />`)
+	page := findByName(recs, "[slug]")
+	if page == nil {
+		t.Fatal("expected dynamic page entity")
+	}
+	if page.Properties["route_path"] != "/blog/{slug}" {
+		t.Errorf("expected /blog/{slug}, got %q", page.Properties["route_path"])
+	}
+}
+
+func TestAstro2857RestRoute(t *testing.T) {
+	recs := mustExtract(t, "src/pages/[...path].astro", `<div />`)
+	page := findByName(recs, "[...path]")
+	if page == nil {
+		t.Fatal("expected rest page entity")
+	}
+	if page.Properties["route_path"] != "/{path*}" {
+		t.Errorf("expected /{path*}, got %q", page.Properties["route_path"])
+	}
+}
+
+func TestAstro2857ComponentNotPage(t *testing.T) {
+	// A component (not under pages/) carries no route_path.
+	recs := mustExtract(t, "src/components/Header.astro", `<header />`)
+	comp := findByName(recs, "Header")
+	if comp == nil {
+		t.Fatal("expected component entity (component_extraction)")
+	}
+	if comp.Subtype != "astro_component" {
+		t.Errorf("expected astro_component subtype, got %q", comp.Subtype)
+	}
+	if _, ok := comp.Properties["route_path"]; ok {
+		t.Error("non-page component should not have route_path")
+	}
+}


### PR DESCRIPTION
Closes part of #2857 (epic #2847). Implements meta-framework Structure (component_extraction, hook_recognition) + Routing (route_extraction, router_pattern) for the React-based trio (Next.js, Remix, Gatsby) plus Astro file-system routing.

## What
- **`react_shared.go`** (new): shared React component + hook recognition (function/arrow/class components, custom-hook definitions, `useXxx(...)` call sites, createContext/useContext) reused by the React-based meta-fw extractors. `react.go` exposes the hook-call regex; no duplicated patterns.
- **`nextjs.go` / `remix.go`**: emit page/route React components + hook usage, gated to `app|pages` (Next) and `routes/` (Remix) so non-host React projects don't get framework-tagged duplicate components (`custom_js_react` still covers generic React).
- **`gatsby.go`** (new, React-based): `src/pages/**` file-system routes, `createPage({path})` programmatic routes, plus React component + hook recognition (`useStaticQuery`, …). Gated to genuine Gatsby context (pages/templates or `import … from 'gatsby'`).
- **astro extractor**: derives a file-system `route_path` + `router=file_system` for `pages/` entities (index → `/`, `[slug]` → `/blog/{slug}`, `[...path]` → `/{path*}`).

## Proven
- Unit fixtures + tests: `internal/custom/javascript/issue2857_meta_structure_test.go`, `internal/extractors/astro/issue2857_routing_test.go` — all green.
- **Real-data**: ran the extraction dispatch over a hand-built multi-file meta-fw corpus (Next app router + API route, Remix `$id` route, Gatsby pages + dynamic + `gatsby-node.js`, Astro index + dynamic). Components, hook calls, and file-convention routes emit correctly. Temp corpus + runner torn down (no daemon touched).
- No new entity/edge Kinds (reuses `SCOPE.UIComponent`/`SCOPE.Operation`/`SCOPE.Component`); `go test ./internal/types/` green.

## Deferred → #2880
Nuxt + SvelteKit component_extraction/router_pattern, and the SvelteKit load-function `params.*` source detection noted on #2857 (from #2868). Filed as #2880.

## implements-capability
```
implements-capability: lang.jsts.framework.astro/Structure/component_extraction:missing→full
implements-capability: lang.jsts.framework.astro/Routing/router_pattern:missing→full
implements-capability: lang.jsts.framework.gatsby/Structure/component_extraction:missing→full
implements-capability: lang.jsts.framework.gatsby/Structure/hook_recognition:missing→full
implements-capability: lang.jsts.framework.gatsby/Routing/route_extraction:partial→full
implements-capability: lang.jsts.framework.gatsby/Routing/router_pattern:missing→full
implements-capability: lang.jsts.framework.next-api/Structure/component_extraction:missing→full
implements-capability: lang.jsts.framework.next-api/Structure/hook_recognition:missing→full
implements-capability: lang.jsts.framework.remix/Structure/component_extraction:missing→full
implements-capability: lang.jsts.framework.remix/Structure/hook_recognition:missing→full
implements-capability: lang.jsts.framework.remix/Routing/router_pattern:missing→full
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)