### PR TITLE
feat(jsts): Sails cross-file policies.js -> routes.js auth attribution (#2897)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1068,8 +1068,10 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	if !i.skipPasses[PassFramework] && len(classified) > 0 {
 		// Build a file-content lookup from the classified slice.
 		contentByPath := make(map[string][]byte, len(classified))
+		allPaths := make([]string, 0, len(classified))
 		for k := range classified {
 			cf := &classified[k]
+			allPaths = append(allPaths, cf.relPath)
 			if cf.content != nil {
 				contentByPath[cf.relPath] = cf.content
 			}
@@ -1091,6 +1093,26 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				shapeStats.HandlerResolved,
 				shapeStats.ShapeExtracted,
 				shapeStats.NoHandlerFound)
+		}
+
+		// Pass 2.7b — corpus-wide Sails policy → endpoint auth attribution
+		// (#2897). Sails gates actions via config/policies.js policy maps, but
+		// the endpoints are synthesised from config/routes.js — a different
+		// file — so the per-file auth pass (#2852) cannot join them. This pass
+		// parses every config/policies.{js,ts}, resolves each Sails endpoint's
+		// controller/action policy chain (action > controller > global '*'),
+		// and stamps the config-method, medium-confidence auth_policy contract.
+		sailsAuthStats := engine.ApplySailsAuthPolicy(
+			concatRecords(pass1Records, pass2Records, pass3Records),
+			allPaths,
+			reader,
+		)
+		if sailsAuthStats.PolicyFiles > 0 {
+			fmt.Fprintf(os.Stderr,
+				"sails-auth-corpus: policy_files=%d endpoints=%d attributed=%d\n",
+				sailsAuthStats.PolicyFiles,
+				sailsAuthStats.Endpoints,
+				sailsAuthStats.Attributed)
 		}
 	}
 

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -78,7 +78,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ✅ 1/1 | — | ✅ 1/1 | — | — | — | ✅ 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | — | ✅ 1/1 | — | — | — | ✅ 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | — | ✅ 1/1 | — | — | — | ✅ 6/6 | |
-| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ⚠️ 0/1 | — | — 0/1 | — | — | — | ✅ 6/6 | |
+| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ✅ 1/1 | — | — 0/1 | — | — | — | ✅ 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | — | ⚠️ 8/17 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/17 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | — | ⚠️ 8/17 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -23,7 +23,7 @@ Back to [summary](../summary.md).
 | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ✅ 1/1 | — | ✅ 1/1 | — | — | — | ✅ 6/6 | |
 | [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | — | ✅ 1/1 | — | — | — | ✅ 6/6 | |
 | [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | — | ✅ 1/1 | — | — | — | ✅ 6/6 | |
-| [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ⚠️ 0/1 | — | — 0/1 | — | — | — | ✅ 6/6 | |
+| [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ✅ 1/1 | — | — 0/1 | — | — | — | ✅ 6/6 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/sails_policies.ts` | — |
+| `auth_coverage` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2897) | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`internal/engine/http_endpoint_jsts_sails_auth.go`<br>`testdata/fixtures/typescript/sails_policies.ts`<br>`testdata/fixtures/typescript/sails_routes.ts` | — |
 
 ### Validation
 
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `policy_map_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/sails_policies.ts` | Sails gates actions via config/policies.js policy maps (e.g. '*': 'isLoggedIn'), a bespoke auth idiom no generic middleware/guard cell captures. ParseSailsPolicies recognises the global default posture (fixture-proven). The standard Security/auth_coverage cell is partial because cross-file policies.js->routes.js per-endpoint attribution is deferred (#2852 follow-up). |
+| `policy_map_recognition` | ✅ `full` | `2026-05-29` | — | — | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_sails_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/sails_policies.ts`<br>`testdata/fixtures/typescript/sails_routes.ts` | Sails gates actions via config/policies.js policy maps (e.g. '*': 'isLoggedIn'), a bespoke auth idiom no generic middleware/guard cell captures. ParseSailsPolicies parses the full map (global '*' default, per-controller object blocks with action-level overrides, controller-level catch-all values). #2897 ApplySailsAuthPolicy is a corpus-wide pass joining this map to the endpoints synthesised from config/routes.js, resolving each route's controller/action with action over controller over global precedence and stamping a config-method medium-confidence auth_policy (fixture-proven, cross-file), lifting the standard Security/auth_coverage cell from partial to full. Prior history: policies.js->routes.js per-endpoint attribution was deferred at #2852 and is now delivered. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12665,9 +12665,10 @@
         },
         "Security": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/sails_policies.ts"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","internal/engine/http_endpoint_jsts_sails_auth.go","testdata/fixtures/typescript/sails_policies.ts","testdata/fixtures/typescript/sails_routes.ts"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2897",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -12721,9 +12722,9 @@
         "Sails Policies": {
           "policy_map_recognition": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/sails_policies.ts"],
-            "notes": "Sails gates actions via config/policies.js policy maps (e.g. '*': 'isLoggedIn'), a bespoke auth idiom no generic middleware/guard cell captures. ParseSailsPolicies recognises the global default posture (fixture-proven). The standard Security/auth_coverage cell is partial because cross-file policies.js-\u003eroutes.js per-endpoint attribution is deferred (#2852 follow-up).",
-            "verified_at": "2026-05-28"
+            "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_sails_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/sails_policies.ts","testdata/fixtures/typescript/sails_routes.ts"],
+            "notes": "Sails gates actions via config/policies.js policy maps (e.g. '*': 'isLoggedIn'), a bespoke auth idiom no generic middleware/guard cell captures. ParseSailsPolicies parses the full map (global '*' default, per-controller object blocks with action-level overrides, controller-level catch-all values). #2897 ApplySailsAuthPolicy is a corpus-wide pass joining this map to the endpoints synthesised from config/routes.js, resolving each route's controller/action with action over controller over global precedence and stamping a config-method medium-confidence auth_policy (fixture-proven, cross-file), lifting the standard Security/auth_coverage cell from partial to full. Prior history: policies.js-\u003eroutes.js per-endpoint attribution was deferred at #2852 and is now delivered.",
+            "verified_at": "2026-05-29"
           }
         }
       }

--- a/internal/engine/http_endpoint_jsts_auth.go
+++ b/internal/engine/http_endpoint_jsts_auth.go
@@ -867,6 +867,33 @@ var sailsGlobalPolicyRe = regexp.MustCompile(
 	`['"` + "`" + `]\*['"` + "`" + `]\s*:\s*(false|true|\[[^\]]*\]|['"` + "`" + `][^'"` + "`" + `]+['"` + "`" + `])`,
 )
 
+// sailsControllerBlockRe captures a per-controller object entry
+// `AuthController: { ... }`. Group 1 = controller name, group 2 = the position
+// of the opening brace is recovered via index match (the braces are balanced
+// by findMatchingBrace, since action values may themselves be arrays). The
+// controller name is a bare identifier ending in `Controller` (the Sails
+// convention) — matching only the suffix keeps this from firing on the
+// `'*'` global or arbitrary nested objects.
+var sailsControllerBlockRe = regexp.MustCompile(
+	`(?m)['"` + "`" + `]?([A-Za-z_$][\w$]*Controller)['"` + "`" + `]?\s*:\s*\{`,
+)
+
+// sailsControllerValueRe captures a controller-level bare value entry
+// `AuthController: 'isLoggedIn'` / `AuthController: true` / `AuthController:
+// ['a','b']` (object form is handled separately by sailsControllerBlockRe).
+// Group 1 = controller name, group 2 = the raw value.
+var sailsControllerValueRe = regexp.MustCompile(
+	`(?m)['"` + "`" + `]?([A-Za-z_$][\w$]*Controller)['"` + "`" + `]?\s*:\s*` +
+		`(false|true|\[[^\]]*\]|['"` + "`" + `][^'"` + "`" + `]+['"` + "`" + `])`,
+)
+
+// sailsActionRe captures one `actionName: <value>` line inside a controller
+// block. Group 1 = action name, group 2 = raw value.
+var sailsActionRe = regexp.MustCompile(
+	`(?m)['"` + "`" + `]?([A-Za-z_$][\w$]*)['"` + "`" + `]?\s*:\s*` +
+		`(false|true|\[[^\]]*\]|['"` + "`" + `][^'"` + "`" + `]+['"` + "`" + `])`,
+)
+
 // SailsPolicyMap is the parsed result of a config/policies.js file.
 type SailsPolicyMap struct {
 	// DefaultProtected is true when the global `'*'` default names a real policy
@@ -875,8 +902,30 @@ type SailsPolicyMap struct {
 	DefaultProtected bool
 	// DefaultPolicy is the raw global default value (policy name / true / false).
 	DefaultPolicy string
+	// HasDefault reports whether a global `'*'` key was present at all.
+	HasDefault bool
+	// Controllers maps each controller name (e.g. "AuthController") to its
+	// per-controller policy block. The block carries an optional
+	// controller-level catch-all policy plus per-action overrides. #2897.
+	Controllers map[string]SailsControllerPolicy
 	// File is the source path the map was parsed from.
 	File string
+}
+
+// SailsControllerPolicy is the policy block for one controller in a Sails
+// config/policies.js map. A controller entry can be either a single policy
+// value applied to every action (`AuthController: 'isLoggedIn'`) or an object
+// of per-action overrides (`AuthController: { login: true, logout: 'x' }`).
+type SailsControllerPolicy struct {
+	// ControllerPolicy is the controller-level catch-all value when the entry
+	// is a bare value (`AuthController: 'isLoggedIn'`). Empty when the entry is
+	// an object of per-action overrides.
+	ControllerPolicy string
+	// HasControllerPolicy reports whether a controller-level value was present.
+	HasControllerPolicy bool
+	// Actions maps action name → raw policy value (`true` | `false` |
+	// `'policyName'` | `['a','b']`) for object-form entries.
+	Actions map[string]string
 }
 
 // sailsPoliciesFile reports whether filePath is a Sails policies-config file.
@@ -893,22 +942,59 @@ func ParseSailsPolicies(content, file string) (SailsPolicyMap, bool) {
 	if !strings.Contains(content, "policies") {
 		return SailsPolicyMap{}, false
 	}
-	m := sailsGlobalPolicyRe.FindStringSubmatch(content)
-	if m == nil {
+	pm := SailsPolicyMap{File: file, Controllers: map[string]SailsControllerPolicy{}}
+
+	// Global default `'*': <value>`.
+	if m := sailsGlobalPolicyRe.FindStringSubmatch(content); m != nil {
+		val := strings.TrimSpace(m[1])
+		pm.DefaultPolicy = val
+		pm.HasDefault = true
+		pm.DefaultProtected = sailsPolicyValueProtected(val)
+	}
+
+	// Per-controller object blocks: `AuthController: { login: true, ... }`.
+	// Parse the balanced `{...}` body and capture each action override.
+	for _, loc := range sailsControllerBlockRe.FindAllStringSubmatchIndex(content, -1) {
+		name := content[loc[2]:loc[3]]
+		braceOpen := loc[1] - 1 // the `{` the regex anchored on
+		braceClose := findMatchingBrace(content, braceOpen)
+		if braceClose < 0 {
+			continue
+		}
+		body := content[braceOpen+1 : braceClose]
+		cp := SailsControllerPolicy{Actions: map[string]string{}}
+		for _, am := range sailsActionRe.FindAllStringSubmatch(body, -1) {
+			cp.Actions[am[1]] = strings.TrimSpace(am[2])
+		}
+		if len(cp.Actions) > 0 {
+			pm.Controllers[name] = cp
+		}
+	}
+
+	// Per-controller bare-value entries: `AuthController: 'isLoggedIn'`.
+	// Skip names already captured as an object block above.
+	for _, m := range sailsControllerValueRe.FindAllStringSubmatch(content, -1) {
+		name := m[1]
+		if _, ok := pm.Controllers[name]; ok {
+			continue
+		}
+		pm.Controllers[name] = SailsControllerPolicy{
+			ControllerPolicy:    strings.TrimSpace(m[2]),
+			HasControllerPolicy: true,
+		}
+	}
+
+	// A file with neither a global default nor any controller block is not a
+	// recognisable Sails policy map.
+	if !pm.HasDefault && len(pm.Controllers) == 0 {
 		return SailsPolicyMap{}, false
 	}
-	val := strings.TrimSpace(m[1])
-	pm := SailsPolicyMap{DefaultPolicy: val, File: file}
-	switch {
-	case val == "false":
-		// Default-deny with no policy → blanket block; treat as protected
-		// (no anonymous access).
-		pm.DefaultProtected = true
-	case val == "true":
-		pm.DefaultProtected = false
-	default:
-		// Named policy (quoted string or array) → protected.
-		pm.DefaultProtected = true
-	}
 	return pm, true
+}
+
+// sailsPolicyValueProtected reports whether a raw Sails policy value gates the
+// action. `true` = public (no policy) → not protected. `false` = blanket deny
+// → protected (no anonymous access). A named policy / array → protected.
+func sailsPolicyValueProtected(val string) bool {
+	return val != "true"
 }

--- a/internal/engine/http_endpoint_jsts_auth_test.go
+++ b/internal/engine/http_endpoint_jsts_auth_test.go
@@ -199,4 +199,93 @@ func TestAuth_SailsPolicies(t *testing.T) {
 	if pm.DefaultPolicy != "'isLoggedIn'" {
 		t.Errorf("DefaultPolicy=%q, want 'isLoggedIn'", pm.DefaultPolicy)
 	}
+	if !pm.HasDefault {
+		t.Error("HasDefault=false, want true")
+	}
+	// AuthController object block: per-action overrides.
+	ac, ok := pm.Controllers["AuthController"]
+	if !ok {
+		t.Fatalf("AuthController block not parsed (controllers: %v)", pm.Controllers)
+	}
+	if ac.Actions["login"] != "true" {
+		t.Errorf("AuthController.login=%q, want true", ac.Actions["login"])
+	}
+	if ac.Actions["logout"] != "'isLoggedIn'" {
+		t.Errorf("AuthController.logout=%q, want 'isLoggedIn'", ac.Actions["logout"])
+	}
+	// DashboardController bare value: controller-level catch-all.
+	dc, ok := pm.Controllers["DashboardController"]
+	if !ok || !dc.HasControllerPolicy {
+		t.Fatalf("DashboardController controller-level policy not parsed (controllers: %v)", pm.Controllers)
+	}
+	if dc.ControllerPolicy != "'isLoggedIn'" {
+		t.Errorf("DashboardController catch-all=%q, want 'isLoggedIn'", dc.ControllerPolicy)
+	}
+}
+
+// TestAuth_SailsCrossFileAttribution — the #2897 cross-file join. Synthesises
+// the Sails endpoints from config/routes.js, then runs the corpus-wide
+// ApplySailsAuthPolicy pass with a reader serving config/policies.js, and
+// asserts the resolved posture per precedence level (action > controller >
+// global '*').
+func TestAuth_SailsCrossFileAttribution(t *testing.T) {
+	routesSrc := readBackendFixture(t, "sails_routes.ts")
+	policiesSrc := readBackendFixture(t, "sails_policies.ts")
+
+	// 1. Synthesise the Sails endpoints from config/routes.js (per-file pass).
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	res, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     "config/routes.js",
+		Content:  []byte(routesSrc),
+		Language: "javascript",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	// 2. Run the corpus-wide policy attribution pass with both files available.
+	reader := func(p string) []byte {
+		switch p {
+		case "config/policies.js":
+			return []byte(policiesSrc)
+		case "config/routes.js":
+			return []byte(routesSrc)
+		}
+		return nil
+	}
+	paths := []string{"config/routes.js", "config/policies.js"}
+	stats := ApplySailsAuthPolicy(res.Entities, paths, reader)
+	if stats.PolicyFiles != 1 {
+		t.Fatalf("PolicyFiles=%d, want 1", stats.PolicyFiles)
+	}
+	if stats.Attributed == 0 {
+		t.Fatal("Attributed=0, want >0 (cross-file join produced no postures)")
+	}
+
+	eps := map[string]types.EntityRecord{}
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		eps[e.Properties["verb"]+" "+e.Properties["path"]] = e
+	}
+
+	// Global '*' default protects UsersController.* (no override).
+	requireProtected(t, eps, "GET /users", "config")
+	if eps["GET /users"].Properties["auth_confidence"] != "medium" {
+		t.Errorf("GET /users: confidence=%q, want medium", eps["GET /users"].Properties["auth_confidence"])
+	}
+	// Controller-level catch-all gates DashboardController.index.
+	requireProtected(t, eps, "GET /dashboard", "config")
+	// Action-level override: AuthController.login is explicitly public (true).
+	requirePublic(t, eps, "POST /login")
+	if eps["POST /login"].Properties["auth_method"] != "config" {
+		t.Errorf("POST /login: method=%q, want config", eps["POST /login"].Properties["auth_method"])
+	}
+	// Action-level override: AuthController.logout is gated.
+	requireProtected(t, eps, "POST /logout", "config")
 }

--- a/internal/engine/http_endpoint_jsts_sails_auth.go
+++ b/internal/engine/http_endpoint_jsts_sails_auth.go
@@ -1,0 +1,232 @@
+// Corpus-wide Sails policy → endpoint auth attribution (#2897).
+//
+// Sails does not gate routes with route-level middleware or guards; it maps
+// controllers/actions to *policies* in `config/policies.js`:
+//
+//	module.exports.policies = {
+//	  '*': 'isLoggedIn',                 // global default
+//	  AuthController: {
+//	    login: true,                     // action-level override (public)
+//	    logout: 'isLoggedIn',
+//	  },
+//	  DashboardController: 'isLoggedIn', // controller-level catch-all
+//	}
+//
+// The endpoints themselves are synthesised from a *different* file,
+// `config/routes.js` (synthesizeSails), so the per-file pass in
+// http_endpoint_jsts_auth.go (#2852) can never see both halves at once — it
+// records only the global default posture as a framework_specific cell and
+// leaves the standard auth_coverage cell at `partial`.
+//
+// This corpus-wide post-pass closes that gap, mirroring the cross-file
+// Java/Quarkus JavaAuthContext approach (java_auth_policy.go) and the
+// ApplyResponseShapesCorpus pass (response_shape_corpus.go): it parses every
+// config/policies.js in the repo, then resolves each Sails endpoint's
+// controller/action against the policy map with honest override precedence and
+// stamps a `config`-method, medium-confidence auth_policy onto the endpoint
+// entity.
+//
+// Precedence (highest first):
+//  1. action-level override  — `AuthController: { login: true }`
+//  2. controller-level value — `DashboardController: 'isLoggedIn'`
+//  3. global `'*'` default
+//
+// A `true` value at any level means the action is explicitly public; a named
+// policy (or `false` blanket-deny) means protected.
+//
+// The pass is additive: it only sets auth_* properties on Sails
+// http_endpoint_definition entities that don't already carry a higher-signal
+// posture, never adds/removes entities, and is a no-op on repos with no Sails
+// policy file.
+//
+// Refs #2897 (follow-up to #2852).
+package engine
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// SailsAuthStats reports counters from the corpus-wide Sails policy pass.
+type SailsAuthStats struct {
+	// PolicyFiles is the number of config/policies.js files parsed.
+	PolicyFiles int
+	// Endpoints is the number of Sails http_endpoint_definition entities seen.
+	Endpoints int
+	// Attributed is the number of endpoints stamped with a resolved auth_policy.
+	Attributed int
+}
+
+// ApplySailsAuthPolicy runs the corpus-wide Sails policy attribution pass over
+// the merged record set. It parses every config/policies.{js,ts} file found in
+// `paths` (via the content reader) into a SailsPolicyMap, then for each Sails
+// endpoint resolves its controller/action policy chain and stamps the
+// auth_policy contract.
+//
+// `entities` is mutated in place (Properties only). `paths` is the
+// repo-relative file set still live at this point of the pipeline (config
+// files often produce no extracted entities, so we discover policy files from
+// the path list rather than entity SourceFiles). `reader` returns file content
+// by repo-relative path. When no policy file is found, the pass is a no-op.
+func ApplySailsAuthPolicy(entities []types.EntityRecord, paths []string, reader CorpusFileReader) SailsAuthStats {
+	var stats SailsAuthStats
+	if reader == nil || len(entities) == 0 || len(paths) == 0 {
+		return stats
+	}
+
+	// Parse every Sails policy file in the corpus, keyed by project dir so a
+	// routes.js endpoint and its sibling policies.js resolve to the same map.
+	policyMaps := map[string]SailsPolicyMap{}
+	for _, sf := range paths {
+		if !sailsPoliciesFile(sf) {
+			continue
+		}
+		content := reader(sf)
+		if len(content) == 0 {
+			continue
+		}
+		pm, ok := ParseSailsPolicies(string(content), sf)
+		if !ok {
+			continue
+		}
+		stats.PolicyFiles++
+		policyMaps[sailsProjectDir(sf)] = pm
+	}
+	if len(policyMaps) == 0 {
+		return stats
+	}
+
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != httpEndpointDefinitionKind || e.Properties == nil {
+			continue
+		}
+		if e.Properties["framework"] != "sails" {
+			continue
+		}
+		stats.Endpoints++
+		// Don't clobber an already-resolved high/medium posture from a prior
+		// pass (defensive — the per-file pass never resolves Sails today).
+		if m := e.Properties["auth_method"]; m != "" && m != "unknown" {
+			continue
+		}
+
+		// Find the policy map for this endpoint's project. Sails endpoints carry
+		// the routes.js path as SourceFile; match the policy file that shares
+		// the same project dir, falling back to the sole map when there is one.
+		pm, ok := policyMaps[sailsProjectDir(e.SourceFile)]
+		if !ok {
+			if len(policyMaps) == 1 {
+				for _, only := range policyMaps {
+					pm, ok = only, true
+				}
+			}
+		}
+		if !ok {
+			continue
+		}
+
+		controller := e.Properties["handler_file"] // e.g. "DashboardController"
+		action := sailsActionFromHandler(e.Properties["source_handler"])
+		policy, resolved := resolveSailsEndpointAuth(pm, controller, action)
+		if !resolved {
+			continue
+		}
+		stampAuthPolicy(e.Properties, policy)
+		stats.Attributed++
+	}
+	return stats
+}
+
+// sailsActionFromHandler extracts the action name from a Sails endpoint's
+// source_handler property. synthesizeSails stamps it as "Controller:<method>"
+// (refKind "Controller", refName the bare action), so we take the segment
+// after the colon.
+func sailsActionFromHandler(ref string) string {
+	if i := strings.IndexByte(ref, ':'); i >= 0 {
+		return strings.TrimSpace(ref[i+1:])
+	}
+	return strings.TrimSpace(ref)
+}
+
+// sailsProjectDir returns the directory two levels above a config/policies.js
+// or config/routes.js path — i.e. the Sails project root — so a routes.js
+// endpoint and a policies.js map in the same project resolve to the same key.
+// For `api/cfg/config/policies.js` → `api/cfg`; for the common
+// `config/policies.js` → "" (repo root).
+func sailsProjectDir(p string) string {
+	p = strings.ReplaceAll(p, "\\", "/")
+	// Strip the trailing `config/<file>` segment.
+	if i := strings.LastIndex(p, "config/"); i >= 0 {
+		return strings.TrimSuffix(p[:i], "/")
+	}
+	return ""
+}
+
+// resolveSailsEndpointAuth resolves the auth posture for a single Sails
+// endpoint by applying the action > controller > global precedence. Returns
+// the resolved AuthPolicy and true when a posture could be determined.
+func resolveSailsEndpointAuth(pm SailsPolicyMap, controller, action string) (AuthPolicy, bool) {
+	// 1. Action-level / controller-level entry.
+	if controller != "" {
+		if cp, ok := pm.Controllers[controller]; ok {
+			// 1a. action-level override.
+			if action != "" {
+				if val, ok := cp.Actions[action]; ok {
+					return sailsPolicyFromValue(pm.File, controller, action, "action", val), true
+				}
+			}
+			// 1b. controller-level catch-all value.
+			if cp.HasControllerPolicy {
+				return sailsPolicyFromValue(pm.File, controller, action, "controller", cp.ControllerPolicy), true
+			}
+			// 1c. object block exists but no matching action and no catch-all →
+			// fall through to the global default below.
+		}
+	}
+
+	// 2. Global '*' default.
+	if pm.HasDefault {
+		return sailsPolicyFromValue(pm.File, controller, action, "global", pm.DefaultPolicy), true
+	}
+
+	return AuthPolicy{}, false
+}
+
+// sailsPolicyFromValue builds an AuthPolicy from a raw Sails policy value and
+// the level it was resolved at (for the evidence text). `true` is public; any
+// named policy (or blanket-deny `false`) is protected. Confidence is medium —
+// the binding is config-driven and cross-file rather than a direct route-level
+// guard.
+func sailsPolicyFromValue(file, controller, action, level, val string) AuthPolicy {
+	protected := sailsPolicyValueProtected(val)
+	desc := sailsLevelDesc(level, controller, action)
+	text := desc + " policy " + val
+	if !protected {
+		text = desc + " public (policy: true)"
+	}
+	return AuthPolicy{
+		Required:   protected,
+		Method:     "config",
+		Confidence: "medium",
+		SourceChain: []AuthSignal{{
+			Kind: "config",
+			Text: text,
+			File: file,
+		}},
+	}
+}
+
+// sailsLevelDesc renders a short human description of the policy resolution
+// level for the evidence source chain.
+func sailsLevelDesc(level, controller, action string) string {
+	switch level {
+	case "action":
+		return "config/policies.js " + controller + "." + action
+	case "controller":
+		return "config/policies.js " + controller
+	default:
+		return "config/policies.js '*' default"
+	}
+}

--- a/testdata/fixtures/typescript/sails_policies.ts
+++ b/testdata/fixtures/typescript/sails_policies.ts
@@ -1,6 +1,14 @@
-// Sails config/policies.js auth_coverage fixture (#2852). Hand-written.
+// Sails config/policies.js auth_coverage fixture (#2852, extended #2897).
+// Hand-written, dependency-manifest-free.
+//
 // A protective global default ('*': 'isLoggedIn') gates every action unless a
-// controller/action explicitly opts out with `true` (public).
+// controller/action explicitly opts out with `true` (public). #2897 joins this
+// map to the routes synthesised from config/routes.js and proves all three
+// precedence levels:
+//   - global '*': 'isLoggedIn' default protects every action,
+//   - AuthController object block: per-action overrides (login public,
+//     logout/signup gated),
+//   - DashboardController bare value: a controller-level catch-all policy.
 module.exports.policies = {
   '*': 'isLoggedIn',
 
@@ -8,4 +16,6 @@ module.exports.policies = {
     login: true,
     logout: 'isLoggedIn',
   },
+
+  DashboardController: 'isLoggedIn',
 }

--- a/testdata/fixtures/typescript/sails_routes.ts
+++ b/testdata/fixtures/typescript/sails_routes.ts
@@ -1,12 +1,21 @@
-// Sails routing fixture (#2851). Represents a Sails config/routes.js map.
-// Hand-written, dependency-manifest-free. The synthesizer is path-gated on
-// the `config/routes.{js,ts}` filename, so the test feeds this content under
-// that path.
+// Sails routing fixture (#2851, extended #2897). Represents a Sails
+// config/routes.js map. Hand-written, dependency-manifest-free. The
+// synthesizer is path-gated on the `config/routes.{js,ts}` filename, so the
+// test feeds this content under that path.
+//
+// #2897 — the controller/action targets here are joined to config/policies.js:
+//   UsersController.*    -> global '*': 'isLoggedIn' (protected, no override)
+//   AuthController.login -> action-level override `true` (public)
+//   AuthController.logout-> action-level 'isLoggedIn' (protected)
+//   DashboardController.*-> controller-level 'isLoggedIn' (protected)
 module.exports.routes = {
   'GET /users': 'UsersController.index',
   'GET /users/:id': 'UsersController.show',
   'POST /users': 'UsersController.create',
   'PUT /users/:id': 'UsersController.update',
   'DELETE /users/:id': 'UsersController.destroy',
+  'POST /login': 'AuthController.login',
+  'POST /logout': 'AuthController.logout',
+  'GET /dashboard': 'DashboardController.index',
   '/health': 'SystemController.health',
 }


### PR DESCRIPTION
Closes #2897

Follow-up to #2852 / PR #2896.

## Problem
Sails gates actions via `config/policies.js` policy maps (`'*': 'isLoggedIn'`, `AuthController: { login: true }`), but its endpoints are synthesised from `config/routes.js` — a *different* file. The per-file auth pass (#2852, `http_endpoint_jsts_auth.go`) only ever sees one file at a time, so it could record only the global-default posture as a `framework_specific` cell and honestly left the standard `Security/auth_coverage` cell at `partial`.

## What this does
Adds a corpus-wide post-pass, mirroring the cross-file Java/Quarkus `JavaAuthContext` (`java_auth_policy.go`) and `ApplyResponseShapesCorpus` (`response_shape_corpus.go`) approaches:

- `ParseSailsPolicies` now parses the **full** map: global `'*'` default, per-controller object blocks with action-level overrides, and controller-level catch-all bare values.
- New `ApplySailsAuthPolicy` (`internal/engine/http_endpoint_jsts_sails_auth.go`) parses every `config/policies.{js,ts}`, then resolves each Sails `http_endpoint_definition`'s controller/action against the map with honest precedence — **action > controller > global `'*'`**; `true` = public — and stamps a `config`-method, `medium`-confidence `auth_policy` (+ the MCP signal-1 `auth_middleware` key) onto the endpoint entity.
- Wired in `cmd/archigraph/index.go` as Pass 2.7b, reusing the classified file set and `CorpusFileReader` already built for the response-shape pass. No new entity/edge Kinds.

## Proof (fixtures, hand-written, dependency-manifest-free)
`testdata/fixtures/typescript/sails_routes.ts` + `sails_policies.ts` prove all three precedence levels:
- global default — `UsersController.*` -> protected (`config`, medium)
- controller-level catch-all — `DashboardController.index` -> protected
- action-level override — `AuthController.login` public (`true`), `AuthController.logout` protected

New test `TestAuth_SailsCrossFileAttribution` exercises the join end-to-end; the extended `TestAuth_SailsPolicies` covers the full-map parse.

## Coverage
Flips `lang.jsts.framework.sails/Security/auth_coverage` **partial -> full** and updates the `framework_specific` "Sails Policies" notes. `go run ./tools/coverage fmt --check` clean, `validate` exit 0, `gen` regenerated docs; registry diff is surgical (13 lines).

## Notes
Issue #2897's body contains no `implements-capability:` tags and names no coverage-delta tool path, so no delta comment is posted (none exists in-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)