### PR TITLE
[JS/TS fwspec] React Internals — lazy/suspense/portal (no double-count of hooks/context/HOC)

### DIFF
--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -78,6 +78,18 @@ Auto-generated. Back to [summary](../summary.md).
 | `template_pattern_catalog` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_react/UserDashboard.tsx`<br>`internal/links/template_pattern_pass.go`<br>`internal/substrate/react_substrate_test.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_jsts.go` | — |
 | `vulnerability_finding` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_react/UserDashboard.tsx`<br>`internal/links/taint_flow.go`<br>`internal/substrate/react_substrate_test.go`<br>`internal/substrate/taint_sites_jsts.go` | — |
 
+## Framework-specific
+
+### React Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `context_hoc` | — `not_applicable` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | — | Covered by generic Structure/context_extraction (createContext, #611) and Structure/hoc_wrapper_recognition (forwardRef/memo/lazy/connect/withX, extractor.go). Not duplicated here to avoid double-counting. |
+| `hooks` | — `not_applicable` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | — | Covered by generic Structure/hook_recognition (react.go USES_HOOK + custom-hook subtype). Not duplicated here to avoid double-counting. |
+| `lazy_code_splitting` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/react_internals.go`<br>`internal/extractors/javascript/issue2875_react_internals_test.go`<br>`internal/extractors/javascript/testdata/react_internals/AppShell.tsx` | React.lazy(() => import('mod')) is decorated react_lazy + lazy_module (the code-split target). Partial: the dynamic-import specifier is recovered only when it is a string literal; computed/template specifiers are not resolved. |
+| `portal_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | `internal/extractors/javascript/react_internals.go`<br>`internal/extractors/javascript/issue2875_react_internals_test.go`<br>`internal/extractors/javascript/testdata/react_internals/AppShell.tsx` | Components calling createPortal / ReactDOM.createPortal are decorated react_portal. |
+| `suspense_error_boundary` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | `internal/extractors/javascript/react_internals.go`<br>`internal/extractors/javascript/issue2875_react_internals_test.go`<br>`internal/extractors/javascript/testdata/react_internals/AppShell.tsx` | Components rendering <Suspense> are decorated react_suspense; class components declaring componentDidCatch / getDerivedStateFromError are decorated react_error_boundary. |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12229,6 +12229,41 @@
             "verified_at": "2026-05-28"
           }
         }
+      },
+      "framework_specific": {
+        "React Internals": {
+          "lazy_code_splitting": {
+            "status": "partial",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/react_internals.go","internal/extractors/javascript/issue2875_react_internals_test.go","internal/extractors/javascript/testdata/react_internals/AppShell.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2875",
+            "verified_at": "2026-05-28",
+            "notes": "React.lazy(() => import('mod')) is decorated react_lazy + lazy_module (the code-split target). Partial: the dynamic-import specifier is recovered only when it is a string literal; computed/template specifiers are not resolved."
+          },
+          "suspense_error_boundary": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/react_internals.go","internal/extractors/javascript/issue2875_react_internals_test.go","internal/extractors/javascript/testdata/react_internals/AppShell.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2875",
+            "verified_at": "2026-05-28",
+            "notes": "Components rendering <Suspense> are decorated react_suspense; class components declaring componentDidCatch / getDerivedStateFromError are decorated react_error_boundary."
+          },
+          "portal_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/react_internals.go","internal/extractors/javascript/issue2875_react_internals_test.go","internal/extractors/javascript/testdata/react_internals/AppShell.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2875",
+            "verified_at": "2026-05-28",
+            "notes": "Components calling createPortal / ReactDOM.createPortal are decorated react_portal."
+          },
+          "hooks": {
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2875",
+            "notes": "Covered by generic Structure/hook_recognition (react.go USES_HOOK + custom-hook subtype). Not duplicated here to avoid double-counting."
+          },
+          "context_hoc": {
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2875",
+            "notes": "Covered by generic Structure/context_extraction (createContext, #611) and Structure/hoc_wrapper_recognition (forwardRef/memo/lazy/connect/withX, extractor.go). Not duplicated here to avoid double-counting."
+          }
+        }
       }
     },
     {

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -714,6 +714,12 @@ func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string
 	propEnts, propRels := x.extractComponentProps(params, name)
 	rels = append(rels, propRels...)
 	x.emitWithRels(name, "SCOPE.Operation", n, subtype, sig, rels)
+	// Issue #2875 — React Internals: decorate the component with
+	// react_suspense / react_portal markers (the emit above appended the
+	// component entity at the current tail, before any prop entities).
+	if isComponentName(name) {
+		x.decorateReactComponentInternals(body, len(x.entities)-1)
+	}
 	x.entities = append(x.entities, propEnts...)
 	// Issue #2654 — stamp discriminator comparisons found in the body.
 	x.stampDiscriminators(body)
@@ -757,6 +763,17 @@ func (x *extractor) handleClassDeclaration(n *sitter.Node) {
 	x.emit(className, "SCOPE.Component", n, "class", fmt.Sprintf("class %s", className))
 
 	body := n.ChildByFieldName("body")
+	// Issue #2875 — React Internals/suspense_error_boundary: a class component
+	// that declares componentDidCatch / getDerivedStateFromError is a React
+	// error boundary. Decorate the class entity so error boundaries are
+	// queryable (decorate-only, no new Kind — #2839 discipline).
+	if x.classIsErrorBoundary(body) && classIdx < len(x.entities) {
+		e := &x.entities[classIdx]
+		if e.Properties == nil {
+			e.Properties = map[string]string{}
+		}
+		e.Properties["react_error_boundary"] = "true"
+	}
 	// Issue #421 — collect the class's typed property declarations and
 	// constructor parameter properties so receiver-typed CALLS inside
 	// any method body can resolve `this.<field>` to the declared type.
@@ -1320,6 +1337,10 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		propEnts, propRels := x.extractComponentProps(params, name)
 		rels = append(rels, propRels...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = (...) =>", name), rels)
+		// Issue #2875 — React Internals: suspense/portal decoration.
+		if isComponentName(name) {
+			x.decorateReactComponentInternals(body, len(x.entities)-1)
+		}
 		x.entities = append(x.entities, propEnts...)
 		// Issue #2654 — stamp discriminator comparisons found in the body.
 		x.stampDiscriminators(body)
@@ -1352,6 +1373,10 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		propEnts, propRels := x.extractComponentProps(params, name)
 		rels = append(rels, propRels...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = function", name), rels)
+		// Issue #2875 — React Internals: suspense/portal decoration.
+		if isComponentName(name) {
+			x.decorateReactComponentInternals(body, len(x.entities)-1)
+		}
 		x.entities = append(x.entities, propEnts...)
 		// Issue #2654 — stamp discriminator comparisons found in the body.
 		x.stampDiscriminators(body)
@@ -1420,6 +1445,14 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 			_ = inner
 			before := len(x.entities)
 			x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = <wrapper>", name), rels)
+			// Issue #2875 — React Internals/lazy_code_splitting: when the
+			// wrapper is React.lazy(() => import('mod')), decorate the entity
+			// with react_lazy + the code-split target module so the split point
+			// is queryable. lazyImportModule returns "" for non-lazy wrappers.
+			if mod := x.lazyImportModule(valueNode); mod != "" {
+				x.stampLastEntityProp("react_lazy", "true")
+				x.stampLastEntityProp("lazy_module", mod)
+			}
 			// Issue #1748 — wrapper calls (forwardRef, memo, etc.) inside a
 			// function body are non-addressable; tag as local_scope.
 			if x.funcDepth > 0 {

--- a/internal/extractors/javascript/issue2875_react_internals_test.go
+++ b/internal/extractors/javascript/issue2875_react_internals_test.go
@@ -1,0 +1,101 @@
+// Package javascript_test — issue #2875 React Internals proving tests.
+//
+// Proves the three genuine React framework_specific idioms (lazy code-split,
+// suspense/error-boundary, portal) against the hand-written fixture
+// testdata/react_internals/AppShell.tsx. Each assertion is the proving artifact
+// for a coverage cell flipped in docs/coverage/registry.json["React Internals"]:
+//   - lazy_code_splitting     → react_lazy + lazy_module on the lazy wrapper.
+//   - suspense_error_boundary → react_suspense on the boundary component +
+//                               react_error_boundary on the ErrorBoundary class.
+//   - portal_recognition      → react_portal on the createPortal component.
+//
+// hooks / context_hoc are deliberately NOT asserted here — they are covered by
+// the generic Structure group (#2854 hook_recognition, #611 context_extraction,
+// HOC wrapper recognition) and marked not_applicable in the registry.
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractTSXFixture parses and extracts a testdata .tsx file with the TSX grammar.
+func extractTSXFixture(t *testing.T, relPath string) []types.EntityRecord {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join("testdata", relPath))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", relPath, err)
+	}
+	tree := parseTSX(t, content)
+	ext, _ := extreg.Get("typescript")
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     relPath,
+		Content:  content,
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", relPath, err)
+	}
+	return ents
+}
+
+func TestIssue2875_ReactInternals(t *testing.T) {
+	ents := extractTSXFixture(t, "react_internals/AppShell.tsx")
+
+	// lazy_code_splitting — the lazy() wrapper carries react_lazy + the
+	// dynamic-import code-split target module.
+	settings := findByName(ents, "SettingsPanel")
+	if settings == nil {
+		t.Fatalf("SettingsPanel (lazy wrapper) not extracted; names: %v", entityNames(ents))
+	}
+	if settings.Properties["react_lazy"] != "true" {
+		t.Errorf("SettingsPanel: react_lazy=%q, want \"true\"; props=%v", settings.Properties["react_lazy"], settings.Properties)
+	}
+	if got := settings.Properties["lazy_module"]; got != "./SettingsPanel" {
+		t.Errorf("SettingsPanel: lazy_module=%q, want \"./SettingsPanel\"", got)
+	}
+
+	// suspense_error_boundary — AppShell renders <Suspense>.
+	appShell := findByName(ents, "AppShell")
+	if appShell == nil {
+		t.Fatalf("AppShell not extracted")
+	}
+	if appShell.Properties["react_suspense"] != "true" {
+		t.Errorf("AppShell: react_suspense=%q, want \"true\"; props=%v", appShell.Properties["react_suspense"], appShell.Properties)
+	}
+
+	// suspense_error_boundary — ErrorBoundary class declares the contract.
+	eb := findByName(ents, "ErrorBoundary")
+	if eb == nil {
+		t.Fatalf("ErrorBoundary class not extracted")
+	}
+	if eb.Properties["react_error_boundary"] != "true" {
+		t.Errorf("ErrorBoundary: react_error_boundary=%q, want \"true\"; props=%v", eb.Properties["react_error_boundary"], eb.Properties)
+	}
+
+	// portal_recognition — Modal renders via createPortal.
+	modal := findByName(ents, "Modal")
+	if modal == nil {
+		t.Fatalf("Modal not extracted")
+	}
+	if modal.Properties["react_portal"] != "true" {
+		t.Errorf("Modal: react_portal=%q, want \"true\"; props=%v", modal.Properties["react_portal"], modal.Properties)
+	}
+
+	// Negative case — PlainCard must NOT pick up any React Internals markers.
+	plain := findByName(ents, "PlainCard")
+	if plain == nil {
+		t.Fatalf("PlainCard not extracted")
+	}
+	for _, k := range []string{"react_lazy", "react_suspense", "react_portal", "react_error_boundary"} {
+		if v, ok := plain.Properties[k]; ok && v != "" {
+			t.Errorf("PlainCard: unexpected %s=%q (false positive)", k, v)
+		}
+	}
+}

--- a/internal/extractors/javascript/react_internals.go
+++ b/internal/extractors/javascript/react_internals.go
@@ -1,0 +1,191 @@
+// react_internals.go — React framework-specific idiom recognition for the
+// JS/TS AST extractor (issue #2875, framework_specific["React Internals"]).
+//
+// Scope: the three genuine React idioms that no generic capability column
+// expresses. hooks (Structure/hook_recognition), context + HOC
+// (context_extraction + hoc_wrapper_recognition) are deliberately NOT handled
+// here — they are already measured by the generic Structure group, and adding
+// them again would double-count. See the React Internals group in
+// docs/coverage/registry.json.
+//
+//   1. lazy_code_splitting — `const X = lazy(() => import('./mod'))`. The lazy
+//      wrapper is already classified as a SCOPE.Operation by
+//      isFunctionWrapperCall (extractor.go). Here we additionally decorate that
+//      entity with react_lazy="true" and lazy_module="<import specifier>" so the
+//      code-split point (the dynamically imported module) is queryable.
+//
+//   2. suspense_error_boundary — a component that renders <Suspense> is a
+//      suspense boundary; a class component that declares componentDidCatch or
+//      a static getDerivedStateFromError is an error boundary. We decorate the
+//      enclosing component entity with react_suspense="true" /
+//      react_error_boundary="true".
+//
+//   3. portal_recognition — a component whose body calls createPortal(...) (or
+//      ReactDOM.createPortal(...)) renders a portal. We decorate the component
+//      entity with react_portal="true".
+//
+// All three DECORATE existing entities (SCOPE.Operation function/arrow
+// components, SCOPE.Component classes) rather than emitting a new entity Kind —
+// per the #2839 prefer-decorate discipline. No new EntityKind / RelationshipKind
+// is introduced.
+package javascript
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// stampProp sets a property on the most-recently-emitted entity (the one a
+// component/wrapper emit site just appended). It is a no-op when no entity was
+// appended (name=="" / "?"), keeping the call sites unconditional.
+func (x *extractor) stampLastEntityProp(key, val string) {
+	if len(x.entities) == 0 {
+		return
+	}
+	e := &x.entities[len(x.entities)-1]
+	if e.Properties == nil {
+		e.Properties = map[string]string{}
+	}
+	e.Properties[key] = val
+}
+
+// decorateReactComponentInternals inspects a component function body for the
+// Suspense / portal idioms and stamps the matching properties on the entity at
+// the supplied index. idx must point at the SCOPE.Operation entity the caller
+// just emitted for this component.
+func (x *extractor) decorateReactComponentInternals(body *sitter.Node, idx int) {
+	if body == nil || idx < 0 || idx >= len(x.entities) {
+		return
+	}
+	suspense := x.bodyRendersSuspense(body)
+	portal := x.bodyUsesCreatePortal(body)
+	if !suspense && !portal {
+		return
+	}
+	e := &x.entities[idx]
+	if e.Properties == nil {
+		e.Properties = map[string]string{}
+	}
+	if suspense {
+		e.Properties["react_suspense"] = "true"
+	}
+	if portal {
+		e.Properties["react_portal"] = "true"
+	}
+}
+
+// bodyRendersSuspense reports whether the function body contains a JSX
+// <Suspense> element (opening or self-closing). React.Suspense (member
+// expression) is also matched.
+func (x *extractor) bodyRendersSuspense(body *sitter.Node) bool {
+	jsxNodes := findAllNodes(body, "jsx_opening_element", "jsx_self_closing_element")
+	for _, jx := range jsxNodes {
+		nameNode := jx.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		tag := x.nodeText(nameNode)
+		// Match both bare `Suspense` and member `React.Suspense`.
+		if tag == "Suspense" || tag == "React.Suspense" {
+			return true
+		}
+	}
+	return false
+}
+
+// bodyUsesCreatePortal reports whether the function body calls createPortal —
+// either bare `createPortal(...)` (named import) or member
+// `ReactDOM.createPortal(...)` / `reactDom.createPortal(...)`.
+func (x *extractor) bodyUsesCreatePortal(body *sitter.Node) bool {
+	calls := findAllNodes(body, "call_expression")
+	for _, c := range calls {
+		if x.calleeLeaf(c) == "createPortal" {
+			return true
+		}
+	}
+	return false
+}
+
+// calleeLeaf returns the leaf identifier of a call_expression's callee: the
+// bare identifier, or the property of a member-expression callee. Returns ""
+// for shapes it cannot reduce (e.g. computed-member callees).
+func (x *extractor) calleeLeaf(call *sitter.Node) string {
+	if call == nil || call.Type() != "call_expression" {
+		return ""
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return ""
+	}
+	switch fn.Type() {
+	case "identifier", "type_identifier":
+		return x.nodeText(fn)
+	case "member_expression":
+		if prop := fn.ChildByFieldName("property"); prop != nil {
+			return x.nodeText(prop)
+		}
+	}
+	return ""
+}
+
+// lazyImportModule returns the import specifier of a React.lazy split point —
+// the module string inside `lazy(() => import('./mod'))`. Returns "" when
+// valueNode is not a lazy(...) wrapper or the dynamic import specifier cannot be
+// recovered as a string literal. Used to decorate the lazy wrapper entity with
+// its code-split target (lazy_code_splitting).
+func (x *extractor) lazyImportModule(valueNode *sitter.Node) string {
+	if x.calleeLeaf(valueNode) != "lazy" {
+		return ""
+	}
+	// Find the dynamic import call inside the lazy() argument: tree-sitter
+	// models `import('m')` as a call_expression whose function child is the
+	// `import` keyword node.
+	for _, c := range findAllNodes(valueNode, "call_expression") {
+		fn := c.ChildByFieldName("function")
+		if fn == nil || fn.Type() != "import" {
+			continue
+		}
+		args := c.ChildByFieldName("arguments")
+		if args == nil {
+			continue
+		}
+		for i := 0; i < int(args.ChildCount()); i++ {
+			arg := args.Child(i)
+			if arg != nil && arg.Type() == "string" {
+				return trimStringQuotes(x.nodeText(arg))
+			}
+		}
+	}
+	return ""
+}
+
+// classIsErrorBoundary reports whether a class body declares the React error
+// boundary contract: an instance componentDidCatch method or a static
+// getDerivedStateFromError method.
+func (x *extractor) classIsErrorBoundary(body *sitter.Node) bool {
+	if body == nil {
+		return false
+	}
+	for _, m := range findAllNodes(body, "method_definition") {
+		nameNode := m.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		switch x.nodeText(nameNode) {
+		case "componentDidCatch", "getDerivedStateFromError":
+			return true
+		}
+	}
+	return false
+}
+
+// trimStringQuotes strips a single pair of surrounding ' or " or ` quotes.
+func trimStringQuotes(s string) string {
+	if len(s) >= 2 {
+		first := s[0]
+		last := s[len(s)-1]
+		if (first == '\'' || first == '"' || first == '`') && last == first {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/internal/extractors/javascript/testdata/react_internals/AppShell.tsx
+++ b/internal/extractors/javascript/testdata/react_internals/AppShell.tsx
@@ -1,0 +1,57 @@
+// Proving fixture for issue #2875 — React Internals framework_specific cells:
+//   - lazy_code_splitting: React.lazy + dynamic import() split point.
+//   - suspense_error_boundary: <Suspense> boundary + ErrorBoundary class.
+//   - portal_recognition: ReactDOM.createPortal target.
+//
+// Hand-written, dependency-manifest-free (no node_modules / lockfile).
+import React, { lazy, Suspense, Component } from 'react';
+import { createPortal } from 'react-dom';
+
+// lazy_code_splitting — the dynamic import('./SettingsPanel') is the code-split
+// point. The extractor decorates this entity react_lazy + lazy_module.
+const SettingsPanel = lazy(() => import('./SettingsPanel'));
+
+// suspense_error_boundary — class error boundary: declares the React contract
+// (static getDerivedStateFromError + instance componentDidCatch).
+class ErrorBoundary extends Component<{ children: React.ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>Something went wrong.</p>;
+    }
+    return this.props.children;
+  }
+}
+
+// suspense_error_boundary — function component renders a <Suspense> boundary.
+export function AppShell() {
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<p>Loading…</p>}>
+        <SettingsPanel />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+// portal_recognition — function component renders into a portal via createPortal.
+export function Modal({ children }: { children: React.ReactNode }) {
+  return createPortal(
+    <div className="modal">{children}</div>,
+    document.body,
+  );
+}
+
+// Plain component — must NOT pick up any React Internals markers (negative case).
+export function PlainCard() {
+  return <div className="card">plain</div>;
+}


### PR DESCRIPTION
Closes #2875. Part of epic #2847.

Adds the `React Internals` framework_specific group to the `lang.jsts.framework.react` coverage record. React had **no** framework_specific group; this creates it with the three genuine React idioms that no generic capability column can express, and explicitly marks the two would-be-duplicate idioms `not_applicable` so they are not double-counted against the generic Structure group.

## React Internals cells

| Cell | Status | Gap | Rationale |
|---|---|---|---|
| `lazy_code_splitting` | ⚠️ partial | A | `React.lazy(() => import('mod'))` — the lazy wrapper (already a SCOPE.Operation via `isFunctionWrapperCall`) is decorated `react_lazy="true"` + `lazy_module="<specifier>"` (the code-split target). Partial: only string-literal specifiers are resolved; computed/template specifiers are not. |
| `suspense_error_boundary` | ✅ full | B | Function components rendering `<Suspense>` are decorated `react_suspense="true"`; class components declaring `componentDidCatch` / static `getDerivedStateFromError` are decorated `react_error_boundary="true"`. |
| `portal_recognition` | ✅ full | B | Components calling `createPortal(...)` / `ReactDOM.createPortal(...)` are decorated `react_portal="true"`. |
| `hooks` | 🚫 not_applicable | N/A | Covered by generic **Structure/hook_recognition** (`react.go` USES_HOOK + custom-hook subtype, #2854). Not duplicated to avoid double-counting. |
| `context_hoc` | 🚫 not_applicable | N/A | Covered by generic **Structure/context_extraction** (`createContext`, #611) + **Structure/hoc_wrapper_recognition** (`forwardRef`/`memo`/`lazy`/`connect`/`withX`, `extractor.go`). Not duplicated. |

## Implementation
- New `internal/extractors/javascript/react_internals.go` — Suspense/portal/lazy/error-boundary detectors.
- Decoration wired into the existing component emit sites in `extractor.go` (function-decl, arrow, function-expression component paths; the lazy wrapper emit; `handleClassDeclaration` for error boundaries).
- **Decorate-only — no new `EntityKind`/`RelationshipKind`** (per the #2839 prefer-decorate rule). `go test ./internal/types/` passes (no enum change required).

## Taxonomy ownership
React owns this group. The genuine idioms (lazy/suspense/portal) are added as real cells with proving code+fixture; the two idioms already measured generically (hooks, context/HOC) are marked `not_applicable` with a "covered by generic <cell>" note rather than added as duplicate `full` cells.

## How proven
- Fixture `internal/extractors/javascript/testdata/react_internals/AppShell.tsx` + `issue2875_react_internals_test.go` assert all four markers (lazy, suspense, error-boundary, portal) and a negative case (a plain component picks up none).
- **Real-data verified** against the in-tree real-world Next.js fixture `testdata/fixtures/real-world/typescript/nextjs_error_boundary.tsx`: the real `ErrorBoundaryHandler` class (extends `React.Component`, declares `getDerivedStateFromError`) is decorated `react_error_boundary="true"`.

## Coverage matrix
`docs/coverage/registry.json` edited by hand (framework_specific has no `update`-tool path), then `go run ./tools/coverage validate` (exit 0) + `go run ./tools/coverage gen` (byte-stable). `docs/coverage/detail/lang.jsts.framework.react.md` regenerated.

```
implements-capability: lang.jsts.framework.react/React Internals/lazy_code_splitting:missing→partial
implements-capability: lang.jsts.framework.react/React Internals/suspense_error_boundary:missing→full
implements-capability: lang.jsts.framework.react/React Internals/portal_recognition:missing→full
implements-capability: lang.jsts.framework.react/React Internals/hooks:missing→🚫
implements-capability: lang.jsts.framework.react/React Internals/context_hoc:missing→🚫
```

## Test plan
- [x] `go test ./internal/extractors/javascript/ ./internal/substrate/ ./internal/links/ ./internal/engine/ ./tools/coverage/ ./internal/types/`
- [x] `go run ./tools/coverage validate` exits 0
- [x] `go run ./tools/coverage gen` byte-stable
- [x] Real-data verification on the Next.js error-boundary fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)