### PR TITLE
feat(jsts): mobile fwspec idioms — RN metro/native-link + Expo EAS/app.json (#2879)

### DIFF
--- a/docs/coverage/detail/lang.jsts.framework.expo.md
+++ b/docs/coverage/detail/lang.jsts.framework.expo.md
@@ -79,8 +79,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `eas_build_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| `expo_config_extraction` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `eas_build_detection` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2879) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/testdata/mobile/expo_config/eas.json` | — |
+| `expo_config_extraction` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2879) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/testdata/mobile/expo_config/app.json` | — |
 | `expo_router_specifics` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/navigation.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.jsts.framework.react-native.md
+++ b/docs/coverage/detail/lang.jsts.framework.react-native.md
@@ -88,8 +88,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `metro_config_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| `native_link_recognition` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `metro_config_detection` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2879) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/testdata/mobile/rn_cli/metro.config.js` | — |
+| `native_link_recognition` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2879) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/testdata/mobile/rn_cli/react-native.config.js` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10963,12 +10963,16 @@
       "framework_specific": {
         "Expo Ecosystem": {
           "eas_build_detection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/extractors/config/discover.go","internal/extractors/config/testdata/mobile/expo_config/eas.json"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2879",
+            "verified_at": "2026-05-29"
           },
           "expo_config_extraction": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/extractors/config/discover.go","internal/extractors/config/testdata/mobile/expo_config/app.json"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2879",
+            "verified_at": "2026-05-29"
           },
           "expo_router_specifics": {
             "status": "full",
@@ -12688,12 +12692,16 @@
         },
         "React Native CLI": {
           "metro_config_detection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/extractors/config/discover.go","internal/extractors/config/testdata/mobile/rn_cli/metro.config.js"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2879",
+            "verified_at": "2026-05-29"
           },
           "native_link_recognition": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/extractors/config/discover.go","internal/extractors/config/testdata/mobile/rn_cli/react-native.config.js"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2879",
+            "verified_at": "2026-05-29"
           }
         }
       }

--- a/internal/extractors/config/discover.go
+++ b/internal/extractors/config/discover.go
@@ -80,6 +80,14 @@ const (
 	formatTestRunnerJSON configKind = "test_runner_json"
 	formatTestRunnerJS   configKind = "test_runner_js"
 	formatTestRunnerYAML configKind = "test_runner_yaml"
+
+	// Mobile (React Native CLI + Expo) config families (issue #2879). JSON
+	// configs (eas.json, app.json) are JSONC-tolerant and mined for build
+	// profiles / the Expo manifest; JS configs (metro.config.js,
+	// react-native.config.js, app.config.{js,ts}) are mined with permissive
+	// regexes — no JS evaluation, just stable structural signal.
+	formatMobileJSON configKind = "mobile_json"
+	formatMobileJS   configKind = "mobile_js"
 )
 
 // configSpec describes one recognised config file. Subtype is the value
@@ -136,6 +144,13 @@ var exactBasenames = map[string]configSpec{
 	"jasmine.json":   {"jasmine_config", formatTestRunnerJSON},
 	".taprc":         {"tap_config", formatTestRunnerYAML},
 
+	// Mobile — React Native CLI + Expo (issue #2879). eas.json carries the
+	// EAS Build/Submit profiles; app.json is the Expo manifest (the "expo"
+	// block). metro.config / react-native.config / app.config.{js,ts} are JS
+	// and matched via regex below.
+	"eas.json": {"eas_config", formatMobileJSON},
+	"app.json": {"expo_config", formatMobileJSON},
+
 	"go.mod": {"go_module", formatGoMod},
 	"go.sum": {"go_sum", formatGoMod}, // existence only
 
@@ -179,6 +194,13 @@ var (
 	playwrightConfigRe = regexp.MustCompile(`^playwright\.config\.(js|ts|mjs|cjs)$`)
 	mocharcJSRe        = regexp.MustCompile(`^\.mocharc\.(js|cjs)$`)
 	avaConfigRe        = regexp.MustCompile(`^ava\.config\.(js|cjs|mjs)$`)
+
+	// Mobile JS config variants (issue #2879). Matched as JS source so the
+	// mobile parser can mine the metro resolver/transformer, react-native.config
+	// native-module links, and the Expo app.config manifest.
+	metroConfigRe   = regexp.MustCompile(`^metro\.config\.(js|ts|mjs|cjs)$`)
+	rnConfigRe      = regexp.MustCompile(`^react-native\.config\.(js|ts|mjs|cjs)$`)
+	expoAppConfigRe = regexp.MustCompile(`^app\.config\.(js|ts|mjs|cjs)$`)
 )
 
 // classify returns the configSpec for filePath, or false when the file is
@@ -219,6 +241,12 @@ func classify(relPath string) (configSpec, bool) {
 		return configSpec{"eslint_config", formatJSConfig}, true
 	case prettierConfigRe.MatchString(base):
 		return configSpec{"prettier_config", formatJSConfig}, true
+	case metroConfigRe.MatchString(base):
+		return configSpec{"metro_config", formatMobileJS}, true
+	case rnConfigRe.MatchString(base):
+		return configSpec{"react_native_config", formatMobileJS}, true
+	case expoAppConfigRe.MatchString(base):
+		return configSpec{"expo_config", formatMobileJS}, true
 	}
 	return configSpec{}, false
 }
@@ -376,9 +404,9 @@ func languageForFormat(f configKind) string {
 		return "env"
 	case formatGradle:
 		return "groovy"
-	case formatJSConfig, formatBundlerJS, formatTestRunnerJS:
+	case formatJSConfig, formatBundlerJS, formatTestRunnerJS, formatMobileJS:
 		return "javascript"
-	case formatBundlerJSON, formatTestRunnerJSON:
+	case formatBundlerJSON, formatTestRunnerJSON, formatMobileJSON:
 		return "json"
 	case formatTestRunnerYAML:
 		return "yaml"
@@ -429,6 +457,10 @@ func parseInto(props map[string]string, spec configSpec, content []byte) {
 		parseTestRunnerJS(props, spec, content)
 	case formatTestRunnerYAML:
 		parseTestRunnerYAML(props, spec, content)
+	case formatMobileJSON:
+		parseMobileJSON(props, spec, content)
+	case formatMobileJS:
+		parseMobileJS(props, spec, content)
 	}
 }
 
@@ -1473,6 +1505,331 @@ func parseTestRunnerYAML(props map[string]string, spec configSpec, content []byt
 	if len(deps) > 0 {
 		props["spec_dependencies"] = capJoin(deps)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Mobile config parsers — React Native CLI + Expo (issue #2879)
+//
+// These power the framework_specific mobile idioms:
+//   - metro_config_detection: metro.config.{js,ts} resolver/transformer block
+//       → Properties["metro_keys"] (resolver/transformer/projectRoot/...)
+//   - native_link_recognition: react-native.config.js native-module links
+//       → Properties["native_modules"] (dependencies.* keys = autolinked deps)
+//   - eas_build_detection: eas.json EAS Build/Submit profiles
+//       → Properties["eas_build_profiles"] / Properties["eas_submit_profiles"]
+//   - expo_config_extraction: app.json / app.config.{js,ts} Expo manifest
+//       → Properties["expo_name"|"expo_slug"|"expo_scheme"|"expo_plugins"]
+//
+// JSON configs (eas.json, app.json) are JSONC-tolerant. JS configs
+// (metro.config.js, react-native.config.js, app.config.{js,ts}) are mined with
+// permissive regexes — no JS evaluation, just stable structural signal.
+// ---------------------------------------------------------------------------
+
+var (
+	// metroSectionRE finds the top-level metro config sections we care about
+	// (resolver/transformer/serializer/server/watchFolders/projectRoot).
+	metroSectionRE = regexp.MustCompile(`(?m)\b(resolver|transformer|serializer|server|watchFolders|projectRoot|maxWorkers|cacheStores)\s*:`)
+)
+
+func parseMobileJSON(props map[string]string, spec configSpec, content []byte) {
+	clean := stripJSONC(content)
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(clean, &generic); err != nil {
+		return
+	}
+	props["keys_top_level"] = joinSortedKeys(generic)
+
+	switch spec.subtype {
+	case "eas_config":
+		parseEASConfig(props, clean)
+	case "expo_config":
+		parseExpoManifest(props, clean)
+	}
+}
+
+// parseEASConfig mines eas.json. EAS Build profiles live under "build"
+// (development/preview/production/...), submit profiles under "submit"; the
+// "cli" block carries the appVersionSource / requireCommit policy.
+func parseEASConfig(props map[string]string, content []byte) {
+	var eas struct {
+		CLI    json.RawMessage            `json:"cli"`
+		Build  map[string]json.RawMessage `json:"build"`
+		Submit map[string]json.RawMessage `json:"submit"`
+	}
+	if err := json.Unmarshal(content, &eas); err != nil {
+		return
+	}
+	if len(eas.Build) > 0 {
+		props["eas_build_profiles"] = joinSortedKeys(eas.Build)
+	}
+	if len(eas.Submit) > 0 {
+		props["eas_submit_profiles"] = joinSortedKeys(eas.Submit)
+	}
+	if len(eas.CLI) > 0 {
+		var cli map[string]json.RawMessage
+		if json.Unmarshal(eas.CLI, &cli) == nil && len(cli) > 0 {
+			props["eas_cli_keys"] = joinSortedKeys(cli)
+		}
+	}
+}
+
+// parseExpoManifest mines app.json / the JSON-decodable head of an Expo
+// manifest. The manifest is conventionally wrapped in an "expo" key, but a
+// bare manifest (no wrapper) is also accepted.
+func parseExpoManifest(props map[string]string, content []byte) {
+	var wrapper struct {
+		Expo json.RawMessage `json:"expo"`
+	}
+	manifest := content
+	if json.Unmarshal(content, &wrapper) == nil && len(wrapper.Expo) > 0 {
+		manifest = wrapper.Expo
+	}
+	var expo struct {
+		Name    string          `json:"name"`
+		Slug    string          `json:"slug"`
+		Version string          `json:"version"`
+		Scheme  json.RawMessage `json:"scheme"`
+		Plugins json.RawMessage `json:"plugins"`
+	}
+	if err := json.Unmarshal(manifest, &expo); err != nil {
+		return
+	}
+	if expo.Name != "" {
+		props["expo_name"] = expo.Name
+	}
+	if expo.Slug != "" {
+		props["expo_slug"] = expo.Slug
+	}
+	if expo.Version != "" {
+		props["expo_version"] = expo.Version
+	}
+	if scheme := decodeStringOrArray(expo.Scheme); len(scheme) > 0 {
+		sort.Strings(scheme)
+		props["expo_scheme"] = capJoin(scheme)
+	}
+	if plugins := decodeExpoPlugins(expo.Plugins); len(plugins) > 0 {
+		sort.Strings(plugins)
+		props["expo_plugins"] = capJoin(plugins)
+	}
+}
+
+// decodeStringOrArray accepts either "x" or ["x","y"] and returns the values.
+func decodeStringOrArray(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		if s == "" {
+			return nil
+		}
+		return []string{s}
+	}
+	var arr []string
+	if json.Unmarshal(raw, &arr) == nil {
+		return arr
+	}
+	return nil
+}
+
+// decodeExpoPlugins accepts the Expo "plugins" array, whose members are either
+// a bare plugin name ("expo-router") or a [name, config] tuple. The plugin
+// name (first element / scalar) is the stable signal.
+func decodeExpoPlugins(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var items []json.RawMessage
+	if json.Unmarshal(raw, &items) != nil {
+		return nil
+	}
+	var names []string
+	for _, item := range items {
+		var name string
+		if json.Unmarshal(item, &name) == nil && name != "" {
+			names = append(names, name)
+			continue
+		}
+		var tuple []json.RawMessage
+		if json.Unmarshal(item, &tuple) == nil && len(tuple) > 0 {
+			if json.Unmarshal(tuple[0], &name) == nil && name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+func parseMobileJS(props map[string]string, spec configSpec, content []byte) {
+	parseJSConfig(props, content) // keep top-level export hints
+	src := string(content)
+
+	switch spec.subtype {
+	case "metro_config":
+		var sections []string
+		for _, m := range metroSectionRE.FindAllStringSubmatch(src, -1) {
+			sections = append(sections, m[1])
+		}
+		sort.Strings(sections)
+		sections = dedup(sections)
+		if len(sections) > 0 {
+			props["metro_keys"] = capJoin(sections)
+		}
+	case "react_native_config":
+		// react-native.config.js declares autolinked native modules under
+		// `dependencies: { 'pkg': { ... } }`. We mine the dependency package
+		// names (the native-module link signal) and note project platforms.
+		var mods []string
+		if block := sliceObjectValue(src, "dependencies"); block != "" {
+			for _, k := range topLevelObjectKeys(block) {
+				mods = append(mods, strings.Trim(k, `'"`))
+			}
+		}
+		sort.Strings(mods)
+		mods = dedup(mods)
+		if len(mods) > 0 {
+			props["native_modules"] = capJoin(mods)
+		}
+		var platforms []string
+		for _, p := range []string{"ios", "android"} {
+			if strings.Contains(src, p+":") || strings.Contains(src, `"`+p+`"`) || strings.Contains(src, "'"+p+"'") {
+				platforms = append(platforms, p)
+			}
+		}
+		if len(platforms) > 0 {
+			props["rn_platforms"] = capJoin(platforms)
+		}
+	case "expo_config":
+		// app.config.{js,ts} returns the manifest from JS. Mine the manifest
+		// fields with permissive regexes (no JS evaluation).
+		if name := jsStringField(src, "name"); name != "" {
+			props["expo_name"] = name
+		}
+		if slug := jsStringField(src, "slug"); slug != "" {
+			props["expo_slug"] = slug
+		}
+		if scheme := jsStringField(src, "scheme"); scheme != "" {
+			props["expo_scheme"] = scheme
+		}
+		var plugins []string
+		if block := sliceArrayValue(src, "plugins"); block != "" {
+			for _, sm := range bundlerStringRE.FindAllStringSubmatch(block, -1) {
+				plugins = append(plugins, sm[1])
+			}
+		}
+		sort.Strings(plugins)
+		plugins = dedup(plugins)
+		if len(plugins) > 0 {
+			props["expo_plugins"] = capJoin(plugins)
+		}
+	}
+}
+
+// objectKeyRE matches an object-literal key (quoted or bare) followed by a
+// colon: `'react-native-foo':` or `myModule:`.
+var objectKeyRE = regexp.MustCompile(`(['"][^'"]+['"]|[A-Za-z_$][\w$.\-]*)\s*:`)
+
+// topLevelObjectKeys returns the depth-1 keys of the object literal `block`
+// (which must start with `{`). Nested object/array keys are skipped so that a
+// `dependencies: { 'pkg': { platforms: { ios: null } } }` block yields only
+// "pkg", not the nested "platforms"/"ios" keys. Permissive; strings are
+// skipped so a colon inside a string value is not mistaken for a key.
+func topLevelObjectKeys(block string) []string {
+	var keys []string
+	depth := 0
+	inStr := byte(0)
+	for i := 0; i < len(block); i++ {
+		c := block[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		// At depth 1 (immediately inside the outer object), a key is the token
+		// preceding a colon. Match it before the quote-as-string-start branch
+		// so quoted keys ('react-native-foo':) are captured, not treated as a
+		// bare string value.
+		if depth == 1 && (c == '"' || c == '\'' || isKeyStart(c)) {
+			if m := objectKeyRE.FindStringSubmatchIndex(block[i:]); m != nil && m[0] == 0 {
+				keys = append(keys, block[i+m[2]:i+m[3]])
+				i += m[1] - 1
+				continue
+			}
+		}
+		switch c {
+		case '"', '\'', '`':
+			inStr = c
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+		}
+	}
+	return keys
+}
+
+func isKeyStart(c byte) bool {
+	return c == '_' || c == '$' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// jsStringField extracts the first `key: 'value'` / `key: "value"` scalar for
+// the given key from a JS source string. Returns "" when absent or non-scalar.
+func jsStringField(src, key string) string {
+	re := regexp.MustCompile(`(?m)\b` + regexp.QuoteMeta(key) + `\s*:\s*['"]([^'"]+)['"]`)
+	if m := re.FindStringSubmatch(src); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// sliceObjectValue returns the brace-balanced object literal that follows
+// `key:` in src, or "" if not found. Permissive — handles nested braces.
+func sliceObjectValue(src, key string) string {
+	return sliceBalanced(src, key, '{', '}')
+}
+
+// sliceArrayValue returns the bracket-balanced array literal that follows
+// `key:` in src, or "" if not found.
+func sliceArrayValue(src, key string) string {
+	return sliceBalanced(src, key, '[', ']')
+}
+
+func sliceBalanced(src, key string, open, close byte) string {
+	keyRE := regexp.MustCompile(`(?m)\b` + regexp.QuoteMeta(key) + `\s*:\s*`)
+	loc := keyRE.FindStringIndex(src)
+	if loc == nil {
+		return ""
+	}
+	i := loc[1]
+	for i < len(src) && src[i] != open {
+		if src[i] != ' ' && src[i] != '\t' && src[i] != '\n' && src[i] != '\r' {
+			return "" // value is not the expected literal type
+		}
+		i++
+	}
+	if i >= len(src) {
+		return ""
+	}
+	depth := 0
+	start := i
+	for ; i < len(src); i++ {
+		switch src[i] {
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return src[start : i+1]
+			}
+		}
+	}
+	return ""
 }
 
 type yamlBlock struct {

--- a/internal/extractors/config/discover_test.go
+++ b/internal/extractors/config/discover_test.go
@@ -804,6 +804,177 @@ func TestClassify_KnownBasenames(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Mobile config — React Native CLI + Expo (issue #2879)
+// ---------------------------------------------------------------------------
+
+func TestClassify_MobileConfigs(t *testing.T) {
+	cases := []struct {
+		path    string
+		subtype string
+	}{
+		{"metro.config.js", "metro_config"},
+		{"metro.config.ts", "metro_config"},
+		{"react-native.config.js", "react_native_config"},
+		{"eas.json", "eas_config"},
+		{"app.json", "expo_config"},
+		{"app.config.js", "expo_config"},
+		{"app.config.ts", "expo_config"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			spec, ok := classify(tc.path)
+			if !ok {
+				t.Fatalf("classify(%q) returned false", tc.path)
+			}
+			if spec.subtype != tc.subtype {
+				t.Errorf("subtype=%q want %q", spec.subtype, tc.subtype)
+			}
+		})
+	}
+}
+
+// TestDiscover_MobileFixtures runs Discover over the on-disk proving fixtures
+// (testdata/mobile/**) — the dependency-free fixture corpus for #2879.
+func TestDiscover_MobileFixtures(t *testing.T) {
+	root := "testdata/mobile"
+	files := []string{
+		"rn_cli/metro.config.js",
+		"rn_cli/react-native.config.js",
+		"expo_config/eas.json",
+		"expo_config/app.json",
+	}
+	ents, rels := runDiscover(t, root, files)
+
+	// metro_config_detection
+	metro := findBySource(ents, "rn_cli/metro.config.js")
+	if metro == nil || metro.Subtype != "metro_config" {
+		t.Fatalf("metro.config.js: entity=%v", metro)
+	}
+	if metro.Kind != string(types.EntityKindConfig) {
+		t.Errorf("metro Kind=%q want SCOPE.Config", metro.Kind)
+	}
+	for _, k := range []string{"resolver", "transformer", "projectRoot", "watchFolders"} {
+		if !strings.Contains(metro.Properties["metro_keys"], k) {
+			t.Errorf("metro_keys missing %q: %q", k, metro.Properties["metro_keys"])
+		}
+	}
+
+	// native_link_recognition
+	rn := findBySource(ents, "rn_cli/react-native.config.js")
+	if rn == nil || rn.Subtype != "react_native_config" {
+		t.Fatalf("react-native.config.js: entity=%v", rn)
+	}
+	for _, m := range []string{"react-native-vector-icons", "react-native-ble-plx"} {
+		if !strings.Contains(rn.Properties["native_modules"], m) {
+			t.Errorf("native_modules missing %q: %q", m, rn.Properties["native_modules"])
+		}
+	}
+	// Nested dependency-config keys (platforms / ios) must NOT leak into the
+	// native-module list — only the depth-1 dependency package names.
+	for _, leak := range []string{"platforms", "ios"} {
+		for _, got := range strings.Split(rn.Properties["native_modules"], ",") {
+			if got == leak {
+				t.Errorf("native_modules leaked nested key %q: %q", leak, rn.Properties["native_modules"])
+			}
+		}
+	}
+	if rn.Properties["rn_platforms"] == "" {
+		t.Errorf("rn_platforms empty")
+	}
+
+	// eas_build_detection
+	eas := findBySource(ents, "expo_config/eas.json")
+	if eas == nil || eas.Subtype != "eas_config" {
+		t.Fatalf("eas.json: entity=%v", eas)
+	}
+	for _, p := range []string{"development", "preview", "production"} {
+		if !strings.Contains(eas.Properties["eas_build_profiles"], p) {
+			t.Errorf("eas_build_profiles missing %q: %q", p, eas.Properties["eas_build_profiles"])
+		}
+	}
+	if !strings.Contains(eas.Properties["eas_submit_profiles"], "production") {
+		t.Errorf("eas_submit_profiles missing production: %q", eas.Properties["eas_submit_profiles"])
+	}
+
+	// expo_config_extraction
+	expo := findBySource(ents, "expo_config/app.json")
+	if expo == nil || expo.Subtype != "expo_config" {
+		t.Fatalf("app.json: entity=%v", expo)
+	}
+	if expo.Properties["expo_name"] != "FixtureMobileApp" {
+		t.Errorf("expo_name=%q", expo.Properties["expo_name"])
+	}
+	if expo.Properties["expo_slug"] != "fixture-mobile-app" {
+		t.Errorf("expo_slug=%q", expo.Properties["expo_slug"])
+	}
+	if expo.Properties["expo_scheme"] != "fixtureapp" {
+		t.Errorf("expo_scheme=%q", expo.Properties["expo_scheme"])
+	}
+	if !strings.Contains(expo.Properties["expo_plugins"], "expo-router") ||
+		!strings.Contains(expo.Properties["expo_plugins"], "expo-build-properties") {
+		t.Errorf("expo_plugins wrong: %q", expo.Properties["expo_plugins"])
+	}
+
+	// Every emitted config gets DEPENDS_ON_CONFIG + CONFIGURES edges.
+	if len(rels) < len(files)*2 {
+		t.Errorf("expected >=%d edges, got %d", len(files)*2, len(rels))
+	}
+}
+
+// TestDiscover_ExpoAppConfigJS covers the app.config.{js,ts} (dynamic) variant,
+// which returns the Expo manifest from JS rather than JSON.
+func TestDiscover_ExpoAppConfigJS(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "app.config.ts", `import { ExpoConfig } from 'expo/config';
+
+const config: ExpoConfig = {
+  name: 'DynamicApp',
+  slug: 'dynamic-app',
+  scheme: 'dynamicapp',
+  plugins: ['expo-router', 'expo-secure-store'],
+};
+
+export default config;`)
+	ents, _ := runDiscover(t, dir, []string{"app.config.ts"})
+	e := findBySource(ents, "app.config.ts")
+	if e == nil || e.Subtype != "expo_config" {
+		t.Fatalf("app.config.ts: entity=%v", e)
+	}
+	if e.Properties["expo_name"] != "DynamicApp" {
+		t.Errorf("expo_name=%q", e.Properties["expo_name"])
+	}
+	if e.Properties["expo_slug"] != "dynamic-app" {
+		t.Errorf("expo_slug=%q", e.Properties["expo_slug"])
+	}
+	if !strings.Contains(e.Properties["expo_plugins"], "expo-router") ||
+		!strings.Contains(e.Properties["expo_plugins"], "expo-secure-store") {
+		t.Errorf("expo_plugins wrong: %q", e.Properties["expo_plugins"])
+	}
+}
+
+// TestDiscover_ExpoManifestBare covers an app.json without the "expo" wrapper.
+func TestDiscover_ExpoManifestBare(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "app.json", `{
+  "name": "BareApp",
+  "slug": "bare-app",
+  "scheme": ["bareapp", "bareapp-dev"]
+}`)
+	ents, _ := runDiscover(t, dir, []string{"app.json"})
+	e := findBySource(ents, "app.json")
+	if e == nil || e.Subtype != "expo_config" {
+		t.Fatalf("app.json: entity=%v", e)
+	}
+	if e.Properties["expo_name"] != "BareApp" {
+		t.Errorf("expo_name=%q", e.Properties["expo_name"])
+	}
+	if !strings.Contains(e.Properties["expo_scheme"], "bareapp") ||
+		!strings.Contains(e.Properties["expo_scheme"], "bareapp-dev") {
+		t.Errorf("expo_scheme wrong: %q", e.Properties["expo_scheme"])
+	}
+}
+
 func TestClassify_IgnoredFiles(t *testing.T) {
 	for _, p := range []string{
 		"src/main.go",

--- a/internal/extractors/config/testdata/mobile/expo_config/app.json
+++ b/internal/extractors/config/testdata/mobile/expo_config/app.json
@@ -1,0 +1,16 @@
+{
+  "expo": {
+    "name": "FixtureMobileApp",
+    "slug": "fixture-mobile-app",
+    "version": "1.0.0",
+    "scheme": "fixtureapp",
+    "platforms": ["ios", "android"],
+    "plugins": [
+      "expo-router",
+      [
+        "expo-build-properties",
+        { "ios": { "useFrameworks": "static" } }
+      ]
+    ]
+  }
+}

--- a/internal/extractors/config/testdata/mobile/expo_config/eas.json
+++ b/internal/extractors/config/testdata/mobile/expo_config/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 5.9.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/internal/extractors/config/testdata/mobile/rn_cli/metro.config.js
+++ b/internal/extractors/config/testdata/mobile/rn_cli/metro.config.js
@@ -1,0 +1,18 @@
+// Metro bundler config (React Native CLI). Issue #2879 fixture.
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+
+const config = {
+  projectRoot: __dirname,
+  watchFolders: ['../shared'],
+  transformer: {
+    babelTransformerPath: require.resolve('react-native-svg-transformer'),
+  },
+  resolver: {
+    sourceExts: ['js', 'jsx', 'ts', 'tsx', 'svg'],
+    alias: {
+      '@app': './src',
+    },
+  },
+};
+
+module.exports = mergeConfig(getDefaultConfig(__dirname), config);

--- a/internal/extractors/config/testdata/mobile/rn_cli/react-native.config.js
+++ b/internal/extractors/config/testdata/mobile/rn_cli/react-native.config.js
@@ -1,0 +1,16 @@
+// React Native CLI native-module autolinking config. Issue #2879 fixture.
+module.exports = {
+  project: {
+    ios: {},
+    android: {},
+  },
+  assets: ['./assets/fonts'],
+  dependencies: {
+    'react-native-vector-icons': {
+      platforms: {
+        ios: null,
+      },
+    },
+    'react-native-ble-plx': {},
+  },
+};


### PR DESCRIPTION
## Summary

Implements the four **mobile framework_specific (B) idioms** for JS/TS as first-class `SCOPE.Config` entities in the config-discovery pass (`internal/extractors/config`), where project-level config files already become graph entities. **No new entity Kind** is introduced — these decorate the existing `SCOPE.Config` kind (per the #2839 prefer-decorate discipline), so `internal/types` is unchanged.

`expo_router_specifics` was already green (navigation.go); the generic Mobile columns `platform_branching` and `native_module_imports` are intentionally **not** duplicated here — this PR only fills the genuine (B) config-parsing gaps.

## framework_specific cells — honest one-line meanings

(no capability-dictionary entry exists for framework_specific cells, so documenting here)

- **`metro_config_detection`** (React Native CLI): `metro.config.{js,ts,mjs,cjs}` is recognized as a config entity and its top-level sections (`resolver`/`transformer`/`serializer`/`server`/`watchFolders`/`projectRoot`/…) are mined into `metro_keys`. Promotes detection beyond `aliases.go`, which only parsed the resolver alias map for import resolution.
- **`native_link_recognition`** (React Native CLI): `react-native.config.js` is parsed; the depth-1 keys of its `dependencies` block (the autolinked native-module package names) become `native_modules`, and declared `project` platforms become `rn_platforms`.
- **`eas_build_detection`** (Expo): `eas.json` is parsed into `eas_build_profiles` (the `build.*` profile names), `eas_submit_profiles` (`submit.*`), and `eas_cli_keys`.
- **`expo_config_extraction`** (Expo): `app.json` / `app.config.{js,ts}` is parsed into the Expo manifest fields `expo_name`/`expo_slug`/`expo_version`/`expo_scheme`/`expo_plugins` (accepts the `"expo"` wrapper or a bare manifest; the dynamic JS variant is mined with permissive regexes — no JS evaluation).

JSON configs are JSONC-tolerant. A brace-balanced depth-1 key scanner keeps nested dependency-config keys (`platforms`/`ios`) out of the native-module list.

## Tests + fixtures

Dependency-free, hand-written proving fixtures under `internal/extractors/config/testdata/mobile/{rn_cli,expo_config}/`:
- `rn_cli/metro.config.js`, `rn_cli/react-native.config.js`
- `expo_config/eas.json`, `expo_config/app.json`

`TestDiscover_MobileFixtures` runs `Discover` over the on-disk fixtures and asserts each emitted `SCOPE.Config` entity's properties (including a negative assertion that nested `platforms`/`ios` keys do **not** leak into `native_modules`). `TestClassify_MobileConfigs`, `TestDiscover_ExpoAppConfigJS` (dynamic `app.config.ts`), and `TestDiscover_ExpoManifestBare` (unwrapped `app.json`) cover the variants.

## Real-data verification

Indexed a hand-built RN+Expo corpus via the real `archigraph index-internal` subprocess (through the daemon extract coordinator, not just the unit `Discover`). All four `SCOPE.Config` entities emit end-to-end with the expected properties:

```
eas_config           | eas.json  → eas_build_profiles=development,preview,production; eas_submit_profiles=production
expo_config          | app.json  → expo_name=FixtureMobileApp; expo_slug=fixture-mobile-app; expo_scheme=fixtureapp; expo_plugins=expo-build-properties,expo-router
metro_config         | metro.config.js          → metro_keys=projectRoot,resolver,transformer,watchFolders
react_native_config  | react-native.config.js   → native_modules=react-native-ble-plx,react-native-vector-icons; rn_platforms=ios,android
```

(Temporary local store torn down after verification; no daemon left attached.)

## Coverage

`go run ./tools/coverage validate` exits 0; `gen` is byte-stable; the `registry.json` diff is the 4 surgically-edited cells only (16 insertions / 8 deletions).

```
implements-capability: lang.jsts.framework.react-native/React Native CLI/metro_config_detection:missing→full
implements-capability: lang.jsts.framework.react-native/React Native CLI/native_link_recognition:missing→full
implements-capability: lang.jsts.framework.expo/Expo Ecosystem/eas_build_detection:missing→full
implements-capability: lang.jsts.framework.expo/Expo Ecosystem/expo_config_extraction:missing→full
```

Closes #2879

🤖 Generated with [Claude Code](https://claude.com/claude-code)
