### PR TITLE
feat(jsts): meta-framework Structure + Routing — Nuxt + SvelteKit

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -174,9 +174,9 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | — 0/1 | ✅ 1/1 | ✅ 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ✅ 1/1 | ✅ 2/2 | ❌ 1/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
 | [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ✅ 1/1 | ✅ 2/2 | ❌ 1/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 4/4 | |
 | [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 3/14 | |
 
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -43,9 +43,9 @@ Back to [summary](../summary.md).
 | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | — 0/1 | ✅ 1/1 | ✅ 4/4 | |
 | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
 | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ❌ 0/2 | ✅ 1/1 | ✅ 2/2 | ❌ 1/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
 | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ❌ 0/2 | ✅ 1/1 | ✅ 2/2 | ❌ 1/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 4/4 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 4/4 | |
 
 
 ### Mobile

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ✅ `full` | — | — | [link](2880) | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` | — |
-| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+| `router_pattern` | ✅ `full` | — | — | [link](2880) | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `component_extraction` | ❌ `missing` | — | — | — | — | — |
+| `component_extraction` | ✅ `full` | — | — | [link](2880) | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/svelte.go` | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `route_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` | — |
-| `router_pattern` | ❌ `missing` | — | — | — | — | — |
+| `router_pattern` | ✅ `full` | — | — | [link](2880) | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/svelte.go` | — |
 
 ### Build
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12062,7 +12062,9 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2880_metafw_routing_test.go","internal/custom/javascript/nuxt.go"],
+            "issue": "2880"
           },
           "hook_recognition": {
             "status": "not_applicable"
@@ -12094,7 +12096,9 @@
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2880_metafw_routing_test.go","internal/custom/javascript/nuxt.go"],
+            "issue": "2880"
           }
         },
         "Build": {
@@ -13076,7 +13080,9 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2880_metafw_routing_test.go","internal/custom/javascript/svelte.go"],
+            "issue": "2880"
           },
           "hook_recognition": {
             "status": "not_applicable"
@@ -13108,7 +13114,9 @@
             "verified_at": "2026-05-28"
           },
           "router_pattern": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2880_metafw_routing_test.go","internal/custom/javascript/svelte.go"],
+            "issue": "2880"
           }
         },
         "Build": {

--- a/internal/custom/javascript/issue2880_metafw_routing_test.go
+++ b/internal/custom/javascript/issue2880_metafw_routing_test.go
@@ -1,0 +1,160 @@
+package javascript_test
+
+import "testing"
+
+// issue2880_metafw_routing_test.go — proving fixtures for the non-React
+// meta-framework Structure (component_extraction) + Routing (router_pattern)
+// coverage cells closed by issue #2880: Nuxt (Vue-based) and SvelteKit
+// (Svelte-based). These are hand-written, dependency-manifest-free source
+// snippets exercised through the registered custom extractors.
+
+// ── Nuxt (Vue-based): page component + file-system router pattern ─────────────
+
+func TestNuxt2880PageComponentAndRouter(t *testing.T) {
+	src := `
+<script setup lang="ts">
+const { data } = await useAsyncData('p', () => $fetch('/api/p'))
+defineProps<{ id: string }>()
+</script>
+<template><div>{{ data }}</div></template>
+`
+	path := "pages/users/[id].vue"
+	ents := extract(t, "custom_js_nuxt", fi(path, "typescript", src))
+
+	// Structure/component_extraction: the Vue SFC page component.
+	if !containsEntity(ents, "SCOPE.UIComponent", "Id") {
+		t.Errorf("expected Nuxt page UIComponent (component_extraction), got %#v", ents)
+	}
+	if !containsSubtype(ents, "page") {
+		t.Error("expected page subtype on Nuxt component")
+	}
+
+	// Routing/router_pattern: file-system route convention on the endpoint.
+	if !rawHasProp(t, "custom_js_nuxt", path, "typescript", src,
+		"/users/{id}", "router", "file_system") {
+		t.Error("expected /users/{id} endpoint tagged router=file_system (router_pattern)")
+	}
+	// router convention also recorded on the component node.
+	if !rawHasProp(t, "custom_js_nuxt", path, "typescript", src,
+		"Id", "route_path", "/users/{id}") {
+		t.Error("expected page component carrying route_path /users/{id}")
+	}
+
+	// Routing/router_pattern: declared `[id]` route-param source node.
+	if !containsEntity(ents, "SCOPE.Pattern", "param:id") {
+		t.Error("expected route_param node param:id (router_pattern)")
+	}
+	if !rawHasProp(t, "custom_js_nuxt", path, "typescript", src,
+		"param:id", "source_segment", "[id]") {
+		t.Error("expected param:id source_segment [id]")
+	}
+}
+
+func TestNuxt2880IndexRouteAndCatchAll(t *testing.T) {
+	// index.vue → "/" ; defineComponent name wins over filename.
+	idxSrc := `<script>export default defineComponent({ name: 'HomePage' })</script>`
+	idx := extract(t, "custom_js_nuxt", fi("pages/index.vue", "javascript", idxSrc))
+	if !containsEntity(idx, "SCOPE.UIComponent", "HomePage") {
+		t.Errorf("expected HomePage component from defineComponent name, got %#v", idx)
+	}
+	if !containsEntity(idx, "SCOPE.Operation", "/") {
+		t.Error("expected index.vue → / route")
+	}
+
+	// catch-all [...slug] → declared catch_all route param.
+	caSrc := `<script setup></script><template/>`
+	if !rawHasProp(t, "custom_js_nuxt", "pages/docs/[...slug].vue", "typescript", caSrc,
+		"param:slug", "catch_all", "true") {
+		t.Error("expected catch-all param:slug catch_all=true")
+	}
+}
+
+func TestNuxt2880NonPageVueNoPageComponent(t *testing.T) {
+	// A .vue file outside pages/ must not be tagged as a routed page component.
+	src := `<script setup></script><template/>`
+	ents := extract(t, "custom_js_nuxt", fi("components/Widget.vue", "typescript", src))
+	if containsSubtype(ents, "page") {
+		t.Errorf("non-pages .vue must not emit a page component, got %#v", ents)
+	}
+}
+
+// ── SvelteKit (Svelte-based): page component + router pattern + param source ──
+
+func TestSvelteKit2880PageComponentAndRouter(t *testing.T) {
+	src := `
+<script lang="ts">
+  export let data
+</script>
+<article>{data.post.title}</article>
+`
+	path := "src/routes/post/[id]/+page.svelte"
+	ents := extract(t, "custom_js_svelte", fi(path, "typescript", src))
+
+	// Structure/component_extraction: the +page.svelte component (subtype page).
+	if !containsSubtype(ents, "page") {
+		t.Errorf("expected SvelteKit page component (component_extraction), got %#v", ents)
+	}
+	// Routing/router_pattern: file-system route convention + derived route_path.
+	if !rawHasProp(t, "custom_js_svelte", path, "typescript", src,
+		"Id", "router", "file_system") {
+		t.Error("expected page component tagged router=file_system (router_pattern)")
+	}
+	if !rawHasProp(t, "custom_js_svelte", path, "typescript", src,
+		"Id", "route_path", "/post/{id}") {
+		t.Error("expected page component route_path /post/{id}")
+	}
+	// Declared `[id]` route-param source node.
+	if !containsEntity(ents, "SCOPE.Pattern", "param:id") {
+		t.Error("expected route_param node param:id (router_pattern)")
+	}
+}
+
+func TestSvelteKit2880LoadParamsSourceDetection(t *testing.T) {
+	// A +page.server.ts load() reading params.id must record params_read=id,
+	// wiring the read to the declared [id] route segment (def-use source).
+	src := `
+export const load = async ({ params }) => {
+  const post = await db.get(params.id)
+  return { post }
+}
+`
+	path := "src/routes/post/[id]/+page.server.ts"
+	if !rawHasProp(t, "custom_js_svelte", path, "typescript", src,
+		"load:/post/{id}", "params_read", "id") {
+		t.Error("expected load() params_read=id wired to [id] segment (param source detection)")
+	}
+	// The declared route-param node is the resolvable source.
+	ents := extract(t, "custom_js_svelte", fi(path, "typescript", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "param:id") {
+		t.Error("expected route_param source node param:id")
+	}
+}
+
+func TestSvelteKit2880UndeclaredParamNotRecorded(t *testing.T) {
+	// `params.foo` with no `[foo]` segment must NOT be recorded — honest def-use:
+	// only reads backed by a real route segment resolve to a source.
+	src := `
+export const load = async ({ params }) => {
+  return { x: params.notARoute }
+}
+`
+	path := "src/routes/post/[id]/+page.server.ts"
+	if rawHasProp(t, "custom_js_svelte", path, "typescript", src,
+		"load:/post/{id}", "params_read", "notARoute") {
+		t.Error("undeclared param must not be recorded as a route-param read")
+	}
+	if rawHasProp(t, "custom_js_svelte", path, "typescript", src,
+		"load:/post/{id}", "params_read", "id") {
+		t.Error("params.id not read in this load(); must not be recorded")
+	}
+}
+
+func TestSvelteKit2880MatcherParamSource(t *testing.T) {
+	// SvelteKit matcher segment `[page=integer]` declares param `page`.
+	src := `<script lang="ts"></script>`
+	path := "src/routes/blog/[page=integer]/+page.svelte"
+	if !rawHasProp(t, "custom_js_svelte", path, "typescript", src,
+		"param:page", "param_name", "page") {
+		t.Error("expected matcher segment to declare param:page (param_name=page)")
+	}
+}

--- a/internal/custom/javascript/nuxt.go
+++ b/internal/custom/javascript/nuxt.go
@@ -73,6 +73,26 @@ func normalizeNuxtPath(fp string) string {
 	return result
 }
 
+// emitNuxtRouteParams emits one route_param node per dynamic `[name]` (or
+// catch-all `[...name]`) segment in a Nuxt pages/ path. These are the declared
+// source of `useRoute().params.<name>` reads, so def-use / data-flow can resolve
+// the param's origin (router_pattern, issue #2880).
+func emitNuxtRouteParams(fp, routePath, filePath, language string, add func(types.EntityRecord)) {
+	for _, m := range reNuxtDynParam.FindAllStringSubmatch(fp, -1) {
+		inner := m[1]
+		catchAll := strings.HasPrefix(inner, "...")
+		name := strings.TrimPrefix(inner, "...")
+		if name == "" {
+			continue
+		}
+		ent := makeEntity("param:"+name, "SCOPE.Pattern", "route_param", filePath, language, 1)
+		setProps(&ent, "framework", "nuxt", "param_name", name, "route_path", routePath,
+			"source_segment", "["+inner+"]", "catch_all", fmt.Sprintf("%v", catchAll),
+			"provenance", "INFERRED_FROM_NUXT_ROUTE_PARAM")
+		add(ent)
+	}
+}
+
 func (e *nuxtExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/javascript")
 	_, span := tracer.Start(ctx, "indexer.nuxt_extractor.extract",
@@ -146,11 +166,15 @@ func (e *nuxtExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]t
 		addEntity(ent)
 	}
 
-	// Pages → route endpoints
+	// Pages → route endpoints + page component (Structure/component_extraction +
+	// Routing/router_pattern, issue #2880). A `pages/**/*.vue` file is both a
+	// file-system route (the `pages/` convention) and a Vue SFC page component.
 	if isPagesFile {
 		routePath := normalizeNuxtPath(fp)
 		if idx := strings.Index(routePath, "/pages/"); idx >= 0 {
 			routePath = routePath[idx+6:]
+		} else if strings.HasPrefix(routePath, "pages/") {
+			routePath = routePath[len("pages"):]
 		}
 		if ext2 := filepath.Ext(routePath); ext2 != "" {
 			routePath = strings.TrimSuffix(routePath, ext2)
@@ -165,10 +189,39 @@ func (e *nuxtExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]t
 		if !strings.HasPrefix(routePath, "/") {
 			routePath = "/" + routePath
 		}
+		// Routing/router_pattern: the route endpoint, tagged with the
+		// file-system router convention so route discovery is provable.
 		ent := makeEntity(routePath, "SCOPE.Operation", "endpoint", file.Path, file.Language, 1)
 		setProps(&ent, "framework", "nuxt", "route_path", routePath,
+			"router", "file_system",
 			"provenance", "INFERRED_FROM_NUXT_FILE_PATH")
 		addEntity(ent)
+
+		// Structure/component_extraction: the Vue SFC page component. Mirror the
+		// vue.go SFC model (is_setup / defineProps / defineEmits) and carry the
+		// route_path + router convention so the page node is both a component and
+		// a routable entity.
+		// Derive a clean component name from the filename, stripping dynamic
+		// `[param]` / catch-all `[...param]` bracket notation (e.g. `[id]` → `Id`).
+		cleanStem := strings.NewReplacer("[", "", "]", "", "...", "").Replace(stem)
+		compName := toPascalCase(cleanStem)
+		if nm := reVueDefineComponentName.FindStringSubmatch(src); nm != nil {
+			compName = nm[1]
+		}
+		comp := makeEntity(compName, "SCOPE.UIComponent", "page", file.Path, file.Language, 1)
+		setProps(&comp, "framework", "nuxt",
+			"is_setup", fmt.Sprintf("%v", reVueScriptSetupAttr.MatchString(src)),
+			"has_define_props", fmt.Sprintf("%v", reVueDefineProps.MatchString(src)),
+			"has_define_emits", fmt.Sprintf("%v", reVueDefineEmits.MatchString(src)),
+			"route_path", routePath, "router", "file_system",
+			"provenance", "INFERRED_FROM_NUXT_PAGE_COMPONENT")
+		addEntity(comp)
+
+		// Routing/router_pattern: a dedicated route-param node per dynamic
+		// `[name]` segment so def-use/data-flow can resolve the route's declared
+		// params as their source (the page's useAsyncData/useFetch read them via
+		// `useRoute().params`).
+		emitNuxtRouteParams(fp, routePath, file.Path, file.Language, addEntity)
 	}
 
 	// Composables (use*)

--- a/internal/custom/javascript/svelte.go
+++ b/internal/custom/javascript/svelte.go
@@ -41,6 +41,9 @@ var (
 	)
 	reSvelteDynParam  = regexp.MustCompile(`\[([^\]]+)\]`)
 	reSvelteGroupPath = regexp.MustCompile(`\([^)]+\)`)
+	// `params.<name>` access inside a load()/actions handler — a read of a route
+	// param whose declared source is the `[name]` route segment (issue #2880).
+	reSvelteParamsRead = regexp.MustCompile(`\bparams\.([A-Za-z_$][A-Za-z0-9_$]*)`)
 
 	// Static generation + render-mode page options (issue #2858). SvelteKit
 	// page-options exports select the render strategy per route:
@@ -65,6 +68,63 @@ func normalizeSveltePath(fp string) string {
 		result = strings.ReplaceAll(result, "//", "/")
 	}
 	return result
+}
+
+// svelteRouteParamNames returns the dynamic param names declared by a
+// SvelteKit route path, stripping the `...` rest prefix and SvelteKit matcher
+// suffixes (`[id=integer]` → `id`).
+func svelteRouteParamNames(fp string) []string {
+	var names []string
+	for _, m := range reSvelteDynParam.FindAllStringSubmatch(fp, -1) {
+		inner := strings.TrimPrefix(m[1], "...")
+		if eq := strings.IndexByte(inner, '='); eq >= 0 {
+			inner = inner[:eq] // drop `=matcher`
+		}
+		if inner != "" {
+			names = append(names, inner)
+		}
+	}
+	return names
+}
+
+// svelteRouteParamSet returns the declared route params as a lookup set.
+func svelteRouteParamSet(fp string) map[string]bool {
+	set := make(map[string]bool)
+	for _, n := range svelteRouteParamNames(fp) {
+		set[n] = true
+	}
+	return set
+}
+
+// emitSvelteRouteParams emits one route_param node per dynamic segment in a
+// SvelteKit route — the declared source for `params.<name>` reads.
+func emitSvelteRouteParams(fp, routePath, filePath, language string, add func(types.EntityRecord)) {
+	for _, m := range reSvelteDynParam.FindAllStringSubmatch(fp, -1) {
+		raw := m[1]
+		catchAll := strings.HasPrefix(raw, "...")
+		inner := strings.TrimPrefix(raw, "...")
+		if eq := strings.IndexByte(inner, '='); eq >= 0 {
+			inner = inner[:eq]
+		}
+		if inner == "" {
+			continue
+		}
+		ent := makeEntity("param:"+inner, "SCOPE.Pattern", "route_param", filePath, language, 1)
+		setProps(&ent, "framework", "svelte", "param_name", inner, "route_path", routePath,
+			"source_segment", "["+raw+"]", "catch_all", fmt.Sprintf("%v", catchAll),
+			"provenance", "INFERRED_FROM_SVELTEKIT_ROUTE_PARAM")
+		add(ent)
+	}
+}
+
+// contains reports whether s is present in xs.
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 // toPascalCase converts kebab-case or underscore_case to PascalCase.
@@ -127,7 +187,10 @@ func (e *svelteExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 		// Derive from directory name
 		stem = filepath.Base(filepath.Dir(fp))
 	}
-	compName := toPascalCase(stem)
+	// Strip dynamic `[param]` / matcher / catch-all bracket notation from the
+	// name (e.g. `[id]` → `Id`, `[page=integer]` → `PageInteger`).
+	cleanStem := strings.NewReplacer("[", "", "]", "", "...", "", "=", "_").Replace(stem)
+	compName := toPascalCase(cleanStem)
 
 	routePath := normalizeSveltePath(fp)
 	if idx := strings.Index(routePath, "/routes/"); idx >= 0 {
@@ -156,11 +219,21 @@ func (e *svelteExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 		} else if strings.HasPrefix(base, "+page") {
 			subtype = "page"
 		}
+		// Structure/component_extraction + Routing/router_pattern (issue #2880):
+		// the Svelte SFC page/layout/error component, tagged with the derived
+		// route_path and the SvelteKit file-system router convention.
 		ent := makeEntity(compName, "SCOPE.UIComponent", subtype, file.Path, file.Language, 1)
 		setProps(&ent, "framework", "svelte", "route_path", routePath,
+			"router", "file_system",
 			"provenance", "INFERRED_FROM_SVELTE_COMPONENT")
 		addEntity(ent)
 	}
+
+	// Routing/router_pattern (issue #2880): one route_param node per dynamic
+	// `[name]` (or rest `[...name]`) segment in the route. These are the declared
+	// source for `params.<name>` reads inside load()/actions, so def-use can
+	// resolve a param read back to its route-segment definition.
+	emitSvelteRouteParams(fp, routePath, file.Path, file.Language, addEntity)
 
 	// SvelteKit load() function — the framework data loader (data_loaders).
 	// A load() in a `+page.server.ts` / `+layout.server.ts` is server-only (a
@@ -177,6 +250,20 @@ func (e *svelteExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 		setProps(&ent, "framework", "svelte", "route_path", routePath,
 			"loader_kind", "load", "rendering", rendering,
 			"provenance", "INFERRED_FROM_SVELTE_LOAD")
+		// Route-param source detection (issue #2880): record which declared
+		// `[name]` route segments this load() reads via `params.<name>`. Only
+		// params backed by a real route segment are recorded, so def-use can
+		// resolve the read to its route_param source node.
+		declared := svelteRouteParamSet(fp)
+		var read []string
+		for _, m := range reSvelteParamsRead.FindAllStringSubmatch(src, -1) {
+			if declared[m[1]] && !contains(read, m[1]) {
+				read = append(read, m[1])
+			}
+		}
+		if len(read) > 0 {
+			setProps(&ent, "params_read", strings.Join(read, ","))
+		}
 		addEntity(ent)
 	}
 


### PR DESCRIPTION
Closes #2880.

Follow-up to #2857 (React-based trio) / #2858 (server + data-loaders). Flips the four deferred **non-React** meta-framework cells to `full`, each fixture-proven:

| Record | Group / Capability | before → after |
|---|---|---|
| `lang.jsts.framework.nuxt` | Structure / `component_extraction` | ❌ missing → ✅ full |
| `lang.jsts.framework.nuxt` | Routing / `router_pattern` | ❌ missing → ✅ full |
| `lang.jsts.framework.sveltekit` | Structure / `component_extraction` | ❌ missing → ✅ full |
| `lang.jsts.framework.sveltekit` | Routing / `router_pattern` | ❌ missing → ✅ full |

implements-capability: jsts/framework/nuxt/component_extraction
implements-capability: jsts/framework/nuxt/router_pattern
implements-capability: jsts/framework/sveltekit/component_extraction
implements-capability: jsts/framework/sveltekit/router_pattern

## Nuxt (`internal/custom/javascript/nuxt.go`)
- `pages/**/*.vue` now emits a Vue SFC **page component** (`SCOPE.UIComponent`, subtype `page`), reusing the `vue.go` SFC model (`is_setup`/`has_define_props`/`has_define_emits`), carrying `route_path` + `router=file_system` — **component_extraction**.
- Route endpoint + page component tagged `router=file_system`; one `route_param` node (`SCOPE.Pattern`) per dynamic `[name]`/catch-all `[...name]` segment as the declared param source — **router_pattern**.
- Hardened: handles a leading `pages/` path prefix and strips `[ ] ...` bracket notation from the derived component name (`[id]` → `Id`; `defineComponent({name})` still wins).

## SvelteKit (`internal/custom/javascript/svelte.go`)
- `+page`/`+layout`/`+error` component tagged `router=file_system` alongside the already-derived `route_path` — **component_extraction + router_pattern**.
- `route_param` source node per dynamic / matcher (`[id=integer]`) / rest segment.
- **Param source detection** (gap flagged on #2857/#2868): `load()` now records `params_read` for each `params.<name>` backed by a real `[name]` route segment, wiring the read to its route-segment source for def-use; undeclared `params.<x>` are intentionally ignored.

## Honesty / mechanics
- No new entity/edge Kind — reuses `SCOPE.UIComponent` / `SCOPE.Operation` / `SCOPE.Pattern` (`go test ./internal/types/` green).
- Proofs in `internal/custom/javascript/issue2880_metafw_routing_test.go` — dependency-free source snippets through the registered extractors (7 tests, incl. negative cases: non-`pages/` `.vue` not a page, undeclared param not recorded).
- Registry flips via the coverage tool; `fmt --check` ok, `validate` exit 0, `gen` regenerated docs; `registry.json` diff is the 4 cells only (12+/4-).

Tests: `./internal/custom/javascript/ ./internal/extractors/javascript/ ./internal/engine/ ./internal/substrate/ ./internal/links/ ./tools/coverage/ ./internal/types/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)