### PR TITLE
feat(jsts-coverage): meta-framework fwspec idioms — Next/Nuxt/Remix/SvelteKit/Gatsby/Astro (#2878)

### DIFF
--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -73,6 +73,15 @@ Auto-generated. Back to [summary](../summary.md).
 | `taint_source_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/taint_sites_markup_script.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_astro/UserPage.astro` | — |
 | `vulnerability_finding` | ✅ `full` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/taint_sites_markup_script.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_astro/UserPage.astro` | — |
 
+## Framework-specific
+
+### Astro Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `astro_frontmatter_fetch` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/extractors/astro/extractor.go`<br>`internal/extractors/astro/issue2878_idioms_test.go` | — |
+| `astro_island_directive` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/extractors/astro/extractor.go`<br>`internal/extractors/astro/issue2878_idioms_test.go` | — |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.framework.gatsby.md
+++ b/docs/coverage/detail/lang.jsts.framework.gatsby.md
@@ -69,6 +69,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
+## Framework-specific
+
+### Gatsby Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `gatsby_graphql_pagequery` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/gatsby.go`<br>`internal/custom/javascript/issue2878_metafw_idioms_test.go` | — |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -75,8 +75,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `middleware_runtime_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| `next_config_detection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| `middleware_runtime_detection` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/nextjs.go` | — |
+| `next_config_detection` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/nextjs.go` | — |
+| `server_actions` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/nextjs.go` | — |
+| `use_client_server_directive` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/metafw_server.go`<br>`internal/custom/javascript/nextjs.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -69,6 +69,15 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
+## Framework-specific
+
+### Nuxt Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `nuxt_auto_import` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
+| `nuxt_server_routes` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -69,6 +69,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
+## Framework-specific
+
+### Remix Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `remix_loader_action_pair` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/remix.go` | — |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -73,6 +73,15 @@ Auto-generated. Back to [summary](../summary.md).
 | `taint_source_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/substrate.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_sveltekit/+page.server.ts` | — |
 | `vulnerability_finding` | ✅ `full` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/substrate.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_sveltekit/+page.server.ts` | — |
 
+## Framework-specific
+
+### SvelteKit Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `sveltekit_form_actions` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/svelte.go` | — |
+| `sveltekit_load_function` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2878) | `internal/custom/javascript/issue2878_metafw_idioms_test.go`<br>`internal/custom/javascript/svelte.go` | — |
+
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10827,6 +10827,22 @@
             "verified_at": "2026-05-28"
           }
         }
+      },
+      "framework_specific": {
+        "Astro Internals": {
+          "astro_frontmatter_fetch": {
+            "status": "full",
+            "cites": ["internal/extractors/astro/extractor.go","internal/extractors/astro/issue2878_idioms_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
+          },
+          "astro_island_directive": {
+            "status": "full",
+            "cites": ["internal/extractors/astro/extractor.go","internal/extractors/astro/issue2878_idioms_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
+          }
+        }
       }
     },
     {
@@ -11347,6 +11363,16 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
+          }
+        }
+      },
+      "framework_specific": {
+        "Gatsby Internals": {
+          "gatsby_graphql_pagequery": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/gatsby.go","internal/custom/javascript/issue2878_metafw_idioms_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -12179,12 +12205,28 @@
       "framework_specific": {
         "Next.js Internals": {
           "middleware_runtime_detection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/nextjs.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
           },
           "next_config_detection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/nextjs.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
+          },
+          "server_actions": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/nextjs.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
+          },
+          "use_client_server_directive": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/metafw_server.go","internal/custom/javascript/nextjs.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -12273,6 +12315,22 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/tests.go"],
             "verified_at": "2026-05-28"
+          }
+        }
+      },
+      "framework_specific": {
+        "Nuxt Internals": {
+          "nuxt_auto_import": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/nuxt.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
+          },
+          "nuxt_server_routes": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/nuxt.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -12901,6 +12959,16 @@
             "verified_at": "2026-05-28"
           }
         }
+      },
+      "framework_specific": {
+        "Remix Internals": {
+          "remix_loader_action_pair": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/remix.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
+          }
+        }
       }
     },
     {
@@ -13387,6 +13455,22 @@
             "status": "full",
             "cites": ["internal/links/taint_flow.go","internal/substrate/substrate.go","internal/substrate/taint_sites_jsts.go","internal/substrate/uimm_substrate_test.go","testdata/fixtures/typescript/substrate_sveltekit/+page.server.ts"],
             "verified_at": "2026-05-28"
+          }
+        }
+      },
+      "framework_specific": {
+        "SvelteKit Internals": {
+          "sveltekit_form_actions": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/svelte.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
+          },
+          "sveltekit_load_function": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/issue2878_metafw_idioms_test.go","internal/custom/javascript/svelte.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2878",
+            "verified_at": "2026-05-29"
           }
         }
       }

--- a/internal/custom/javascript/issue2878_metafw_idioms_test.go
+++ b/internal/custom/javascript/issue2878_metafw_idioms_test.go
@@ -1,0 +1,259 @@
+package javascript_test
+
+import "testing"
+
+// issue2878_metafw_idioms_test.go — proving fixtures for the meta-framework
+// framework_specific *idiom* cells closed by issue #2878. These are the
+// first-class framework idioms the generic meta_framework columns
+// (server_components / data_loaders / hydration_boundaries / static_generation /
+// route_extraction, closed by #2858 / #2880) cannot express:
+//
+//   Next.js : use_client_server_directive, server_actions,
+//             middleware_runtime_detection, next_config_detection
+//   Nuxt    : nuxt_auto_import, nuxt_server_routes
+//   Remix   : remix_loader_action_pair
+//   SvelteKit: sveltekit_load_function, sveltekit_form_actions
+//   Gatsby  : gatsby_graphql_pagequery
+//
+// (Astro's idiom cells — astro_island_directive, astro_frontmatter_fetch — are
+// proven in internal/extractors/astro/issue2878_idioms_test.go.)
+//
+// Each fixture is hand-written and dependency-manifest-free, exercised through
+// the registered custom extractors.
+
+// ── Next.js: 'use client' / 'use server' directive boundary ──────────────────
+
+func TestNext2878UseClientServerDirective(t *testing.T) {
+	client := `'use client'
+import { useState } from 'react'
+export default function Toggle() {
+  const [on, setOn] = useState(false)
+  return <button onClick={() => setOn(!on)}>{String(on)}</button>
+}
+`
+	c := extract(t, "custom_js_nextjs", fi("app/toggle/page.tsx", "typescript", client))
+	if !containsEntity(c, "SCOPE.Pattern", "use client") {
+		t.Error("expected 'use client' directive boundary (use_client_server_directive)")
+	}
+
+	server := `'use server'
+export async function submit(form: FormData) {}
+`
+	s := extract(t, "custom_js_nextjs", fi("app/lib/actions.ts", "typescript", server))
+	if !containsEntity(s, "SCOPE.Pattern", "use server") {
+		t.Error("expected 'use server' directive boundary (use_client_server_directive)")
+	}
+}
+
+// ── Next.js: server actions ('use server' + exported async fns) ──────────────
+
+func TestNext2878ServerActions(t *testing.T) {
+	src := `'use server'
+export async function createTodo(form: FormData) {}
+export async function deleteTodo(id: string) {}
+`
+	ents := extract(t, "custom_js_nextjs", fi("app/todos/actions.ts", "typescript", src))
+	if !containsEntity(ents, "SCOPE.Operation", "createTodo") {
+		t.Error("expected createTodo server_action (server_actions)")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "deleteTodo") {
+		t.Error("expected deleteTodo server_action (server_actions)")
+	}
+	if !containsSubtype(ents, "server_action") {
+		t.Error("expected server_action subtype (server_actions)")
+	}
+}
+
+// ── Next.js: middleware runtime detection ────────────────────────────────────
+
+func TestNext2878MiddlewareRuntimeDetection(t *testing.T) {
+	// Default (no runtime override) → edge runtime.
+	edge := `import { NextResponse } from 'next/server'
+export function middleware(request) { return NextResponse.next() }
+export const config = { matcher: ['/dashboard/:path*'] }
+`
+	e := extract(t, "custom_js_nextjs", fi("middleware.ts", "typescript", edge))
+	if !containsEntity(e, "SCOPE.Pattern", "middleware") {
+		t.Fatal("expected middleware entity (middleware_runtime_detection)")
+	}
+
+	// Explicit nodejs runtime override.
+	node := `export async function middleware(req) {}
+export const config = { runtime: 'nodejs', matcher: '/api/:path*' }
+`
+	n := extract(t, "custom_js_nextjs", fi("src/middleware.js", "javascript", node))
+	if !containsEntity(n, "SCOPE.Pattern", "middleware") {
+		t.Error("expected middleware entity with nodejs runtime (middleware_runtime_detection)")
+	}
+
+	// A non-middleware file must NOT emit a middleware marker.
+	other := `export function middleware() {}`
+	o := extract(t, "custom_js_nextjs", fi("app/lib/helpers.ts", "typescript", other))
+	if containsSubtype(o, "middleware") {
+		t.Error("non-middleware.ts file should not emit a middleware marker")
+	}
+}
+
+// ── Next.js: next.config detection ───────────────────────────────────────────
+
+func TestNext2878NextConfigDetection(t *testing.T) {
+	cfg := `/** @type {import('next').NextConfig} */
+const nextConfig = { reactStrictMode: true, images: { domains: ['cdn.example.com'] } }
+module.exports = nextConfig
+`
+	c := extract(t, "custom_js_nextjs", fi("next.config.js", "javascript", cfg))
+	if !containsEntity(c, "SCOPE.Pattern", "next.config") {
+		t.Error("expected next.config framework_config (next_config_detection)")
+	}
+
+	ts := `import type { NextConfig } from 'next'
+const config: NextConfig = { experimental: { ppr: true } }
+export default config
+`
+	tc := extract(t, "custom_js_nextjs", fi("next.config.ts", "typescript", ts))
+	if !containsSubtype(tc, "framework_config") {
+		t.Error("expected next.config framework_config from .ts (next_config_detection)")
+	}
+}
+
+// ── Nuxt: auto-import ─────────────────────────────────────────────────────────
+
+func TestNuxt2878AutoImport(t *testing.T) {
+	// useState / useRoute used with NO import → resolved by Nuxt auto-import.
+	page := `<script setup lang="ts">
+const counter = useState('count', () => 0)
+const route = useRoute()
+function inc() { counter.value++ }
+</script>
+<template><button @click="inc">{{ counter }} {{ route.path }}</button></template>
+`
+	ents := extract(t, "custom_js_nuxt", fi("pages/counter.vue", "typescript", page))
+	if !containsSubtype(ents, "auto_import") {
+		t.Fatal("expected auto_import marker (nuxt_auto_import)")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "auto_import:useState") {
+		t.Error("expected auto_import:useState marker (nuxt_auto_import)")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "auto_import:useRoute") {
+		t.Error("expected auto_import:useRoute marker (nuxt_auto_import)")
+	}
+}
+
+func TestNuxt2878AutoImportSkipsExplicitImport(t *testing.T) {
+	// An explicitly-imported helper is a normal import, not an auto-import.
+	src := `<script setup lang="ts">
+import { useState } from '#imports'
+const n = useState('n', () => 1)
+</script>
+`
+	ents := extract(t, "custom_js_nuxt", fi("pages/explicit.vue", "typescript", src))
+	if containsEntity(ents, "SCOPE.Pattern", "auto_import:useState") {
+		t.Error("explicitly-imported useState should not be marked as auto_import")
+	}
+}
+
+// ── Nuxt: server routes (file-system server-route convention) ────────────────
+
+func TestNuxt2878ServerRoutes(t *testing.T) {
+	api := `export default defineEventHandler(async (event) => { return { users: [] } })`
+	a := extract(t, "custom_js_nuxt", fi("server/api/users.get.ts", "typescript", api))
+	if !containsEntity(a, "SCOPE.Pattern", "server_route:users.get") {
+		t.Error("expected server_route marker for server/api handler (nuxt_server_routes)")
+	}
+
+	routes := `export default defineEventHandler((event) => 'hello')`
+	r := extract(t, "custom_js_nuxt", fi("server/routes/hello.ts", "typescript", routes))
+	if !containsSubtype(r, "server_route") {
+		t.Error("expected server_route marker for server/routes handler (nuxt_server_routes)")
+	}
+
+	// A non-server-route file must NOT emit a server_route marker.
+	page := `<script setup>const x = 1</script>`
+	p := extract(t, "custom_js_nuxt", fi("pages/index.vue", "typescript", page))
+	if containsSubtype(p, "server_route") {
+		t.Error("a pages/ file should not emit a server_route marker")
+	}
+}
+
+// ── Remix: loader/action pairing ─────────────────────────────────────────────
+
+func TestRemix2878LoaderActionPair(t *testing.T) {
+	both := `import { json } from '@remix-run/node'
+export async function loader({ params }) { return json({ id: params.id }) }
+export async function action({ request }) { return json({ ok: true }) }
+export default function Route() { return <div /> }
+`
+	b := extract(t, "custom_js_remix", fi("app/routes/posts.$id.tsx", "typescript", both))
+	if !containsSubtype(b, "loader_action_pair") {
+		t.Error("expected loader_action_pair marker when both loader+action present (remix_loader_action_pair)")
+	}
+
+	// Loader only → no pair.
+	loaderOnly := `export async function loader() { return null }
+export default function Route() { return <div /> }
+`
+	l := extract(t, "custom_js_remix", fi("app/routes/index.tsx", "typescript", loaderOnly))
+	if containsSubtype(l, "loader_action_pair") {
+		t.Error("loader-only route should not emit a loader_action_pair marker")
+	}
+}
+
+// ── SvelteKit: load() function ────────────────────────────────────────────────
+
+func TestSveltekit2878LoadFunction(t *testing.T) {
+	universal := `import type { PageLoad } from './$types'
+export const load: PageLoad = async ({ fetch }) => {
+  const res = await fetch('/api/posts')
+  return { posts: await res.json() }
+}
+`
+	u := extract(t, "custom_js_svelte", fi("src/routes/blog/+page.ts", "typescript", universal))
+	if !containsEntity(u, "SCOPE.Operation", "load:/blog") {
+		t.Error("expected universal load() data_loader (sveltekit_load_function)")
+	}
+
+	server := `import type { PageServerLoad } from './$types'
+export const load: PageServerLoad = async ({ params }) => { return { id: params.id } }
+`
+	s := extract(t, "custom_js_svelte", fi("src/routes/post/[id]/+page.server.ts", "typescript", server))
+	if !containsSubtype(s, "data_loader") {
+		t.Error("expected server load() data_loader (sveltekit_load_function)")
+	}
+}
+
+// ── SvelteKit: form actions ───────────────────────────────────────────────────
+
+func TestSveltekit2878FormActions(t *testing.T) {
+	src := `import type { Actions } from './$types'
+export const actions: Actions = {
+  default: async ({ request }) => { const data = await request.formData(); return { success: true } },
+  delete: async ({ request }) => { return { deleted: true } },
+}
+`
+	ents := extract(t, "custom_js_svelte", fi("src/routes/contact/+page.server.ts", "typescript", src))
+	if !containsSubtype(ents, "form_actions") {
+		t.Error("expected form_actions marker (sveltekit_form_actions)")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "actions:/contact") {
+		t.Error("expected actions:/contact form_actions node (sveltekit_form_actions)")
+	}
+}
+
+// ── Gatsby: GraphQL page query ────────────────────────────────────────────────
+
+func TestGatsby2878GraphqlPageQuery(t *testing.T) {
+	src := "import { graphql } from 'gatsby'\n" +
+		"export default function BlogPost({ data }) { return <article>{data.markdownRemark.frontmatter.title}</article> }\n" +
+		"export const query = graphql`\n" +
+		"  query($slug: String!) {\n" +
+		"    markdownRemark(fields: { slug: { eq: $slug } }) { frontmatter { title } }\n" +
+		"  }\n" +
+		"`\n"
+	ents := extract(t, "custom_js_gatsby", fi("src/templates/blog-post.tsx", "typescript", src))
+	if !containsEntity(ents, "SCOPE.Operation", "pageQuery") {
+		t.Error("expected pageQuery data_loader from `export const query = graphql` (gatsby_graphql_pagequery)")
+	}
+	if !containsSubtype(ents, "data_loader") {
+		t.Error("expected data_loader subtype for the page query (gatsby_graphql_pagequery)")
+	}
+}

--- a/internal/custom/javascript/issue2878_realdata_test.go
+++ b/internal/custom/javascript/issue2878_realdata_test.go
@@ -1,0 +1,114 @@
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the base .astro SFC extractor used for the Astro corpus file.
+	_ "github.com/cajasmota/archigraph/internal/extractors/astro"
+)
+
+// issue2878_realdata_test.go — real-data verification for the meta-framework
+// framework_specific *idiom* cells (#2878). Runs the registered extractors over
+// the realistic, multi-file, manifest-free corpus under
+// testdata/fixtures/real-world/meta-framework/ — the same dispatch the indexer
+// uses — and asserts the new idiom markers fire on real-shaped source.
+
+func runIdiomExtractor(t *testing.T, extractorName, rel, lang string) []types.EntityRecord {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "testdata", "fixtures", "real-world", "meta-framework", rel)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("corpus file %s not present: %v", rel, err)
+	}
+	e, ok := extreg.Get(extractorName)
+	if !ok {
+		t.Fatalf("extractor %q not registered", extractorName)
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{Path: path, Language: lang, Content: content})
+	if err != nil {
+		t.Fatalf("extract %s: %v", rel, err)
+	}
+	return ents
+}
+
+func idiomHasSubtype(ents []types.EntityRecord, subtype string) bool {
+	for i := range ents {
+		if ents[i].Subtype == subtype {
+			return true
+		}
+	}
+	return false
+}
+
+func idiomHasName(ents []types.EntityRecord, name string) bool {
+	for i := range ents {
+		if ents[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIssue2878RealData_Next(t *testing.T) {
+	// 'use client' directive boundary on the App-Router client component.
+	client := runIdiomExtractor(t, "custom_js_nextjs", "next-app/app/blog/[slug]/CommentBox.tsx", "typescript")
+	if !idiomHasName(client, "use client") {
+		t.Error("real-data: expected 'use client' directive (use_client_server_directive)")
+	}
+	// 'use server' module with server actions.
+	actions := runIdiomExtractor(t, "custom_js_nextjs", "next-app/app/blog/[slug]/actions.ts", "typescript")
+	if !idiomHasName(actions, "use server") {
+		t.Error("real-data: expected 'use server' directive (use_client_server_directive)")
+	}
+	if !idiomHasSubtype(actions, "server_action") {
+		t.Error("real-data: expected server_action (server_actions)")
+	}
+	// middleware runtime detection.
+	mw := runIdiomExtractor(t, "custom_js_nextjs", "next-app/middleware.ts", "typescript")
+	if !idiomHasSubtype(mw, "middleware") {
+		t.Error("real-data: expected middleware marker (middleware_runtime_detection)")
+	}
+	// next.config detection.
+	cfg := runIdiomExtractor(t, "custom_js_nextjs", "next-app/next.config.ts", "typescript")
+	if !idiomHasSubtype(cfg, "framework_config") {
+		t.Error("real-data: expected next.config framework_config (next_config_detection)")
+	}
+}
+
+func TestIssue2878RealData_Nuxt(t *testing.T) {
+	page := runIdiomExtractor(t, "custom_js_nuxt", "nuxt-app/pages/users.vue", "typescript")
+	if !idiomHasSubtype(page, "auto_import") {
+		t.Error("real-data: expected auto_import marker for useRoute/useState (nuxt_auto_import)")
+	}
+	srv := runIdiomExtractor(t, "custom_js_nuxt", "nuxt-app/server/api/users.get.ts", "typescript")
+	if !idiomHasSubtype(srv, "server_route") {
+		t.Error("real-data: expected server_route marker (nuxt_server_routes)")
+	}
+}
+
+func TestIssue2878RealData_Remix(t *testing.T) {
+	route := runIdiomExtractor(t, "custom_js_remix", "remix-app/app/routes/posts.$id.tsx", "typescript")
+	if !idiomHasSubtype(route, "loader_action_pair") {
+		t.Error("real-data: expected loader_action_pair marker (remix_loader_action_pair)")
+	}
+}
+
+func TestIssue2878RealData_SvelteKit(t *testing.T) {
+	load := runIdiomExtractor(t, "custom_js_svelte", "sveltekit-app/src/routes/post/[id]/+page.server.ts", "typescript")
+	if !idiomHasSubtype(load, "data_loader") {
+		t.Error("real-data: expected SvelteKit load() data_loader (sveltekit_load_function)")
+	}
+}
+
+func TestIssue2878RealData_Gatsby(t *testing.T) {
+	page := runIdiomExtractor(t, "custom_js_gatsby", "gatsby-app/src/pages/blog.tsx", "typescript")
+	if !idiomHasName(page, "pageQuery") {
+		t.Error("real-data: expected pageQuery data_loader (gatsby_graphql_pagequery)")
+	}
+}

--- a/internal/custom/javascript/nextjs.go
+++ b/internal/custom/javascript/nextjs.go
@@ -54,6 +54,26 @@ var (
 	reNextjsRouteSegmentRevalidate = regexp.MustCompile(
 		`export\s+const\s+revalidate\s*=\s*(\d+|false)`,
 	)
+
+	// Next.js middleware (issue #2878, middleware_runtime_detection). A
+	// project-root `middleware.{ts,js}` exporting `middleware()` (or a default)
+	// runs in the Edge runtime by default; `export const config = { matcher, runtime }`
+	// declares the path matcher and (optionally) opts the function into the
+	// 'nodejs' runtime. We detect the middleware export and the runtime/matcher
+	// from its `config` object.
+	reNextjsMiddlewareExport = regexp.MustCompile(
+		`export\s+(?:async\s+)?function\s+middleware\s*\(|export\s+default\s+(?:async\s+)?function\s+middleware\b|export\s+const\s+middleware\s*=`,
+	)
+	reNextjsConfigRuntime = regexp.MustCompile(`\bruntime\s*:\s*['"](edge|nodejs|experimental-edge)['"]`)
+	reNextjsConfigMatcher = regexp.MustCompile(`\bmatcher\s*:`)
+
+	// next.config detection (issue #2878, next_config_detection). The
+	// `next.config.{js,ts,mjs,cjs}` file is the framework's build/runtime config;
+	// it is recognised by file name and its `defineConfig`/`NextConfig`/default
+	// export shape.
+	reNextjsConfigExport = regexp.MustCompile(
+		`export\s+default\b|module\.exports\s*=|\bdefineConfig\s*\(|:\s*NextConfig\b`,
+	)
 )
 
 var (
@@ -295,6 +315,44 @@ func (e *nextjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 				"provenance", "INFERRED_FROM_NEXTJS_SERVER_ACTION")
 			addEntity(ent)
 		}
+	}
+
+	// Middleware runtime detection (issue #2878, middleware_runtime_detection).
+	//
+	// Next.js runs a root `middleware.{ts,js}` on every matched request. It
+	// executes in the Edge runtime by default; `export const config` declares the
+	// `matcher` paths and may opt into `runtime: 'nodejs'`. Detecting the
+	// middleware export + its runtime/matcher is the idiom — a request-pipeline
+	// interceptor distinct from route handlers.
+	isMiddlewareFile := stem == "middleware" &&
+		(fp == "middleware.ts" || fp == "middleware.js" ||
+			strings.HasSuffix(fp, "/middleware.ts") || strings.HasSuffix(fp, "/middleware.js") ||
+			strings.HasSuffix(fp, "/src/middleware.ts") || strings.HasSuffix(fp, "/src/middleware.js"))
+	if isMiddlewareFile && reNextjsMiddlewareExport.MatchString(src) {
+		runtime := "edge" // Next.js middleware defaults to the Edge runtime.
+		if m := reNextjsConfigRuntime.FindStringSubmatch(src); m != nil {
+			runtime = m[1]
+		}
+		ent := makeEntity("middleware", "SCOPE.Pattern", "middleware", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "nextjs", "runtime", runtime,
+			"has_matcher", fmt.Sprintf("%v", reNextjsConfigMatcher.MatchString(src)),
+			"provenance", "INFERRED_FROM_NEXTJS_MIDDLEWARE")
+		addEntity(ent)
+	}
+
+	// next.config detection (issue #2878, next_config_detection). The
+	// `next.config.{js,ts,mjs,cjs}` file configures the Next.js build/runtime
+	// (rewrites, redirects, images, experimental flags). Recognise it by name +
+	// its config-export shape so the project's framework configuration is a
+	// first-class, queryable node.
+	isNextConfig := stem == "next.config" &&
+		(strings.HasSuffix(fp, "next.config.js") || strings.HasSuffix(fp, "next.config.ts") ||
+			strings.HasSuffix(fp, "next.config.mjs") || strings.HasSuffix(fp, "next.config.cjs"))
+	if isNextConfig && reNextjsConfigExport.MatchString(src) {
+		ent := makeEntity("next.config", "SCOPE.Pattern", "framework_config", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "nextjs", "config_kind", "next_config",
+			"provenance", "INFERRED_FROM_NEXTJS_CONFIG")
+		addEntity(ent)
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))

--- a/internal/custom/javascript/nuxt.go
+++ b/internal/custom/javascript/nuxt.go
@@ -52,7 +52,35 @@ var (
 	reNuxtRouteRules    = regexp.MustCompile(`\b(routeRules|defineRouteRules)\b`)
 	// `ssr: false` in nuxt.config switches the app to client-only SPA build.
 	reNuxtSSRFalse = regexp.MustCompile(`\bssr\s*:\s*false\b`)
+
+	// Nuxt auto-import (issue #2878, nuxt_auto_import). Nuxt's build-time
+	// auto-import makes its composables, the Vue reactivity API, and `#imports`
+	// virtual-module helpers callable WITHOUT an explicit `import` statement — the
+	// idiom a plain AST import-graph misses. We detect a call to a known
+	// auto-imported helper that has no matching import in the file, and emit one
+	// auto_import marker naming the resolved source module.
+	reNuxtImportStmt    = regexp.MustCompile(`(?m)^\s*import\b`)
+	reNuxtImportsAlias  = regexp.MustCompile(`from\s+['"]#imports['"]`)
+	reNuxtAutoImportUse = regexp.MustCompile(`\b(useRoute|useRouter|useState|useRuntimeConfig|useNuxtApp|useRequestHeaders|useCookie|useHead|useSeoMeta|navigateTo|defineNuxtRouteMiddleware|definePageMeta)\s*\(`)
 )
+
+// nuxtAutoImportModule maps an auto-imported Nuxt helper to the virtual module
+// that provides it, so the emitted auto_import marker records the resolved
+// origin (what `#imports` / nuxt/dist would expose).
+var nuxtAutoImportModule = map[string]string{
+	"useRoute":                  "vue-router",
+	"useRouter":                 "vue-router",
+	"useState":                  "#app",
+	"useRuntimeConfig":          "#app",
+	"useNuxtApp":                "#app",
+	"useRequestHeaders":         "#app",
+	"useCookie":                 "#app",
+	"useHead":                   "@unhead/vue",
+	"useSeoMeta":                "@unhead/vue",
+	"navigateTo":                "#app",
+	"defineNuxtRouteMiddleware": "#app",
+	"definePageMeta":            "#app",
+}
 
 var (
 	nuxtServerDirs   = map[string]bool{"server/api": true, "server/routes": true}
@@ -91,6 +119,37 @@ func emitNuxtRouteParams(fp, routePath, filePath, language string, add func(type
 			"provenance", "INFERRED_FROM_NUXT_ROUTE_PARAM")
 		add(ent)
 	}
+}
+
+// nuxtImportsHelper reports whether src has an `import` statement that names the
+// given helper, so a normally-imported helper is not misclassified as an
+// auto-import. It scans each import line for the helper as a whole identifier.
+func nuxtImportsHelper(src, helper string) bool {
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "import") {
+			continue
+		}
+		if idx := strings.Index(trimmed, helper); idx >= 0 {
+			before := byte(' ')
+			if idx > 0 {
+				before = trimmed[idx-1]
+			}
+			after := byte(' ')
+			if end := idx + len(helper); end < len(trimmed) {
+				after = trimmed[end]
+			}
+			if !isIdentByte(before) && !isIdentByte(after) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isIdentByte reports whether b can be part of a JS identifier.
+func isIdentByte(b byte) bool {
+	return b == '_' || b == '$' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
 func (e *nuxtExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
@@ -293,6 +352,48 @@ func (e *nuxtExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]t
 		setProps(&cb, "framework", "nuxt", "hydration", "client",
 			"provenance", "INFERRED_FROM_NUXT_CLIENT_ONLY")
 		addEntity(cb)
+	}
+
+	// Nuxt server routes (issue #2878, nuxt_server_routes). Files under
+	// `server/api/**` and `server/routes/**` that export a `defineEventHandler`
+	// are Nitro server routes — Nuxt's file-system server-route convention. The
+	// directory chooses the mount prefix (`/api` vs root) and the `.<method>.ts`
+	// filename suffix the HTTP verb. This idiom is the server-routing convention
+	// itself (distinct from the generic endpoint node emitted above).
+	if isServerAPI && reNuxtHTTPHandler.MatchString(src) {
+		mount := "routes"
+		if strings.Contains(fp, "/server/api/") || strings.HasPrefix(fp, "server/api/") {
+			mount = "api"
+		}
+		sr := makeEntity("server_route:"+stem, "SCOPE.Pattern", "server_route", file.Path, file.Language, 1)
+		setProps(&sr, "framework", "nuxt", "mount", mount, "router", "file_system",
+			"provenance", "INFERRED_FROM_NUXT_SERVER_ROUTE_CONVENTION")
+		addEntity(sr)
+	}
+
+	// Nuxt auto-import (issue #2878, nuxt_auto_import). A call to a known
+	// auto-imported helper with NO `import` for it in the file is resolved by
+	// Nuxt's build-time auto-import. Emit one auto_import marker per distinct
+	// helper used, naming the virtual module that provides it, so the dependency
+	// a plain import-graph cannot see becomes a first-class node.
+	hasExplicitImport := reNuxtImportStmt.MatchString(src) || reNuxtImportsAlias.MatchString(src)
+	emittedAutoImport := make(map[string]bool)
+	for _, m := range reNuxtAutoImportUse.FindAllStringSubmatchIndex(src, -1) {
+		helper := src[m[2]:m[3]]
+		if emittedAutoImport[helper] {
+			continue
+		}
+		// If the file explicitly imports this exact helper, it is a normal import,
+		// not an auto-import — skip it.
+		if hasExplicitImport && nuxtImportsHelper(src, helper) {
+			continue
+		}
+		emittedAutoImport[helper] = true
+		ai := makeEntity("auto_import:"+helper, "SCOPE.Pattern", "auto_import", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ai, "framework", "nuxt", "helper", helper,
+			"source_module", nuxtAutoImportModule[helper], "resolution", "auto_import",
+			"provenance", "INFERRED_FROM_NUXT_AUTO_IMPORT")
+		addEntity(ai)
 	}
 
 	// Static generation (issue #2858): prerender route rules / SPA mode.

--- a/internal/custom/javascript/remix.go
+++ b/internal/custom/javascript/remix.go
@@ -145,6 +145,21 @@ func (e *remixExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]
 		addEntity(ent)
 	}
 
+	// Loader/action pairing (issue #2878, remix_loader_action_pair). Remix's
+	// signature idiom is colocating a server `loader` (GET data) and `action`
+	// (non-GET mutation) in the SAME route module alongside the default-export
+	// component. Emit a dedicated pair marker only when both are present, so the
+	// full server round-trip of a route is a single queryable node (distinct from
+	// the independent loader/action data-flow nodes above).
+	if hasLoader && hasAction {
+		name := fmt.Sprintf("loader_action_pair:%s", routePath)
+		ent := makeEntity(name, "SCOPE.Pattern", "loader_action_pair", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "remix", "route_path", routePath, "stem", stem,
+			"has_loader", "true", "has_action", "true", "rendering", "server",
+			"provenance", "INFERRED_FROM_REMIX_LOADER_ACTION_PAIR")
+		addEntity(ent)
+	}
+
 	// Default export (page component)
 	for _, m := range reRemixDefaultExport.FindAllStringSubmatchIndex(src, -1) {
 		compName := src[m[2]:m[3]]

--- a/internal/custom/javascript/svelte.go
+++ b/internal/custom/javascript/svelte.go
@@ -34,7 +34,7 @@ var (
 		`export\s+(?:async\s+)?(?:const\s+load|function\s+load)\b`,
 	)
 	reSvelteFormActions = regexp.MustCompile(
-		`export\s+const\s+actions\s*=`,
+		`export\s+const\s+actions\s*(?::\s*[A-Za-z_$][\w.$<>\[\] ]*)?=`,
 	)
 	reSvelteHTTPHandler = regexp.MustCompile(
 		`export\s+(?:async\s+)?function\s+(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(`,
@@ -198,7 +198,9 @@ func (e *svelteExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 	}
 	// Strip file suffixes
 	for _, suffix := range []string{"/+page.svelte", "/+layout.svelte", "/+error.svelte",
-		"/+server.ts", "/+server.js", "/+page.server.ts", "/+page.server.js"} {
+		"/+server.ts", "/+server.js", "/+page.server.ts", "/+page.server.js",
+		"/+page.ts", "/+page.js", "/+layout.server.ts", "/+layout.server.js",
+		"/+layout.ts", "/+layout.js"} {
 		routePath = strings.TrimSuffix(routePath, suffix)
 	}
 	if ext2 := filepath.Ext(routePath); ext2 != "" {

--- a/internal/extractors/astro/extractor.go
+++ b/internal/extractors/astro/extractor.go
@@ -101,6 +101,14 @@ var (
 	// statically-generated page; false opts a page into on-demand (server)
 	// rendering when the project output is "server"/"hybrid".
 	prerenderRE = regexp.MustCompile(`export\s+const\s+prerender\s*=\s*(true|false)`)
+
+	// frontmatterFetchRE matches a top-level `fetch(...)` / `await fetch(...)`
+	// call in the Astro frontmatter (issue #2878, astro_frontmatter_fetch). The
+	// frontmatter runs server-side (build time for static output, per request for
+	// SSR), so a `fetch` there is a server-side data load that bakes its result
+	// into the rendered HTML — Astro's idiomatic data-fetching pattern, distinct
+	// from the content-collection / getStaticPaths loaders.
+	frontmatterFetchRE = regexp.MustCompile(`\b(?:await\s+)?fetch\s*\(`)
 )
 
 // Extract parses the Astro SFC source and returns entity records.
@@ -445,6 +453,16 @@ func extractServerBuildEntities(fm string, fmStartLine int, filePath, subtype st
 		out = append(out, mk(fn, "SCOPE.Operation", "data_loader", lineOf(m[0]),
 			map[string]string{"loader_kind": fn, "rendering": "ssg",
 				"provenance": "INFERRED_FROM_ASTRO_CONTENT_COLLECTION"}))
+	}
+
+	// Frontmatter fetch (issue #2878, astro_frontmatter_fetch). A `fetch(...)`
+	// in the frontmatter is a server-side data load whose result is rendered into
+	// the page; emit one data_loader marker for it so the server data dependency
+	// is queryable.
+	if m := frontmatterFetchRE.FindStringIndex(fm); m != nil {
+		out = append(out, mk("frontmatter_fetch", "SCOPE.Operation", "data_loader", lineOf(m[0]),
+			map[string]string{"loader_kind": "frontmatter_fetch", "rendering": "server",
+				"provenance": "INFERRED_FROM_ASTRO_FRONTMATTER_FETCH"}))
 	}
 
 	// export const prerender = true → static generation marker.

--- a/internal/extractors/astro/issue2878_idioms_test.go
+++ b/internal/extractors/astro/issue2878_idioms_test.go
@@ -1,0 +1,82 @@
+package astro
+
+import "testing"
+
+// issue2878_idioms_test.go — proving fixtures for the Astro framework_specific
+// *idiom* cells closed by issue #2878:
+//
+//   astro_island_directive  — client:* hydration directives on a child component
+//                             (the partial-hydration island idiom).
+//   astro_frontmatter_fetch — a server-side `fetch(...)` in the --- frontmatter,
+//                             Astro's idiomatic data-fetch baked into the render.
+//
+// Hand-written, dependency-manifest-free .astro snippets exercised through the
+// extractor.
+
+func TestAstro2878IslandDirective(t *testing.T) {
+	src := `---
+import Counter from '../components/Counter.jsx'
+import Chart from '../components/Chart.jsx'
+---
+<main>
+  <Counter client:load />
+  <Chart client:visible />
+</main>
+`
+	ents := astroExtract(t, "src/pages/index.astro", src)
+
+	// IMPLEMENTS island edges on the host component entity.
+	var islandEdges int
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPLEMENTS" && r.Properties["island_directive"] != "" {
+				islandEdges++
+			}
+		}
+	}
+	if islandEdges < 2 {
+		t.Errorf("expected >=2 island IMPLEMENTS edges, got %d (astro_island_directive)", islandEdges)
+	}
+
+	// First-class island marker entities.
+	if !hasSubtype(ents, "client_boundary") {
+		t.Error("expected client_boundary island marker (astro_island_directive)")
+	}
+	if !hasName(ents, "island:Counter") {
+		t.Error("expected island:Counter marker (astro_island_directive)")
+	}
+}
+
+func TestAstro2878FrontmatterFetch(t *testing.T) {
+	src := `---
+const res = await fetch('https://api.example.com/posts')
+const posts = await res.json()
+---
+<ul>{posts.map((p) => <li>{p.title}</li>)}</ul>
+`
+	ents := astroExtract(t, "src/pages/posts.astro", src)
+	if !hasName(ents, "frontmatter_fetch") {
+		t.Error("expected frontmatter_fetch data_loader (astro_frontmatter_fetch)")
+	}
+	var found bool
+	for _, e := range ents {
+		if e.Name == "frontmatter_fetch" && e.Subtype == "data_loader" &&
+			e.Properties["loader_kind"] == "frontmatter_fetch" && e.Properties["rendering"] == "server" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("frontmatter_fetch must be a server-rendering data_loader (astro_frontmatter_fetch)")
+	}
+
+	// A frontmatter with no fetch must NOT emit a frontmatter_fetch marker.
+	noFetch := `---
+const title = 'Static'
+---
+<h1>{title}</h1>
+`
+	nf := astroExtract(t, "src/pages/static.astro", noFetch)
+	if hasName(nf, "frontmatter_fetch") {
+		t.Error("a frontmatter with no fetch should not emit frontmatter_fetch")
+	}
+}

--- a/internal/extractors/astro/issue2878_realdata_test.go
+++ b/internal/extractors/astro/issue2878_realdata_test.go
@@ -1,0 +1,44 @@
+package astro
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// issue2878_realdata_test.go — real-data verification for the Astro idiom cells
+// (#2878) over the shared meta-framework corpus.
+
+func TestAstro2878RealDataIslandDirective(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "testdata", "fixtures", "real-world",
+		"meta-framework", "astro-app", "src", "pages", "blog", "[slug].astro")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("corpus file not present: %v", err)
+	}
+	e := &Extractor{}
+	ents, err := e.Extract(context.Background(), extractor.FileInput{
+		Path: path, Language: "astro", Content: content,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	// The corpus page renders `<Counter client:visible />` — an island.
+	var islandEdges int
+	for _, ent := range ents {
+		for _, r := range ent.Relationships {
+			if r.Kind == "IMPLEMENTS" && r.Properties["island_directive"] != "" {
+				islandEdges++
+			}
+		}
+	}
+	if islandEdges == 0 {
+		t.Error("real-data: expected >=1 island IMPLEMENTS edge (astro_island_directive)")
+	}
+	if !hasSubtype(ents, "client_boundary") {
+		t.Error("real-data: expected client_boundary island marker (astro_island_directive)")
+	}
+}

--- a/testdata/fixtures/real-world/meta-framework/next-app/app/blog/[slug]/actions.ts
+++ b/testdata/fixtures/real-world/meta-framework/next-app/app/blog/[slug]/actions.ts
@@ -1,0 +1,10 @@
+'use server'
+// Next.js server actions — 'use server' module of exported async mutations.
+export async function addComment(formData: FormData) {
+  const text = formData.get('text')
+  await db.query('INSERT INTO comments (text) VALUES (?)', [text])
+}
+
+export async function deleteComment(id: string) {
+  await db.query('DELETE FROM comments WHERE id = ?', [id])
+}

--- a/testdata/fixtures/real-world/meta-framework/next-app/middleware.ts
+++ b/testdata/fixtures/real-world/meta-framework/next-app/middleware.ts
@@ -1,0 +1,15 @@
+// Next.js middleware — Edge-runtime request interceptor with a path matcher.
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('session')
+  if (!token) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/account/:path*'],
+}

--- a/testdata/fixtures/real-world/meta-framework/next-app/next.config.ts
+++ b/testdata/fixtures/real-world/meta-framework/next-app/next.config.ts
@@ -1,0 +1,14 @@
+// Next.js framework config — build/runtime configuration.
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  images: {
+    domains: ['cdn.example.com'],
+  },
+  experimental: {
+    ppr: true,
+  },
+}
+
+export default nextConfig

--- a/testdata/fixtures/real-world/meta-framework/nuxt-app/pages/users.vue
+++ b/testdata/fixtures/real-world/meta-framework/nuxt-app/pages/users.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 // Nuxt page — useAsyncData/useFetch loaders + reactive state + ClientOnly.
+// useRoute / useState are auto-imported (no import statement) by Nuxt.
+const route = useRoute()
+const count = useState('count', () => 0)
 const { data: users } = await useAsyncData('users', () => $fetch('/api/users'))
 const { data: profile } = useFetch('/api/profile')
-const count = ref(0)
 
 function increment() {
   count.value++


### PR DESCRIPTION
Closes #2878 — part of epic #2847.

Adds the **framework_specific idiom cells** for the JS/TS meta-frameworks: the first-class framework idioms the generic `meta_framework` columns (`server_components` / `data_loaders` / `hydration_boundaries` / `static_generation` / `route_extraction`, closed by #2858 / #2880) cannot express. **12 cells across 6 records, all flipped `missing → full`**, each backed by a proving unit fixture **and** a real-data corpus run. No double-counting: where a generic cell already measures the idiom it is left to the generic cell.

## framework_specific cells (honest one-line meanings — no dictionary exists for fwspec)

**`lang.jsts.framework.next-api` / Next.js Internals**
- `use_client_server_directive` — detects the literal `'use client'` / `'use server'` RSC directive marking a module's client/server boundary (emitted as `SCOPE.Pattern` `client_boundary`/`server_boundary` by `emitRSCBoundary`).
- `server_actions` — `'use server'` module + its exported async functions surfaced as `SCOPE.Operation` `server_action` nodes.
- `middleware_runtime_detection` — root `middleware.{ts,js}` request interceptor + its runtime (`edge` default, or `nodejs` from `export const config`) and whether a `matcher` is declared.
- `next_config_detection` — `next.config.{js,ts,mjs,cjs}` recognised as a first-class `framework_config` node by name + config-export shape.

**`lang.jsts.framework.nuxt` / Nuxt Internals**
- `nuxt_auto_import` — a call to a known Nuxt auto-imported helper (`useRoute`/`useState`/`navigateTo`/…) with **no** matching `import` → an `auto_import` marker naming the virtual source module (`#app`, `vue-router`, …). Captures the dependency a plain import-graph cannot see.
- `nuxt_server_routes` — the `server/api/**` & `server/routes/**` `defineEventHandler` file-system server-route convention (mount prefix + verb), emitted as a dedicated `server_route` marker.

**`lang.jsts.framework.remix` / Remix Internals**
- `remix_loader_action_pair` — the colocated `loader` (GET) + `action` (mutation) pair on the same route module → a single `loader_action_pair` marker (distinct from the independent loader/action data-flow nodes).

**`lang.jsts.framework.sveltekit` / SvelteKit Internals**
- `sveltekit_load_function` — `+page(.server).ts` `load()` data loader (universal vs server rendering).
- `sveltekit_form_actions` — `export const actions` form-action handlers (now also accepts the `: Actions` type annotation).

**`lang.jsts.framework.gatsby` / Gatsby Internals**
- `gatsby_graphql_pagequery` — the build-time `export const query = graphql\`…\`` page query → `pageQuery` data loader.

**`lang.jsts.framework.astro` / Astro Internals**
- `astro_island_directive` — `client:*` partial-hydration directives on child components (IMPLEMENTS island edges + `client_boundary` markers).
- `astro_frontmatter_fetch` — a top-level `fetch(...)` in the `---` frontmatter → a server-side `data_loader` (distinct from `getCollection`/`getStaticPaths`).

## Implementation
- `internal/custom/javascript/nextjs.go` — middleware + next.config detection (the directive/server-action emitters already existed from #2858; proven here).
- `internal/custom/javascript/nuxt.go` — auto-import detection (+ `nuxtImportsHelper` whole-identifier import guard) and the server-route convention marker.
- `internal/custom/javascript/remix.go` — loader/action pair marker.
- `internal/custom/javascript/svelte.go` — `reSvelteFormActions` accepts `: Actions`; routePath strips `+page.ts`/`+layout.*` suffixes so `load:`/`actions:` nodes carry the clean route.
- `internal/extractors/astro/extractor.go` — frontmatter `fetch()` data-loader marker (island directives already emitted).

**No new entity/edge Kinds** — all markers are existing `SCOPE.Pattern` / `SCOPE.Operation` entities, so no `internal/types/kinds.go` change needed (`go test ./internal/types/` passes).

## Proofs
- Unit fixtures: `internal/custom/javascript/issue2878_metafw_idioms_test.go`, `internal/extractors/astro/issue2878_idioms_test.go` (hand-written, manifest-free; include negative cases — non-`middleware.ts`, loader-only route, explicitly-imported helper, no-fetch frontmatter).
- Real-data: `internal/custom/javascript/issue2878_realdata_test.go` + `internal/extractors/astro/issue2878_realdata_test.go` run the registered extractors over `testdata/fixtures/real-world/meta-framework/**` (added `next-app/middleware.ts`, `next-app/next.config.ts`, `next-app/app/blog/[slug]/actions.ts`; extended `nuxt-app/pages/users.vue` with auto-imported `useRoute`/`useState`).

## Registry discipline
`docs/coverage/registry.json` `framework_specific` blocks edited **by hand, surgically** (next-api's 2 existing missing cells flipped + 2 added; new `framework_specific` blocks on nuxt/remix/sveltekit/gatsby/astro). `validate` exit 0, `fmt --check` reports canonical (no recompaction), `gen` byte-stable. Registry diff is **+88/-4** — only the 12 cells — plus regenerated `docs/coverage/detail/*.md`.

## implements-capability tags
```
implements-capability: lang.jsts.framework.next-api/Next.js Internals/use_client_server_directive:missing→full
implements-capability: lang.jsts.framework.next-api/Next.js Internals/server_actions:missing→full
implements-capability: lang.jsts.framework.next-api/Next.js Internals/middleware_runtime_detection:missing→full
implements-capability: lang.jsts.framework.next-api/Next.js Internals/next_config_detection:missing→full
implements-capability: lang.jsts.framework.nuxt/Nuxt Internals/nuxt_auto_import:missing→full
implements-capability: lang.jsts.framework.nuxt/Nuxt Internals/nuxt_server_routes:missing→full
implements-capability: lang.jsts.framework.remix/Remix Internals/remix_loader_action_pair:missing→full
implements-capability: lang.jsts.framework.sveltekit/SvelteKit Internals/sveltekit_load_function:missing→full
implements-capability: lang.jsts.framework.sveltekit/SvelteKit Internals/sveltekit_form_actions:missing→full
implements-capability: lang.jsts.framework.gatsby/Gatsby Internals/gatsby_graphql_pagequery:missing→full
implements-capability: lang.jsts.framework.astro/Astro Internals/astro_island_directive:missing→full
implements-capability: lang.jsts.framework.astro/Astro Internals/astro_frontmatter_fetch:missing→full
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
