### PR TITLE
coverage(jsts): GREEN rpc Transport column — http/ws/grpc transport binding (#2906)

### DIFF
--- a/cmd/archigraph/issue2906_transport_test.go
+++ b/cmd/archigraph/issue2906_transport_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+// TestRPCTransportBinding_FullPipeline is the real-data integration guard for
+// #2906. It runs the production indexer over a small multi-file JS/TS corpus
+// (a tRPC standalone HTTP+WS server and an Apollo standalone HTTP GraphQL
+// server) and asserts that the RPC procedure / resolver synthetics carry the
+// `transport` property derived from the server-setup adapter — proving the
+// binding survives the full extract → engine → pass pipeline, not just the
+// isolated synthesizer unit test.
+func TestRPCTransportBinding_FullPipeline(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/transport2906_jsts_rpc", "transport_2906", nil)
+	if len(doc.Entities) == 0 {
+		t.Fatalf("no entities emitted from transport fixture corpus")
+	}
+
+	// Collect transport per (framework) over the http_endpoint_definition
+	// entities the RPC synthesizers emitted.
+	trpcTransports := map[string]bool{}
+	gqlTransports := map[string]bool{}
+	var trpcCount, gqlCount int
+	for _, e := range doc.Entities {
+		if e.Kind != "http_endpoint_definition" || e.Properties == nil {
+			continue
+		}
+		switch e.Properties["framework"] {
+		case "trpc":
+			trpcCount++
+			if tr := e.Properties["transport"]; tr != "" {
+				trpcTransports[tr] = true
+			}
+		case "graphql":
+			gqlCount++
+			if tr := e.Properties["transport"]; tr != "" {
+				gqlTransports[tr] = true
+			}
+		}
+	}
+
+	if trpcCount == 0 {
+		t.Fatalf("no tRPC endpoints synthesised from corpus")
+	}
+	if gqlCount == 0 {
+		t.Fatalf("no GraphQL resolver endpoints synthesised from corpus")
+	}
+
+	// tRPC server.ts wires BOTH the standalone HTTP adapter and the WS
+	// adapter against the same router → http+ws.
+	if !trpcTransports["http+ws"] {
+		t.Errorf("tRPC transport: want http+ws stamped, got set %v", trpcTransports)
+	}
+	// Apollo standalone serves the resolver map over HTTP only.
+	if !gqlTransports["http"] {
+		t.Errorf("GraphQL transport: want http stamped, got set %v", gqlTransports)
+	}
+}

--- a/cmd/archigraph/testdata/transport2906_jsts_rpc/src/graphql/server.ts
+++ b/cmd/archigraph/testdata/transport2906_jsts_rpc/src/graphql/server.ts
@@ -1,0 +1,17 @@
+// Apollo Server standalone — resolver map served over HTTP only. The
+// resolver-field synthetics emitted here are stamped transport=http.
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+
+const resolvers = {
+  Query: {
+    posts: () => [],
+    post: (_: unknown, { id }: { id: string }) => ({ id }),
+  },
+  Mutation: {
+    createPost: (_: unknown, { title }: { title: string }) => ({ id: 1, title }),
+  },
+};
+
+const server = new ApolloServer({ resolvers });
+await startStandaloneServer(server, { listen: { port: 4000 } });

--- a/cmd/archigraph/testdata/transport2906_jsts_rpc/src/server/router.ts
+++ b/cmd/archigraph/testdata/transport2906_jsts_rpc/src/server/router.ts
@@ -1,0 +1,17 @@
+// Domain router — transport-agnostic, exported for both the HTTP and the
+// WebSocket entry points. This is the idiomatic split: the router knows
+// nothing about how it is served.
+import { initTRPC } from "@trpc/server";
+import { z } from "zod";
+
+const t = initTRPC.create();
+
+export const appRouter = t.router({
+  health: t.procedure.query(() => ({ ok: true })),
+  createPost: t.procedure
+    .input(z.object({ title: z.string() }))
+    .mutation(({ input }) => ({ id: 1, title: input.title })),
+  onPost: t.procedure.subscription(() => null),
+});
+
+export type AppRouter = typeof appRouter;

--- a/cmd/archigraph/testdata/transport2906_jsts_rpc/src/server/server.ts
+++ b/cmd/archigraph/testdata/transport2906_jsts_rpc/src/server/server.ts
@@ -1,0 +1,24 @@
+// tRPC standalone HTTP + WebSocket server. Both adapters are wired in this
+// module against the same router, so queries/mutations are reachable over
+// HTTP and the subscription over WS — the procedures synthesised here are
+// stamped transport=http+ws.
+import { createHTTPServer } from "@trpc/server/adapters/standalone";
+import { applyWSSHandler } from "@trpc/server/adapters/ws";
+import { initTRPC } from "@trpc/server";
+import { WebSocketServer } from "ws";
+import { z } from "zod";
+
+const t = initTRPC.create();
+
+const appRouter = t.router({
+  health: t.procedure.query(() => ({ ok: true })),
+  createPost: t.procedure
+    .input(z.object({ title: z.string() }))
+    .mutation(({ input }) => ({ id: 1, title: input.title })),
+  onPost: t.procedure.subscription(() => null),
+});
+
+const { server, listen } = createHTTPServer({ router: appRouter });
+const wss = new WebSocketServer({ server });
+applyWSSHandler({ wss, router: appRouter });
+listen(3000);

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -215,11 +215,11 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 ## RPC Framework
 
-| Language | Name | Schema | Codegen | Substrate | Notes |
-|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/14 | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | — | |
+| Language | Name | Schema | Codegen | Transport | Substrate | Notes |
+|---|---|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/14 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | ✅ 1/1 | — | |
 
 
 ## AI Integration

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -67,10 +67,10 @@ Back to [summary](../summary.md).
 
 ### RPC Framework
 
-| Name | Schema | Codegen | Notes |
-|---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | |
-| [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | |
+| Name | Schema | Codegen | Transport | Notes |
+|---|---|---|---|---|
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | ❌ 0/1 | ✅ 1/1 | |
+| [tRPC](../detail/lang.jsts.framework.trpc.md) | ⚠️ 1/2 | ❌ 0/1 | ✅ 1/1 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
@@ -28,6 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `transport_binding` | ✅ `full` | `2026-05-28` | — | [link](2906) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_transport_binding.go`<br>`internal/engine/http_endpoint_transport_binding_test.go`<br>`testdata/fixtures/typescript/graphql_transport_http.ts`<br>`testdata/fixtures/typescript/graphql_transport_http_ws.ts` | — |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** RPC Framework
-- **Capability cells:** 3
+- **Capability cells:** 4
 
 ## Capabilities
 
@@ -28,6 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `transport_binding` | ✅ `full` | `2026-05-28` | — | [link](2906) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_transport_binding.go`<br>`internal/engine/http_endpoint_transport_binding_test.go`<br>`testdata/fixtures/typescript/trpc_transport_http.ts`<br>`testdata/fixtures/typescript/trpc_transport_http_ws.ts`<br>`testdata/fixtures/typescript/trpc_transport_none.ts`<br>`testdata/fixtures/typescript/trpc_transport_ws.ts` | — |
 
 ### Substrate
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -11263,6 +11263,14 @@
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/2735"
           }
+        },
+        "Transport": {
+          "transport_binding": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_transport_binding.go","internal/engine/http_endpoint_transport_binding_test.go","testdata/fixtures/typescript/graphql_transport_http.ts","testdata/fixtures/typescript/graphql_transport_http_ws.ts"],
+            "issue": "2906",
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -13031,6 +13039,14 @@
           "client_codegen": {
             "status": "missing",
             "issue": "https://github.com/cajasmota/archigraph/issues/2735"
+          }
+        },
+        "Transport": {
+          "transport_binding": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_transport_binding.go","internal/engine/http_endpoint_transport_binding_test.go","testdata/fixtures/typescript/trpc_transport_http.ts","testdata/fixtures/typescript/trpc_transport_http_ws.ts","testdata/fixtures/typescript/trpc_transport_none.ts","testdata/fixtures/typescript/trpc_transport_ws.ts"],
+            "issue": "2906",
+            "verified_at": "2026-05-28"
           }
         }
       }

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -411,7 +411,15 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Producer side: Apollo / GraphQL resolvers (#1422). GraphQL is
 		// schema-first rather than REST, so resolver fields are emitted as
 		// graphql_field endpoint-ish entities keyed by operation + field.
+		gqlTransportBefore := len(entities)
 		synthesizeGraphQLResolvers(string(content), emit)
+		// #2906 — RPC transport binding. GraphQL resolvers are
+		// transport-agnostic; the server-setup adapter (startStandaloneServer /
+		// expressMiddleware over HTTP, graphql-ws useServer over WS) decides the
+		// wire protocol. Stamp `transport` on the resolver-field synthetics this
+		// file just emitted when an adapter signal is present in the module.
+		applyRPCTransportBinding(string(content), entities, gqlTransportBefore,
+			"graphql", gqlHTTPAdapterSignals, gqlWSAdapterSignals)
 		// Producer side: tRPC procedure resolvers (#2693). Each leaf
 		// procedure inside a `router({ ... })` literal becomes an
 		// addressable endpoint identified by its dotted path
@@ -423,7 +431,15 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// addressable handler symbol, no source_handler is stamped — the
 		// shared resolver short-circuits the rebind and preserves the
 		// precise attribution this synthesizer produces.
+		trpcTransportBefore := len(entities)
 		synthesizeTRPC(string(content), emitDef)
+		// #2906 — RPC transport binding. tRPC routers are transport-agnostic;
+		// the adapter that serves them (createHTTPServer / fetchRequestHandler /
+		// express|fastify|next adapter over HTTP, applyWSSHandler over WS)
+		// decides the wire protocol. Stamp `transport` on the procedure
+		// synthetics this file just emitted when an adapter signal is present.
+		applyRPCTransportBinding(string(content), entities, trpcTransportBefore,
+			"trpc", trpcHTTPAdapterSignals, trpcWSAdapterSignals)
 		// #2852 — resolve auth_coverage over the producer-side endpoints emitted
 		// above. Detects passport/express-jwt/session middleware, Nest
 		// @UseGuards (class + method), Hapi route auth, AdonisJS .middleware('auth')

--- a/internal/engine/http_endpoint_transport_binding.go
+++ b/internal/engine/http_endpoint_transport_binding.go
@@ -1,0 +1,145 @@
+// RPC transport-binding detection (#2906). tRPC and GraphQL are
+// transport-agnostic RPC layers: the same router / resolver map is served
+// over HTTP, WebSocket, or both depending on which adapter the server-setup
+// code wires up. The procedure / resolver-field synthesizers
+// (synthesizeTRPC, synthesizeGraphQLResolvers) emit the addressable endpoints
+// but say nothing about HOW they are reached. This pass scans the same file
+// for the adapter/handler call that binds the router to a wire protocol and
+// stamps a `transport` property on each synthetic the RPC pass just emitted.
+//
+// The result is one of:
+//
+//	http     — request/response adapter only (createHTTPServer,
+//	           fetchRequestHandler, express/fastify/next adapter,
+//	           startStandaloneServer, expressMiddleware, createYoga, …)
+//	ws       — WebSocket adapter only (@trpc/server/adapters/ws,
+//	           applyWSSHandler, graphql-ws useServer, SubscriptionServer, …)
+//	http+ws  — both wired in the same module (the common "queries+mutations
+//	           over HTTP, subscriptions over WS" setup)
+//
+// Detection is intentionally same-file and signal-based (substring/marker
+// match on the well-known adapter import + call), mirroring the same-file
+// scope of synthesizeTRPC / synthesizeGraphQLResolvers. When no adapter
+// signal is present (e.g. a router defined in a standalone module that is
+// served from elsewhere) the property is left unset rather than guessed —
+// the cell stays honest.
+
+package engine
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// transportHTTP / transportWS / transportBoth are the canonical values of
+// the `transport` property stamped on RPC http_endpoint_definition entities.
+const (
+	transportHTTP = "http"
+	transportWS   = "ws"
+	transportBoth = "http+ws"
+)
+
+// trpcHTTPAdapterSignals are the well-known tRPC adapter imports / calls that
+// bind a router to an HTTP request/response transport. Matching any one of
+// these in the module is sufficient to claim the HTTP binding.
+var trpcHTTPAdapterSignals = []string{
+	"@trpc/server/adapters/standalone", // createHTTPServer
+	"createHTTPServer",
+	"@trpc/server/adapters/express", // createExpressMiddleware
+	"createExpressMiddleware",
+	"@trpc/server/adapters/fastify", // fastifyTRPCPlugin
+	"fastifyTRPCPlugin",
+	"@trpc/server/adapters/next", // createNextApiHandler
+	"createNextApiHandler",
+	"@trpc/server/adapters/fetch", // fetchRequestHandler
+	"fetchRequestHandler",
+	"@trpc/server/adapters/aws-lambda", // awsLambdaRequestHandler
+	"awsLambdaRequestHandler",
+}
+
+// trpcWSAdapterSignals are the tRPC adapter imports / calls that bind a
+// router to a WebSocket transport.
+var trpcWSAdapterSignals = []string{
+	"@trpc/server/adapters/ws", // applyWSSHandler
+	"applyWSSHandler",
+}
+
+// gqlHTTPAdapterSignals are the well-known GraphQL server-setup calls that
+// serve a resolver map over HTTP.
+var gqlHTTPAdapterSignals = []string{
+	"startStandaloneServer", // @apollo/server/standalone
+	"expressMiddleware",     // @apollo/server/express4
+	"applyMiddleware",       // apollo-server-express (v3)
+	"createYoga",            // graphql-yoga
+	"createHandler",         // graphql-http
+}
+
+// gqlWSAdapterSignals are the GraphQL server-setup calls that serve
+// subscriptions over a WebSocket transport.
+var gqlWSAdapterSignals = []string{
+	"graphql-ws",                   // import marker
+	"useServer",                    // graphql-ws/lib/use/ws
+	"subscriptions-transport-ws",   // legacy import marker
+	"SubscriptionServer",           // legacy subscriptions-transport-ws
+	"WebSocketServer",              // ws server paired with useServer
+	"@apollo/server/plugin/drainHttpServer",
+}
+
+// applyRPCTransportBinding stamps the `transport` property on the RPC
+// http_endpoint_definition entities emitted into `entities` at index `from`
+// or later. `framework` scopes the stamp to this synthesizer's own
+// synthetics (trpc / graphql), so a file that wires both layers does not
+// cross-contaminate. The label is derived once per file from the adapter
+// signals; when no adapter is wired in this module the property is left
+// unset (honest "binding not visible here" rather than a guessed default).
+func applyRPCTransportBinding(
+	content string,
+	entities []types.EntityRecord,
+	from int,
+	framework string,
+	httpSignals, wsSignals []string,
+) {
+	transport := detectTransportBinding(content, httpSignals, wsSignals)
+	if transport == "" {
+		return
+	}
+	for i := from; i < len(entities); i++ {
+		e := &entities[i]
+		if e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		if e.Properties == nil || e.Properties["framework"] != framework {
+			continue
+		}
+		e.Properties["transport"] = transport
+	}
+}
+
+// detectTransportBinding returns the transport label implied by the adapter
+// signals present in `content`, or "" when no adapter is wired in this file.
+// `httpSignals` / `wsSignals` are the framework-specific signal sets.
+func detectTransportBinding(content string, httpSignals, wsSignals []string) string {
+	hasHTTP := containsAny(content, httpSignals)
+	hasWS := containsAny(content, wsSignals)
+	switch {
+	case hasHTTP && hasWS:
+		return transportBoth
+	case hasWS:
+		return transportWS
+	case hasHTTP:
+		return transportHTTP
+	default:
+		return ""
+	}
+}
+
+// containsAny reports whether `content` contains any of `signals`.
+func containsAny(content string, signals []string) bool {
+	for _, s := range signals {
+		if strings.Contains(content, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/http_endpoint_transport_binding_test.go
+++ b/internal/engine/http_endpoint_transport_binding_test.go
@@ -1,0 +1,110 @@
+package engine
+
+import "testing"
+
+// transportOf returns the `transport` property of the first
+// http_endpoint_definition with the given framework, or "" if none carries it.
+func transportOf(ents []entityRec, framework string) string {
+	for _, e := range ents {
+		if e.kind == httpEndpointDefinitionKind &&
+			e.framework == framework && e.transport != "" {
+			return e.transport
+		}
+	}
+	return ""
+}
+
+type entityRec struct {
+	kind, framework, transport string
+}
+
+// collectRPCDefs reads a committed fixture under testdata/fixtures/typescript/
+// and returns the RPC http_endpoint_definition entities the synthesis pass
+// emits for it, projected to (kind, framework, transport).
+func collectRPCDefs(t *testing.T, path, fixture string) []entityRec {
+	t.Helper()
+	src := readBackendFixture(t, fixture)
+	res := runDetectWS(t, "typescript", path, src)
+	var out []entityRec
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		out = append(out, entityRec{
+			kind:      e.Kind,
+			framework: e.Properties["framework"],
+			transport: e.Properties["transport"],
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// tRPC transport binding (#2906)
+// ---------------------------------------------------------------------------
+
+func TestTRPCTransport_HTTPStandaloneAdapter(t *testing.T) {
+	defs := collectRPCDefs(t, "server.ts", "trpc_transport_http.ts")
+	if len(defs) == 0 {
+		t.Fatalf("no tRPC endpoints emitted")
+	}
+	if got := transportOf(defs, "trpc"); got != transportHTTP {
+		t.Fatalf("transport = %q, want %q", got, transportHTTP)
+	}
+}
+
+func TestTRPCTransport_WSAdapter(t *testing.T) {
+	defs := collectRPCDefs(t, "ws.ts", "trpc_transport_ws.ts")
+	if len(defs) == 0 {
+		t.Fatalf("no tRPC endpoints emitted")
+	}
+	if got := transportOf(defs, "trpc"); got != transportWS {
+		t.Fatalf("transport = %q, want %q", got, transportWS)
+	}
+}
+
+func TestTRPCTransport_HTTPAndWS(t *testing.T) {
+	defs := collectRPCDefs(t, "both.ts", "trpc_transport_http_ws.ts")
+	if len(defs) == 0 {
+		t.Fatalf("no tRPC endpoints emitted")
+	}
+	if got := transportOf(defs, "trpc"); got != transportBoth {
+		t.Fatalf("transport = %q, want %q", got, transportBoth)
+	}
+}
+
+func TestTRPCTransport_NoAdapterLeavesUnset(t *testing.T) {
+	// Router defined in a standalone module with no adapter wired — the
+	// transport binding is not visible here, so the property stays unset.
+	defs := collectRPCDefs(t, "router.ts", "trpc_transport_none.ts")
+	if len(defs) == 0 {
+		t.Fatalf("no tRPC endpoints emitted")
+	}
+	if got := transportOf(defs, "trpc"); got != "" {
+		t.Fatalf("transport = %q, want unset (no adapter in module)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL resolver transport binding (#2906)
+// ---------------------------------------------------------------------------
+
+func TestGraphQLTransport_StandaloneHTTP(t *testing.T) {
+	defs := collectRPCDefs(t, "apollo.ts", "graphql_transport_http.ts")
+	if len(defs) == 0 {
+		t.Fatalf("no GraphQL resolver endpoints emitted")
+	}
+	if got := transportOf(defs, "graphql"); got != transportHTTP {
+		t.Fatalf("transport = %q, want %q", got, transportHTTP)
+	}
+}
+
+func TestGraphQLTransport_HTTPAndWS(t *testing.T) {
+	defs := collectRPCDefs(t, "apollo_ws.ts", "graphql_transport_http_ws.ts")
+	if len(defs) == 0 {
+		t.Fatalf("no GraphQL resolver endpoints emitted")
+	}
+	if got := transportOf(defs, "graphql"); got != transportBoth {
+		t.Fatalf("transport = %q, want %q", got, transportBoth)
+	}
+}

--- a/testdata/fixtures/typescript/graphql_transport_http.ts
+++ b/testdata/fixtures/typescript/graphql_transport_http.ts
@@ -1,0 +1,16 @@
+// GraphQL resolvers over HTTP — Apollo Server standalone (#2906).
+// startStandaloneServer binds the resolver map to an HTTP transport.
+import { ApolloServer } from '@apollo/server';
+import { startStandaloneServer } from '@apollo/server/standalone';
+
+const resolvers = {
+  Query: {
+    hello: () => 'world',
+  },
+  Mutation: {
+    setName: (_: unknown, { name }: { name: string }) => name,
+  },
+};
+
+const server = new ApolloServer({ resolvers });
+await startStandaloneServer(server, { listen: { port: 4000 } });

--- a/testdata/fixtures/typescript/graphql_transport_http_ws.ts
+++ b/testdata/fixtures/typescript/graphql_transport_http_ws.ts
@@ -1,0 +1,20 @@
+// GraphQL resolvers over both HTTP and WebSocket (#2906).
+// Queries/mutations are served via the Apollo express4 middleware (HTTP);
+// subscriptions are served via graphql-ws useServer over a WebSocketServer.
+import { expressMiddleware } from '@apollo/server/express4';
+import { useServer } from 'graphql-ws/lib/use/ws';
+import { WebSocketServer } from 'ws';
+
+const resolvers = {
+  Query: {
+    hello: () => 'world',
+  },
+  Subscription: {
+    messageAdded: { subscribe: () => null },
+  },
+};
+
+app.use('/graphql', expressMiddleware(server));
+
+const wsServer = new WebSocketServer({ server: httpServer, path: '/graphql' });
+useServer({ schema }, wsServer);

--- a/testdata/fixtures/typescript/trpc_transport_http.ts
+++ b/testdata/fixtures/typescript/trpc_transport_http.ts
@@ -1,0 +1,14 @@
+// tRPC over HTTP — standalone request/response adapter (#2906).
+// The router is transport-agnostic; createHTTPServer from
+// @trpc/server/adapters/standalone binds it to an HTTP transport.
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+export const appRouter = t.router({
+  list: t.procedure.query(() => [{ id: 1 }]),
+  create: t.procedure.mutation(({ input }) => ({ ok: true, input })),
+});
+
+createHTTPServer({ router: appRouter }).listen(3000);

--- a/testdata/fixtures/typescript/trpc_transport_http_ws.ts
+++ b/testdata/fixtures/typescript/trpc_transport_http_ws.ts
@@ -1,0 +1,20 @@
+// tRPC over both HTTP and WebSocket (#2906). The common production setup:
+// queries/mutations over the standalone HTTP adapter, subscriptions over the
+// WebSocket adapter, sharing the same router and HTTP server instance.
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import { applyWSSHandler } from '@trpc/server/adapters/ws';
+import { initTRPC } from '@trpc/server';
+import { WebSocketServer } from 'ws';
+
+const t = initTRPC.create();
+
+export const appRouter = t.router({
+  list: t.procedure.query(() => []),
+  create: t.procedure.mutation(() => ({})),
+  onTick: t.procedure.subscription(() => null),
+});
+
+const { server } = createHTTPServer({ router: appRouter });
+const wss = new WebSocketServer({ server });
+applyWSSHandler({ wss, router: appRouter });
+server.listen(3000);

--- a/testdata/fixtures/typescript/trpc_transport_none.ts
+++ b/testdata/fixtures/typescript/trpc_transport_none.ts
@@ -1,0 +1,14 @@
+// tRPC router defined in a standalone module with NO adapter (#2906).
+// This is the idiomatic split where the router type is exported for the
+// client and the transport is wired elsewhere. The transport binding is not
+// visible here, so the synthesizer leaves `transport` unset (honest "unknown
+// in this module" rather than a guessed default).
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+export const appRouter = t.router({
+  list: t.procedure.query(() => []),
+});
+
+export type AppRouter = typeof appRouter;

--- a/testdata/fixtures/typescript/trpc_transport_ws.ts
+++ b/testdata/fixtures/typescript/trpc_transport_ws.ts
@@ -1,0 +1,15 @@
+// tRPC over WebSocket — applyWSSHandler from @trpc/server/adapters/ws (#2906).
+// Subscriptions are served over a WebSocket transport; no HTTP adapter is
+// wired in this module.
+import { applyWSSHandler } from '@trpc/server/adapters/ws';
+import { initTRPC } from '@trpc/server';
+import { WebSocketServer } from 'ws';
+
+const t = initTRPC.create();
+
+export const appRouter = t.router({
+  onTick: t.procedure.subscription(() => null),
+});
+
+const wss = new WebSocketServer({ port: 3001 });
+applyWSSHandler({ wss, router: appRouter });

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -329,6 +329,7 @@ subcategories:
       - procedure_extraction
       - schema_extraction
       - client_codegen
+      - transport_binding
       - constant_propagation
       - env_fallback_recognition
       - import_resolution_quality
@@ -356,7 +357,7 @@ subcategories:
       - name: Codegen
         keys: [client_codegen]
       - name: Transport
-        keys: []
+        keys: [transport_binding]
       - name: Substrate
         keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
 

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -929,6 +929,44 @@ records:
           issues_implemented: ["2671", "2687"]
           verified_at: "2026-05-28"
 
+  lang.jsts.framework.graphql-resolvers:
+    capabilities:
+      Transport:
+        transport_binding:
+          # #2906: resolver-map synthetics are stamped with a `transport`
+          # property (http / ws / http+ws) derived from the GraphQL
+          # server-setup adapter (startStandaloneServer / expressMiddleware
+          # over HTTP, graphql-ws useServer over WS) present in the module.
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_transport_binding.go
+              functions: [applyRPCTransportBinding, detectTransportBinding, containsAny]
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeGraphQLResolvers]
+          tests:
+            - file: internal/engine/http_endpoint_transport_binding_test.go
+          issues_implemented: ["2906"]
+          verified_at: "2026-05-28"
+
+  lang.jsts.framework.trpc:
+    capabilities:
+      Transport:
+        transport_binding:
+          # #2906: tRPC procedure synthetics are stamped with a `transport`
+          # property (http / ws / http+ws) derived from the adapter that
+          # serves the router (createHTTPServer / fetchRequestHandler /
+          # express|fastify|next adapter over HTTP, applyWSSHandler over WS).
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_transport_binding.go
+              functions: [applyRPCTransportBinding, detectTransportBinding, containsAny]
+            - file: internal/engine/http_endpoint_trpc.go
+              functions: [synthesizeTRPC]
+          tests:
+            - file: internal/engine/http_endpoint_transport_binding_test.go
+          issues_implemented: ["2906"]
+          verified_at: "2026-05-28"
+
   lang.java.framework.spring-boot:
     capabilities:
       Routing:


### PR DESCRIPTION
## Summary

GREENs the all-`—` (UNTRACKED) **Transport** column on the JS/TS **RPC Framework** subcategory. The `rpc_framework` Transport group had no keys and no extraction; this issue defines a `transport_binding` capability, backs it with a real extractor signal + proving fixtures, and populates both rpc records honestly.

Before: Transport column = 2/2 `—`. After: `✅ 1/1` on both records.

## What changed

**Extractor signal (Type B).** tRPC routers and GraphQL resolver maps are transport-agnostic — the server-setup adapter decides the wire protocol. A new same-file pass `applyRPCTransportBinding` (`internal/engine/http_endpoint_transport_binding.go`) scans the module for the well-known adapter import/call and stamps a `transport` property (`http` / `ws` / `http+ws`) on the procedure / resolver-field synthetics the RPC pass just emitted:

| Layer | HTTP signals | WS signals |
|---|---|---|
| tRPC | `createHTTPServer`, `fetchRequestHandler`, express/fastify/next/aws-lambda adapters | `@trpc/server/adapters/ws`, `applyWSSHandler` |
| GraphQL | `startStandaloneServer`, `expressMiddleware`, `applyMiddleware`, `createYoga`, graphql-http `createHandler` | graphql-ws `useServer`, `subscriptions-transport-ws`, `WebSocketServer` |

When no adapter is wired in the module the property is left unset (honest "binding not visible here") rather than guessed — matching the existing same-file scope of `synthesizeTRPC` / `synthesizeGraphQLResolvers`.

No new entity/edge Kind — this decorates the existing `http_endpoint_definition` with a property, so `internal/types/kinds.go` is unchanged (#2839 rule N/A but `go test ./internal/types/` run regardless).

**Taxonomy / coverage.**
- `capability-dictionary.yaml`: added `transport_binding` to the `rpc_framework` **Transport** group (was `keys: []`) + the capabilities list.
- `capability-map.yaml`: mapped `transport_binding` → the implementing functions for both rpc records (citations resolve `[ok]` via `map-status`).
- `registry.json`: both cells set to `full` via the `update` tool (diff is exactly the two Transport blocks — no whole-file reformat).

## Proof

- Unit tests over committed dependency-free fixtures under `testdata/fixtures/typescript/` (http / ws / http+ws / no-adapter for tRPC; http / http+ws for GraphQL).
- **Real-data full-pipeline** integration test (`cmd/archigraph/issue2906_transport_test.go`) over a multi-file corpus (`testdata/transport2906_jsts_rpc/`): the indexer synthesises 9 endpoints across files; tRPC server (HTTP+WS adapters co-located) → `transport=http+ws`, Apollo standalone → `transport=http`, and the standalone router module (no adapter) leaves transport unset.

Tests run green: `./internal/engine/ ./internal/extractors/javascript/ ./internal/substrate/ ./internal/links/ ./tools/coverage/ ./internal/types/ ./cmd/archigraph/`. `validate` exits 0, `gen` byte-stable, `fmt --check` canonical.

## implements-capability

```
implements-capability: lang.jsts.framework.graphql-resolvers/Transport/transport_binding:—→full
implements-capability: lang.jsts.framework.trpc/Transport/transport_binding:—→full
```

Closes #2906

🤖 Generated with [Claude Code](https://claude.com/claude-code)