### PR TITLE
[JS/TS coverage] Backend auth_coverage across all 12 backend-HTTP frameworks (#2852)

### DIFF
--- a/cmd/archigraph/audit2852_jsauth_test.go
+++ b/cmd/archigraph/audit2852_jsauth_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestAudit2852_JSBackendAuth is the real-data integration guard for #2852.
+// It indexes a multi-framework backend-HTTP corpus with auth middleware /
+// guards / route config through the full indexer pipeline (not single-file
+// unit fixtures) and asserts that the resolved auth_policy survives onto the
+// http_endpoint_definition entities the pipeline emits, covering:
+//
+//   - Express  — app-level passport.authenticate + route-level requireAuth.
+//   - NestJS   — class-level @UseGuards (medium) + method-level guard+roles.
+//   - Hapi     — per-route options.auth (protected) + auth:false (public).
+//   - AdonisJS — route-chain .middleware('auth').
+//   - Feathers — app-level authenticate() gating mounted services.
+//   - Marble   — authorize$ effect piped into the route.
+func TestAudit2852_JSBackendAuth(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/audit2852_js", "audit2852_js", nil)
+	endpoints := collectHTTPEndpointDefs(doc)
+	if len(endpoints) == 0 {
+		t.Fatalf("audit2852_js: no http_endpoint_definition entities emitted")
+	}
+
+	requireAuthed := func(t *testing.T, verb, path, wantMethod string) *graph.Entity {
+		t.Helper()
+		ep := findEndpointBySuffix(endpoints, verb, path)
+		if ep == nil {
+			t.Fatalf("missing endpoint %s %s", verb, path)
+		}
+		if ep.Properties["auth_required"] != "true" {
+			t.Errorf("%s %s: auth_required=%q, want true", verb, path, ep.Properties["auth_required"])
+		}
+		if wantMethod != "" && ep.Properties["auth_method"] != wantMethod {
+			t.Errorf("%s %s: auth_method=%q, want %q", verb, path, ep.Properties["auth_method"], wantMethod)
+		}
+		if ep.Properties["auth_middleware"] == "" && ep.Properties["auth_guard"] == "" {
+			t.Errorf("%s %s: no MCP signal-1 key (auth_middleware/auth_guard) stamped", verb, path)
+		}
+		return ep
+	}
+	requireOpen := func(t *testing.T, verb, path string) {
+		t.Helper()
+		ep := findEndpointBySuffix(endpoints, verb, path)
+		if ep == nil {
+			t.Fatalf("missing endpoint %s %s", verb, path)
+		}
+		if ep.Properties["auth_required"] == "true" {
+			t.Errorf("%s %s: auth_required=true, want public/unknown", verb, path)
+		}
+	}
+
+	t.Run("Express", func(t *testing.T) {
+		requireAuthed(t, "GET", "/account", "middleware")
+		requireAuthed(t, "POST", "/account", "middleware")
+		// /ping inherits the app-level passport gate.
+		requireAuthed(t, "GET", "/ping", "middleware")
+	})
+
+	t.Run("NestJS", func(t *testing.T) {
+		requireAuthed(t, "GET", "/orders", "guard")
+		create := requireAuthed(t, "POST", "/orders", "guard")
+		if create.Properties["auth_roles"] != "admin" {
+			t.Errorf("POST /orders: auth_roles=%q, want admin", create.Properties["auth_roles"])
+		}
+	})
+
+	t.Run("Hapi", func(t *testing.T) {
+		requireAuthed(t, "GET", "/private", "config")
+		// auth: false → explicit public.
+		ep := findEndpointBySuffix(endpoints, "POST", "/login")
+		if ep == nil {
+			t.Fatal("missing endpoint POST /login")
+		}
+		if ep.Properties["auth_required"] != "false" {
+			t.Errorf("POST /login: auth_required=%q, want false", ep.Properties["auth_required"])
+		}
+	})
+
+	t.Run("AdonisJS", func(t *testing.T) {
+		requireAuthed(t, "GET", "/dashboard", "middleware")
+		requireOpen(t, "GET", "/about")
+	})
+
+	t.Run("Feathers", func(t *testing.T) {
+		requireAuthed(t, "GET", "/messages", "middleware")
+		requireAuthed(t, "POST", "/messages", "middleware")
+	})
+
+	t.Run("Marble", func(t *testing.T) {
+		requireAuthed(t, "GET", "/me", "middleware")
+		requireOpen(t, "GET", "/status")
+	})
+}

--- a/cmd/archigraph/testdata/audit2852_js/adonisjs/routes.ts
+++ b/cmd/archigraph/testdata/audit2852_js/adonisjs/routes.ts
@@ -1,0 +1,5 @@
+// AdonisJS auth corpus file (#2852 real-data verification).
+import Route from '@ioc:Adonis/Core/Route'
+
+Route.get('/dashboard', 'DashboardController.index').middleware('auth')
+Route.get('/about', 'PagesController.about')

--- a/cmd/archigraph/testdata/audit2852_js/express/app.ts
+++ b/cmd/archigraph/testdata/audit2852_js/express/app.ts
@@ -1,0 +1,15 @@
+// Express auth corpus file (#2852 real-data verification).
+import express from 'express'
+import passport from 'passport'
+
+const app = express()
+app.use(passport.authenticate('jwt', { session: false }))
+
+function requireAuth(req, res, next) { next() }
+function getAccount(req, res) { res.json({}) }
+function updateAccount(req, res) { res.json({}) }
+function ping(req, res) { res.send('ok') }
+
+app.get('/account', requireAuth, getAccount)
+app.post('/account', requireAuth, updateAccount)
+app.get('/ping', ping)

--- a/cmd/archigraph/testdata/audit2852_js/feathers/app.ts
+++ b/cmd/archigraph/testdata/audit2852_js/feathers/app.ts
@@ -1,0 +1,6 @@
+// Feathers auth corpus file (#2852 real-data verification).
+import { feathers } from '@feathersjs/feathers'
+
+const app = feathers()
+app.use(authenticate('jwt'))
+app.use('/messages', new MessageService())

--- a/cmd/archigraph/testdata/audit2852_js/hapi/server.ts
+++ b/cmd/archigraph/testdata/audit2852_js/hapi/server.ts
@@ -1,0 +1,18 @@
+// Hapi auth corpus file (#2852 real-data verification).
+import Hapi from '@hapi/hapi'
+
+const server = Hapi.server({ port: 4000 })
+
+server.route({
+  method: 'GET',
+  path: '/private',
+  options: { auth: 'session' },
+  handler: (request, h) => ({ ok: true }),
+})
+
+server.route({
+  method: 'POST',
+  path: '/login',
+  options: { auth: false },
+  handler: (request, h) => ({ token: 'x' }),
+})

--- a/cmd/archigraph/testdata/audit2852_js/marblejs/user.effects.ts
+++ b/cmd/archigraph/testdata/audit2852_js/marblejs/user.effects.ts
@@ -1,0 +1,15 @@
+// Marble.js auth corpus file (#2852 real-data verification).
+import { r } from '@marblejs/http'
+
+const getMe$ = r.pipe(
+  r.matchPath('/me'),
+  r.matchType('GET'),
+  use(authorize$),
+  r.useEffect(req$ => req$),
+)
+
+const getStatus$ = r.pipe(
+  r.matchPath('/status'),
+  r.matchType('GET'),
+  r.useEffect(req$ => req$),
+)

--- a/cmd/archigraph/testdata/audit2852_js/nestjs/orders.controller.ts
+++ b/cmd/archigraph/testdata/audit2852_js/nestjs/orders.controller.ts
@@ -1,0 +1,15 @@
+// NestJS auth corpus file (#2852 real-data verification).
+import { Controller, Get, Post, UseGuards } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+
+@Controller('orders')
+@UseGuards(AuthGuard('jwt'))
+export class OrdersController {
+  @Get()
+  findAll() {}
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  create() {}
+}

--- a/cmd/archigraph/testdata/audit2852_js/package.json
+++ b/cmd/archigraph/testdata/audit2852_js/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "audit2852-js-auth-corpus",
+  "private": true,
+  "version": "0.0.0"
+}

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -67,18 +67,18 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ⚠️ 7/20 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 5/6 | |
-| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/17 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/17 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/17 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -12,18 +12,18 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Security | Validation | Middleware | Testing | Observability | Data | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | — | ✅ 6/6 | |
-| [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [Feathers](../detail/lang.jsts.framework.feathers.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [Hapi](../detail/lang.jsts.framework.hapi.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | — | ✅ 6/6 | |
-| [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
-| [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ✅ 6/6 | |
+| [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [Feathers](../detail/lang.jsts.framework.feathers.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [Hapi](../detail/lang.jsts.framework.hapi.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | — | ✅ 6/6 | |
+| [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
+| [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | — | ✅ 6/6 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `cmd/archigraph/audit2852_jsauth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/adonisjs_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `cmd/archigraph/audit2852_jsauth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/express_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/fastify_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `cmd/archigraph/audit2852_jsauth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/feathers_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `cmd/archigraph/audit2852_jsauth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/hapi_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/hono_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/koa_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `cmd/archigraph/audit2852_jsauth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/marblejs_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `cmd/archigraph/audit2852_jsauth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/nestjs_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/polka_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/restify_auth.ts` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ❌ `missing` | — | — | — | — | — |
+| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/sails_policies.ts` | — |
 
 ### Validation
 
@@ -60,6 +60,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
+
+## Framework-specific
+
+### Sails Policies
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `policy_map_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/sails_policies.ts` | Sails gates actions via config/policies.js policy maps (e.g. '*': 'isLoggedIn'), a bespoke auth idiom no generic middleware/guard cell captures. ParseSailsPolicies recognises the global default posture (fixture-proven). The standard Security/auth_coverage cell is partial because cross-file policies.js->routes.js per-endpoint attribution is deferred (#2852 follow-up). |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10473,7 +10473,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/adonisjs_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -10978,7 +10980,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/express_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -11043,7 +11047,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/fastify_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -11108,7 +11114,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/feathers_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -11285,7 +11293,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/hapi_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -11348,7 +11358,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/hono_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -11513,7 +11525,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/koa_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -11607,7 +11621,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/marblejs_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -11776,8 +11792,8 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml"],
+            "status": "full",
+            "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/nestjs_auth.ts"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12019,7 +12035,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/polka_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -12514,7 +12532,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/restify_auth.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -12579,7 +12599,9 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/sails_policies.ts"],
+            "verified_at": "2026-05-28"
           }
         },
         "Middleware": {
@@ -12617,6 +12639,16 @@
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
             "verified_at": "2026-05-27"
+          }
+        }
+      },
+      "framework_specific": {
+        "Sails Policies": {
+          "policy_map_recognition": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/sails_policies.ts"],
+            "notes": "Sails gates actions via config/policies.js policy maps (e.g. '*': 'isLoggedIn'), a bespoke auth idiom no generic middleware/guard cell captures. ParseSailsPolicies recognises the global default posture (fixture-proven). The standard Security/auth_coverage cell is partial because cross-file policies.js-\u003eroutes.js per-endpoint attribution is deferred (#2852 follow-up).",
+            "verified_at": "2026-05-28"
           }
         }
       }

--- a/internal/engine/http_endpoint_jsts_auth.go
+++ b/internal/engine/http_endpoint_jsts_auth.go
@@ -1,0 +1,914 @@
+// Cross-framework auth_coverage for the JS/TS backend-HTTP frameworks (#2852).
+//
+// This pass resolves a structured `auth_policy` for every synthetic
+// http_endpoint_definition emitted by the JS/TS backend synthesizers
+// (#2851 + the pre-existing Express/Koa/Fastify/Hono/Nest passes). It mirrors
+// the Java auth_policy resolver (java_auth_policy.go, #1942) and the Django
+// DRF class-level approach (#2816): combine route-level, router/app-level and
+// (Nest) class-level signals into a per-endpoint posture, with honest
+// precedence and confidence.
+//
+// The analog of Django's "class-level + decorator + default permissions" for
+// JS/TS backends is:
+//
+//   - route-level middleware/guard — the strongest signal: an auth middleware
+//     passed directly to the route registration, e.g.
+//     `app.get('/me', requireAuth, handler)` or Nest `@UseGuards(AuthGuard)`
+//     on the handler method.
+//   - router/app-level middleware — `app.use(passport.authenticate('jwt'))`,
+//     `router.use(requireAuth)`, a Nest `@UseGuards(...)` on the controller
+//     class, or a Hapi server-default auth strategy. Applies to every endpoint
+//     registered after it in the same file (router/app scope).
+//   - framework auth config — Hapi route `options.auth` / `config.auth`,
+//     AdonisJS `.middleware('auth')` route chains, Sails policy maps.
+//
+// The recognised auth-middleware vocabulary is deliberately cross-framework
+// (passport, express-jwt, express-session, the Nest @nestjs/passport guards,
+// Hapi auth strategies, and the common hand-rolled `requireAuth` /
+// `isAuthenticated` / `ensureLoggedIn` / `authenticate` idioms) so a single
+// recogniser greens all twelve framework families.
+//
+// Output: the same property contract the Java resolver writes, so the
+// archigraph_auth_coverage MCP tool (auth_coverage.go signal 1) and the
+// security dashboard light up uniformly across languages:
+//
+//	auth_policy     — JSON-encoded AuthPolicy (source chain for the dashboard)
+//	auth_method     — "middleware" | "guard" | "config" | "framework_default" | "unknown"
+//	auth_confidence — "high" | "medium" | "low"
+//	auth_required   — "true" | "false" (omitted when method=="unknown")
+//	auth_middleware — the recognised middleware symbol (MCP signal-1 key)
+//	auth_guard      — the recognised Nest guard symbol (MCP signal-1 key)
+//
+// Refs #2852.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// jsAuthMiddlewareNames is the cross-framework vocabulary of auth/authz
+// middleware and helper names. Matching is case-insensitive on the bare
+// symbol (the trailing call args, if any, are ignored). The list covers the
+// well-known libraries plus the conventional hand-rolled guard names that
+// recur across Express/Koa/Fastify/Hono/Adonis/Restify/Polka apps.
+var jsAuthMiddlewareNames = map[string]bool{
+	// passport.js — `passport.authenticate('jwt')`, `passport.authorize(...)`.
+	"passport.authenticate": true,
+	"passport.authorize":    true,
+	// express-jwt — `expressjwt({...})` / `jwt({...})` (the express-jwt v7
+	// default export is conventionally imported as `expressjwt` or `jwt`).
+	"expressjwt":     true,
+	"expressjwt.jwt": true,
+	// express-session / cookie-session gate — session presence is a weak but
+	// real auth signal when paired with a guard; we treat the explicit guard
+	// names below as the decisive ones.
+	"ensureauthenticated":   true,
+	"ensureloggedin":        true,
+	"isauthenticated":       true,
+	"requireauth":           true,
+	"requireauthentication": true,
+	"requirelogin":          true,
+	"requireuser":           true,
+	"authenticate":          true,
+	"authrequired":          true,
+	"authmiddleware":        true,
+	"authguard":             true,
+	"checkauth":             true,
+	"checkjwt":              true,
+	"verifytoken":           true,
+	"verifyjwt":             true,
+	"jwtauth":               true,
+	"protect":               true,
+	"protectroute":          true,
+	"authorized":            true,
+	"loginrequired":         true,
+	"mustbeauthenticated":   true,
+}
+
+// jsAuthMiddlewareSubstrings catches qualified / namespaced auth helpers whose
+// exact symbol varies but whose intent is unambiguous, e.g.
+// `auth.required`, `authMiddleware.verify`, `guards.jwt`. Matched as a
+// lowercase substring of the bare receiver+method symbol. Kept narrow to avoid
+// false positives on incidental identifiers.
+var jsAuthMiddlewareSubstrings = []string{
+	"passport.authenticate",
+	"passport.authorize",
+}
+
+// jsAuthGuardDecoratorRe captures NestJS `@UseGuards(AuthGuard)` /
+// `@UseGuards(AuthGuard('jwt'), RolesGuard)`. Group 1 = the raw argument list.
+var jsAuthGuardDecoratorRe = regexp.MustCompile(`@UseGuards\s*\(([^)]*)\)`)
+
+// jsAuthGuardArgRe extracts each guard identifier from a @UseGuards argument
+// list, handling both `AuthGuard` and the factory form `AuthGuard('jwt')`.
+var jsAuthGuardArgRe = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*(?:\([^)]*\))?`)
+
+// jsRolesDecoratorRe captures NestJS `@Roles('admin', 'user')` /
+// `@Roles(Role.Admin)` role declarations. Group 1 = the raw argument list.
+var jsRolesDecoratorRe = regexp.MustCompile(`@Roles\s*\(([^)]*)\)`)
+
+// jsQuotedTokenRe pulls single- or double-quoted tokens out of an argument
+// list (the Java extractQuotedTokens helper is double-quote only; JS/TS role
+// strings are conventionally single-quoted).
+var jsQuotedTokenRe = regexp.MustCompile(`['"` + "`" + `]([^'"` + "`" + `]+)['"` + "`" + `]`)
+
+// jsAppUseRe captures `app.use(...)` / `router.use(...)` / `server.use(...)`
+// registrations. Group 1 = receiver, group 2 = the first argument (up to a
+// comma or close paren). App/router-level auth middleware applies to every
+// endpoint registered in the same file/router scope.
+var jsAppUseRe = regexp.MustCompile(
+	`\b(app|router|server|fastify|api|r|v\d+)\.(?:use|register|addHook|decorate)\s*\(\s*([^,)\r\n]+)`,
+)
+
+// jsRouteRegistrationRe captures an Express-shaped route registration so we can
+// inspect its middleware chain (everything between the path and the final
+// handler). Group 1 = receiver, 2 = verb, 3 = path, 4 = the remaining args
+// (middleware chain + handler).
+var jsRouteRegistrationRe = regexp.MustCompile(
+	`\b([$\w][\w$]*)\.(get|post|put|patch|delete|del|all|head|options|opts)\s*\(` +
+		`\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]\s*,\s*([^\r\n]*)`,
+)
+
+// jsHapiAuthKwargRe captures a Hapi route `options.auth` / `config.auth` /
+// top-level `auth:` setting. Group 1 = the auth value (strategy name, `false`,
+// or an object). `auth: false` is an explicit public marker; any other value
+// names a strategy and means the route is protected.
+var jsHapiAuthKwargRe = regexp.MustCompile(
+	`\bauth\s*:\s*(false|true|\{[^}]*\}|['"` + "`" + `][^'"` + "`" + `]+['"` + "`" + `]|[A-Za-z_$][\w$.]*)`,
+)
+
+// jsAdonisMiddlewareRe captures an AdonisJS route-chain middleware call
+// `.middleware('auth')` / `.middleware(['auth', 'acl:admin'])` /
+// `.use([middleware.auth()])` (Adonis 6). Group 1 = the raw argument list.
+var jsAdonisMiddlewareRe = regexp.MustCompile(
+	`\.(?:middleware|use)\s*\(\s*(\[[^\]]*\]|['"` + "`" + `][^'"` + "`" + `]+['"` + "`" + `]|[^)]*)\)`,
+)
+
+// jsClassDeclRe matches a Nest controller class declaration so a directly
+// preceding @UseGuards decorator block can be classified as class-level.
+var jsClassDeclRe = regexp.MustCompile(`(?m)^[ \t]*(?:export\s+)?(?:abstract\s+)?class\s+[A-Za-z_$][\w$]*`)
+
+// jsMarbleAuthRe captures a Marble.js auth middleware in an effect pipe, e.g.
+// `authorize$`, `requireAuth$`, `use(authorize$)`. Marble auth middlewares are
+// conventionally suffixed `$` (they are RxJS-operator effects). Group 1 = name.
+var jsMarbleAuthRe = regexp.MustCompile(`\b((?:authorize|requireAuth|auth|isAuthenticated)\$)`)
+
+// normalizeAuthSymbol lowercases and trims a candidate middleware symbol,
+// stripping any trailing call arguments so `passport.authenticate('jwt')`
+// reduces to `passport.authenticate`.
+func normalizeAuthSymbol(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '('); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.TrimSpace(s)
+	return strings.ToLower(s)
+}
+
+// recognizeAuthMiddleware reports whether `arg` names a recognised auth
+// middleware and returns the canonical (original-case) symbol for evidence.
+func recognizeAuthMiddleware(arg string) (string, bool) {
+	raw := strings.TrimSpace(arg)
+	norm := normalizeAuthSymbol(raw)
+	if norm == "" {
+		return "", false
+	}
+	if jsAuthMiddlewareNames[norm] {
+		return symbolHead(raw), true
+	}
+	for _, sub := range jsAuthMiddlewareSubstrings {
+		if strings.Contains(norm, sub) {
+			return symbolHead(raw), true
+		}
+	}
+	// Bare identifier ending in a guard-ish token, e.g. `requireJwtAuth`,
+	// `verifyAccessToken`, `ensureSignedIn` — recognise the common compound
+	// patterns without exploding the explicit table.
+	if jsAuthCompoundRe.MatchString(norm) {
+		return symbolHead(raw), true
+	}
+	return "", false
+}
+
+// jsAuthCompoundRe matches compound hand-rolled guard identifiers that combine
+// a verb (require/ensure/verify/check/assert/is) with an auth noun
+// (auth/authenticated/login/loggedin/jwt/token/session/user). This catches the
+// long tail of project-local guard names without enumerating every spelling.
+var jsAuthCompoundRe = regexp.MustCompile(
+	`^(?:require|ensure|verify|check|assert|is|must|need)[a-z]*` +
+		`(?:auth|authenticated|login|loggedin|signedin|jwt|token|session|user|admin|role|permission)`,
+)
+
+// symbolHead returns the first whitespace-delimited token of a candidate arg,
+// preserving original case (used as evidence text).
+func symbolHead(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, " \t(,)"); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+// jsAuthContext is the per-file resolved auth state, computed once per file and
+// then projected onto each synthetic endpoint in that file.
+type jsAuthContext struct {
+	// appLevel is the set of router/app-level middlewares (file scope). Any
+	// non-empty entry means every endpoint in the file inherits coverage at
+	// MEDIUM confidence unless a route-level signal overrides.
+	appLevel []AuthSignal
+	// classGuards maps a 0-based byte offset (the @UseGuards site) so an
+	// endpoint can inherit its enclosing Nest controller class guard. We model
+	// this coarsely as "any class-level guard in the file" → file-scope medium
+	// coverage, plus the precise route-level guard below for high confidence.
+	classGuards []AuthSignal
+	// hapiServerDefaultAuth is true when the file sets a Hapi server-wide
+	// default auth strategy (`server.auth.default(...)` / `auth.strategy` +
+	// default). Endpoints inherit it unless they opt out with `auth: false`.
+	hapiServerDefaultAuth bool
+	hapiServerDefaultLine int
+	file                  string
+}
+
+// resolveJSTSFileAuth scans a file once and returns its app/router-level and
+// class-level auth signals (the cross-endpoint context).
+func resolveJSTSFileAuth(content, file string) jsAuthContext {
+	ctx := jsAuthContext{file: file}
+
+	// App/router-level middleware: app.use(passport.authenticate('jwt')).
+	for _, m := range jsAppUseRe.FindAllStringSubmatchIndex(content, -1) {
+		arg := content[m[4]:m[5]]
+		if sym, ok := recognizeAuthMiddleware(arg); ok {
+			ctx.appLevel = append(ctx.appLevel, AuthSignal{
+				Kind: "middleware",
+				Text: "app/router-level: " + sym,
+				File: file,
+				Line: lineAtOffset(content, m[0]),
+			})
+		}
+	}
+
+	// Nest class-level @UseGuards on the controller — only the @UseGuards whose
+	// decorator block sits directly above a `class` declaration (not a method),
+	// so method-level guards don't leak into the file-scope inheritance set.
+	for _, m := range jsClassDeclRe.FindAllStringSubmatchIndex(content, -1) {
+		block := precedingDecoratorBlock(content, m[0])
+		if block == "" {
+			continue
+		}
+		gm := jsAuthGuardDecoratorRe.FindStringSubmatch(block)
+		if gm == nil || len(parseGuardArgs(gm[1])) == 0 {
+			continue
+		}
+		ctx.classGuards = append(ctx.classGuards, AuthSignal{
+			Kind: "guard",
+			Text: "class @UseGuards(" + strings.TrimSpace(gm[1]) + ")",
+			File: file,
+			Line: lineAtOffset(content, m[0]),
+		})
+	}
+
+	// Hapi server-wide default auth strategy.
+	if strings.Contains(content, "auth.default") || strings.Contains(content, "auth.strategy") {
+		if idx := strings.Index(content, "auth.default"); idx >= 0 {
+			ctx.hapiServerDefaultAuth = true
+			ctx.hapiServerDefaultLine = lineAtOffset(content, idx)
+		}
+	}
+
+	return ctx
+}
+
+// parseGuardArgs extracts guard identifiers from a @UseGuards argument list.
+func parseGuardArgs(args string) []string {
+	var out []string
+	for _, m := range jsAuthGuardArgRe.FindAllStringSubmatch(args, -1) {
+		name := strings.TrimSpace(m[1])
+		if name == "" {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
+// lineAtOffset returns the 1-based line number of byte offset off in content.
+func lineAtOffset(content string, off int) int {
+	if off < 0 || off > len(content) {
+		return 0
+	}
+	return strings.Count(content[:off], "\n") + 1
+}
+
+// applyJSTSAuthPolicy resolves and stamps an auth_policy on every JS/TS
+// synthetic backend endpoint emitted for this file. It mutates the Properties
+// map in place and never adds or removes entities, so it cannot regress the
+// surrounding synthesis pass.
+//
+// `before` is the entity-slice length captured before the JS/TS synthesizers
+// ran; only entities at index >= before that belong to this file are
+// considered (the producer-side synthetics this file just emitted).
+func applyJSTSAuthPolicy(content, path string, entities []types.EntityRecord, before int) {
+	if len(content) == 0 || before >= len(entities) {
+		return
+	}
+	ctx := resolveJSTSFileAuth(content, path)
+
+	// Index route-level middleware chains by (verb, canonical path) so each
+	// endpoint can look up its own registration site.
+	routeAuth := indexRouteLevelAuth(content, path)
+	// Index Nest method-level guards by handler symbol (the decorator sits
+	// immediately above the @Get/@Post method; we attribute by nearest method).
+	methodGuards := indexNestMethodGuards(content, path)
+	// Index Hapi per-route auth from the route object bodies.
+	hapiRouteAuth := indexHapiRouteAuth(content, path)
+	// Index Adonis route-chain middleware by canonical path.
+	adonisRouteAuth := indexAdonisRouteAuth(content, path)
+	// Index Marble.js per-effect auth middleware by canonical path.
+	marbleRouteAuth := indexMarbleRouteAuth(content, path)
+
+	for i := before; i < len(entities); i++ {
+		e := &entities[i]
+		if e.Kind != httpEndpointDefinitionKind || e.SourceFile != path {
+			continue
+		}
+		if e.Properties == nil {
+			continue
+		}
+		framework := e.Properties["framework"]
+		verb := strings.ToUpper(e.Properties["verb"])
+		canonical := e.Properties["path"]
+		key := verb + " " + canonical
+
+		policy := resolveEndpointAuth(
+			framework, key, e.Properties["source_handler"],
+			ctx, routeAuth, methodGuards, hapiRouteAuth, adonisRouteAuth, marbleRouteAuth,
+		)
+		stampAuthPolicy(e.Properties, policy)
+	}
+}
+
+// resolveEndpointAuth combines the per-endpoint and per-file signals into a
+// final AuthPolicy with honest precedence (highest first):
+//
+//  1. route-level middleware / Nest method @UseGuards / Hapi route auth /
+//     Adonis route .middleware('auth') — HIGH.
+//  2. Hapi explicit `auth: false` — HIGH public.
+//  3. router/app-level middleware / Nest class @UseGuards / Hapi server default
+//     — MEDIUM (file scope).
+//  4. unknown — no signal.
+func resolveEndpointAuth(
+	framework, key, sourceHandler string,
+	ctx jsAuthContext,
+	routeAuth map[string][]AuthSignal,
+	methodGuards map[string][]AuthSignal,
+	hapiRouteAuth map[string]hapiAuth,
+	adonisRouteAuth map[string][]AuthSignal,
+	marbleRouteAuth map[string][]AuthSignal,
+) AuthPolicy {
+	// 1a. Express-shaped route-level middleware chain.
+	if sigs, ok := routeAuth[key]; ok && len(sigs) > 0 {
+		return AuthPolicy{
+			Required: true, Method: "middleware", Confidence: "high",
+			SourceChain: sigs,
+		}
+	}
+	// 1b. Nest method-level guard (attributed by handler method symbol).
+	if handler := nestHandlerName(sourceHandler); handler != "" {
+		if sigs, ok := methodGuards[handler]; ok && len(sigs) > 0 {
+			return AuthPolicy{
+				Required: true, Method: "guard", Confidence: "high",
+				Roles:       rolesFromSignals(sigs),
+				SourceChain: sigs,
+			}
+		}
+	}
+	// 1c. Hapi per-route auth.
+	if ha, ok := hapiRouteAuth[key]; ok && ha.set {
+		if ha.public {
+			return AuthPolicy{
+				Required: false, Method: "config", Confidence: "high",
+				SourceChain: []AuthSignal{ha.signal},
+			}
+		}
+		return AuthPolicy{
+			Required: true, Method: "config", Confidence: "high",
+			SourceChain: []AuthSignal{ha.signal},
+		}
+	}
+	// 1d. Adonis route-chain middleware.
+	if sigs, ok := adonisRouteAuth[key]; ok && len(sigs) > 0 {
+		return AuthPolicy{
+			Required: true, Method: "middleware", Confidence: "high",
+			SourceChain: sigs,
+		}
+	}
+	// 1e. Marble.js per-effect auth middleware.
+	if sigs, ok := marbleRouteAuth[key]; ok && len(sigs) > 0 {
+		return AuthPolicy{
+			Required: true, Method: "middleware", Confidence: "high",
+			SourceChain: sigs,
+		}
+	}
+
+	// 3. File-scope signals (router/app-level middleware, Nest class guards,
+	//    Hapi server default). MEDIUM confidence — the endpoint inherits the
+	//    posture but the binding is file-scoped rather than route-direct.
+	if len(ctx.appLevel) > 0 {
+		return AuthPolicy{
+			Required: true, Method: "middleware", Confidence: "medium",
+			SourceChain: ctx.appLevel,
+		}
+	}
+	if len(ctx.classGuards) > 0 {
+		return AuthPolicy{
+			Required: true, Method: "guard", Confidence: "medium",
+			Roles:       rolesFromSignals(ctx.classGuards),
+			SourceChain: ctx.classGuards,
+		}
+	}
+	if ctx.hapiServerDefaultAuth && framework == "hapi" {
+		return AuthPolicy{
+			Required: true, Method: "framework_default", Confidence: "low",
+			SourceChain: []AuthSignal{{
+				Kind: "framework_default",
+				Text: "hapi server.auth.default strategy; routes require auth unless auth:false",
+				File: ctx.file, Line: ctx.hapiServerDefaultLine,
+			}},
+		}
+	}
+
+	// 4. No signal.
+	return AuthPolicy{Method: "unknown", Confidence: "low"}
+}
+
+// nestHandlerName extracts the bare method name from a Nest source_handler ref
+// such as "SCOPE.Operation:UsersController.findOne" → "findOne", or
+// "Controller:findOne" → "findOne".
+func nestHandlerName(ref string) string {
+	if ref == "" {
+		return ""
+	}
+	if i := strings.IndexByte(ref, ':'); i >= 0 {
+		ref = ref[i+1:]
+	}
+	if i := strings.LastIndexByte(ref, '.'); i >= 0 {
+		ref = ref[i+1:]
+	}
+	return strings.TrimSpace(ref)
+}
+
+// rolesFromSignals scans @Roles decorators captured alongside guard signals.
+// (Roles are merged into the guard source chain text by the indexers.)
+func rolesFromSignals(sigs []AuthSignal) []string {
+	var roles []string
+	for _, s := range sigs {
+		if i := strings.Index(s.Text, "@Roles("); i >= 0 {
+			inner := s.Text[i+len("@Roles("):]
+			if j := strings.IndexByte(inner, ')'); j >= 0 {
+				inner = inner[:j]
+			}
+			for _, q := range jsQuotedTokenRe.FindAllStringSubmatch(inner, -1) {
+				if tok := strings.TrimSpace(q[1]); tok != "" {
+					roles = append(roles, tok)
+				}
+			}
+		}
+	}
+	return roles
+}
+
+// stampAuthPolicy writes the resolved policy onto an endpoint Properties map
+// using the same contract as the Java resolver (java_annotation_routes.go).
+func stampAuthPolicy(props map[string]string, policy AuthPolicy) {
+	if policyJSON := EncodeAuthPolicy(policy); policyJSON != "" {
+		props["auth_policy"] = policyJSON
+	}
+	props["auth_method"] = policy.Method
+	props["auth_confidence"] = policy.Confidence
+	if policy.Required {
+		props["auth_required"] = "true"
+	} else if policy.Method != "unknown" {
+		props["auth_required"] = "false"
+	}
+	if len(policy.Roles) > 0 {
+		props["auth_roles"] = strings.Join(policy.Roles, ",")
+	}
+	// MCP signal-1 keys (auth_coverage.go): a single recognised middleware /
+	// guard symbol so the tool's cheap property check fires without parsing
+	// the JSON source chain. Only stamp when the endpoint is protected.
+	if policy.Required && len(policy.SourceChain) > 0 {
+		head := policy.SourceChain[0]
+		switch policy.Method {
+		case "guard":
+			props["auth_guard"] = authEvidenceSymbol(head.Text)
+		case "middleware", "config", "framework_default":
+			props["auth_middleware"] = authEvidenceSymbol(head.Text)
+		}
+	}
+}
+
+// authEvidenceSymbol returns a compact symbol for the MCP signal-1 property,
+// stripping the "app/router-level: " prefix and decorator wrapping.
+func authEvidenceSymbol(text string) string {
+	text = strings.TrimPrefix(text, "app/router-level: ")
+	text = strings.TrimPrefix(text, "route-level: ")
+	return text
+}
+
+// ---------------------------------------------------------------------------
+// Route-level middleware indexers
+// ---------------------------------------------------------------------------
+
+// indexRouteLevelAuth scans Express-shaped route registrations for auth
+// middleware in the route's middleware chain. Covers Express, Koa-Router,
+// Hono, Fastify (via the same receiver/verb shape), Polka and Restify. The
+// returned map is keyed by "<VERB> <canonical-path>" matching the synthetic
+// endpoint property contract.
+func indexRouteLevelAuth(content, _ string) map[string][]AuthSignal {
+	out := map[string][]AuthSignal{}
+	for _, m := range jsRouteRegistrationRe.FindAllStringSubmatchIndex(content, -1) {
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		if verb == "DEL" {
+			verb = "DELETE"
+		}
+		if verb == "OPTS" {
+			verb = "OPTIONS"
+		}
+		raw := content[m[6]:m[7]]
+		rest := content[m[8]:m[9]]
+		sym, ok := middlewareChainHasAuth(rest)
+		if !ok {
+			continue
+		}
+		// Express-family canonicalization (Koa/Hono/Polka/Restify share it).
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		if canonical == "" {
+			continue
+		}
+		key := verb + " " + canonical
+		out[key] = append(out[key], AuthSignal{
+			Kind: "middleware",
+			Text: "route-level: " + sym,
+			File: "",
+			Line: lineAtOffset(content, m[0]),
+		})
+	}
+	return out
+}
+
+// middlewareChainHasAuth scans the args following the path (the middleware
+// chain plus final handler) for a recognised auth middleware. Returns the
+// canonical symbol and true on the first match.
+func middlewareChainHasAuth(rest string) (string, bool) {
+	// Split on commas at depth 0 to isolate each chain argument.
+	for _, arg := range splitTopLevelArgs(rest) {
+		if sym, ok := recognizeAuthMiddleware(arg); ok {
+			return sym, true
+		}
+	}
+	return "", false
+}
+
+// splitTopLevelArgs (defined in http_endpoint_client_synthesis.go) splits a
+// comma-separated argument list respecting nesting and quoting; reused here to
+// isolate each middleware-chain argument.
+
+// ---------------------------------------------------------------------------
+// NestJS method-level guard indexer
+// ---------------------------------------------------------------------------
+
+// nestHandlerMethodRe matches a Nest handler method declaration that is
+// preceded (on earlier lines) by a route verb decorator. We instead scan
+// methods bottom-up: this regex finds the method declaration line itself.
+// Group 1 = method name. The `(?m)^` anchor keeps it to a declaration, not a
+// nested call.
+var nestHandlerMethodRe = regexp.MustCompile(
+	`(?m)^[ \t]*(?:public\s+|private\s+|protected\s+|static\s+|readonly\s+|async\s+)*([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*[:{]`,
+)
+
+// nestVerbDecoratorRe identifies a route decorator (@Get/@Post/...). Used to
+// confirm a decorator block belongs to a route handler.
+var nestVerbDecoratorRe = regexp.MustCompile(`@(Get|Post|Put|Patch|Delete|All|Options|Head)\b`)
+
+// indexNestMethodGuards attributes each handler method's *own* preceding
+// decorator block to that method. The decorator block is the contiguous run of
+// `@...` decorator lines (and blank lines) immediately above the method
+// declaration — so a method-level @UseGuards / @Roles binds only to its method,
+// never bleeding into a sibling. A method whose block carries a verb decorator
+// but NO @UseGuards still binds nothing (it inherits the class-level guard via
+// the file-scope classGuards path). Returns a map keyed by method name.
+func indexNestMethodGuards(content, _ string) map[string][]AuthSignal {
+	out := map[string][]AuthSignal{}
+	if !strings.Contains(content, "@UseGuards") {
+		return out
+	}
+	for _, loc := range nestHandlerMethodRe.FindAllStringSubmatchIndex(content, -1) {
+		method := content[loc[2]:loc[3]]
+		block := precedingDecoratorBlock(content, loc[0])
+		if block == "" || !nestVerbDecoratorRe.MatchString(block) {
+			continue
+		}
+		gm := jsAuthGuardDecoratorRe.FindStringSubmatch(block)
+		if gm == nil {
+			continue
+		}
+		if len(parseGuardArgs(gm[1])) == 0 {
+			continue
+		}
+		text := "@UseGuards(" + strings.TrimSpace(gm[1]) + ")"
+		if rm := jsRolesDecoratorRe.FindStringSubmatch(block); rm != nil {
+			text += " @Roles(" + strings.TrimSpace(rm[1]) + ")"
+		}
+		out[method] = append(out[method], AuthSignal{
+			Kind: "guard",
+			Text: text,
+			Line: lineAtOffset(content, loc[0]),
+		})
+	}
+	return out
+}
+
+// precedingDecoratorBlock returns the contiguous block of decorator / blank
+// lines immediately above the line containing byte offset `declStart`. Walks
+// backwards line-by-line, stopping at the first line that is neither blank nor
+// a decorator (`@...`) — that boundary is the previous statement (the prior
+// method's closing brace or the class opener), so the block belongs solely to
+// the method at declStart.
+func precedingDecoratorBlock(content string, declStart int) string {
+	// Find the start of the declaration's own line.
+	lineStart := declStart
+	for lineStart > 0 && content[lineStart-1] != '\n' {
+		lineStart--
+	}
+	end := lineStart
+	cur := lineStart
+	for cur > 0 {
+		// Move cur to the start of the previous line.
+		prevEnd := cur - 1 // the '\n' terminating the previous line
+		prevStart := prevEnd
+		for prevStart > 0 && content[prevStart-1] != '\n' {
+			prevStart--
+		}
+		line := strings.TrimSpace(content[prevStart:prevEnd])
+		if line == "" || strings.HasPrefix(line, "@") || strings.HasPrefix(line, "//") {
+			cur = prevStart
+			continue
+		}
+		break
+	}
+	if cur >= end {
+		return ""
+	}
+	return content[cur:end]
+}
+
+// ---------------------------------------------------------------------------
+// Hapi per-route auth indexer
+// ---------------------------------------------------------------------------
+
+// hapiAuth captures a per-route Hapi auth verdict.
+type hapiAuth struct {
+	set    bool
+	public bool // auth: false
+	signal AuthSignal
+}
+
+// indexHapiRouteAuth scans each `server.route({ ... })` object body for a
+// `path`, `method` and `auth`/`options.auth`/`config.auth` setting and maps
+// the resulting (verb, canonical path) to a hapiAuth verdict.
+func indexHapiRouteAuth(content, _ string) map[string]hapiAuth {
+	out := map[string]hapiAuth{}
+	if !strings.Contains(content, ".route(") {
+		return out
+	}
+	for _, idx := range hapiRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		braceOpen := idx[2]
+		braceClose := findMatchingBrace(content, braceOpen)
+		if braceClose < 0 {
+			continue
+		}
+		body := content[braceOpen : braceClose+1]
+		pm := hapiPathKwargRe.FindStringSubmatch(body)
+		if len(pm) < 2 {
+			continue
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkHapi, stripHapiPathModifiers(pm[1]))
+		if canonical == "" {
+			continue
+		}
+		verbs := parseHapiMethods(body)
+		if len(verbs) == 0 {
+			continue
+		}
+		am := jsHapiAuthKwargRe.FindStringSubmatch(body)
+		if am == nil {
+			continue
+		}
+		val := strings.TrimSpace(am[1])
+		ha := hapiAuth{set: true}
+		if val == "false" {
+			ha.public = true
+			ha.signal = AuthSignal{Kind: "config", Text: "auth: false (explicit public)", Line: lineAtOffset(content, braceOpen)}
+		} else {
+			ha.signal = AuthSignal{Kind: "config", Text: "route auth: " + val, Line: lineAtOffset(content, braceOpen)}
+		}
+		for _, verb := range verbs {
+			out[verb+" "+canonical] = ha
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// AdonisJS route-chain middleware indexer
+// ---------------------------------------------------------------------------
+
+// indexAdonisRouteAuth scans AdonisJS route registrations for a chained
+// `.middleware('auth')` / `.use([middleware.auth()])` call. Adonis chains the
+// middleware onto the route expression, so we scan each Route.<verb>(...) line
+// (and its continuation up to the statement end) for an auth middleware token.
+func indexAdonisRouteAuth(content, _ string) map[string][]AuthSignal {
+	out := map[string][]AuthSignal{}
+	if !strings.Contains(content, "Route.") {
+		return out
+	}
+	for _, m := range adonisVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkAdonis, raw)
+		if canonical == "" {
+			continue
+		}
+		// Scan from the route call to the end of the statement (next newline
+		// that isn't a chain continuation) for a .middleware(...) auth token.
+		stmt := adonisStatementFrom(content, m[0])
+		if mw := jsAdonisMiddlewareRe.FindStringSubmatch(stmt); mw != nil {
+			if adonisMiddlewareIsAuth(mw[1]) {
+				out[verb+" "+canonical] = append(out[verb+" "+canonical], AuthSignal{
+					Kind: "middleware",
+					Text: "route-level: .middleware(" + strings.TrimSpace(mw[1]) + ")",
+					Line: lineAtOffset(content, m[0]),
+				})
+			}
+		}
+	}
+	return out
+}
+
+// adonisStatementFrom returns the source span from offset `start` to the end of
+// the AdonisJS route statement, following chained `.method(...)` continuations
+// across newlines (a leading `.` or open paren means the chain continues).
+func adonisStatementFrom(content string, start int) string {
+	end := start
+	depth := 0
+	for end < len(content) {
+		c := content[end]
+		switch c {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case '\n':
+			if depth == 0 {
+				// Peek ahead: a chain continuation begins with optional
+				// whitespace then a '.'.
+				rest := strings.TrimLeft(content[end+1:], " \t\r")
+				if !strings.HasPrefix(rest, ".") {
+					return content[start:end]
+				}
+			}
+		}
+		end++
+		if end-start > 4096 {
+			break
+		}
+	}
+	return content[start:end]
+}
+
+// adonisMiddlewareIsAuth reports whether an Adonis middleware argument list
+// references an auth middleware. Adonis names middleware by string key
+// ('auth', 'auth:api') or by the Adonis 6 `middleware.auth()` reference.
+func adonisMiddlewareIsAuth(args string) bool {
+	low := strings.ToLower(args)
+	for _, tok := range []string{"auth", "authenticate", "guard", "silentauth"} {
+		if strings.Contains(low, tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Marble.js per-route auth indexer
+// ---------------------------------------------------------------------------
+
+// indexMarbleRouteAuth scans each Marble.js routing Effect (`const x$ =
+// r.pipe(...)`) for an auth middleware effect piped before useEffect, e.g.
+// `r.pipe(r.matchPath('/me'), r.matchType('GET'), use(authorize$), ...)`.
+// Returns a map keyed by (verb, canonical path).
+func indexMarbleRouteAuth(content, _ string) map[string][]AuthSignal {
+	out := map[string][]AuthSignal{}
+	if !strings.Contains(content, "r.pipe") || !strings.Contains(content, "matchPath") {
+		return out
+	}
+	for _, idx := range marbleEffectRe.FindAllStringSubmatchIndex(content, -1) {
+		parenOpen := idx[1] - 1
+		parenClose := findMatchingParenFrom(content, parenOpen)
+		if parenClose < 0 {
+			continue
+		}
+		body := content[parenOpen : parenClose+1]
+		pm := marbleMatchPathRe.FindStringSubmatch(body)
+		if len(pm) < 2 {
+			continue
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkMarble, pm[1])
+		if canonical == "" {
+			continue
+		}
+		verb := "ANY"
+		if tm := marbleMatchTypeRe.FindStringSubmatch(body); len(tm) >= 2 {
+			verb = strings.ToUpper(tm[1])
+		}
+		if am := jsMarbleAuthRe.FindStringSubmatch(body); am != nil {
+			out[verb+" "+canonical] = append(out[verb+" "+canonical], AuthSignal{
+				Kind: "middleware",
+				Text: "route-level: use(" + am[1] + ")",
+				Line: lineAtOffset(content, idx[0]),
+			})
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Sails policy-map recognition (#2852 — framework_specific idiom)
+// ---------------------------------------------------------------------------
+//
+// Sails does not gate routes with middleware or guards; it maps controllers /
+// actions to *policies* in `config/policies.js`. A protective global default
+// (`'*': 'isLoggedIn'`) authenticates every action unless an action opts out
+// with `true`. This is a bespoke auth surface that the generic route/app/guard
+// middleware recognisers do not capture, so the Sails auth_coverage cell is
+// classified `framework_specific` in the registry. The recogniser below proves
+// the capability: it parses a policies.js map into a default posture plus the
+// explicit per-action overrides.
+
+// sailsGlobalPolicyRe captures the global default policy `'*': <value>`.
+// Group 1 = value (`false` | `true` | a policy name | `[ ... ]`).
+var sailsGlobalPolicyRe = regexp.MustCompile(
+	`['"` + "`" + `]\*['"` + "`" + `]\s*:\s*(false|true|\[[^\]]*\]|['"` + "`" + `][^'"` + "`" + `]+['"` + "`" + `])`,
+)
+
+// SailsPolicyMap is the parsed result of a config/policies.js file.
+type SailsPolicyMap struct {
+	// DefaultProtected is true when the global `'*'` default names a real policy
+	// (not `true` and not absent). A `true` global default means "public by
+	// default" → not protected.
+	DefaultProtected bool
+	// DefaultPolicy is the raw global default value (policy name / true / false).
+	DefaultPolicy string
+	// File is the source path the map was parsed from.
+	File string
+}
+
+// sailsPoliciesFile reports whether filePath is a Sails policies-config file.
+func sailsPoliciesFile(filePath string) bool {
+	p := strings.ReplaceAll(filePath, "\\", "/")
+	return strings.HasSuffix(p, "config/policies.js") ||
+		strings.HasSuffix(p, "config/policies.ts")
+}
+
+// ParseSailsPolicies parses a Sails config/policies.js map and reports the
+// global default auth posture. A global default that names a policy (e.g.
+// `'isLoggedIn'`) protects every action; `true` means public-by-default.
+func ParseSailsPolicies(content, file string) (SailsPolicyMap, bool) {
+	if !strings.Contains(content, "policies") {
+		return SailsPolicyMap{}, false
+	}
+	m := sailsGlobalPolicyRe.FindStringSubmatch(content)
+	if m == nil {
+		return SailsPolicyMap{}, false
+	}
+	val := strings.TrimSpace(m[1])
+	pm := SailsPolicyMap{DefaultPolicy: val, File: file}
+	switch {
+	case val == "false":
+		// Default-deny with no policy → blanket block; treat as protected
+		// (no anonymous access).
+		pm.DefaultProtected = true
+	case val == "true":
+		pm.DefaultProtected = false
+	default:
+		// Named policy (quoted string or array) → protected.
+		pm.DefaultProtected = true
+	}
+	return pm, true
+}

--- a/internal/engine/http_endpoint_jsts_auth_test.go
+++ b/internal/engine/http_endpoint_jsts_auth_test.go
@@ -1,0 +1,202 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// authProps runs detection on a JS/TS fixture and returns the synthetic
+// http_endpoint_definition entities keyed by "<VERB> <path>".
+func authProps(t *testing.T, language, path, content string) map[string]types.EntityRecord {
+	t.Helper()
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	res, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(content),
+		Language: language,
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	out := map[string]types.EntityRecord{}
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		key := e.Properties["verb"] + " " + e.Properties["path"]
+		out[key] = e
+	}
+	return out
+}
+
+// requireProtected asserts the endpoint at key is present and carries an
+// auth_required=true posture with the expected method and (optionally) confidence.
+func requireProtected(t *testing.T, eps map[string]types.EntityRecord, key, wantMethod string) {
+	t.Helper()
+	e, ok := eps[key]
+	if !ok {
+		t.Fatalf("endpoint %q not synthesised (got: %v)", key, keysOf(eps))
+	}
+	if e.Properties["auth_required"] != "true" {
+		t.Errorf("%s: auth_required=%q, want true (props: %v)", key, e.Properties["auth_required"], e.Properties)
+	}
+	if wantMethod != "" && e.Properties["auth_method"] != wantMethod {
+		t.Errorf("%s: auth_method=%q, want %q", key, e.Properties["auth_method"], wantMethod)
+	}
+	// The MCP signal-1 key must be present so archigraph_auth_coverage fires.
+	if e.Properties["auth_middleware"] == "" && e.Properties["auth_guard"] == "" {
+		t.Errorf("%s: neither auth_middleware nor auth_guard stamped (props: %v)", key, e.Properties)
+	}
+}
+
+// requirePublic asserts the endpoint is present and is NOT marked auth_required.
+func requirePublic(t *testing.T, eps map[string]types.EntityRecord, key string) {
+	t.Helper()
+	e, ok := eps[key]
+	if !ok {
+		t.Fatalf("endpoint %q not synthesised (got: %v)", key, keysOf(eps))
+	}
+	if e.Properties["auth_required"] == "true" {
+		t.Errorf("%s: auth_required=true, want public/unknown (props: %v)", key, e.Properties)
+	}
+}
+
+func keysOf(m map[string]types.EntityRecord) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestAuth_Express — app-level passport + route-level requireAuth.
+func TestAuth_Express(t *testing.T) {
+	eps := authProps(t, "typescript", "app.ts", readBackendFixture(t, "express_auth.ts"))
+	requireProtected(t, eps, "GET /me", "middleware")
+	requireProtected(t, eps, "POST /orders", "middleware")
+	// /health inherits the app-level passport gate (medium confidence).
+	e := eps["GET /health"]
+	if e.Properties["auth_required"] != "true" || e.Properties["auth_confidence"] != "medium" {
+		t.Errorf("GET /health: want app-level medium coverage, got %v", e.Properties)
+	}
+	if eps["GET /me"].Properties["auth_confidence"] != "high" {
+		t.Errorf("GET /me: want high confidence, got %q", eps["GET /me"].Properties["auth_confidence"])
+	}
+}
+
+// TestAuth_Koa — koa-router route-level guard + a public route.
+func TestAuth_Koa(t *testing.T) {
+	eps := authProps(t, "typescript", "routes.ts", readBackendFixture(t, "koa_auth.ts"))
+	requireProtected(t, eps, "GET /profile", "middleware")
+	requireProtected(t, eps, "PUT /profile", "middleware")
+	requirePublic(t, eps, "GET /ping")
+}
+
+// TestAuth_Hono — app-level jwtAuth + route-level verifyToken.
+func TestAuth_Hono(t *testing.T) {
+	eps := authProps(t, "typescript", "app.ts", readBackendFixture(t, "hono_auth.ts"))
+	requireProtected(t, eps, "GET /secure", "middleware")
+	// /items inherits the app-level jwtAuth gate.
+	requireProtected(t, eps, "GET /items", "middleware")
+}
+
+// TestAuth_Fastify — route-level requireAuth + a public route.
+func TestAuth_Fastify(t *testing.T) {
+	eps := authProps(t, "typescript", "server.ts", readBackendFixture(t, "fastify_auth.ts"))
+	requireProtected(t, eps, "GET /account", "middleware")
+	requireProtected(t, eps, "POST /account", "middleware")
+	requirePublic(t, eps, "GET /status")
+}
+
+// TestAuth_Nest — class-level @UseGuards (medium) + method-level guard+roles (high).
+func TestAuth_Nest(t *testing.T) {
+	eps := authProps(t, "typescript", "users.controller.ts", readBackendFixture(t, "nestjs_auth.ts"))
+	// Class-level guard → every method protected.
+	requireProtected(t, eps, "GET /users", "guard")
+	requireProtected(t, eps, "GET /users/{id}", "guard")
+	// Method-level @UseGuards(RolesGuard) @Roles('admin') → high + roles.
+	create := eps["POST /users"]
+	if create.Properties["auth_required"] != "true" || create.Properties["auth_confidence"] != "high" {
+		t.Errorf("POST /users: want method-level high guard, got %v", create.Properties)
+	}
+	if create.Properties["auth_roles"] != "admin" {
+		t.Errorf("POST /users: auth_roles=%q, want admin", create.Properties["auth_roles"])
+	}
+	if create.Properties["auth_guard"] == "" {
+		t.Errorf("POST /users: auth_guard not stamped (props: %v)", create.Properties)
+	}
+}
+
+// TestAuth_Adonis — route-chain .middleware('auth') + a public route.
+func TestAuth_Adonis(t *testing.T) {
+	eps := authProps(t, "typescript", "start/routes.ts", readBackendFixture(t, "adonisjs_auth.ts"))
+	requireProtected(t, eps, "GET /dashboard", "middleware")
+	requireProtected(t, eps, "POST /posts", "middleware")
+	requirePublic(t, eps, "GET /about")
+}
+
+// TestAuth_Hapi — per-route options.auth (protected) + auth:false (public).
+func TestAuth_Hapi(t *testing.T) {
+	eps := authProps(t, "typescript", "server.ts", readBackendFixture(t, "hapi_auth.ts"))
+	requireProtected(t, eps, "GET /private", "config")
+	// auth: false → explicitly public.
+	e, ok := eps["POST /login"]
+	if !ok {
+		t.Fatalf("POST /login not synthesised (got: %v)", keysOf(eps))
+	}
+	if e.Properties["auth_required"] != "false" {
+		t.Errorf("POST /login: auth_required=%q, want false (auth:false)", e.Properties["auth_required"])
+	}
+}
+
+// TestAuth_Feathers — app-level authenticate() gates mounted services.
+func TestAuth_Feathers(t *testing.T) {
+	eps := authProps(t, "typescript", "app.ts", readBackendFixture(t, "feathers_auth.ts"))
+	// Service verbs inherit the app-level authenticate() gate.
+	requireProtected(t, eps, "GET /messages", "middleware")
+	requireProtected(t, eps, "POST /messages", "middleware")
+	requireProtected(t, eps, "GET /users", "middleware")
+}
+
+// TestAuth_Marble — authorize$ effect in the pipe (protected) + a public effect.
+func TestAuth_Marble(t *testing.T) {
+	eps := authProps(t, "typescript", "user.effects.ts", readBackendFixture(t, "marblejs_auth.ts"))
+	requireProtected(t, eps, "GET /me", "middleware")
+	requirePublic(t, eps, "GET /status")
+}
+
+// TestAuth_Polka — route-level requireAuth + a public route.
+func TestAuth_Polka(t *testing.T) {
+	eps := authProps(t, "typescript", "server.ts", readBackendFixture(t, "polka_auth.ts"))
+	requireProtected(t, eps, "GET /private", "middleware")
+	requirePublic(t, eps, "GET /public")
+}
+
+// TestAuth_Restify — server.use passport gate + route-level requireAuth.
+func TestAuth_Restify(t *testing.T) {
+	eps := authProps(t, "typescript", "server.ts", readBackendFixture(t, "restify_auth.ts"))
+	requireProtected(t, eps, "GET /secrets", "middleware")
+	requireProtected(t, eps, "GET /info", "middleware") // inherits server.use gate
+}
+
+// TestAuth_SailsPolicies — config/policies.js global default-protected posture
+// (framework_specific idiom). Proves the policy-map recogniser.
+func TestAuth_SailsPolicies(t *testing.T) {
+	pm, ok := ParseSailsPolicies(readBackendFixture(t, "sails_policies.ts"), "config/policies.js")
+	if !ok {
+		t.Fatal("ParseSailsPolicies: expected a parsed policy map")
+	}
+	if !pm.DefaultProtected {
+		t.Errorf("DefaultProtected=false, want true for '*': 'isLoggedIn'")
+	}
+	if pm.DefaultPolicy != "'isLoggedIn'" {
+		t.Errorf("DefaultPolicy=%q, want 'isLoggedIn'", pm.DefaultPolicy)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -363,6 +363,10 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Now emits FETCHES edges at extraction time.
 		synthesizePyClientWithRuntime(string(content), emitClientRuntime)
 	case "javascript", "typescript":
+		// Capture the producer-side entity count before the JS/TS backend
+		// synthesizers run so #2852 can resolve auth_coverage over exactly the
+		// http_endpoint_definition entities this file just emitted.
+		jstsAuthBefore := len(entities)
 		// Producer side (#2851): Polka / Restify are Express-shaped but use
 		// distinct receiver/import conventions. Run BEFORE synthesizeExpress
 		// so their endpoints are tagged with the correct framework — the
@@ -420,6 +424,15 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// shared resolver short-circuits the rebind and preserves the
 		// precise attribution this synthesizer produces.
 		synthesizeTRPC(string(content), emitDef)
+		// #2852 — resolve auth_coverage over the producer-side endpoints emitted
+		// above. Detects passport/express-jwt/session middleware, Nest
+		// @UseGuards (class + method), Hapi route auth, AdonisJS .middleware('auth')
+		// and Marble.js auth effects, stamping the auth_policy property contract
+		// (auth_policy/auth_method/auth_confidence/auth_required + the MCP
+		// signal-1 auth_middleware/auth_guard keys). Runs before the consumer
+		// (client) synthesizers so it only sees producer http_endpoint_definition
+		// entities.
+		applyJSTSAuthPolicy(string(content), path, entities, jstsAuthBefore)
 		// Consumer side (#721): fetch / axios / generic *Client
 		// HTTP client calls. Now emits FETCHES edges at extraction time.
 		//

--- a/testdata/fixtures/typescript/adonisjs_auth.ts
+++ b/testdata/fixtures/typescript/adonisjs_auth.ts
@@ -1,0 +1,9 @@
+// AdonisJS auth_coverage fixture (#2852). Hand-written.
+import Route from '@ioc:Adonis/Core/Route'
+
+// Route-chain .middleware('auth') → high confidence protected.
+Route.get('/dashboard', 'DashboardController.index').middleware('auth')
+Route.post('/posts', 'PostsController.store').middleware(['auth', 'acl:author'])
+
+// Public route — no auth middleware.
+Route.get('/about', 'PagesController.about')

--- a/testdata/fixtures/typescript/express_auth.ts
+++ b/testdata/fixtures/typescript/express_auth.ts
@@ -1,0 +1,17 @@
+// Express auth_coverage fixture (#2852). Hand-written, dependency-manifest-free.
+// Mixes app-level passport, route-level requireAuth, and an unprotected route.
+import express from 'express'
+import passport from 'passport'
+
+const app = express()
+
+// App-level auth middleware → file-scope (medium) coverage for endpoints with
+// no stronger route-level signal.
+app.use(passport.authenticate('jwt', { session: false }))
+
+// Route-level auth middleware (high confidence).
+app.get('/me', requireAuth, getMe)
+app.post('/orders', ensureAuthenticated, createOrder)
+
+// Public health check — relies only on the app-level passport gate (medium).
+app.get('/health', healthCheck)

--- a/testdata/fixtures/typescript/fastify_auth.ts
+++ b/testdata/fixtures/typescript/fastify_auth.ts
@@ -1,0 +1,11 @@
+// Fastify auth_coverage fixture (#2852). Hand-written.
+import Fastify from 'fastify'
+
+const fastify = Fastify()
+
+// Route-level preHandler auth via a recognised guard middleware in the chain.
+fastify.get('/account', requireAuth, getAccount)
+fastify.post('/account', requireAuth, updateAccount)
+
+// Public route.
+fastify.get('/status', getStatus)

--- a/testdata/fixtures/typescript/feathers_auth.ts
+++ b/testdata/fixtures/typescript/feathers_auth.ts
@@ -1,0 +1,14 @@
+// Feathers auth_coverage fixture (#2852). Hand-written.
+// Feathers gates services with app-level authentication middleware
+// (@feathersjs/authentication). The app.use(authenticate(...)) registration is
+// the cross-service auth gate; every service mounted in the app inherits it.
+import { feathers } from '@feathersjs/feathers'
+
+const app = feathers()
+
+// App-level authentication hook → file-scope coverage for mounted services.
+app.use(authenticate('jwt'))
+
+// Service registrations (REST verb expansion happens in the routing synth).
+app.use('/messages', new MessageService())
+app.use('/users', new UserService())

--- a/testdata/fixtures/typescript/hapi_auth.ts
+++ b/testdata/fixtures/typescript/hapi_auth.ts
@@ -1,0 +1,17 @@
+// Hapi auth_coverage fixture (#2852). Hand-written.
+// Per-route options.auth strategy → protected; auth: false → explicit public.
+const server = Hapi.server({ port: 3000 })
+
+server.route({
+  method: 'GET',
+  path: '/private',
+  options: { auth: 'jwt' },
+  handler: getPrivate,
+})
+
+server.route({
+  method: 'POST',
+  path: '/login',
+  options: { auth: false },
+  handler: login,
+})

--- a/testdata/fixtures/typescript/hono_auth.ts
+++ b/testdata/fixtures/typescript/hono_auth.ts
@@ -1,0 +1,13 @@
+// Hono auth_coverage fixture (#2852). Hand-written.
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+// App-level JWT middleware → file-scope coverage.
+app.use(jwtAuth)
+
+// Route-level guard (high confidence).
+app.get('/secure', verifyToken, getSecure)
+
+// Inherits the app-level jwtAuth gate (medium).
+app.get('/items', listItems)

--- a/testdata/fixtures/typescript/koa_auth.ts
+++ b/testdata/fixtures/typescript/koa_auth.ts
@@ -1,0 +1,11 @@
+// Koa (koa-router) auth_coverage fixture (#2852). Hand-written.
+import Router from '@koa/router'
+
+const router = new Router()
+
+// Route-level guard middleware (high confidence).
+router.get('/profile', requireAuth, getProfile)
+router.put('/profile', requireAuth, updateProfile)
+
+// Public route — no auth middleware in the chain.
+router.get('/ping', ping)

--- a/testdata/fixtures/typescript/marblejs_auth.ts
+++ b/testdata/fixtures/typescript/marblejs_auth.ts
@@ -1,0 +1,17 @@
+// Marble.js auth_coverage fixture (#2852). Hand-written.
+// Auth is an Effect (`authorize$`) piped into the route via `use(...)`.
+import { r } from '@marblejs/http'
+
+const getMe$ = r.pipe(
+  r.matchPath('/me'),
+  r.matchType('GET'),
+  use(authorize$),
+  r.useEffect(req$ => req$),
+)
+
+// Public route — no authorize$ in the pipe.
+const getStatus$ = r.pipe(
+  r.matchPath('/status'),
+  r.matchType('GET'),
+  r.useEffect(req$ => req$),
+)

--- a/testdata/fixtures/typescript/nestjs_auth.ts
+++ b/testdata/fixtures/typescript/nestjs_auth.ts
@@ -1,0 +1,25 @@
+// NestJS auth_coverage fixture (#2852). Hand-written.
+// Class-level @UseGuards → all methods inherit (medium); a method-level
+// @UseGuards + @Roles → high confidence with roles.
+import { Controller, Get, Post, Delete, UseGuards } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+
+@Controller('users')
+@UseGuards(AuthGuard('jwt'))
+export class UsersController {
+  @Get()
+  findAll() {}
+
+  @Get(':id')
+  findOne() {}
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  create() {}
+
+  @Delete(':id')
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  remove() {}
+}

--- a/testdata/fixtures/typescript/polka_auth.ts
+++ b/testdata/fixtures/typescript/polka_auth.ts
@@ -1,0 +1,10 @@
+// Polka auth_coverage fixture (#2852). Hand-written.
+import polka from 'polka'
+
+const app = polka()
+
+// Route-level guard middleware (high confidence).
+app.get('/private', requireAuth, getPrivate)
+
+// Public route.
+app.get('/public', getPublic)

--- a/testdata/fixtures/typescript/restify_auth.ts
+++ b/testdata/fixtures/typescript/restify_auth.ts
@@ -1,0 +1,13 @@
+// Restify auth_coverage fixture (#2852). Hand-written.
+import restify from 'restify'
+
+const server = restify.createServer()
+
+// App-level auth gate via server.use(...).
+server.use(passport.authenticate('jwt'))
+
+// Route-level guard (high confidence).
+server.get('/secrets', requireAuth, getSecrets)
+
+// Inherits the server.use passport gate (medium).
+server.get('/info', getInfo)

--- a/testdata/fixtures/typescript/sails_policies.ts
+++ b/testdata/fixtures/typescript/sails_policies.ts
@@ -1,0 +1,11 @@
+// Sails config/policies.js auth_coverage fixture (#2852). Hand-written.
+// A protective global default ('*': 'isLoggedIn') gates every action unless a
+// controller/action explicitly opts out with `true` (public).
+module.exports.policies = {
+  '*': 'isLoggedIn',
+
+  AuthController: {
+    login: true,
+    logout: 'isLoggedIn',
+  },
+}


### PR DESCRIPTION
Closes #2852. Part of epic #2847.

## Summary
Implements cross-framework auth-middleware / guard recognition for the twelve JS/TS backend-HTTP framework families, attributing auth coverage per synthesized endpoint. A new per-file pass (`internal/engine/http_endpoint_jsts_auth.go`) resolves a structured `auth_policy` over the `http_endpoint_definition` entities emitted by the #2851 routing synthesizers, mirroring the Java auth_policy resolver (#1942) and the Django DRF class-level approach (#2816).

Layer: engine (the JS/TS backend routing/security layer per the issue map). No `internal/engine/rules/.../*.yaml` change needed — the Go synthesizers are the source of truth for backend endpoints, and auth is a post-synthesis enrichment over them.

### Detection (the JS/TS analog of Django's class-level + decorator + default)
- **route-level middleware chain** — `app.get('/me', requireAuth, h)` (Express, Koa, Hono, Fastify, Polka, Restify) — HIGH.
- **router/app-level middleware** — `app.use(passport.authenticate('jwt'))` / `router.use(requireAuth)` — MEDIUM (file scope).
- **NestJS @UseGuards** — class-level (medium, inherited) + method-level + `@Roles` (high, with roles).
- **Hapi** per-route `options.auth` strategy (protected) / `auth: false` (explicit public).
- **AdonisJS** route-chain `.middleware('auth')`.
- **Marble.js** `authorize$` effect piped into the route.
- **Sails** `config/policies.js` policy-map recognition (bespoke idiom — see taxonomy below).

Output reuses the Java property contract — `auth_policy` (JSON source chain) + flat `auth_method`/`auth_confidence`/`auth_required`/`auth_roles` + the MCP signal-1 `auth_middleware`/`auth_guard` keys — so `archigraph_auth_coverage` and the security dashboard light up uniformly across languages.

### New Kinds
None. The pass only stamps Properties on existing `http_endpoint_definition` entities, so the #2839 register-new-Kind rule does not apply. `go test ./internal/types/` passes.

## Taxonomy changes
- 11 standard `Security/auth_coverage` cells flipped `missing|partial -> full` (Nest was partial).
- **Sails** set to `partial` (not `full`): Sails has no generic route/app/guard middleware auth surface — it gates actions via `config/policies.js` policy maps, a bespoke idiom the generic cells don't capture, and cross-file `policies.js`→`routes.js` per-endpoint attribution is deferred. Added a hand-edited `framework_specific` cell **"Sails Policies" / `policy_map_recognition` = full**, fixture-proven by `ParseSailsPolicies` (the tool can't write `framework_specific`, so registry.json was hand-edited; gen + validate are byte-stable). Follow-up for full per-endpoint attribution: see Limits.

## Proven by
- Unit fixtures + tests (`internal/engine/http_endpoint_jsts_auth_test.go`) — one per framework family under `testdata/fixtures/typescript/*_auth.ts` (+ `sails_policies.ts`).
- Real-data integration: `cmd/archigraph/testdata/audit2852_js/` (express/nestjs/hapi/adonisjs/feathers/marblejs) indexed through the full pipeline by `TestAudit2852_JSBackendAuth` — asserts the resolved auth_policy survives resolve/prune.

## implements-capability
```
implements-capability: lang.jsts.framework.adonisjs/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.express/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.fastify/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.feathers/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.hapi/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.hono/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.koa/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.marblejs/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.nestjs/Security/auth_coverage:partial→full
implements-capability: lang.jsts.framework.polka/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.restify/Security/auth_coverage:missing→full
implements-capability: lang.jsts.framework.sails/Security/auth_coverage:missing→partial (+ framework_specific Sails Policies/policy_map_recognition:→full)
```

## Test plan
- [x] `go test ./internal/engine/ ./internal/substrate/ ./internal/links/ ./internal/types/ ./tools/coverage/ ./internal/mcp/ ./cmd/archigraph/`
- [x] `go run ./tools/coverage validate` exits 0; `go run ./tools/coverage gen` byte-stable
- [x] Real-data integration via `TestAudit2852_JSBackendAuth`
- [x] Self-rebased on origin/main

## Limits / deferred
- Sails per-endpoint attribution from `config/policies.js` to `config/routes.js` endpoints (cross-file join) is deferred — the global default posture is recognised (framework_specific cell) but not joined to individual route entities. Follow-up: #2897.
- This PR does not touch `middleware_coverage` (sibling #2853).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
