### PR TITLE
feat(jsts): compose router-mount/group/plugin prefix in endpoint paths (#2934)

### DIFF
--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml`<br>`testdata/fixtures/typescript/adonisjs_routes.ts` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml`<br>`testdata/fixtures/typescript/adonisjs_group_prefix.ts`<br>`testdata/fixtures/typescript/adonisjs_routes.ts` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml`<br>`testdata/fixtures/typescript/adonisjs_routes.ts` | — |
 
 ### Security

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml` | — |
 
 ### Security

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
+| `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 
 ### Security

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10462,7 +10462,7 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_jsts_backend.go","internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml","testdata/fixtures/typescript/adonisjs_routes.ts"],
+            "cites": ["internal/engine/http_endpoint_jsts_backend.go","internal/engine/http_endpoint_jsts_backend_test.go","internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml","testdata/fixtures/typescript/adonisjs_group_prefix.ts","testdata/fixtures/typescript/adonisjs_routes.ts"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2851",
             "verified_at": "2026-05-28"
           },
@@ -11032,7 +11032,7 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/http_endpoint_synthesis_test.go","internal/engine/rules/javascript_typescript/frameworks/express.yaml","internal/extractors/javascript/framework_dsl.go"],
             "issue": "2932",
             "verified_at": "2026-05-28"
           },
@@ -11128,7 +11128,7 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_jsts_extra.go","internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
+            "cites": ["internal/engine/http_endpoint_jsts_extra.go","internal/engine/http_endpoint_synthesis_test.go","internal/engine/rules/javascript_typescript/frameworks/fastify.yaml"],
             "issue": "2932",
             "verified_at": "2026-05-28"
           },

--- a/internal/engine/http_endpoint_jsts_backend.go
+++ b/internal/engine/http_endpoint_jsts_backend.go
@@ -30,10 +30,50 @@ package engine
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
 )
+
+// allIndexes returns the byte offsets of every (possibly overlapping at
+// distinct positions) occurrence of sub in s. Used to enumerate route-group
+// openers for #2934 prefix composition.
+func allIndexes(s, sub string) []int {
+	var out []int
+	for off := 0; ; {
+		i := strings.Index(s[off:], sub)
+		if i < 0 {
+			break
+		}
+		out = append(out, off+i)
+		off += i + len(sub)
+	}
+	return out
+}
+
+// matchBrace returns the byte offset of the `}` that closes the `{` at index
+// open in s, honoring nested braces. Returns -1 when unbalanced. String/
+// comment contents are not specially handled — adequate for the route-config
+// files this scans, where braces inside string literals are vanishingly rare.
+func matchBrace(s string, open int) int {
+	if open < 0 || open >= len(s) || s[open] != '{' {
+		return -1
+	}
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
 
 // feathersServiceVerbs is the standard REST verb set a Feathers service
 // exposes at its mount path. `find` (list) and `create` map to the collection
@@ -91,34 +131,109 @@ var adonisResourceRoutes = []struct {
 	{"DELETE", "/{id}", "destroy"},
 }
 
+// adonisGroupSpan describes one `Route.group(() => { … }).prefix('/x')` block:
+// the byte range [bodyStart, bodyEnd) covering the callback body, and the
+// normalized prefix declared via the chained `.prefix(...)` (empty when the
+// group declares no prefix). #2934 composes the prefix of every group whose
+// body span ENCLOSES a route's match offset, so nested groups stack.
+type adonisGroupSpan struct {
+	bodyStart int
+	bodyEnd   int
+	prefix    string
+}
+
+// adonisGroupPrefixRe captures the `.prefix('/x')` chained onto a closed
+// Route.group(...) call. Scanned in the short window after the group body's
+// closing brace+paren. Group 1 = prefix string.
+var adonisGroupPrefixRe = regexp.MustCompile(
+	`^\s*\)?\s*\.prefix\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r]*)['"` + "`" + `]`,
+)
+
+// buildAdonisGroupSpans locates every `Route.group(` callback body via brace
+// matching and pairs it with the trailing `.prefix(...)` declaration (#2934).
+// Returns spans in source order; callers compose the prefixes of all enclosing
+// spans for a given route offset.
+func buildAdonisGroupSpans(content string) []adonisGroupSpan {
+	if !strings.Contains(content, "Route.group") {
+		return nil
+	}
+	var spans []adonisGroupSpan
+	for _, idx := range allIndexes(content, "Route.group") {
+		// Find the first `{` after `Route.group(` — the callback body open.
+		open := strings.IndexByte(content[idx:], '{')
+		if open < 0 {
+			continue
+		}
+		open += idx
+		end := matchBrace(content, open)
+		if end < 0 {
+			continue
+		}
+		// Scan the window after the body for `).prefix('/x')`.
+		prefix := ""
+		tail := content[end+1:]
+		if len(tail) > 64 {
+			tail = tail[:64]
+		}
+		if m := adonisGroupPrefixRe.FindStringSubmatch(tail); m != nil {
+			prefix = normalizeMountPrefix(m[1])
+		}
+		spans = append(spans, adonisGroupSpan{bodyStart: open, bodyEnd: end, prefix: prefix})
+	}
+	return spans
+}
+
+// adonisComposedPrefix returns the joined prefix of every group span whose
+// body encloses offset, outermost first (#2934). Empty when no enclosing group
+// declares a prefix.
+func adonisComposedPrefix(spans []adonisGroupSpan, offset int) string {
+	// Collect enclosing spans; they nest, so sorting by bodyStart gives
+	// outermost→innermost order.
+	var enclosing []adonisGroupSpan
+	for _, s := range spans {
+		if offset > s.bodyStart && offset < s.bodyEnd && s.prefix != "" {
+			enclosing = append(enclosing, s)
+		}
+	}
+	sort.Slice(enclosing, func(i, j int) bool { return enclosing[i].bodyStart < enclosing[j].bodyStart })
+	composed := ""
+	for _, s := range enclosing {
+		composed = joinPathFragments(composed, s.prefix)
+	}
+	return composed
+}
+
 func synthesizeAdonis(content string, emit emitFileFn) {
 	if !strings.Contains(content, "Route.") {
 		return
 	}
-	for _, m := range adonisVerbRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 3 {
+	groups := buildAdonisGroupSpans(content)
+	for _, m := range adonisVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		// m holds index pairs: [fullStart, fullEnd, g1s, g1e, g2s, g2e, g3s, g3e].
+		if len(m) < 6 {
 			continue
 		}
-		verb := strings.ToUpper(m[1])
-		raw := m[2]
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]]
 		handler := ""
-		if len(m) >= 4 {
-			handler = m[3]
+		if len(m) >= 8 && m[6] >= 0 {
+			handler = content[m[6]:m[7]]
 		}
-		canonical := httproutes.Canonicalize(httproutes.FrameworkAdonis, raw)
+		full := joinPathFragments(adonisComposedPrefix(groups, m[0]), raw)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkAdonis, full)
 		if canonical == "" {
 			continue
 		}
 		method, fileHint := splitControllerActionRef(handler)
 		emit(verb, canonical, "adonisjs", "Controller", method, fileHint, 0)
 	}
-	for _, m := range adonisResourceRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 3 {
+	for _, m := range adonisResourceRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
 			continue
 		}
-		name := strings.Trim(m[1], "/")
-		controller := m[2]
-		base := "/" + name
+		name := strings.Trim(content[m[2]:m[3]], "/")
+		controller := content[m[4]:m[5]]
+		base := joinPathFragments(adonisComposedPrefix(groups, m[0]), "/"+name)
 		for _, rr := range adonisResourceRoutes {
 			canonical := httproutes.Canonicalize(httproutes.FrameworkAdonis, base+rr.suffix)
 			emit(rr.verb, canonical, "adonisjs", "Controller", rr.action, controller, 0)

--- a/internal/engine/http_endpoint_jsts_backend_test.go
+++ b/internal/engine/http_endpoint_jsts_backend_test.go
@@ -41,6 +41,25 @@ func TestSynth_Adonis(t *testing.T) {
 	requireContains(t, got, want, "adonis")
 }
 
+// TestSynth_Adonis_GroupPrefix covers #2934: routes enclosed by a
+// `Route.group(() => {...}).prefix('/x')` compose the group prefix, nested
+// groups stack, and an ungrouped route stays bare.
+func TestSynth_Adonis_GroupPrefix(t *testing.T) {
+	src := readBackendFixture(t, "adonisjs_group_prefix.ts")
+	got, _ := runDetect(t, "typescript", "start/routes.ts", src)
+	want := []string{
+		// Single-group prefix composition.
+		"http:GET:/admin/users",
+		"http:POST:/admin/users",
+		"http:GET:/admin/users/{id}",
+		// Nested-group prefix stacking.
+		"http:GET:/api/v1/reports",
+		// Ungrouped route — composition is a no-op.
+		"http:GET:/health",
+	}
+	requireContains(t, got, want, "adonis-group-prefix")
+}
+
 // TestSynth_Hapi covers server.route({ method, path, handler }) including the
 // array-method and {id?} optional-param forms.
 func TestSynth_Hapi(t *testing.T) {

--- a/internal/engine/http_endpoint_jsts_extra.go
+++ b/internal/engine/http_endpoint_jsts_extra.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
@@ -69,6 +70,93 @@ var fastifyRouteRe = regexp.MustCompile(
 		`[^}]*?\}`,
 )
 
+// fastifyRegisterRe captures the opening of a `<recv>.register(` call so #2934
+// can locate plugin-registration spans and their `{ prefix: '/x' }` option.
+// Group 1 = receiver (gated by fastifyAllowedReceiverRe).
+var fastifyRegisterRe = regexp.MustCompile(`([$\w][\w$]*)\.register\s*\(`)
+
+// fastifyPrefixOptRe captures the `prefix: '/v1'` option inside a register
+// call's options object. Group 1 = prefix string.
+var fastifyPrefixOptRe = regexp.MustCompile(
+	`\bprefix\s*:\s*['"` + "`" + `]([^'"` + "`" + `\n\r]*)['"` + "`" + `]`,
+)
+
+// fastifyPluginSpan describes one `fastify.register(plugin, { prefix: '/x' })`
+// registration: the byte range [bodyStart, bodyEnd) covering the inline plugin
+// function body and the normalized prefix declared in the options object.
+// Routes registered on the plugin instance inside that body compose the prefix
+// (#2934). Only inline plugin functions (with a `{ … }` body in the same file)
+// are span-resolvable; imported plugins compose nothing here (the cross-repo
+// matcher's prefix-stripping still links those).
+type fastifyPluginSpan struct {
+	bodyStart int
+	bodyEnd   int
+	prefix    string
+}
+
+// buildFastifyPluginSpans locates each `<recv>.register(` call, brace-matches
+// the FIRST `{ … }` after the opening paren (the inline plugin function body),
+// and pairs it with the `prefix:` option found in the register call's argument
+// region (#2934). Registrations with no inline body or no prefix are skipped.
+func buildFastifyPluginSpans(content string) []fastifyPluginSpan {
+	if !strings.Contains(content, ".register") {
+		return nil
+	}
+	var spans []fastifyPluginSpan
+	for _, loc := range fastifyRegisterRe.FindAllStringSubmatchIndex(content, -1) {
+		recv := content[loc[2]:loc[3]]
+		if !fastifyAllowedReceiverRe.MatchString(recv) {
+			continue
+		}
+		openParen := loc[1] - 1 // index of `(`
+		// Plugin body: the first `{` after the open paren that is part of the
+		// callback (inline async (instance) => { … } or function (f) { … }).
+		bodyOpen := strings.IndexByte(content[openParen:], '{')
+		if bodyOpen < 0 {
+			continue
+		}
+		bodyOpen += openParen
+		bodyEnd := matchBrace(content, bodyOpen)
+		if bodyEnd < 0 {
+			continue
+		}
+		// The options object with `prefix:` follows the plugin body, before the
+		// register call's closing paren. Scan the window after the body.
+		tail := content[bodyEnd+1:]
+		if len(tail) > 128 {
+			tail = tail[:128]
+		}
+		m := fastifyPrefixOptRe.FindStringSubmatch(tail)
+		if m == nil {
+			continue
+		}
+		spans = append(spans, fastifyPluginSpan{
+			bodyStart: bodyOpen,
+			bodyEnd:   bodyEnd,
+			prefix:    normalizeMountPrefix(m[1]),
+		})
+	}
+	return spans
+}
+
+// fastifyComposedPrefix returns the joined prefix of every plugin span whose
+// body encloses offset, outermost first (#2934) — supporting nested
+// register(...) plugins. Empty when no enclosing plugin declares a prefix.
+func fastifyComposedPrefix(spans []fastifyPluginSpan, offset int) string {
+	var enclosing []fastifyPluginSpan
+	for _, s := range spans {
+		if offset > s.bodyStart && offset < s.bodyEnd && s.prefix != "" {
+			enclosing = append(enclosing, s)
+		}
+	}
+	sort.Slice(enclosing, func(i, j int) bool { return enclosing[i].bodyStart < enclosing[j].bodyStart })
+	composed := ""
+	for _, s := range enclosing {
+		composed = joinPathFragments(composed, s.prefix)
+	}
+	return composed
+}
+
 // synthesizeFastify emits http_endpoint_definition entities for Fastify
 // route registrations. It complements synthesizeExpress, which would miss
 // these because its receiver allowlist excludes "fastify".
@@ -77,25 +165,29 @@ func synthesizeFastify(content string, emit emitFn) {
 	if !strings.Contains(content, "fastify") && !strings.Contains(content, "Fastify") {
 		return
 	}
+	// #2934 — plugin-registration prefixes: routes registered inside an inline
+	// `fastify.register(plugin, { prefix: '/v1' })` body compose `/v1`.
+	pluginSpans := buildFastifyPluginSpans(content)
 	withHandler := map[string]bool{}
-	for _, m := range fastifyVerbRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 5 {
+	for _, m := range fastifyVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
 			continue
 		}
-		receiver := m[1]
+		receiver := content[m[2]:m[3]]
 		if !fastifyAllowedReceiverRe.MatchString(receiver) {
 			continue
 		}
-		raw := m[3]
+		raw := content[m[6]:m[7]]
 		if !looksLikeExpressPath(raw) {
 			continue
 		}
-		verb := strings.ToUpper(m[2])
-		handler := m[4]
-		if isInlineExpressHandler(m[0], raw) {
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		handler := content[m[8]:m[9]]
+		if isInlineExpressHandler(content[m[0]:m[1]], raw) {
 			handler = ""
 		}
-		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		full := joinPathFragments(fastifyComposedPrefix(pluginSpans, m[0]), raw)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, full)
 		if verb == "ALL" {
 			verb = "ANY"
 		}
@@ -103,20 +195,21 @@ func synthesizeFastify(content string, emit emitFn) {
 		withHandler[key] = true
 		emit(verb, canonical, "fastify", "Controller", handler)
 	}
-	for _, m := range fastifyVerbPathOnlyRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 4 {
+	for _, m := range fastifyVerbPathOnlyRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
 			continue
 		}
-		receiver := m[1]
+		receiver := content[m[2]:m[3]]
 		if !fastifyAllowedReceiverRe.MatchString(receiver) {
 			continue
 		}
-		raw := m[3]
+		raw := content[m[6]:m[7]]
 		if !looksLikeExpressPath(raw) {
 			continue
 		}
-		verb := strings.ToUpper(m[2])
-		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		full := joinPathFragments(fastifyComposedPrefix(pluginSpans, m[0]), raw)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, full)
 		if verb == "ALL" {
 			verb = "ANY"
 		}
@@ -127,24 +220,25 @@ func synthesizeFastify(content string, emit emitFn) {
 		emit(verb, canonical, "fastify", "Controller", "")
 	}
 	// Structured form: fastify.route({ method, url, handler }).
-	for _, m := range fastifyRouteRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 4 {
+	for _, m := range fastifyRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
 			continue
 		}
-		receiver := m[1]
+		receiver := content[m[2]:m[3]]
 		if !fastifyAllowedReceiverRe.MatchString(receiver) {
 			continue
 		}
-		verb := strings.ToUpper(m[2])
-		raw := m[3]
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		raw := content[m[6]:m[7]]
 		handler := ""
-		if len(m) >= 5 {
-			handler = m[4]
+		if len(m) >= 10 && m[8] >= 0 {
+			handler = content[m[8]:m[9]]
 		}
 		if !looksLikeExpressPath(raw) {
 			continue
 		}
-		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		full := joinPathFragments(fastifyComposedPrefix(pluginSpans, m[0]), raw)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, full)
 		emit(verb, canonical, "fastify", "Controller", handler)
 	}
 }

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1617,6 +1617,98 @@ var expressVerbRe = regexp.MustCompile(`([$\w][\w$]*)\.(get|post|put|patch|delet
 // capture group 1 = receiver, 2 = verb, 3 = path string.
 var expressVerbRePathOnly = regexp.MustCompile(`([$\w][\w$]*)\.(get|post|put|patch|delete|head|options|all)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]`)
 
+// expressMountRe captures an Express sub-router mount of the form
+// `<recv>.use('/prefix', <subRouter>)`, mirroring the express.yaml ROUTES_TO
+// rule (~:104). The mount prefix (group 2) is composed onto every route the
+// mounted sub-router (group 3) registers, so a route file's producer path
+// carries the full canonical mount path (#2934). Group 1 = mounting receiver
+// (unused — the prefix attaches to the sub-router var, which is what later
+// routes register against).
+//
+// Only string-literal first-argument mounts are captured; bare
+// `app.use(middleware)` (no path) is correctly ignored.
+var expressMountRe = regexp.MustCompile(
+	`([$\w][\w$]*)\.use\s*\(\s*['"` + "`" + `](/[^'"` + "`" + `\n\r]*)['"` + "`" + `]\s*,\s*([$\w][\w$]*)\s*[\),]`,
+)
+
+// buildExpressMountPrefixes returns a map of sub-router variable name → fully
+// composed mount prefix for every `<recv>.use('/prefix', subRouter)` mount in
+// the file, resolving NESTED mounts transitively (#2934). For
+//
+//	app.use('/api', v1)
+//	v1.use('/admin', adminRouter)
+//
+// the result is {v1: "/api", adminRouter: "/api/admin"}. Routes registered on
+// adminRouter then compose to `/api/admin/...`.
+//
+// The resolution is order-independent: we first collect every (parent, prefix,
+// child) mount edge, then walk the chains to a fixed point. Self-mounts and
+// cycles (pathological) are bounded by the edge count so the loop always
+// terminates. A child with no resolvable parent prefix simply maps to its own
+// literal prefix.
+func buildExpressMountPrefixes(content string) map[string]string {
+	type mount struct {
+		parent string
+		prefix string
+		child  string
+	}
+	var mounts []mount
+	for _, m := range expressMountRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		mounts = append(mounts, mount{parent: m[1], prefix: m[2], child: m[3]})
+	}
+	if len(mounts) == 0 {
+		return nil
+	}
+	// Seed each child with its own literal mount prefix.
+	prefixes := make(map[string]string, len(mounts))
+	for _, mt := range mounts {
+		prefixes[mt.child] = normalizeMountPrefix(mt.prefix)
+	}
+	// Iterate to a fixed point, prepending each parent's resolved prefix.
+	// Bounded by len(mounts) passes (longest chain length).
+	for i := 0; i < len(mounts); i++ {
+		changed := false
+		for _, mt := range mounts {
+			if mt.parent == mt.child {
+				continue // self-mount guard
+			}
+			parentPrefix, ok := prefixes[mt.parent]
+			if !ok {
+				continue
+			}
+			composed := joinPathFragments(parentPrefix, normalizeMountPrefix(mt.prefix))
+			if prefixes[mt.child] != composed {
+				prefixes[mt.child] = composed
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return prefixes
+}
+
+// composeExpressMount prepends the resolved mount prefix for `receiver` (if
+// any) onto the raw route path (#2934). When the receiver var was never
+// mounted at a string-literal prefix the raw path is returned unchanged,
+// preserving the pre-#2934 producer path for the common single-file /
+// top-level-app case. The composed path is fed to Canonicalize so params and
+// slashes normalize uniformly.
+func composeExpressMount(mountPrefixes map[string]string, receiver, raw string) string {
+	if len(mountPrefixes) == 0 {
+		return raw
+	}
+	prefix, ok := mountPrefixes[receiver]
+	if !ok || prefix == "" {
+		return raw
+	}
+	return joinPathFragments(prefix, raw)
+}
+
 // isExpressReceiver returns true when the receiver identifier looks like an
 // Express app/router variable (allowlist) and is not on the hard blocklist.
 // It also consults the per-file HTTP-client symbol table built by
@@ -1672,6 +1764,12 @@ func synthesizeExpress(content string, emit emitFn) {
 	// Variables assigned from axios.create() / ky.create() / got.extend()
 	// are consumer-side and must never be emitted as Express producers (#684).
 	clientSymbols := buildExpressClientSymbolTable(content)
+	// #2934 — sub-router mount prefixes. `app.use('/api', router)` mounts
+	// `router` at `/api`, so routes registered on `router` must compose to
+	// `/api/<path>`. Resolves nested mounts transitively. nil when the file
+	// has no string-literal mounts (the common single-file case), making the
+	// composition lookup a no-op that preserves the pre-#2934 bare path.
+	mountPrefixes := buildExpressMountPrefixes(content)
 
 	// First pass: handler-named form (groups: receiver, verb, path, handler).
 	withHandler := map[string]bool{}
@@ -1707,7 +1805,7 @@ func synthesizeExpress(content string, emit emitFn) {
 		if isInlineExpressHandler(m[0], raw) {
 			handler = ""
 		}
-		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, composeExpressMount(mountPrefixes, receiver, raw))
 		// Express `.all(...)` registers every verb on the path; emit as ANY.
 		if verb == "ALL" {
 			verb = "ANY"
@@ -1732,7 +1830,7 @@ func synthesizeExpress(content string, emit emitFn) {
 		if !looksLikeExpressPath(raw) {
 			continue
 		}
-		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, composeExpressMount(mountPrefixes, receiver, raw))
 		if verb == "ALL" {
 			verb = "ANY"
 		}
@@ -1938,6 +2036,26 @@ func lineOfOffset(content string, off int) int {
 // path, mirroring the slash convention used by joinRoutePaths in
 // spring_routes.go. An empty prefix or method passes the other through
 // verbatim.
+// normalizeMountPrefix cleans a raw mount/group/plugin prefix into a leading-
+// slash, no-trailing-slash form suitable for joinPathFragments composition
+// (#2934). `"/api/"` → `"/api"`, `"api"` → `"/api"`, `"/"` and `""` → `""`
+// (root mount contributes nothing). The trailing-slash trim keeps the join
+// idempotent; the empty result lets a root-level `app.use('/', router)` mount
+// pass child paths through unchanged.
+func normalizeMountPrefix(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" || p == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for len(p) > 1 && strings.HasSuffix(p, "/") {
+		p = strings.TrimSuffix(p, "/")
+	}
+	return p
+}
+
 func joinPathFragments(prefix, method string) string {
 	switch {
 	case prefix == "" && method == "":

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -145,6 +145,64 @@ func TestSynth_Express(t *testing.T) {
 	requireContains(t, got, want, "Express")
 }
 
+// TestSynth_Express_MountPrefix covers #2934: a sub-router mounted at a path
+// prefix via `app.use('/api', router)` composes that prefix onto every route
+// the sub-router registers, and nested mounts stack. Routes on the top-level
+// `app` (no mount) keep their bare path (regression guard).
+func TestSynth_Express_MountPrefix(t *testing.T) {
+	src := "const express = require('express');\n" +
+		"const app = express();\n" +
+		"const apiRouter = express.Router();\n" +
+		"const adminRouter = express.Router();\n" +
+		"\n" +
+		"apiRouter.get('/users/:id', getUser);\n" +
+		"apiRouter.post('/users', createUser);\n" +
+		"adminRouter.delete('/users/:id', deleteUser);\n" +
+		"\n" +
+		"// Nested mount: adminRouter under apiRouter under /api.\n" +
+		"apiRouter.use('/admin', adminRouter);\n" +
+		"app.use('/api', apiRouter);\n" +
+		"\n" +
+		"// Top-level route on app — NOT mounted, stays bare.\n" +
+		"app.get('/health', healthCheck);\n"
+	got, _ := runDetect(t, "javascript", "app.js", src)
+	want := []string{
+		"http:GET:/api/users/{id}",
+		"http:POST:/api/users",
+		"http:DELETE:/api/admin/users/{id}",
+		"http:GET:/health",
+	}
+	requireContains(t, got, want, "Express-mount-prefix")
+}
+
+// TestSynth_Fastify_PluginPrefix covers #2934: routes registered inside an
+// inline `fastify.register(plugin, { prefix: '/v1' })` body compose the plugin
+// prefix, nested register() plugins stack, and a top-level route (no plugin
+// prefix) stays bare.
+func TestSynth_Fastify_PluginPrefix(t *testing.T) {
+	src := "const fastify = require('fastify')();\n" +
+		"\n" +
+		"fastify.register(async (instance) => {\n" +
+		"  instance.get('/users/:id', getUser);\n" +
+		"  instance.post('/users', createUser);\n" +
+		"  // Nested plugin under /v1.\n" +
+		"  instance.register(async (adminInstance) => {\n" +
+		"    adminInstance.delete('/users/:id', deleteUser);\n" +
+		"  }, { prefix: '/admin' });\n" +
+		"}, { prefix: '/v1' });\n" +
+		"\n" +
+		"// Top-level route — no plugin prefix, stays bare.\n" +
+		"fastify.get('/health', healthCheck);\n"
+	got, _ := runDetect(t, "javascript", "server.js", src)
+	want := []string{
+		"http:GET:/v1/users/{id}",
+		"http:POST:/v1/users",
+		"http:DELETE:/v1/admin/users/{id}",
+		"http:GET:/health",
+	}
+	requireContains(t, got, want, "Fastify-plugin-prefix")
+}
+
 // ---------------------------------------------------------------------------
 // Express false-positive guard tests — round 1 (#653) + round 2 (#684)
 // ---------------------------------------------------------------------------

--- a/testdata/fixtures/typescript/adonisjs_group_prefix.ts
+++ b/testdata/fixtures/typescript/adonisjs_group_prefix.ts
@@ -1,0 +1,22 @@
+// AdonisJS route-group prefix fixture (#2934). Hand-written,
+// dependency-manifest-free. Asserts that routes enclosed by a
+// `Route.group(() => {...}).prefix('/x')` compose the group prefix, and that
+// nested groups stack their prefixes.
+import Route from '@ioc:Adonis/Core/Route'
+
+// Single group prefix → /admin/users, /admin/users/{id}.
+Route.group(() => {
+  Route.get('/users', 'AdminUsersController.index')
+  Route.post('/users', 'AdminUsersController.store')
+  Route.get('/users/:id', 'AdminUsersController.show')
+}).prefix('/admin')
+
+// Nested groups → /api/v1/reports.
+Route.group(() => {
+  Route.group(() => {
+    Route.get('/reports', 'ReportsController.index')
+  }).prefix('/v1')
+}).prefix('/api')
+
+// Ungrouped route stays bare → /health (composition is a no-op here).
+Route.get('/health', 'HealthController.show')


### PR DESCRIPTION
## Summary
Phase 0c of the JS/TS capability-expansion audit (#2847). Composes the enclosing mount/group/plugin prefix into synthesized backend endpoint paths for Express, AdonisJS, and Fastify, so split route files produce structurally correct canonical producer paths instead of bare child paths.

Before: `router.get('/users')` mounted via `app.use('/api', router)` → `/users`.
After: → `/api/users`.

## What's composed per framework
- **Express** (`synthesizeExpress`): `buildExpressMountPrefixes` scans `<recv>.use('/prefix', subRouter)` mounts (the same shape as the `express.yaml` ROUTES_TO rule) into a sub-router→prefix map and composes onto routes registered against the mounted router. **Nested mounts** resolve transitively to a fixed point (`app.use('/api', v1); v1.use('/admin', admin)` → `/api/admin/...`).
- **AdonisJS** (`synthesizeAdonis`): brace-matches each `Route.group(() => {...})` body and pairs it with its chained `.prefix('/x')`. Routes and `Route.resource(...)` expansions enclosed by a group compose its prefix; **nested groups stack** (`/api/v1/...`).
- **Fastify** (`synthesizeFastify`): locates inline `fastify.register(plugin, { prefix: '/v1' })` plugin bodies and composes the prefix onto routes on the plugin instance; **nested `register()` plugins stack**.

## Safety / no regressions
- Top-level / unmounted routes keep their bare path — the prefix map / span lookup is a no-op, so the common single-file case is byte-for-byte unchanged.
- NestJS `@Controller` composition is untouched.
- Match-side API-prefix stripping (`stripEndpointAPIPrefix` / `prefixCandidates`) still links prefixed producers to unprefixed consumers — `TestHTTPLinker_PrefixNormalization_ApiV1` and the full match suite pass.
- Brace matcher (`matchBrace`) + bounded fixed-point iteration guard against unbalanced input, self-mounts, and cycles.

## Fixtures & tests
- `testdata/fixtures/typescript/adonisjs_group_prefix.ts` + `TestSynth_Adonis_GroupPrefix` (single + nested group, ungrouped no-op).
- `TestSynth_Express_MountPrefix` (single + nested mount, top-level no-op).
- `TestSynth_Fastify_PluginPrefix` (single + nested plugin, top-level no-op).

## Verification
- `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` — all pass.
- `go build ./...` — pass. `gofmt` clean. `go run ./tools/coverage validate` — 0 errors.
- Updated the express/adonisjs/fastify `endpoint_synthesis` registry cells (cites + verified_at) and regenerated `docs/coverage/`.

Closes #2934

🤖 Generated with [Claude Code](https://claude.com/claude-code)