### PR TITLE
audit(coverage): independent verification + taxonomy corrections for JS/TS greening (#2847)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -159,7 +159,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ⚠️ 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 5/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
@@ -191,7 +191,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 | [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 | [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -30,7 +30,7 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ⚠️ 3/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 | [React](../detail/lang.jsts.framework.react.md) | ✅ 5/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 17/17 | |
 | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
 | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
@@ -54,7 +54,7 @@ Back to [summary](../summary.md).
 |---|---|---|---|---|---|---|---|---|---|---|
 | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 2/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 1/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 
 

--- a/docs/coverage/detail/lang.jsts.framework.angular.md
+++ b/docs/coverage/detail/lang.jsts.framework.angular.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `branch_conditions` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go`<br>`testdata/fixtures/real-world/typescript/angular_dataflow_component.ts` | — |
 | `data_fetching` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go`<br>`testdata/fixtures/real-world/typescript/angular_dataflow_component.ts` | — |
 | `prop_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go`<br>`testdata/fixtures/real-world/typescript/angular_dataflow_component.ts` | — |
-| `state_management` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go`<br>`testdata/fixtures/real-world/typescript/angular_dataflow_component.ts` | — |
+| `state_management` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2855) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2855_angular_dataflow_test.go` | AUDIT(#2847) full->partial: angularStateManagement only detects ngrx Store (select/dispatch/pipe/selectSignal). On angular-realworld (gothinkster) all 11 stateful files use Angular signals + RxJS BehaviorSubject and 0 use ngrx, so the cell fired on the ngrx fixture but missed the dominant modern Angular state idiom. Follow-up filed for signal()/computed()/BehaviorSubject support. |
 
 ### Navigation
 
@@ -70,10 +70,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `decorator_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| `dependency_injection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| `ngmodule_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| `rxjs_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `decorator_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2847) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | AUDIT(#2847) taxonomy: angular.go angularClassDecorators emits component/service/directive/pipe/module subtypes. Verified on angular-realworld: angular_component x18, angular_service x6, angular_pipe x2, angular_directive x1. |
+| `dependency_injection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2847) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | AUDIT(#2847) taxonomy: constructor-DI -> INJECTED_INTO edges. Verified on angular-realworld (5 INJECTED_INTO->ArticleComponent etc.), incl. modern inject() function-DI. |
+| `directive_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2847) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | AUDIT(#2847) NEW idiom cell: @Directive -> angular_directive subtype. Verified on angular-realworld + nativescript-ng. |
+| `ngmodule_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2847) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | AUDIT(#2847) taxonomy: @NgModule -> angular_module subtype. Verified on real NativeScript-Angular app (angular_module x47). |
+| `pipe_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2847) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | AUDIT(#2847) NEW idiom cell: @Pipe -> angular_pipe subtype. Verified on angular-realworld (angular_pipe x2). |
+| `rxjs_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | AUDIT(#2847): genuinely unimplemented — angular.go does not extract Observable/pipe/subscribe operators as entities. Held at missing. |
+| `service_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2847) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | AUDIT(#2847) NEW idiom cell: @Injectable -> angular_service subtype. Verified on angular-realworld (angular_service x6). |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nativescript.md
+++ b/docs/coverage/detail/lang.jsts.framework.nativescript.md
@@ -42,8 +42,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `branch_conditions` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/discriminator.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts` | — |
-| `state_management` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts` | — |
+| `branch_conditions` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/discriminator.go` | AUDIT(#2847) full->partial: NS branch_conditions relies on the discriminator pass, which stamped 0 discriminators across 19 real NativeScript view-models (official @nativescript app-templates) whose if-branches are member comparisons (if (this._x !== value)). Fires only on the toy fixture's bare-identifier compare. Follow-up filed. |
+| `state_management` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts` | AUDIT(#2847) HOLDS: state_setter fires on 6 real NativeScript-Core view-models (notifyPropertyChange/this.set/set-accessor) from @nativescript app-templates. |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10506,10 +10506,11 @@
             "verified_at": "2026-05-28"
           },
           "state_management": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2855_angular_dataflow_test.go","testdata/fixtures/real-world/typescript/angular_dataflow_component.ts"],
+            "status": "partial",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2855_angular_dataflow_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2855",
-            "verified_at": "2026-05-28"
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) full->partial: angularStateManagement only detects ngrx Store (select/dispatch/pipe/selectSignal). On angular-realworld (gothinkster) all 11 stateful files use Angular signals + RxJS BehaviorSubject and 0 use ngrx, so the cell fired on the ngrx fixture but missed the dominant modern Angular state idiom. Follow-up filed for signal()/computed()/BehaviorSubject support."
           }
         },
         "Navigation": {
@@ -10572,20 +10573,51 @@
       "framework_specific": {
         "Angular Internals": {
           "decorator_recognition": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2854_angular_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2847",
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) taxonomy: angular.go angularClassDecorators emits component/service/directive/pipe/module subtypes. Verified on angular-realworld: angular_component x18, angular_service x6, angular_pipe x2, angular_directive x1."
           },
           "dependency_injection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2854_angular_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2847",
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) taxonomy: constructor-DI -> INJECTED_INTO edges. Verified on angular-realworld (5 INJECTED_INTO->ArticleComponent etc.), incl. modern inject() function-DI."
           },
           "ngmodule_extraction": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2854_angular_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2847",
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) taxonomy: @NgModule -> angular_module subtype. Verified on real NativeScript-Angular app (angular_module x47)."
+          },
+          "service_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2854_angular_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2847",
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) NEW idiom cell: @Injectable -> angular_service subtype. Verified on angular-realworld (angular_service x6)."
+          },
+          "directive_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2854_angular_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2847",
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) NEW idiom cell: @Directive -> angular_directive subtype. Verified on angular-realworld + nativescript-ng."
+          },
+          "pipe_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/issue2854_angular_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2847",
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) NEW idiom cell: @Pipe -> angular_pipe subtype. Verified on angular-realworld (angular_pipe x2)."
           },
           "rxjs_pattern_detection": {
             "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "issue": "https://github.com/cajasmota/archigraph/issues/2739",
+            "notes": "AUDIT(#2847): genuinely unimplemented — angular.go does not extract Observable/pipe/subscribe operators as entities. Held at missing."
           }
         }
       }
@@ -11582,14 +11614,18 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/discriminator.go","internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
+            "status": "partial",
+            "cites": ["internal/extractors/javascript/discriminator.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859",
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) full->partial: NS branch_conditions relies on the discriminator pass, which stamped 0 discriminators across 19 real NativeScript view-models (official @nativescript app-templates) whose if-branches are member comparisons (if (this._x !== value)). Fires only on the toy fixture's bare-identifier compare. Follow-up filed."
           },
           "state_management": {
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_nativescript/main-view-model.ts"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859",
+            "verified_at": "2026-05-28",
+            "notes": "AUDIT(#2847) HOLDS: state_setter fires on 6 real NativeScript-Core view-models (notifyPropertyChange/this.set/set-accessor) from @nativescript app-templates."
           }
         },
         "Type System": {


### PR DESCRIPTION
## Summary
Independent + adversarial audit of the ~74 cells the JS/TS greening PRs flipped to `full`
(#2867/#2868/#2871 substrate, #2870 ui-structure, #2873 ui-dataflow, #2872 mobile),
verified against **genuinely unseen real OSS apps** — NOT the implementer's in-repo
`testdata/fixtures/real-world/*` fixtures.

**Corpus (cloned to /tmp, unseen by the implementer):** angular-realworld (standalone +
signals + `inject()`), vue3-realworld, sveltejs/realworld, react-redux-realworld (legacy
class+connect), jsoncrack (modern hooks+zustand), ignite (RN), ionic-react-conference-app,
nativescript-sdk-examples-ng + `@nativescript/app-templates`. A standalone harness ran the
**registered** extractors over each and tallied subtypes/edges/discriminators; substrate
probed via `SnifferFor("jsts")`.

## Verdict: REAL WINS — 84 of 86 audited cells HOLD (~98%)
This is not a bare-minimum status-flip campaign. The substrate sweep is a legitimate
framework-agnostic recording win; Angular/Vue/Svelte/React/mobile structure + data-flow
extraction fires with good recall on real apps.

### Reverts (2, full → partial) — with follow-ups
- **angular `state_management`**: `angularStateManagement` only detects ngrx Store. Real
  angular-realworld is 11/11 signals + RxJS BehaviorSubject, **0 ngrx**. → #2884
- **nativescript `branch_conditions`**: discriminator pass stamps **0** across 19 real NS
  view-models (member-comparison branches `if (this._x !== value)`). → #2885

### Taxonomy corrections (angular `framework_specific` "Angular Internals")
- Promote `decorator_recognition` / `dependency_injection` / `ngmodule_extraction`
  missing→full (angular.go #2854 delivers them; verified on real code: angular_component x18,
  angular_service x6, angular_pipe x2, angular_directive x1, INJECTED_INTO incl. `inject()`).
- Add NEW idiom cells `service_extraction` / `directive_recognition` / `pipe_extraction`.
- Hold `rxjs_pattern_detection` at missing (genuinely unimplemented).

No `capability-dictionary.yaml` edits (framework_specific isn't dictionary-governed); no new
`internal/types` Kinds (idiom cells reuse existing subtypes — #2839 N/A).

Coverage delta is intentionally **negative** on the two reverts — that is the point of the audit.
Full report: `~/private/benchmarks/jsts-greening-audit-1.md`.

## Test plan
- [x] `go run ./tools/coverage validate` → exit 0
- [x] `go run ./tools/coverage gen` → byte-stable / idempotent
- [x] `go test ./internal/types/ ./tools/coverage/` → green
- [x] Self-rebased on origin/main (resolved registry.json + regenerated .md conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)