### PR TITLE
[JS/TS fwspec] Vue Internals — composition/options/SFC/provide-inject (A); directives/slots (B); scoped-style N/A

### DIFF
--- a/docs/coverage/detail/lang.jsts.framework.vue.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue.md
@@ -70,13 +70,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 ## Framework-specific
 
-### Vue Ecosystem
+### Vue Internals
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `composition_api_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| `pinia_pattern_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| `scoped_style_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `composition_api` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go`<br>`internal/extractors/javascript/testdata/vue_internals/Comp.vue` | — |
+| `directive_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go`<br>`internal/extractors/javascript/testdata/vue_internals/Comp.vue` | — |
+| `options_api` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go`<br>`internal/extractors/javascript/testdata/vue_internals/OptionsComp.vue` | — |
+| `pinia_store` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go`<br>`internal/extractors/javascript/testdata/vue_internals/Comp.vue` | — |
+| `props_emits_macros` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go`<br>`internal/extractors/javascript/testdata/vue_internals/Comp.vue` | — |
+| `provide_inject` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go`<br>`internal/extractors/javascript/testdata/vue_internals/Comp.vue` | — |
+| `scoped_style_extraction` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | — | — |
+| `sfc_block_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go`<br>`internal/extractors/javascript/testdata/vue_internals/Comp.vue` | — |
+| `slot_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go`<br>`internal/extractors/javascript/testdata/vue_internals/Comp.vue` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12978,18 +12978,59 @@
         }
       },
       "framework_specific": {
-        "Vue Ecosystem": {
-          "composition_api_extraction": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+        "Vue Internals": {
+          "composition_api": {
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go","internal/extractors/javascript/testdata/vue_internals/Comp.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
           },
-          "pinia_pattern_detection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+          "options_api": {
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go","internal/extractors/javascript/testdata/vue_internals/OptionsComp.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
+          },
+          "sfc_block_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go","internal/extractors/javascript/testdata/vue_internals/Comp.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
+          },
+          "provide_inject": {
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go","internal/extractors/javascript/testdata/vue_internals/Comp.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
+          },
+          "props_emits_macros": {
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go","internal/extractors/javascript/testdata/vue_internals/Comp.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
+          },
+          "pinia_store": {
+            "status": "partial",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go","internal/extractors/javascript/testdata/vue_internals/Comp.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
+          },
+          "directive_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go","internal/extractors/javascript/testdata/vue_internals/Comp.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
+          },
+          "slot_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go","internal/extractors/javascript/testdata/vue_internals/Comp.vue"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
           },
           "scoped_style_extraction": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
           }
         }
       }

--- a/internal/extractors/javascript/testdata/vue_internals/Comp.vue
+++ b/internal/extractors/javascript/testdata/vue_internals/Comp.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+// Vue Internals proving fixture (issue #2876).
+// Exercises: composition_api (ref/computed/watch), props_emits_macros
+// (defineProps/defineEmits/defineExpose), provide_inject (provide/inject),
+// pinia_store (defineStore import + useXxxStore), sfc_block_extraction
+// (this <script setup> + <template> + <style scoped> split).
+import { ref, computed, watch, provide, inject } from 'vue'
+import { useCounterStore } from '@/stores/counter'
+
+const props = defineProps<{ label: string; max?: number }>()
+const emit = defineEmits<{ (e: 'change', value: number): void }>()
+
+const counterStore = useCounterStore()
+const count = ref(0)
+const doubled = computed(() => count.value * 2)
+watch(count, (n) => emit('change', n))
+
+provide('theme', 'dark')
+const injectedUser = inject('currentUser')
+
+defineExpose({ count })
+</script>
+
+<template>
+  <section>
+    <!-- directive_recognition: v-for, v-model, v-bind shorthand, v-on shorthand -->
+    <input v-model="count" :max="props.max" @input="emit('change', count)" />
+    <li v-for="item in items" :key="item.id">{{ item.name }}</li>
+    <ChildPanel v-if="doubled > 0">
+      <!-- slot_extraction: content provided to a child's named slot -->
+      <template #header>{{ props.label }}</template>
+      <template v-slot:footer>{{ injectedUser }}</template>
+    </ChildPanel>
+    <!-- slot_extraction: this component's own slot outlets -->
+    <slot name="title" />
+    <slot />
+  </section>
+</template>
+
+<style scoped>
+/* scoped_style_extraction is N/A — CSS is ignored by the extractor by design. */
+.section { color: red; }
+</style>

--- a/internal/extractors/javascript/testdata/vue_internals/OptionsComp.vue
+++ b/internal/extractors/javascript/testdata/vue_internals/OptionsComp.vue
@@ -1,0 +1,30 @@
+<script lang="ts">
+// Vue Internals proving fixture (issue #2876) — Options API variant.
+// Exercises: options_api (export default options object with a method block),
+// provide_inject (provide/inject options), props (Options-API props).
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'OptionsComp',
+  props: {
+    title: String,
+    count: Number,
+  },
+  provide() {
+    return { theme: 'light' }
+  },
+  inject: ['currentUser'],
+  methods: {
+    increment() {
+      this.count += 1
+    },
+    reset() {
+      this.count = 0
+    },
+  },
+})
+</script>
+
+<template>
+  <div>{{ title }}</div>
+</template>

--- a/internal/extractors/vue/extractor.go
+++ b/internal/extractors/vue/extractor.go
@@ -169,6 +169,33 @@ var (
 	// Vue's conditional-rendering directives (branch_conditions).
 	reVueBranch = regexp.MustCompile(`\b(v-if|v-else-if|v-else|v-show)\b`)
 
+	// ── Template directives (issue #2876 — Vue Internals/directive_recognition) ─
+	// Vue template directives are `v-<name>` attributes. We recognise the full
+	// built-in set plus user-defined ones. The branch directives (v-if/v-else/
+	// v-show) are also captured by reVueBranch for Data-Flow branch_conditions;
+	// here we model the directive itself as a first-class template idiom. We
+	// capture the directive name and (for v-on:click / @click and :prop / v-bind)
+	// the argument so the directive entity carries the bound event/attribute.
+	//   v-model / v-model:value
+	//   v-for="item in items"
+	//   v-bind:href / :href            (shorthand `:`)
+	//   v-on:click  / @click           (shorthand `@`)
+	//   v-html / v-text / v-slot / v-cloak / v-once / v-pre / v-memo
+	//   custom: v-focus, v-tooltip, …
+	reVueDirective = regexp.MustCompile(`(?:\b(v-[a-z][a-z0-9-]*)(?::([a-zA-Z][\w.-]*))?|(?:^|\s)([:@])([a-zA-Z][\w.-]*))(?:=|\s|>|/)`)
+
+	// ── Slots (issue #2876 — Vue Internals/slot_extraction) ──────────────────
+	// Slot outlets declared in a child component's <template>:
+	//   <slot />                      default slot
+	//   <slot name="header" />        named slot
+	// Slot content provided by a parent at a usage site:
+	//   <template #header>            shorthand named-slot
+	//   <template v-slot:footer>      explicit v-slot
+	//   <template v-slot="{ row }">   default scoped slot
+	reSlotOutlet = regexp.MustCompile(`(?i)<slot\b([^>]*?)/?>`)
+	reSlotName   = regexp.MustCompile(`(?i)\bname\s*=\s*["']([^"']+)["']`)
+	reSlotUse    = regexp.MustCompile(`(?i)<template\b[^>]*?(?:#([a-zA-Z][\w.-]*)|v-slot:([a-zA-Z][\w.-]*)|(v-slot)\b)`)
+
 	// ── Navigation (issue #2856) ─────────────────────────────────────────────
 
 	// vue-router route table: createRouter({ routes: [ … ] }). We locate the
@@ -379,6 +406,20 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 		// NAVIGATES_TO edges.
 		linkRels := extractRouterLinks(templateSrc, templateOffset, src, componentName)
 		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, linkRels...)
+
+		// Vue Internals (#2876) — directive_recognition: v-model/v-for/v-bind/
+		// v-on/etc. template directives → SCOPE.Operation subtype="directive"
+		// with CONTAINS edges from the component.
+		dirEntities, dirRels := extractDirectives(templateSrc, templateOffset, src, file.Path, componentName)
+		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, dirRels...)
+		entities = append(entities, dirEntities...)
+
+		// Vue Internals (#2876) — slot_extraction: <slot>/<slot name="x"> outlets
+		// and <template #x>/<template v-slot:x> usage → SCOPE.Operation
+		// subtype="slot" with CONTAINS edges from the component.
+		slotEntities, slotRels := extractSlots(templateSrc, templateOffset, src, file.Path, componentName)
+		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, slotRels...)
+		entities = append(entities, slotEntities...)
 	}
 
 	// --- 5. Tag relationships with language ----------------------------------
@@ -408,19 +449,49 @@ func extractScriptBlock(src string) (content string, offset int, isSetup bool) {
 	return src[contentStart:contentEnd], contentStart, isSetup
 }
 
-// extractTemplateBlock locates the first <template> section.
+// reTopTemplateOpen matches a top-level SFC <template …> block — anchored to
+// the start of a line so a `<template>` mention inside a <script> comment or a
+// nested (indented) slot template is not mistaken for the root block.
+var reTopTemplateOpen = regexp.MustCompile(`(?im)^<template(\s[^>]*)?>`)
+
+// extractTemplateBlock locates the outermost <template> section. Vue templates
+// nest <template> elements (slot content via <template #slot> / v-slot), so the
+// closing tag must be matched at the same depth as the opening one rather than
+// stopping at the first </template>. The root block is found via a line-anchored
+// match so a `<template>` literal inside a <script> comment is not picked up.
 func extractTemplateBlock(src string) (content string, offset int, found bool) {
-	openLoc := reTemplateOpen.FindStringIndex(src)
+	openLoc := reTopTemplateOpen.FindStringIndex(src)
+	if openLoc == nil {
+		// Fall back to a non-anchored match for minified/one-line SFCs.
+		openLoc = reTemplateOpen.FindStringIndex(src)
+	}
 	if openLoc == nil {
 		return "", 0, false
 	}
 	contentStart := openLoc[1]
-	closeLoc := reTemplateClose.FindStringIndex(src[contentStart:])
-	if closeLoc == nil {
-		return "", 0, false
+
+	// Walk forward, tracking <template …> open / </template> close depth.
+	depth := 1
+	pos := contentStart
+	for depth > 0 {
+		rest := src[pos:]
+		nextOpen := reTemplateOpen.FindStringIndex(rest)
+		nextClose := reTemplateClose.FindStringIndex(rest)
+		if nextClose == nil {
+			return "", 0, false
+		}
+		if nextOpen != nil && nextOpen[0] < nextClose[0] {
+			depth++
+			pos += nextOpen[1]
+			continue
+		}
+		depth--
+		if depth == 0 {
+			return src[contentStart : pos+nextClose[0]], contentStart, true
+		}
+		pos += nextClose[1]
 	}
-	contentEnd := contentStart + closeLoc[0]
-	return src[contentStart:contentEnd], contentStart, true
+	return "", 0, false
 }
 
 // extractSetupMacros scans a <script setup> block for defineProps, defineEmits,
@@ -900,6 +971,176 @@ func extractBranchConditions(templateSrc string, templateOffset int, fullSrc, fi
 			},
 		})
 	}
+	return ents, rels
+}
+
+// extractDirectives scans the <template> block for Vue template directives
+// (issue #2876 — Vue Internals/directive_recognition) and returns
+// SCOPE.Operation subtype="directive" entities plus CONTAINS edges from the
+// component. Vue's directives are `v-<name>` attributes (v-model, v-for,
+// v-bind, v-on, v-html, v-slot, custom directives, …) together with their
+// shorthands `:attr` (v-bind) and `@event` (v-on). Each distinct directive
+// (keyed by directive + argument) yields one entity so the component's template
+// surface is introspectable. The `directive` property holds the canonical
+// directive name (shorthand normalised to v-bind / v-on); `arg` holds the
+// bound argument when present (e.g. v-on:click → arg="click").
+func extractDirectives(templateSrc string, templateOffset int, fullSrc, filePath, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+
+	for _, m := range reVueDirective.FindAllStringSubmatchIndex(templateSrc, -1) {
+		var directive, arg string
+		off := m[0]
+		switch {
+		case m[2] >= 0: // v-<name>[:arg]
+			directive = templateSrc[m[2]:m[3]]
+			if m[4] >= 0 {
+				arg = templateSrc[m[4]:m[5]]
+			}
+		case m[6] >= 0: // shorthand `:` or `@`
+			short := templateSrc[m[6]:m[7]]
+			if m[8] >= 0 {
+				arg = templateSrc[m[8]:m[9]]
+			}
+			if short == "@" {
+				directive = "v-on"
+			} else {
+				directive = "v-bind"
+			}
+			// Shorthand match consumes a leading whitespace; align the offset to
+			// the sigil itself for accurate line numbers.
+			off = m[6]
+		}
+		if directive == "" {
+			continue
+		}
+		key := directive
+		if arg != "" {
+			key = directive + ":" + arg
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		safe := strings.NewReplacer("-", "_", ":", "_", ".", "_").Replace(key)
+		lineNum := lineOf(fullSrc, templateOffset+off)
+		props := map[string]string{
+			"component": componentName,
+			"directive": directive,
+			"framework": "vue",
+		}
+		if arg != "" {
+			props["arg"] = arg
+		}
+		ents = append(ents, types.EntityRecord{
+			Name:             safe,
+			QualifiedName:    fmt.Sprintf("%s.%s", componentName, safe),
+			Kind:             "SCOPE.Operation",
+			Subtype:          "directive",
+			SourceFile:       filePath,
+			Language:         "vue",
+			StartLine:        lineNum,
+			EndLine:          lineNum,
+			Signature:        "template " + key,
+			QualityScore:     0.8,
+			EnrichmentStatus: types.StatusPending,
+			Properties:       props,
+		})
+		rels = append(rels, types.RelationshipRecord{
+			ToID: safe,
+			Kind: "CONTAINS",
+			Properties: map[string]string{
+				"component": componentName,
+				"directive": directive,
+				"framework": "vue",
+			},
+		})
+	}
+	return ents, rels
+}
+
+// extractSlots scans the <template> block for Vue slots (issue #2876 — Vue
+// Internals/slot_extraction) and returns SCOPE.Operation subtype="slot"
+// entities plus CONTAINS edges from the component. Two roles are recognised:
+//
+//	<slot /> / <slot name="header" />           → role="outlet" (this component
+//	                                               declares a slot)
+//	<template #header> / <template v-slot:footer>→ role="content" (this component
+//	                                               fills a child's slot)
+//
+// An unnamed <slot> or default v-slot is keyed as "default". The slot name is
+// carried in the `slot_name` property so the component's slot surface is
+// introspectable.
+func extractSlots(templateSrc string, templateOffset int, fullSrc, filePath, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+
+	emit := func(name, role string, off int) {
+		if name == "" {
+			name = "default"
+		}
+		dedupe := role + ":" + name
+		if seen[dedupe] {
+			return
+		}
+		seen[dedupe] = true
+		safe := strings.NewReplacer("-", "_", ".", "_").Replace(role + "_" + name)
+		lineNum := lineOf(fullSrc, templateOffset+off)
+		ents = append(ents, types.EntityRecord{
+			Name:             safe,
+			QualifiedName:    fmt.Sprintf("%s.%s", componentName, safe),
+			Kind:             "SCOPE.Operation",
+			Subtype:          "slot",
+			SourceFile:       filePath,
+			Language:         "vue",
+			StartLine:        lineNum,
+			EndLine:          lineNum,
+			Signature:        "slot " + role + " " + name,
+			QualityScore:     0.8,
+			EnrichmentStatus: types.StatusPending,
+			Properties: map[string]string{
+				"component": componentName,
+				"slot_name": name,
+				"slot_role": role,
+				"framework": "vue",
+			},
+		})
+		rels = append(rels, types.RelationshipRecord{
+			ToID: safe,
+			Kind: "CONTAINS",
+			Properties: map[string]string{
+				"component": componentName,
+				"slot_name": name,
+				"slot_role": role,
+				"framework": "vue",
+			},
+		})
+	}
+
+	// Slot outlets: <slot /> / <slot name="header" />.
+	for _, m := range reSlotOutlet.FindAllStringSubmatchIndex(templateSrc, -1) {
+		attrs := templateSrc[m[2]:m[3]]
+		name := ""
+		if nm := reSlotName.FindStringSubmatch(attrs); nm != nil {
+			name = nm[1]
+		}
+		emit(name, "outlet", m[0])
+	}
+
+	// Slot content: <template #name> / <template v-slot:name> / <template v-slot>.
+	for _, m := range reSlotUse.FindAllStringSubmatchIndex(templateSrc, -1) {
+		name := ""
+		if m[2] >= 0 {
+			name = templateSrc[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			name = templateSrc[m[4]:m[5]]
+		}
+		emit(name, "content", m[0])
+	}
+
 	return ents, rels
 }
 

--- a/internal/extractors/vue/issue2876_internals_test.go
+++ b/internal/extractors/vue/issue2876_internals_test.go
@@ -1,0 +1,152 @@
+package vue_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #2876 — Vue Internals framework_specific group. One proving fixture per
+// idiom family. The (A) recording cells (composition_api, options_api,
+// sfc_block_extraction, provide_inject, props_emits_macros, pinia_store) and the
+// newly implemented (B) cells (directive_recognition, slot_extraction) are all
+// asserted against hand-written .vue fixtures so no cell is flipped without a
+// proving fixture.
+
+func loadVueFixture(t *testing.T, rel string) string {
+	t.Helper()
+	// Test runs from internal/extractors/vue/; fixtures live in the sibling
+	// javascript extractor testdata tree (per the issue's fixture path).
+	p := filepath.Join("..", "javascript", "testdata", "vue_internals", rel)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", p, err)
+	}
+	return string(b)
+}
+
+func hasEntity(ents []types.EntityRecord, subtype, name string) bool {
+	for i := range ents {
+		if ents[i].Subtype == subtype && ents[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSubtype(ents []types.EntityRecord, subtype string) bool {
+	for i := range ents {
+		if ents[i].Subtype == subtype {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIssue2876_VueInternals_ScriptSetup proves the <script setup> idiom cells:
+// composition_api, props_emits_macros, provide_inject, pinia_store,
+// sfc_block_extraction, directive_recognition, slot_extraction.
+func TestIssue2876_VueInternals_ScriptSetup(t *testing.T) {
+	src := loadVueFixture(t, "Comp.vue")
+	ents := extract(t, "src/components/Comp.vue", src)
+
+	comp := findByName(ents, "Comp")
+	if comp == nil {
+		t.Fatalf("Comp component not extracted; %s", dump(ents))
+	}
+
+	// composition_api: ref/computed/watch/provide/inject → CALLS edges.
+	for _, callee := range []string{"ref", "computed", "watch", "provide", "inject"} {
+		if !relTarget(comp, "CALLS", callee) {
+			t.Errorf("composition_api: missing CALLS %s; %s", callee, dump(ents))
+		}
+	}
+
+	// props_emits_macros: defineProps / defineEmits / defineExpose operations.
+	if !hasEntity(ents, "define_props", "defineProps") {
+		t.Errorf("props_emits_macros: missing defineProps; %s", dump(ents))
+	}
+	if !hasEntity(ents, "define_emits", "defineEmits") {
+		t.Errorf("props_emits_macros: missing defineEmits")
+	}
+	if !hasEntity(ents, "define_expose", "defineExpose") {
+		t.Errorf("props_emits_macros: missing defineExpose")
+	}
+
+	// provide_inject: provider/consumer context operations.
+	if !hasEntity(ents, "provide_context", "provider:theme") {
+		t.Errorf("provide_inject: missing provider:theme; %s", dump(ents))
+	}
+	if !hasEntity(ents, "inject_context", "consumer:currentUser") {
+		t.Errorf("provide_inject: missing consumer:currentUser")
+	}
+
+	// pinia_store: defineStore import + useCounterStore() → state_store.
+	if !hasEntity(ents, "state_store", "useCounterStore") {
+		t.Errorf("pinia_store: missing state_store useCounterStore; %s", dump(ents))
+	}
+
+	// sfc_block_extraction: a vue_component entity is produced from the SFC and
+	// the <script setup> block was parsed (proven by the macro/CALLS extraction
+	// above which only runs on a successfully split <script> block). The <style>
+	// block is intentionally ignored (scoped_style_extraction = N/A).
+	if comp.Subtype != "vue_component" {
+		t.Errorf("sfc_block_extraction: component subtype = %q, want vue_component", comp.Subtype)
+	}
+
+	// directive_recognition (B): v-model, v-for, v-bind (:max shorthand),
+	// v-on (@input shorthand).
+	dirs := map[string]bool{}
+	for i := range ents {
+		if ents[i].Subtype == "directive" {
+			dirs[ents[i].Properties["directive"]] = true
+		}
+	}
+	for _, d := range []string{"v-model", "v-for", "v-bind", "v-on"} {
+		if !dirs[d] {
+			t.Errorf("directive_recognition: missing directive %s; dirs=%v; %s", d, dirs, dump(ents))
+		}
+	}
+
+	// slot_extraction (B): outlet slots (default + named "title") and content
+	// slots (#header, v-slot:footer).
+	if !hasEntity(ents, "slot", "outlet_default") {
+		t.Errorf("slot_extraction: missing default slot outlet; %s", dump(ents))
+	}
+	if !hasEntity(ents, "slot", "outlet_title") {
+		t.Errorf("slot_extraction: missing named slot outlet 'title'")
+	}
+	if !hasEntity(ents, "slot", "content_header") {
+		t.Errorf("slot_extraction: missing content slot 'header'")
+	}
+	if !hasEntity(ents, "slot", "content_footer") {
+		t.Errorf("slot_extraction: missing content slot 'footer'")
+	}
+
+	// scoped_style_extraction (N/A): the <style scoped> block must NOT produce a
+	// style entity — CSS is ignored by design (extractor.go package doc).
+	if hasSubtype(ents, "style") {
+		t.Errorf("scoped_style_extraction is N/A but a style entity was emitted; %s", dump(ents))
+	}
+}
+
+// TestIssue2876_VueInternals_OptionsAPI proves the options_api cell.
+func TestIssue2876_VueInternals_OptionsAPI(t *testing.T) {
+	src := loadVueFixture(t, "OptionsComp.vue")
+	ents := extract(t, "src/components/OptionsComp.vue", src)
+
+	comp := findByName(ents, "OptionsComp")
+	if comp == nil {
+		t.Fatalf("OptionsComp not extracted; %s", dump(ents))
+	}
+
+	// options_api: methods declared in the methods: { … } block.
+	if !hasEntity(ents, "method", "increment") {
+		t.Errorf("options_api: missing method increment; %s", dump(ents))
+	}
+	if !hasEntity(ents, "method", "reset") {
+		t.Errorf("options_api: missing method reset")
+	}
+}


### PR DESCRIPTION
Closes #2876. Part of epic #2847.

Adds the honest **Vue Internals** `framework_specific` group to `lang.jsts.framework.vue` (renamed from the thin placeholder "Vue Ecosystem"). Honest greening — every `full` cell has a proving fixture + test, verified on a real Vue corpus.

## Taxonomy decisions
- Renamed `framework_specific["Vue Ecosystem"]` → `"Vue Internals"` (the issue's convention: `<Framework> Internals`).
- Reused/renamed the prior placeholder keys: `composition_api_extraction`→`composition_api`, `pinia_pattern_detection`→`pinia_store`, kept `scoped_style_extraction`.
- Added the missing first-class Vue idiom cells: `options_api`, `sfc_block_extraction`, `provide_inject`, `props_emits_macros`, `directive_recognition`, `slot_extraction`.

## Gap classification & status
| Cell | Gap | Status | Rationale |
|---|---|---|---|
| `composition_api` | A | ✅ full | `reCompositionCall` ref/reactive/computed/watch/provide/inject → CALLS (extractor.go) |
| `options_api` | A | ✅ full | `extractOptionsMethods` — `methods: { … }` block → SCOPE.Operation |
| `sfc_block_extraction` | A | ✅ full | `extractScriptBlock`/`extractTemplateBlock` split <script setup>/<template> |
| `provide_inject` | A | ✅ full | `extractContext` provide()/inject() → context operations |
| `props_emits_macros` | A | ✅ full | `extractSetupMacros` defineProps/defineEmits/defineExpose |
| `pinia_store` | A-partial | ⚠️ partial | `defineStore`/`useXxxStore()` modeled as a `state_store` operation + CONTAINS edge — NOT yet a dedicated store entity (the issue's promote-to-full path is deferred; left honest partial) |
| `directive_recognition` | **B** | ✅ full | **New** `extractDirectives` — v-model/v-for/v-bind(:)/v-on(@)/v-html/v-slot + custom v-* → SCOPE.Operation subtype="directive" |
| `slot_extraction` | **B** | ✅ full | **New** `extractSlots` — `<slot>`/`<slot name>` outlets + `<template #x>`/`v-slot:x` content → SCOPE.Operation subtype="slot" |
| `scoped_style_extraction` | N/A | 🚫 not_applicable | CSS is ignored by design (extractor.go package doc) |

## (B) implementation notes
- New `extractDirectives` / `extractSlots` in `internal/extractors/vue/extractor.go`.
- Fixed `extractTemplateBlock` to anchor on the root `<template>` at line start and balance nested slot `<template>` elements — previously it stopped at the first `</template>`, truncating slot content.
- **No new entity Kind** — reuses `SCOPE.Operation` + `CONTAINS` (per the "decorate existing entities" discipline; `go test ./internal/types/` green).

## Fixtures & tests
- `internal/extractors/javascript/testdata/vue_internals/Comp.vue` — <script setup>: ref/computed/watch + defineProps/Emits/Expose + provide/inject + defineStore import + v-model/v-for/v-bind/v-on directives + named/default slot outlets + slot content + <style scoped>.
- `internal/extractors/javascript/testdata/vue_internals/OptionsComp.vue` — Options API methods/props/provide/inject.
- `internal/extractors/vue/issue2876_internals_test.go` — asserts every flipped cell.
- **Real-data check**: ran the extractor over vuejs/vue-router example `.vue` files (15 files) → 25 directives (v-bind/v-for/v-if/v-else/v-model/v-on), 4 slots, 5 options methods. (Throwaway clone, torn down.)

## Validation
- `go run ./tools/coverage validate` → exit 0.
- `go run ./tools/coverage gen` → byte-stable (ran twice, identical).
- `go test ./internal/extractors/vue/ ./internal/extractors/javascript/ ./internal/types/ ./internal/substrate/ ./internal/links/ ./tools/coverage/` → all pass.

implements-capability: lang.jsts.framework.vue/Vue Internals/composition_api:missing→full
implements-capability: lang.jsts.framework.vue/Vue Internals/options_api:missing→full
implements-capability: lang.jsts.framework.vue/Vue Internals/sfc_block_extraction:missing→full
implements-capability: lang.jsts.framework.vue/Vue Internals/provide_inject:missing→full
implements-capability: lang.jsts.framework.vue/Vue Internals/props_emits_macros:missing→full
implements-capability: lang.jsts.framework.vue/Vue Internals/pinia_store:missing→partial
implements-capability: lang.jsts.framework.vue/Vue Internals/directive_recognition:missing→full
implements-capability: lang.jsts.framework.vue/Vue Internals/slot_extraction:missing→full
implements-capability: lang.jsts.framework.vue/Vue Internals/scoped_style_extraction:missing→not_applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)