### PR TITLE
[JS/TS coverage] ORM migration_parsing + model_extraction — Drizzle/Knex/MikroORM/Objection/Prisma/Sequelize/TypeORM (#2861)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -71,15 +71,15 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ | ⚠️ | ⚠️ | |
 | [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | — | — | ⚠️ | |
 | [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | — | — | ⚠️ | |
-| [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ❌ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ | — | ⚠️ | |
-| [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ | ⚠️ | ⚠️ | |
+| [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ✅ | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ | — | ⚠️ | |
+| [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ✅ | ✅ | ⚠️ | |
 | [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | — | — | ⚠️ | |
 | [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | — | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ | ❌ | ❌ | |
-| [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | ⚠️ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ✅ | ✅ | ❌ | |
+| [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | ✅ | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ✅ | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ✅ | ✅ | ✅ | |
 | [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | — | — | ⚠️ | |
 | [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | — | — | ⚠️ | |
 | [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | — | — | ⚠️ | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -112,15 +112,15 @@ Back to [summary](../summary.md).
 |---|---|---|---|---|
 | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | — | — | ⚠️ | |
 | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | — | — | ⚠️ | |
-| [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ❌ | ✅ | ✅ | |
-| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ | — | ⚠️ | |
-| [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ | ⚠️ | ⚠️ | |
+| [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ✅ | ✅ | ✅ | |
+| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ | — | ⚠️ | |
+| [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ✅ | ✅ | ⚠️ | |
 | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | — | — | ⚠️ | |
 | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | — | ✅ | ✅ | |
-| [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ | ❌ | ❌ | |
-| [Prisma](../detail/lang.jsts.orm.prisma.md) | ⚠️ | ✅ | ✅ | |
-| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ | ✅ | ✅ | |
-| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ | ✅ | ✅ | |
+| [Objection.js](../detail/lang.jsts.orm.objection.md) | ✅ | ✅ | ❌ | |
+| [Prisma](../detail/lang.jsts.orm.prisma.md) | ✅ | ✅ | ✅ | |
+| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ✅ | ✅ | ✅ | |
+| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ✅ | ✅ | ✅ | |
 | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | — | — | ⚠️ | |
 | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | — | — | ⚠️ | |
 | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | — | — | ⚠️ | |

--- a/docs/coverage/detail/lang.jsts.orm.drizzle.md
+++ b/docs/coverage/detail/lang.jsts.orm.drizzle.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/drizzle.go`<br>`internal/custom/javascript/extractors_coverage_test.go` | — |
 | `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/drizzle.yaml` | — |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 

--- a/docs/coverage/detail/lang.jsts.orm.knex.md
+++ b/docs/coverage/detail/lang.jsts.orm.knex.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
-| `model_extraction` | — `not_applicable` | — | — | — | — | — |
+| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/knex.go` | — |
+| `model_extraction` | — `not_applicable` | — | — | — | — | Knex is a SQL query builder, not an ORM — it has no model/entity layer to extract. Persistent model_extraction belongs to Objection.js, which layers Active-Record models on top of Knex (see lang.jsts.orm.objection). |
 | `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/knex.yaml` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
+++ b/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
-| `model_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` | — |
+| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mikroorm.go` | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mikroorm.go`<br>`internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` | — |
 | `query_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.orm.objection.md
+++ b/docs/coverage/detail/lang.jsts.orm.objection.md
@@ -11,9 +11,17 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
-| `model_extraction` | ❌ `missing` | — | — | — | — | — |
+| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | — |
+| `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go`<br>`internal/engine/rules/javascript_typescript/orms/objection.yaml` | — |
 | `query_attribution` | ❌ `missing` | — | — | — | — | — |
+
+## Framework-specific
+
+### Objection Relation Graph
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `relation_graph_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/objection.go`<br>`internal/custom/javascript/extractors_coverage_test.go` | Objection's bespoke `static relationMappings` declaration (BelongsToOneRelation / HasManyRelation / ManyToManyRelation / HasOneThroughRelation) drives its eager-load + nested-mutation graph API (withGraphFetched / upsertGraph). No standard ORM cell (model_extraction / query_attribution / migration_parsing) captures this relation-graph topology, so it is recorded as a framework-specific capability. Each relation entry is emitted as a SCOPE.Component relation entity tagged with its relation_type. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.prisma.md
+++ b/docs/coverage/detail/lang.jsts.orm.prisma.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `migration_parsing` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/prisma/_manifest.yaml` | — |
+| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/prisma.go` | — |
 | `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/prisma.yaml`<br>`internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml`<br>`internal/engine/rules/prisma/_manifest.yaml` | — |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 

--- a/docs/coverage/detail/lang.jsts.orm.sequelize.md
+++ b/docs/coverage/detail/lang.jsts.orm.sequelize.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/sequelize.go` | — |
 | `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/sequelize.yaml` | — |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 

--- a/docs/coverage/detail/lang.jsts.orm.typeorm.md
+++ b/docs/coverage/detail/lang.jsts.orm.typeorm.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `migration_parsing` | ❌ `missing` | — | — | — | — | — |
+| `migration_parsing` | ✅ `full` | `2026-05-28` | — | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/typeorm.go` | — |
 | `model_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/orms/typeorm.yaml` | — |
 | `query_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/orm_queries_jsts.go` | — |
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -13120,7 +13120,9 @@
       "label": "Drizzle",
       "capabilities": {
         "migration_parsing": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/javascript/drizzle.go","internal/custom/javascript/extractors_coverage_test.go"],
+          "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
@@ -13141,10 +13143,13 @@
       "label": "Knex (query builder)",
       "capabilities": {
         "migration_parsing": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/knex.go"],
+          "verified_at": "2026-05-28"
         },
         "model_extraction": {
-          "status": "not_applicable"
+          "status": "not_applicable",
+          "notes": "Knex is a SQL query builder, not an ORM — it has no model/entity layer to extract. Persistent model_extraction belongs to Objection.js, which layers Active-Record models on top of Knex (see lang.jsts.orm.objection)."
         },
         "query_attribution": {
           "status": "partial",
@@ -13160,11 +13165,13 @@
       "label": "MikroORM",
       "capabilities": {
         "migration_parsing": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mikroorm.go"],
+          "verified_at": "2026-05-28"
         },
         "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
+          "status": "full",
+          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mikroorm.go","internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
           "verified_at": "2026-05-28"
         },
         "query_attribution": {
@@ -13202,13 +13209,27 @@
       "label": "Objection.js",
       "capabilities": {
         "migration_parsing": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go"],
+          "verified_at": "2026-05-28"
         },
         "model_extraction": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go","internal/engine/rules/javascript_typescript/orms/objection.yaml"],
+          "verified_at": "2026-05-28"
         },
         "query_attribution": {
           "status": "missing"
+        }
+      },
+      "framework_specific": {
+        "Objection Relation Graph": {
+          "relation_graph_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/objection.go","internal/custom/javascript/extractors_coverage_test.go"],
+            "verified_at": "2026-05-28",
+            "notes": "Objection's bespoke `static relationMappings` declaration (BelongsToOneRelation / HasManyRelation / ManyToManyRelation / HasOneThroughRelation) drives its eager-load + nested-mutation graph API (withGraphFetched / upsertGraph). No standard ORM cell (model_extraction / query_attribution / migration_parsing) captures this relation-graph topology, so it is recorded as a framework-specific capability. Each relation entry is emitted as a SCOPE.Component relation entity tagged with its relation_type."
+          }
         }
       }
     },
@@ -13219,8 +13240,8 @@
       "label": "Prisma",
       "capabilities": {
         "migration_parsing": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/prisma/_manifest.yaml"],
+          "status": "full",
+          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/prisma.go"],
           "verified_at": "2026-05-28"
         },
         "model_extraction": {
@@ -13242,7 +13263,9 @@
       "label": "Sequelize",
       "capabilities": {
         "migration_parsing": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/sequelize.go"],
+          "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",
@@ -13263,7 +13286,9 @@
       "label": "TypeORM",
       "capabilities": {
         "migration_parsing": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/typeorm.go"],
+          "verified_at": "2026-05-28"
         },
         "model_extraction": {
           "status": "full",

--- a/internal/custom/javascript/drizzle.go
+++ b/internal/custom/javascript/drizzle.go
@@ -1,0 +1,148 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_drizzle", &drizzleExtractor{})
+}
+
+type drizzleExtractor struct{}
+
+func (e *drizzleExtractor) Language() string { return "custom_js_drizzle" }
+
+var (
+	// export const users = pgTable("users", { ... }) — also mysqlTable/sqliteTable.
+	// First group = the JS const binding, second = the SQL table name.
+	reDrizzleTable = regexp.MustCompile(
+		`(?:export\s+)?const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(pgTable|mysqlTable|sqliteTable)\s*\(\s*['"]([A-Za-z0-9_.]+)['"]`,
+	)
+	// export const myEnum = pgEnum("role", [...])
+	reDrizzleEnum = regexp.MustCompile(
+		`(?:export\s+)?const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:pgEnum|mysqlEnum)\s*\(\s*['"]([A-Za-z0-9_.]+)['"]`,
+	)
+	// export const usersRelations = relations(users, ({ many }) => ({ ... }))
+	reDrizzleRelations = regexp.MustCompile(
+		`relations\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,`,
+	)
+	// drizzle(client) / drizzle(pool, { schema })
+	reDrizzleClient = regexp.MustCompile(
+		`\bdrizzle\s*\(`,
+	)
+)
+
+func (e *drizzleExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.drizzle_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "drizzle"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	// drizzle-kit emits raw SQL migration files (0000_xxx.sql). Parse those in
+	// addition to TS/JS schema definitions.
+	isSQLMigration := strings.HasSuffix(file.Path, ".sql") &&
+		strings.Contains(filepath.ToSlash(file.Path), "migrations/")
+	isDrizzleMigrationsDir := strings.Contains(filepath.ToSlash(file.Path), "drizzle/") &&
+		strings.HasSuffix(file.Path, ".sql")
+	sqlMode := isSQLMigration || isDrizzleMigrationsDir
+	if lang != "typescript" && lang != "javascript" && !sqlMode {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	if lang == "typescript" || lang == "javascript" {
+		// Table model definitions.
+		for _, m := range reDrizzleTable.FindAllStringSubmatchIndex(src, -1) {
+			binding := src[m[2]:m[3]]
+			builder := src[m[4]:m[5]]
+			table := src[m[6]:m[7]]
+			ent := makeEntity(table, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "drizzle", "binding", binding, "builder", builder,
+				"table", table, "provenance", "INFERRED_FROM_DRIZZLE_TABLE")
+			addEntity(ent)
+		}
+
+		// Enum definitions.
+		for _, m := range reDrizzleEnum.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[6]:m[7]]
+			ent := makeEntity(name, "SCOPE.Schema", "enum", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "drizzle", "provenance", "INFERRED_FROM_DRIZZLE_ENUM")
+			addEntity(ent)
+		}
+
+		// Relations.
+		for _, m := range reDrizzleRelations.FindAllStringSubmatchIndex(src, -1) {
+			model := src[m[2]:m[3]]
+			ent := makeEntity("relations:"+model, "SCOPE.Pattern", "relation", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "drizzle", "model", model,
+				"provenance", "INFERRED_FROM_DRIZZLE_RELATIONS")
+			addEntity(ent)
+		}
+
+		// drizzle() client.
+		for _, m := range reDrizzleClient.FindAllStringIndex(src, -1) {
+			ent := makeEntity("drizzle", "SCOPE.Service", "database", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "drizzle", "provenance", "INFERRED_FROM_DRIZZLE_CLIENT")
+			addEntity(ent)
+		}
+	}
+
+	// SQL migration DDL ops.
+	if sqlMode {
+		emit := func(subtype, target string, off int) {
+			ent := makeEntity(subtype+":"+target, "SCOPE.Evolution", subtype, file.Path, file.Language, lineOf(src, off))
+			setProps(&ent, "framework", "drizzle", "table", target,
+				"provenance", "INFERRED_FROM_DRIZZLE_MIGRATION_SQL")
+			addEntity(ent)
+		}
+		for _, m := range reSQLCreateTable.FindAllStringSubmatchIndex(src, -1) {
+			emit("create_table", src[m[2]:m[3]], m[0])
+		}
+		for _, m := range reSQLDropTable.FindAllStringSubmatchIndex(src, -1) {
+			emit("drop_table", src[m[2]:m[3]], m[0])
+		}
+		for _, m := range reSQLAlterTable.FindAllStringSubmatchIndex(src, -1) {
+			emit(alterTableOpSubtype(src[m[4]:m[5]]), src[m[2]:m[3]], m[0])
+		}
+		for _, m := range reSQLCreateIndex.FindAllStringSubmatchIndex(src, -1) {
+			emit("create_index", src[m[2]:m[3]], m[0])
+		}
+		for _, m := range reSQLDropIndex.FindAllStringSubmatchIndex(src, -1) {
+			emit("drop_index", src[m[2]:m[3]], m[0])
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/javascript/extractors_coverage_test.go
+++ b/internal/custom/javascript/extractors_coverage_test.go
@@ -568,6 +568,243 @@ func TestFastifyInstance(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ORM migration_parsing — issue #2861
+// ---------------------------------------------------------------------------
+
+func TestTypeORMMigrationOps(t *testing.T) {
+	src := `
+export class CreateUsers1700000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({ name: "users", columns: [] }))
+    await queryRunner.addColumn("users", new TableColumn({ name: "email" }))
+    await queryRunner.createIndex("users", new TableIndex({ name: "idx_email" }))
+  }
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn("users", "email")
+    await queryRunner.dropTable("users")
+  }
+}
+`
+	ents := extract(t, "custom_js_typeorm", fi("1700-create-users.ts", "typescript", src))
+	if !containsSubtype(ents, "migration") {
+		t.Error("expected migration class entity")
+	}
+	for _, st := range []string{"create_table", "add_column", "create_index", "drop_column", "drop_table"} {
+		if !containsSubtype(ents, st) {
+			t.Errorf("expected migration op subtype %q", st)
+		}
+	}
+	if !containsEntity(ents, "SCOPE.Evolution", "create_table:users") {
+		t.Error("expected create_table:users evolution entity with table name")
+	}
+}
+
+func TestSequelizeMigrationOps(t *testing.T) {
+	src := `
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Users', { id: { type: Sequelize.INTEGER } })
+    await queryInterface.addColumn('Users', 'email', { type: Sequelize.STRING })
+    await queryInterface.addIndex('Users', ['email'])
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Users', 'email')
+    await queryInterface.dropTable('Users')
+  }
+}
+`
+	ents := extract(t, "custom_js_sequelize", fi("20240101-users.js", "javascript", src))
+	for _, st := range []string{"create_table", "add_column", "create_index", "drop_column", "drop_table"} {
+		if !containsSubtype(ents, st) {
+			t.Errorf("expected migration op subtype %q", st)
+		}
+	}
+	if !containsEntity(ents, "SCOPE.Evolution", "create_table:Users") {
+		t.Error("expected create_table:Users evolution entity")
+	}
+}
+
+func TestPrismaMigrationSQL(t *testing.T) {
+	src := `
+CREATE TABLE "User" (
+    "id" SERIAL NOT NULL,
+    "email" TEXT NOT NULL
+);
+ALTER TABLE "User" ADD COLUMN "name" TEXT;
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+`
+	ents := extract(t, "custom_js_prisma", fi("prisma/migrations/20240101_init/migration.sql", "sql", src))
+	if !containsEntity(ents, "SCOPE.Evolution", "create_table:User") {
+		t.Error("expected create_table:User from prisma migration.sql")
+	}
+	if !containsSubtype(ents, "add_column") {
+		t.Error("expected add_column from ALTER TABLE")
+	}
+	if !containsSubtype(ents, "create_index") {
+		t.Error("expected create_index from CREATE UNIQUE INDEX")
+	}
+}
+
+func TestPrismaMigrationSQLNotTriggeredOnAppCode(t *testing.T) {
+	// A regular TS file with an embedded SQL string must NOT yield migration ops.
+	src := "const q = `CREATE TABLE foo (id int)`"
+	ents := extract(t, "custom_js_prisma", fi("src/db.ts", "typescript", src))
+	if containsSubtype(ents, "create_table") {
+		t.Error("CREATE TABLE in app TS should not be a prisma migration op")
+	}
+}
+
+func TestDrizzleModel(t *testing.T) {
+	src := `
+import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+export const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  email: text("email").notNull(),
+})
+export const usersRelations = relations(users, ({ many }) => ({ posts: many(posts) }))
+`
+	ents := extract(t, "custom_js_drizzle", fi("schema.ts", "typescript", src))
+	if !containsEntity(ents, "SCOPE.Schema", "users") {
+		t.Error("expected users table model")
+	}
+	if !containsSubtype(ents, "relation") {
+		t.Error("expected drizzle relations entity")
+	}
+}
+
+func TestDrizzleMigrationSQL(t *testing.T) {
+	src := `
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"email" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "name" text;
+`
+	ents := extract(t, "custom_js_drizzle", fi("drizzle/migrations/0000_init.sql", "sql", src))
+	if !containsEntity(ents, "SCOPE.Evolution", "create_table:users") {
+		t.Error("expected create_table:users from drizzle migration")
+	}
+	if !containsSubtype(ents, "add_column") {
+		t.Error("expected add_column from drizzle ALTER TABLE")
+	}
+}
+
+func TestKnexMigration(t *testing.T) {
+	src := `
+exports.up = function(knex) {
+  return knex.schema.createTable('users', (t) => {
+    t.increments('id')
+    t.string('email')
+    t.index(['email'])
+  })
+}
+exports.down = function(knex) {
+  return knex.schema.dropTable('users')
+}
+`
+	ents := extract(t, "custom_js_knex", fi("20240101_users.js", "javascript", src))
+	if !containsSubtype(ents, "migration") {
+		t.Error("expected migration up/down entity")
+	}
+	if !containsEntity(ents, "SCOPE.Evolution", "create_table:users") {
+		t.Error("expected create_table:users")
+	}
+	if !containsSubtype(ents, "drop_table") {
+		t.Error("expected drop_table")
+	}
+	if !containsSubtype(ents, "add_column") {
+		t.Error("expected add_column from column builders")
+	}
+}
+
+func TestMikroORMModelAndMigration(t *testing.T) {
+	model := `
+@Entity()
+export class User {
+  @PrimaryKey()
+  id!: number
+
+  @Property()
+  email!: string
+
+  @ManyToOne(() => Org)
+  org!: Org
+}
+`
+	ents := extract(t, "custom_js_mikroorm", fi("user.entity.ts", "typescript", model))
+	if !containsEntity(ents, "SCOPE.Schema", "User") {
+		t.Error("expected User entity")
+	}
+	if !containsSubtype(ents, "field") {
+		t.Error("expected @Property field entity")
+	}
+	if !containsSubtype(ents, "relation") {
+		t.Error("expected @ManyToOne relation entity")
+	}
+
+	mig := `
+import { Migration } from '@mikro-orm/migrations'
+export class Migration20240101 extends Migration {
+  async up(): Promise<void> {
+    this.addSql('CREATE TABLE "user" ("id" serial primary key, "email" varchar);')
+    this.addSql('ALTER TABLE "user" ADD COLUMN "name" varchar;')
+  }
+}
+`
+	ments := extract(t, "custom_js_mikroorm", fi("Migration20240101.ts", "typescript", mig))
+	if !containsSubtype(ments, "migration") {
+		t.Error("expected migration class entity")
+	}
+	if !containsEntity(ments, "SCOPE.Evolution", "create_table:user") {
+		t.Error("expected create_table:user from addSql")
+	}
+	if !containsSubtype(ments, "add_column") {
+		t.Error("expected add_column from addSql ALTER TABLE")
+	}
+}
+
+func TestObjectionModelAndMigration(t *testing.T) {
+	model := `
+const { Model } = require('objection')
+class Person extends Model {
+  static get tableName() { return 'persons' }
+  static get jsonSchema() { return { type: 'object', properties: { name: { type: 'string' } } } }
+  static get relationMappings() {
+    return {
+      pets: { relation: Model.HasManyRelation, modelClass: Pet },
+    }
+  }
+}
+`
+	ents := extract(t, "custom_js_objection", fi("person.model.js", "javascript", model))
+	if !containsEntity(ents, "SCOPE.Schema", "Person") {
+		t.Error("expected Person model")
+	}
+	if !containsSubtype(ents, "json_schema") {
+		t.Error("expected jsonSchema entity")
+	}
+	if !containsSubtype(ents, "relation_mappings") {
+		t.Error("expected relationMappings entity")
+	}
+	if !containsSubtype(ents, "relation") {
+		t.Error("expected individual relation entity")
+	}
+
+	mig := `
+exports.up = (knex) => knex.schema.createTable('persons', (t) => { t.increments('id') })
+exports.down = (knex) => knex.schema.dropTable('persons')
+`
+	ments := extract(t, "custom_js_objection", fi("20240101_persons.js", "javascript", mig))
+	if !containsEntity(ments, "SCOPE.Evolution", "create_table:persons") {
+		t.Error("expected create_table:persons from objection/knex migration")
+	}
+	if !containsSubtype(ments, "drop_table") {
+		t.Error("expected drop_table")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Wrong language guard — one per key extractor
 // ---------------------------------------------------------------------------
 

--- a/internal/custom/javascript/knex.go
+++ b/internal/custom/javascript/knex.go
@@ -1,0 +1,146 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_knex", &knexExtractor{})
+}
+
+type knexExtractor struct{}
+
+func (e *knexExtractor) Language() string { return "custom_js_knex" }
+
+var (
+	// knex.schema.createTable('users', ...) and friends. The leading receiver
+	// is commonly `knex.schema`, `this.schema`, or a destructured `schema`.
+	// Group 1 = method, group 2 = table name literal.
+	reKnexSchemaOp = regexp.MustCompile(
+		`\.\s*(createTable|createTableIfNotExists|dropTable|dropTableIfExists|renameTable|alterTable|table)\s*\(\s*['"]([A-Za-z0-9_.]+)['"]`,
+	)
+	// Column builder calls inside a table closure: t.string('name'), t.integer('age').
+	reKnexColumnBuilder = regexp.MustCompile(
+		`\.\s*(increments|bigIncrements|integer|bigInteger|text|string|float|decimal|boolean|date|datetime|timestamp|time|binary|json|jsonb|uuid|enu|enum|uuid)\s*\(\s*['"]([A-Za-z0-9_]+)['"]`,
+	)
+	// Index ops: t.index([...]), t.unique('col'), t.dropIndex(...).
+	reKnexIndexOp = regexp.MustCompile(
+		`\.\s*(index|unique|dropIndex|dropUnique)\s*\(`,
+	)
+	// exports.up / export async function up / export const up — migration entry points.
+	reKnexMigrationFn = regexp.MustCompile(
+		`(?:exports\.(up|down)\s*=|export\s+(?:async\s+)?function\s+(up|down)\b|export\s+const\s+(up|down)\s*=)`,
+	)
+)
+
+func knexSchemaOpSubtype(method string) string {
+	switch method {
+	case "createTable", "createTableIfNotExists":
+		return "create_table"
+	case "dropTable", "dropTableIfExists":
+		return "drop_table"
+	case "renameTable":
+		return "rename_table"
+	case "alterTable", "table":
+		return "alter_table"
+	default:
+		return "schema_change"
+	}
+}
+
+func (e *knexExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.knex_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "knex"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// Migration up()/down() entry points.
+	for _, m := range reKnexMigrationFn.FindAllStringSubmatchIndex(src, -1) {
+		var dir string
+		for i := 2; i+1 < len(m); i += 2 {
+			if m[i] >= 0 {
+				dir = src[m[i]:m[i+1]]
+				break
+			}
+		}
+		if dir == "" {
+			continue
+		}
+		ent := makeEntity("migration:"+dir, "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "knex", "direction", dir,
+			"provenance", "INFERRED_FROM_KNEX_MIGRATION_FN")
+		addEntity(ent)
+	}
+
+	// Schema-builder ops.
+	for _, m := range reKnexSchemaOp.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		table := src[m[4]:m[5]]
+		opSubtype := knexSchemaOpSubtype(method)
+		ent := makeEntity(opSubtype+":"+table, "SCOPE.Evolution", opSubtype, file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "knex", "migration_op", method, "table", table,
+			"provenance", "INFERRED_FROM_KNEX_SCHEMA_OP")
+		addEntity(ent)
+	}
+
+	// Column builders (attribute columns added by a migration).
+	for _, m := range reKnexColumnBuilder.FindAllStringSubmatchIndex(src, -1) {
+		colType := src[m[2]:m[3]]
+		colName := src[m[4]:m[5]]
+		ent := makeEntity("add_column:"+colName, "SCOPE.Evolution", "add_column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "knex", "column", colName, "column_type", colType,
+			"provenance", "INFERRED_FROM_KNEX_COLUMN_BUILDER")
+		addEntity(ent)
+	}
+
+	// Index ops.
+	for _, m := range reKnexIndexOp.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		subtype := "create_index"
+		if strings.HasPrefix(method, "drop") {
+			subtype = "drop_index"
+		}
+		ent := makeEntity(subtype+":"+method, "SCOPE.Evolution", subtype, file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "knex", "migration_op", method,
+			"provenance", "INFERRED_FROM_KNEX_INDEX_OP")
+		addEntity(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/javascript/mikroorm.go
+++ b/internal/custom/javascript/mikroorm.go
@@ -1,0 +1,165 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_mikroorm", &mikroORMExtractor{})
+}
+
+type mikroORMExtractor struct{}
+
+func (e *mikroORMExtractor) Language() string { return "custom_js_mikroorm" }
+
+var (
+	// @Entity() class User {} — also @Entity({ tableName: 'users' }).
+	reMikroEntity = regexp.MustCompile(
+		`@Entity\s*\([^@]*?\)\s*(?:export\s+)?(?:abstract\s+)?class\s+([A-Z][A-Za-z0-9_]*)`,
+	)
+	// @Embeddable() class Address {}
+	reMikroEmbeddable = regexp.MustCompile(
+		`@Embeddable\s*\(\s*\)\s*(?:export\s+)?class\s+([A-Z][A-Za-z0-9_]*)`,
+	)
+	// @Property() / @PrimaryKey() / @Enum() field declarations.
+	reMikroProperty = regexp.MustCompile(
+		`@(Property|PrimaryKey|Enum|Unique|Formula)\s*\([^@]*?\)\s+(\w+)`,
+	)
+	// @ManyToOne / @OneToMany / @OneToOne / @ManyToMany relations.
+	reMikroRelation = regexp.MustCompile(
+		`@(ManyToOne|OneToMany|OneToOne|ManyToMany)\s*\([^@]*?\)\s+(\w+)`,
+	)
+	// MikroORM migration class: class Migration20240101 extends Migration {}
+	reMikroMigrationClass = regexp.MustCompile(
+		`(?:export\s+)?class\s+([A-Za-z0-9_]+)\s+extends\s+Migration\b`,
+	)
+	// this.addSql('...') / this.addSql("...") / this.addSql(`...`) — raw SQL DDL
+	// inside a migration. Each alternative captures the body up to the matching
+	// closing quote so SQL containing the other quote styles is preserved.
+	reMikroAddSql = regexp.MustCompile(
+		"this\\s*\\.\\s*addSql\\s*\\(\\s*(?:'([^']*)'|\"([^\"]*)\"|`([^`]*)`)",
+	)
+)
+
+func (e *mikroORMExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.mikroorm_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "mikro-orm"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// @Entity classes.
+	for _, m := range reMikroEntity.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Schema", "entity", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "mikro-orm", "provenance", "INFERRED_FROM_MIKROORM_ENTITY")
+		addEntity(ent)
+	}
+
+	// @Embeddable classes.
+	for _, m := range reMikroEmbeddable.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Schema", "embeddable", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "mikro-orm", "provenance", "INFERRED_FROM_MIKROORM_EMBEDDABLE")
+		addEntity(ent)
+	}
+
+	// @Property / @PrimaryKey / @Enum fields.
+	for _, m := range reMikroProperty.FindAllStringSubmatchIndex(src, -1) {
+		decorator := src[m[2]:m[3]]
+		fieldName := src[m[4]:m[5]]
+		ent := makeEntity(fieldName, "SCOPE.Component", "field", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "mikro-orm", "decorator", decorator, "field_name", fieldName,
+			"provenance", "INFERRED_FROM_MIKROORM_PROPERTY")
+		addEntity(ent)
+	}
+
+	// Relations.
+	for _, m := range reMikroRelation.FindAllStringSubmatchIndex(src, -1) {
+		relType := src[m[2]:m[3]]
+		fieldName := src[m[4]:m[5]]
+		ent := makeEntity(relType+":"+fieldName, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "mikro-orm", "relation_type", relType, "field_name", fieldName,
+			"provenance", "INFERRED_FROM_MIKROORM_RELATION")
+		addEntity(ent)
+	}
+
+	// Migration classes.
+	isMigration := false
+	for _, m := range reMikroMigrationClass.FindAllStringSubmatchIndex(src, -1) {
+		isMigration = true
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "mikro-orm", "provenance", "INFERRED_FROM_MIKROORM_MIGRATION")
+		addEntity(ent)
+	}
+
+	// addSql() raw DDL — only treat as migration ops within a migration class.
+	if isMigration {
+		for _, m := range reMikroAddSql.FindAllStringSubmatchIndex(src, -1) {
+			sqlText := ""
+			for g := 2; g+1 < len(m); g += 2 {
+				if m[g] >= 0 {
+					sqlText = src[m[g]:m[g+1]]
+					break
+				}
+			}
+			off := m[0]
+			emit := func(subtype, target string) {
+				ent := makeEntity(subtype+":"+target, "SCOPE.Evolution", subtype, file.Path, file.Language, lineOf(src, off))
+				setProps(&ent, "framework", "mikro-orm", "table", target,
+					"provenance", "INFERRED_FROM_MIKROORM_ADDSQL")
+				addEntity(ent)
+			}
+			if cm := reSQLCreateTable.FindStringSubmatch(sqlText); cm != nil {
+				emit("create_table", cm[1])
+			}
+			if cm := reSQLDropTable.FindStringSubmatch(sqlText); cm != nil {
+				emit("drop_table", cm[1])
+			}
+			if cm := reSQLAlterTable.FindStringSubmatch(sqlText); cm != nil {
+				emit(alterTableOpSubtype(cm[2]), cm[1])
+			}
+			if cm := reSQLCreateIndex.FindStringSubmatch(sqlText); cm != nil {
+				emit("create_index", cm[1])
+			}
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/javascript/objection.go
+++ b/internal/custom/javascript/objection.go
@@ -1,0 +1,132 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_objection", &objectionExtractor{})
+}
+
+type objectionExtractor struct{}
+
+func (e *objectionExtractor) Language() string { return "custom_js_objection" }
+
+var (
+	// class User extends Model {} — Objection models subclass Model.
+	reObjectionModel = regexp.MustCompile(
+		`(?:export\s+)?(?:default\s+)?class\s+([A-Z][A-Za-z0-9_]*)\s+extends\s+Model\b`,
+	)
+	// static get tableName() { return 'users' } — binds a model to its table.
+	reObjectionTableName = regexp.MustCompile(
+		`static\s+get\s+tableName\s*\(\s*\)\s*\{[^}]*return\s+['"]([A-Za-z0-9_.]+)['"]`,
+	)
+	// static get jsonSchema() — JSON-schema based field definitions.
+	reObjectionJSONSchema = regexp.MustCompile(
+		`static\s+get\s+jsonSchema\s*\(\s*\)`,
+	)
+	// static get relationMappings() — relation declarations.
+	reObjectionRelationMappings = regexp.MustCompile(
+		`static\s+(?:get\s+)?relationMappings\b`,
+	)
+	// Individual relation entries inside relationMappings: `friends: { relation: Model.HasManyRelation`.
+	reObjectionRelation = regexp.MustCompile(
+		`([A-Za-z_][A-Za-z0-9_]*)\s*:\s*\{[^}]*relation\s*:\s*Model\s*\.\s*(BelongsToOneRelation|HasManyRelation|HasOneRelation|ManyToManyRelation|HasOneThroughRelation)`,
+	)
+)
+
+func (e *objectionExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.objection_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "objection"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// Model classes (extends Model). Capture an optional bound table name.
+	tableName := ""
+	if tm := reObjectionTableName.FindStringSubmatch(src); tm != nil {
+		tableName = tm[1]
+	}
+	for _, m := range reObjectionModel.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "objection", "provenance", "INFERRED_FROM_OBJECTION_MODEL")
+		if tableName != "" {
+			setProps(&ent, "table", tableName)
+		}
+		addEntity(ent)
+	}
+
+	// jsonSchema field-set marker.
+	for _, m := range reObjectionJSONSchema.FindAllStringIndex(src, -1) {
+		ent := makeEntity("jsonSchema", "SCOPE.Component", "json_schema", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "objection", "provenance", "INFERRED_FROM_OBJECTION_JSON_SCHEMA")
+		addEntity(ent)
+	}
+
+	// relationMappings.
+	for _, m := range reObjectionRelationMappings.FindAllStringIndex(src, -1) {
+		ent := makeEntity("relationMappings", "SCOPE.Pattern", "relation_mappings", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "objection", "provenance", "INFERRED_FROM_OBJECTION_RELATION_MAPPINGS")
+		addEntity(ent)
+	}
+
+	// Individual relations.
+	for _, m := range reObjectionRelation.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		relType := src[m[4]:m[5]]
+		ent := makeEntity(relType+":"+field, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "objection", "relation_type", relType, "field_name", field,
+			"provenance", "INFERRED_FROM_OBJECTION_RELATION")
+		addEntity(ent)
+	}
+
+	// Migration schema-change ops. Objection runs migrations through Knex, so a
+	// migration file uses the same schema-builder DSL (knex.schema.createTable).
+	for _, m := range reKnexSchemaOp.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		table := src[m[4]:m[5]]
+		opSubtype := knexSchemaOpSubtype(method)
+		ent := makeEntity(opSubtype+":"+table, "SCOPE.Evolution", opSubtype, file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "objection", "migration_op", method, "table", table,
+			"provenance", "INFERRED_FROM_OBJECTION_MIGRATION_OP")
+		addEntity(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/javascript/prisma.go
+++ b/internal/custom/javascript/prisma.go
@@ -3,6 +3,7 @@ package javascript
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -51,7 +52,40 @@ var (
 	rePrismaMiddleware = regexp.MustCompile(
 		`(?:prisma|db)\s*\.\s*\$use\s*\(`,
 	)
+	// Raw SQL DDL ops inside Prisma migration.sql files. Prisma emits
+	// migrations as plain SQL under prisma/migrations/<ts>/migration.sql.
+	reSQLCreateTable = regexp.MustCompile(
+		`(?i)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["` + "`" + `']?([A-Za-z0-9_.]+)["` + "`" + `']?`,
+	)
+	reSQLDropTable = regexp.MustCompile(
+		`(?i)DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?["` + "`" + `']?([A-Za-z0-9_.]+)["` + "`" + `']?`,
+	)
+	reSQLAlterTable = regexp.MustCompile(
+		`(?i)ALTER\s+TABLE\s+["` + "`" + `']?([A-Za-z0-9_.]+)["` + "`" + `']?\s+(ADD|DROP|ALTER|RENAME|MODIFY|CHANGE)`,
+	)
+	reSQLCreateIndex = regexp.MustCompile(
+		`(?i)CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?["` + "`" + `']?([A-Za-z0-9_.]+)["` + "`" + `']?`,
+	)
+	reSQLDropIndex = regexp.MustCompile(
+		`(?i)DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?["` + "`" + `']?([A-Za-z0-9_.]+)["` + "`" + `']?`,
+	)
 )
+
+// alterTableOpSubtype maps an ALTER TABLE clause keyword to a schema-change subtype.
+func alterTableOpSubtype(clause string) string {
+	switch strings.ToUpper(clause) {
+	case "ADD":
+		return "add_column"
+	case "DROP":
+		return "drop_column"
+	case "ALTER", "MODIFY", "CHANGE":
+		return "alter_column"
+	case "RENAME":
+		return "rename_column"
+	default:
+		return "alter_table"
+	}
+}
 
 func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/javascript")
@@ -70,9 +104,12 @@ func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 	src := string(file.Content)
 	lang := strings.ToLower(file.Language)
 	// Prisma schema files are not JS/TS but we still extract from .prisma files
-	// by checking both JS/TS and .prisma extension.
+	// by checking both JS/TS and .prisma extension. Prisma migrations are raw
+	// SQL files under prisma/migrations/<ts>/migration.sql; parse those too.
 	isPrismaSchema := strings.HasSuffix(file.Path, ".prisma")
-	if lang != "typescript" && lang != "javascript" && !isPrismaSchema {
+	isPrismaMigration := strings.HasSuffix(file.Path, "migration.sql") &&
+		strings.Contains(filepath.ToSlash(file.Path), "migrations/")
+	if lang != "typescript" && lang != "javascript" && !isPrismaSchema && !isPrismaMigration {
 		return nil, nil
 	}
 
@@ -140,6 +177,34 @@ func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 		ent := makeEntity("$use", "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "prisma", "provenance", "INFERRED_FROM_PRISMA_MIDDLEWARE")
 		addEntity(ent)
+	}
+
+	// Migration SQL DDL ops — only for migration.sql files so we don't treat
+	// raw SQL embedded in application TS/JS as Prisma migrations.
+	if isPrismaMigration {
+		emitSQLMigrationOp := func(subtype, target string, off int) {
+			ent := makeEntity(subtype+":"+target, "SCOPE.Evolution", subtype, file.Path, file.Language, lineOf(src, off))
+			setProps(&ent, "framework", "prisma", "table", target,
+				"provenance", "INFERRED_FROM_PRISMA_MIGRATION_SQL")
+			addEntity(ent)
+		}
+		for _, m := range reSQLCreateTable.FindAllStringSubmatchIndex(src, -1) {
+			emitSQLMigrationOp("create_table", src[m[2]:m[3]], m[0])
+		}
+		for _, m := range reSQLDropTable.FindAllStringSubmatchIndex(src, -1) {
+			emitSQLMigrationOp("drop_table", src[m[2]:m[3]], m[0])
+		}
+		for _, m := range reSQLAlterTable.FindAllStringSubmatchIndex(src, -1) {
+			table := src[m[2]:m[3]]
+			clause := src[m[4]:m[5]]
+			emitSQLMigrationOp(alterTableOpSubtype(clause), table, m[0])
+		}
+		for _, m := range reSQLCreateIndex.FindAllStringSubmatchIndex(src, -1) {
+			emitSQLMigrationOp("create_index", src[m[2]:m[3]], m[0])
+		}
+		for _, m := range reSQLDropIndex.FindAllStringSubmatchIndex(src, -1) {
+			emitSQLMigrationOp("drop_index", src[m[2]:m[3]], m[0])
+		}
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))

--- a/internal/custom/javascript/sequelize.go
+++ b/internal/custom/javascript/sequelize.go
@@ -51,7 +51,47 @@ var (
 	reSequelizeHook = regexp.MustCompile(
 		`([A-Z][A-Za-z0-9_]*)\s*\.\s*(addHook|beforeCreate|afterCreate|beforeUpdate|afterUpdate|beforeDestroy|afterDestroy|beforeFind|afterFind|beforeBulkCreate|afterBulkCreate)\s*\(`,
 	)
+	// Migration schema-change ops via the queryInterface inside up()/down().
+	// First captured group = method, second = the table name string literal.
+	reSequelizeMigrationOp = regexp.MustCompile(
+		`queryInterface\s*\.\s*(createTable|dropTable|renameTable|addColumn|removeColumn|changeColumn|renameColumn|addIndex|removeIndex|addConstraint|removeConstraint|bulkInsert|bulkDelete)\s*\(\s*['"]([A-Za-z0-9_.]+)['"]`,
+	)
 )
+
+// sequelizeMigrationOpSubtype normalizes a queryInterface method to a shared
+// schema-change op subtype.
+func sequelizeMigrationOpSubtype(method string) string {
+	switch method {
+	case "createTable":
+		return "create_table"
+	case "dropTable":
+		return "drop_table"
+	case "renameTable":
+		return "rename_table"
+	case "addColumn":
+		return "add_column"
+	case "removeColumn":
+		return "drop_column"
+	case "changeColumn":
+		return "alter_column"
+	case "renameColumn":
+		return "rename_column"
+	case "addIndex":
+		return "create_index"
+	case "removeIndex":
+		return "drop_index"
+	case "addConstraint":
+		return "add_constraint"
+	case "removeConstraint":
+		return "drop_constraint"
+	case "bulkInsert":
+		return "data_insert"
+	case "bulkDelete":
+		return "data_delete"
+	default:
+		return "schema_change"
+	}
+}
 
 func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/javascript")
@@ -153,6 +193,17 @@ func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		ent := makeEntity(name, "SCOPE.Pattern", "lifecycle_hook", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "sequelize", "model_name", modelName, "hook_type", hookType,
 			"provenance", "INFERRED_FROM_SEQUELIZE_HOOK")
+		addEntity(ent)
+	}
+
+	// Migration schema-change operations (queryInterface.*).
+	for _, m := range reSequelizeMigrationOp.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		table := src[m[4]:m[5]]
+		opSubtype := sequelizeMigrationOpSubtype(method)
+		ent := makeEntity(opSubtype+":"+table, "SCOPE.Evolution", opSubtype, file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "sequelize", "migration_op", method, "table", table,
+			"provenance", "INFERRED_FROM_SEQUELIZE_MIGRATION_OP")
 		addEntity(ent)
 	}
 

--- a/internal/custom/javascript/typeorm.go
+++ b/internal/custom/javascript/typeorm.go
@@ -61,7 +61,77 @@ var (
 	reTypeORMQueryBuilder = regexp.MustCompile(
 		`createQueryBuilder\s*\(\s*['"]([A-Za-z0-9_]+)['"]`,
 	)
+	// Migration schema-change ops inside up()/down(): queryRunner.createTable,
+	// addColumn, dropColumn, dropTable, createIndex, etc.
+	reTypeORMMigrationOp = regexp.MustCompile(
+		`queryRunner\s*\.\s*(createTable|dropTable|renameTable|addColumn|addColumns|dropColumn|dropColumns|changeColumn|renameColumn|createIndex|dropIndex|createForeignKey|dropForeignKey|createPrimaryKey|dropPrimaryKey|createUniqueConstraint|dropUniqueConstraint|createCheckConstraint|dropCheckConstraint)\s*\(`,
+	)
+	// new Table({ name: "users" }) target inside a migration op.
+	reTypeORMMigrationTable = regexp.MustCompile(
+		`new\s+Table\s*\(\s*\{\s*name\s*:\s*['"]([A-Za-z0-9_.]+)['"]`,
+	)
 )
+
+// typeormMigrationOpSubtype maps a queryRunner method name to a normalized
+// schema-change op subtype shared across ORM migration extractors.
+func typeormMigrationOpSubtype(method string) string {
+	switch method {
+	case "createTable":
+		return "create_table"
+	case "dropTable":
+		return "drop_table"
+	case "renameTable":
+		return "rename_table"
+	case "addColumn", "addColumns":
+		return "add_column"
+	case "dropColumn", "dropColumns":
+		return "drop_column"
+	case "changeColumn":
+		return "alter_column"
+	case "renameColumn":
+		return "rename_column"
+	case "createIndex":
+		return "create_index"
+	case "dropIndex":
+		return "drop_index"
+	case "createForeignKey":
+		return "add_foreign_key"
+	case "dropForeignKey":
+		return "drop_foreign_key"
+	case "createPrimaryKey":
+		return "add_primary_key"
+	case "dropPrimaryKey":
+		return "drop_primary_key"
+	case "createUniqueConstraint":
+		return "add_unique_constraint"
+	case "dropUniqueConstraint":
+		return "drop_unique_constraint"
+	case "createCheckConstraint":
+		return "add_check_constraint"
+	case "dropCheckConstraint":
+		return "drop_check_constraint"
+	default:
+		return "schema_change"
+	}
+}
+
+// typeormMigrationOpTable extracts a table name from the first argument of a
+// queryRunner migration op. Handles both a bare string literal
+// (`dropTable("users")`) and a `new Table({ name: "users" })` object.
+func typeormMigrationOpTable(window string) string {
+	if m := reTypeORMMigrationTable.FindStringSubmatch(window); m != nil {
+		return m[1]
+	}
+	// Bare string-literal first arg: `(  "users"` or `( 'users'`.
+	trimmed := strings.TrimLeft(window, " \t\n\r")
+	if len(trimmed) > 0 && (trimmed[0] == '"' || trimmed[0] == '\'') {
+		q := trimmed[0]
+		if end := strings.IndexByte(trimmed[1:], q); end >= 0 {
+			return trimmed[1 : 1+end]
+		}
+	}
+	return ""
+}
 
 func (e *typeormExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/javascript")
@@ -179,6 +249,28 @@ func (e *typeormExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		ent := makeEntity(name, "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "typeorm", "alias", alias,
 			"provenance", "INFERRED_FROM_TYPEORM_QUERY_BUILDER")
+		addEntity(ent)
+	}
+
+	// Migration schema-change operations (queryRunner.*). Each op becomes a
+	// SCOPE.Evolution entity carrying the normalized change kind so downstream
+	// tooling can reconstruct the schema delta a migration applies.
+	for _, m := range reTypeORMMigrationOp.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		opSubtype := typeormMigrationOpSubtype(method)
+		// Look ahead a small window to capture an inline table name argument.
+		window := src[m[1]:min(len(src), m[1]+200)]
+		table := typeormMigrationOpTable(window)
+		name := opSubtype
+		if table != "" {
+			name = opSubtype + ":" + table
+		}
+		ent := makeEntity(name, "SCOPE.Evolution", opSubtype, file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "typeorm", "migration_op", method,
+			"provenance", "INFERRED_FROM_TYPEORM_MIGRATION_OP")
+		if table != "" {
+			setProps(&ent, "table", table)
+		}
 		addEntity(ent)
 	}
 

--- a/internal/engine/rules/javascript_typescript/orms/objection.yaml
+++ b/internal/engine/rules/javascript_typescript/orms/objection.yaml
@@ -1,0 +1,26 @@
+orms_and_database:
+  name: objection
+  npm_packages:
+  - objection
+  config_files:
+  - knexfile.js
+  - knexfile.ts
+  detection_signals:
+    package_json_deps:
+    - objection
+    import_patterns:
+    - from 'objection'
+    - require('objection')
+  code_patterns:
+  - extends Model
+  - static get tableName
+  - static get jsonSchema
+  - static get relationMappings
+  notes: Active-record style ORM built on top of Knex; models subclass Model and
+    declare tableName/jsonSchema/relationMappings. Migrations reuse the Knex schema
+    builder.
+  custom_extractors:
+  - module: archigraph.internal.custom.javascript.objection
+    callable: Extract
+    frameworks:
+    - objection

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -43,6 +43,13 @@ var customPrefixForLanguage = map[string]string{
 	"go":         "custom_go_",
 	"javascript": "custom_js_",
 	"typescript": "custom_js_", // TS reuses the JS framework extractor set
+	// Prisma schema files (.prisma) and raw SQL migration files (.sql) are
+	// classified as their own languages but carry ORM model/migration content
+	// the JS custom extractors parse (Prisma model DSL, Prisma/Drizzle
+	// migration SQL). Route them to the JS extractor set; each extractor
+	// path/language-gates internally and no-ops on files it does not own.
+	"prisma": "custom_js_",
+	"sql":    "custom_js_",
 	"java":       "custom_java_",
 	"kotlin":     "custom_kotlin_",
 	"scala":      "custom_scala_",

--- a/internal/extractors/zz_orm_realdata_test.go
+++ b/internal/extractors/zz_orm_realdata_test.go
@@ -1,0 +1,74 @@
+package extractors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// TestORMRealDataCorpus walks an on-disk multi-file ORM corpus and runs the
+// full custom-extractor dispatch pipeline (RunCustomExtractors + dispatch +
+// language detection by extension) against it. This is the real-data check for
+// issue #2861 — distinct from the in-package unit fixtures, it exercises the
+// disk-backed dispatch path the daemon uses, including the prisma/sql →
+// custom_js_ language routing. Defaults to the in-repo fixture corpus; set
+// ORM_CORPUS to point at a different corpus dir.
+func TestORMRealDataCorpus(t *testing.T) {
+	root := os.Getenv("ORM_CORPUS")
+	if root == "" {
+		// Repo-root testdata/fixtures/orm_corpus, relative to this package dir
+		// (internal/extractors/) which is the test's working directory.
+		root = filepath.Join("..", "..", "testdata", "fixtures", "orm_corpus")
+	}
+	langByExt := map[string]string{
+		".ts":     "typescript",
+		".js":     "javascript",
+		".sql":    "sql",
+		".prisma": "prisma",
+	}
+	type want struct{ subtype, table string }
+	got := map[string]int{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		lang := langByExt[strings.ToLower(filepath.Ext(path))]
+		if lang == "" {
+			return nil
+		}
+		content, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		ents, _ := RunCustomExtractors(context.Background(), FileInput{Path: path, Language: lang, Content: content})
+		for _, e := range ents {
+			if e.Kind == "SCOPE.Evolution" {
+				got[e.Properties["framework"]+"/"+e.Subtype]++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every ORM must yield at least its create/drop table schema-change ops.
+	for _, w := range []want{
+		{"prisma/create_table", ""},
+		{"drizzle/create_table", ""},
+		{"sequelize/create_table", ""},
+		{"typeorm/create_table", ""},
+		{"knex/create_table", ""},
+		{"mikro-orm/create_table", ""},
+		{"objection/create_table", ""},
+	} {
+		if got[w.subtype] == 0 {
+			t.Errorf("real-data corpus: no migration op %q emitted", w.subtype)
+		} else {
+			t.Logf("real-data corpus: %s x%d", w.subtype, got[w.subtype])
+		}
+	}
+}

--- a/testdata/fixtures/orm_corpus/drizzle/migrations/0000_init.sql
+++ b/testdata/fixtures/orm_corpus/drizzle/migrations/0000_init.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "users" ("id" serial PRIMARY KEY NOT NULL, "email" text);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "name" text;

--- a/testdata/fixtures/orm_corpus/drizzle/schema.ts
+++ b/testdata/fixtures/orm_corpus/drizzle/schema.ts
@@ -1,0 +1,3 @@
+import { pgTable, serial, text } from 'drizzle-orm/pg-core'
+export const users = pgTable("users", { id: serial("id").primaryKey(), email: text("email") })
+export const usersRelations = relations(users, ({ many }) => ({ posts: many(posts) }))

--- a/testdata/fixtures/orm_corpus/knex/migrations/20240101_users.js
+++ b/testdata/fixtures/orm_corpus/knex/migrations/20240101_users.js
@@ -1,0 +1,2 @@
+exports.up = (knex) => knex.schema.createTable('users', (t) => { t.increments('id'); t.string('email'); t.index(['email']) })
+exports.down = (knex) => knex.schema.dropTable('users')

--- a/testdata/fixtures/orm_corpus/mikroorm/User.ts
+++ b/testdata/fixtures/orm_corpus/mikroorm/User.ts
@@ -1,0 +1,2 @@
+@Entity()
+export class User { @PrimaryKey() id!: number; @Property() email!: string; @ManyToOne(() => Org) org!: Org }

--- a/testdata/fixtures/orm_corpus/mikroorm/migrations/Migration20240101.ts
+++ b/testdata/fixtures/orm_corpus/mikroorm/migrations/Migration20240101.ts
@@ -1,0 +1,4 @@
+import { Migration } from '@mikro-orm/migrations'
+export class Migration20240101 extends Migration {
+  async up() { this.addSql('CREATE TABLE "user" ("id" serial primary key);'); this.addSql('ALTER TABLE "user" ADD COLUMN "name" varchar;') }
+}

--- a/testdata/fixtures/orm_corpus/objection/migrations/20240101_persons.js
+++ b/testdata/fixtures/orm_corpus/objection/migrations/20240101_persons.js
@@ -1,0 +1,2 @@
+exports.up = (knex) => knex.schema.createTable('persons', (t) => { t.increments('id') })
+exports.down = (knex) => knex.schema.dropTable('persons')

--- a/testdata/fixtures/orm_corpus/objection/models/Person.js
+++ b/testdata/fixtures/orm_corpus/objection/models/Person.js
@@ -1,0 +1,6 @@
+const { Model } = require('objection')
+class Person extends Model {
+  static get tableName() { return 'persons' }
+  static get jsonSchema() { return { type: 'object', properties: { name: { type: 'string' } } } }
+  static get relationMappings() { return { pets: { relation: Model.HasManyRelation, modelClass: Pet } } }
+}

--- a/testdata/fixtures/orm_corpus/prisma/migrations/20240101_init/migration.sql
+++ b/testdata/fixtures/orm_corpus/prisma/migrations/20240101_init/migration.sql
@@ -1,0 +1,3 @@
+CREATE TABLE "User" ("id" SERIAL NOT NULL, "email" TEXT NOT NULL, CONSTRAINT "User_pkey" PRIMARY KEY ("id"));
+ALTER TABLE "User" ADD COLUMN "name" TEXT;
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/testdata/fixtures/orm_corpus/sequelize/migrations/20240101-users.js
+++ b/testdata/fixtures/orm_corpus/sequelize/migrations/20240101-users.js
@@ -1,0 +1,7 @@
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Users', { id: { type: Sequelize.INTEGER } })
+    await queryInterface.addColumn('Users', 'email', { type: Sequelize.STRING })
+  },
+  async down(queryInterface) { await queryInterface.dropTable('Users') }
+}

--- a/testdata/fixtures/orm_corpus/typeorm/migrations/1700-users.ts
+++ b/testdata/fixtures/orm_corpus/typeorm/migrations/1700-users.ts
@@ -1,0 +1,7 @@
+export class CreateUsers1700 implements MigrationInterface {
+  async up(queryRunner) {
+    await queryRunner.createTable(new Table({ name: "users", columns: [] }))
+    await queryRunner.addColumn("users", new TableColumn({ name: "email" }))
+  }
+  async down(queryRunner) { await queryRunner.dropTable("users") }
+}


### PR DESCRIPTION
Closes #2861 (part of epic #2847).

## Summary
Implements **migration_parsing** for all seven JS/TS ORMs and completes **model_extraction** for MikroORM and Objection.js. Each migration op is emitted as a `SCOPE.Evolution` entity (already a registered Kind — no new Kind needed), with schema-change subtypes normalized across ORMs (`create_table`, `add_column`, `drop_column`, `alter_column`, `create_index`, `drop_index`, ...).

### migration_parsing (B-gap — was genuinely unimplemented)
- **TypeORM** (`internal/custom/javascript/typeorm.go`): `queryRunner.createTable/addColumn/dropColumn/createIndex/...` ops inside `up()`/`down()`, with inline `new Table({name})`/string-literal table attribution.
- **Sequelize** (`sequelize.go`): `queryInterface.createTable/addColumn/addIndex/removeColumn/dropTable/...`.
- **Prisma** (`prisma.go`, partial→full): raw SQL DDL parsing in `prisma/migrations/*/migration.sql` (path-gated so embedded SQL strings in app code are NOT treated as migrations).
- **Drizzle** (new `drizzle.go`): drizzle-kit `.sql` migration files + `pgTable`/`mysqlTable`/`sqliteTable` models, enums, relations.
- **Knex** (new `knex.go`): `knex.schema.createTable/dropTable/alterTable` + column/index builders + `up`/`down` entry points.
- **MikroORM** (new `mikroorm.go`): `Migration` subclass `this.addSql()` raw DDL.
- **Objection** (new `objection.go`): Knex-based schema-builder migration ops (Objection runs on Knex).

### model_extraction
- **MikroORM** (partial→full): `@Entity`/`@Embeddable` + `@Property`/`@PrimaryKey`/`@Enum` fields + `@ManyToOne`/`@OneToMany`/etc relations.
- **Objection** (missing→full): `class X extends Model` + `tableName` + `jsonSchema` + `relationMappings` (+ individual relations). New `internal/engine/rules/javascript_typescript/orms/objection.yaml`.

### Dispatch wiring (real-data correctness)
`prisma`- and `sql`-classified files are now routed to the `custom_js_` extractor set in `custom_dispatch.go`, so `.prisma` schemas and `.sql` migration files actually reach the ORM extractors in the daemon pipeline (each extractor path/language-gates internally and no-ops on files it does not own). Without this, the SQL-based migration parsing would never fire in production.

### Taxonomy ownership
- `lang.jsts.orm.knex` / `model_extraction` stays **not_applicable** with an added reason note: Knex is a SQL query builder, not an ORM — persistent models belong to Objection layered on top.
- Added a **framework_specific** cell `Objection Relation Graph` / `relation_graph_extraction` capturing Objection's bespoke `relationMappings` graph topology (drives `withGraphFetched`/`upsertGraph`), which no standard ORM cell models. Hand-edited into `registry.json` (framework_specific is intentionally outside the capability dictionary, so `tools/coverage update` cannot write it), then `validate` + `gen` clean.

### Kinds
No new entity Kind: migration ops reuse the already-registered `SCOPE.Evolution`. `go test ./internal/types/` passes (producer-kind literal guard green).

## Test plan
- [x] `go test ./internal/custom/javascript/` — per-ORM unit fixtures (inline, dependency-manifest-free) for every flipped cell
- [x] Real-data: disk-backed corpus `testdata/fixtures/orm_corpus/` (10 files, 7 ORMs) run through the full `RunCustomExtractors` dispatch incl. prisma/sql→custom_js_ routing (`TestORMRealDataCorpus`); all 7 ORMs emit `create_table` ops
- [x] `go test ./internal/extractors/javascript/ ./internal/substrate/ ./internal/links/ ./internal/engine/ ./tools/coverage/ ./internal/types/ ./internal/extractors/` — all green
- [x] `go run ./tools/coverage validate` exits 0; `go run ./tools/coverage gen` byte-stable
- [x] `go build ./...` + `go vet` clean

implements-capability: lang.jsts.orm.drizzle/migration_parsing/migration_parsing:missing→full
implements-capability: lang.jsts.orm.knex/migration_parsing/migration_parsing:missing→full
implements-capability: lang.jsts.orm.mikro-orm/migration_parsing/migration_parsing:missing→full
implements-capability: lang.jsts.orm.objection/migration_parsing/migration_parsing:missing→full
implements-capability: lang.jsts.orm.prisma/migration_parsing/migration_parsing:partial→full
implements-capability: lang.jsts.orm.sequelize/migration_parsing/migration_parsing:missing→full
implements-capability: lang.jsts.orm.typeorm/migration_parsing/migration_parsing:missing→full
implements-capability: lang.jsts.orm.mikro-orm/model_extraction/model_extraction:partial→full
implements-capability: lang.jsts.orm.objection/model_extraction/model_extraction:missing→full

🤖 Generated with [Claude Code](https://claude.com/claude-code)