### PR TITLE
[taxonomy] Remove React-only keys (jsx_template, hoc_wrapper_recognition) from shared ui_frontend/mobile groups (#2938)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -153,16 +153,16 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 5/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 18/18 | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 18/18 | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
+| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
 
 
 ## Meta Framework
@@ -184,17 +184,17 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 
 
 ## Desktop

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -32,7 +32,7 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 
 
 ### Desktop

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -24,17 +24,17 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 
 
 ### Mobile
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 
 
 ### Desktop

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -33,7 +33,7 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ### Desktop

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -31,8 +31,8 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/5 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ### Meta Framework
@@ -46,8 +46,8 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
 
 
 ### AI Integration

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -30,10 +30,10 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [React](../detail/lang.jsts.framework.react.md) | ✅ 5/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 18/18 | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/5 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
+| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 18/18 | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
+| [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
 
 
 ### Meta Framework
@@ -52,10 +52,10 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
 
 
 ### Desktop

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -26,8 +26,8 @@ Back to [summary](../summary.md).
 
 | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
 |---|---|---|---|---|---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/lang.c-cpp.framework.qt.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.qt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 29
+- **Capability cells:** 27
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — | — |
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — | — |
-| `jsx_template` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 29
+- **Capability cells:** 27
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — | — |
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — | — |
-| `jsx_template` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 29
+- **Capability cells:** 27
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — | — |
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — | — |
-| `jsx_template` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 29
+- **Capability cells:** 27
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — | — |
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — | — |
-| `jsx_template` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.csharp.framework.net-maui.md
+++ b/docs/coverage/detail/lang.csharp.framework.net-maui.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 28
+- **Capability cells:** 27
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.csharp.framework.xamarin.md
+++ b/docs/coverage/detail/lang.csharp.framework.xamarin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 28
+- **Capability cells:** 27
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.go.framework.gomobile.md
+++ b/docs/coverage/detail/lang.go.framework.gomobile.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [go](../by-language/go.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.java.framework.android-jetpack.md
+++ b/docs/coverage/detail/lang.java.framework.android-jetpack.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.java.framework.android-sdk.md
+++ b/docs/coverage/detail/lang.java.framework.android-sdk.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 18
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — | — |
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — | — |
-| `jsx_template` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.java.framework.vaadin.md
+++ b/docs/coverage/detail/lang.java.framework.vaadin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 18
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ❌ `missing` | — | — | — | — | — |
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 | `hook_recognition` | ❌ `missing` | — | — | — | — | — |
-| `jsx_template` | ❌ `missing` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.angular.md
+++ b/docs/coverage/detail/lang.jsts.framework.angular.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 18
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | — |
 | `context_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | — |
-| `hoc_wrapper_recognition` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2854) | — | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — | — |
-| `jsx_template` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.expo.md
+++ b/docs/coverage/detail/lang.jsts.framework.expo.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
-| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Navigation
 
@@ -82,6 +81,12 @@ Auto-generated. Back to [summary](../summary.md).
 | `eas_build_detection` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2879) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/testdata/mobile/expo_config/eas.json` | — |
 | `expo_config_extraction` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2879) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/testdata/mobile/expo_config/app.json` | — |
 | `expo_router_specifics` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/navigation.go` | — |
+
+### Expo Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.ionic.md
+++ b/docs/coverage/detail/lang.jsts.framework.ionic.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | `internal/extractors/javascript/extractor.go` | — |
-| `hoc_wrapper_recognition` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx` | — |
 
 ### Navigation
 
@@ -72,6 +71,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | `import_resolution_quality` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_mobile/App.tsx` | — |
+
+## Framework-specific
+
+### Ionic Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hoc_wrapper_recognition` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.nativescript.md
+++ b/docs/coverage/detail/lang.jsts.framework.nativescript.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx` | — |
-| `hoc_wrapper_recognition` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx` | — |
 
 ### Navigation
 
@@ -72,6 +71,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | `import_resolution_quality` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_mobile/App.tsx` | — |
+
+## Framework-specific
+
+### NativeScript Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hoc_wrapper_recognition` | ✅ `full` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2859) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx` | Genuine HOC signal only for the react-nativescript flavor (memo/withOrientation, recognised by the framework-agnostic React HOC detector in extractor.go). Core/Angular/Vue NativeScript flavors have no HOC equivalent; re-homed out of the shared mobile Structure column so it no longer reads as a paradigm-wide claim. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react-native.md
+++ b/docs/coverage/detail/lang.jsts.framework.react-native.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 17
+- **Capability cells:** 16
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
-| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Navigation
 
@@ -93,6 +92,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `metro_config_detection` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2879) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/testdata/mobile/rn_cli/metro.config.js` | — |
 | `native_link_recognition` | ✅ `full` | `2026-05-29` | — | [link](https://github.com/cajasmota/archigraph/issues/2879) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/testdata/mobile/rn_cli/react-native.config.js` | — |
+
+### React Native Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 33
+- **Capability cells:** 31
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/extractors/javascript/react.go` | — |
 | `context_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
-| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 | `hook_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2854_react_test.go`<br>`internal/extractors/javascript/react.go` | — |
-| `jsx_template` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 
 ### Data Flow
 
@@ -98,7 +96,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_hoc` | — `not_applicable` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | — | Covered by generic Structure/context_extraction (createContext, #611) and Structure/hoc_wrapper_recognition (forwardRef/memo/lazy/connect/withX, extractor.go). Not duplicated here to avoid double-counting. |
+| `hoc_wrapper_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 | `hooks` | — `not_applicable` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | — | Covered by generic Structure/hook_recognition (react.go USES_HOOK + custom-hook subtype). Not duplicated here to avoid double-counting. |
+| `jsx_template` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/extractor.go` | — |
 | `lazy_code_splitting` | ⚠️ `partial` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2875_react_internals_test.go`<br>`internal/extractors/javascript/react_internals.go`<br>`internal/extractors/javascript/testdata/react_internals/AppShell.tsx` | React.lazy(() => import('mod')) is decorated react_lazy + lazy_module (the code-split target). Partial: the dynamic-import specifier is recovered only when it is a string literal; computed/template specifiers are not resolved. |
 | `portal_recognition` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | `internal/extractors/javascript/issue2875_react_internals_test.go`<br>`internal/extractors/javascript/react_internals.go`<br>`internal/extractors/javascript/testdata/react_internals/AppShell.tsx` | Components calling createPortal / ReactDOM.createPortal are decorated react_portal. |
 | `suspense_error_boundary` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | `internal/extractors/javascript/issue2875_react_internals_test.go`<br>`internal/extractors/javascript/react_internals.go`<br>`internal/extractors/javascript/testdata/react_internals/AppShell.tsx` | Components rendering <Suspense> are decorated react_suspense; class components declaring componentDidCatch / getDerivedStateFromError are decorated react_error_boundary. |

--- a/docs/coverage/detail/lang.jsts.framework.svelte.md
+++ b/docs/coverage/detail/lang.jsts.framework.svelte.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 22
+- **Capability cells:** 20
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/svelte/extractor.go`<br>`internal/extractors/svelte/issue2854_test.go` | — |
 | `context_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | `internal/extractors/svelte/extractor.go`<br>`internal/extractors/svelte/issue2854_test.go` | — |
-| `hoc_wrapper_recognition` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2854) | — | — |
 | `hook_recognition` | — `not_applicable` | — | — | — | — | — |
-| `jsx_template` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.vue.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 22
+- **Capability cells:** 20
 
 ## Capabilities
 
@@ -17,9 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `component_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2854_test.go` | — |
 | `context_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2751) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2854_test.go` | — |
-| `hoc_wrapper_recognition` | — `not_applicable` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2854) | — | — |
 | `hook_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2854_test.go` | — |
-| `jsx_template` | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 28
+- **Capability cells:** 27
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Mobile
-- **Capability cells:** 28
+- **Capability cells:** 27
 
 ## Capabilities
 
@@ -16,7 +16,6 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `context_extraction` | ❌ `missing` | — | — | — | — | — |
-| `hoc_wrapper_recognition` | ❌ `missing` | — | — | — | — | — |
 
 ### Navigation
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -3199,13 +3199,7 @@
           "context_extraction": {
             "status": "missing"
           },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
-          },
           "hook_recognition": {
-            "status": "missing"
-          },
-          "jsx_template": {
             "status": "missing"
           }
         },
@@ -4399,13 +4393,7 @@
           "context_extraction": {
             "status": "missing"
           },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
-          },
           "hook_recognition": {
-            "status": "missing"
-          },
-          "jsx_template": {
             "status": "missing"
           }
         },
@@ -4537,13 +4525,7 @@
           "context_extraction": {
             "status": "missing"
           },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
-          },
           "hook_recognition": {
-            "status": "missing"
-          },
-          "jsx_template": {
             "status": "missing"
           }
         },
@@ -4675,13 +4657,7 @@
           "context_extraction": {
             "status": "missing"
           },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
-          },
           "hook_recognition": {
-            "status": "missing"
-          },
-          "jsx_template": {
             "status": "missing"
           }
         },
@@ -5254,9 +5230,6 @@
         "Structure": {
           "context_extraction": {
             "status": "missing"
-          },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
           }
         },
         "Navigation": {
@@ -5686,9 +5659,6 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
-          },
-          "hoc_wrapper_recognition": {
             "status": "missing"
           }
         },
@@ -7957,9 +7927,6 @@
         "Structure": {
           "context_extraction": {
             "status": "missing"
-          },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
           }
         },
         "Navigation": {
@@ -8720,9 +8687,6 @@
         "Structure": {
           "context_extraction": {
             "status": "missing"
-          },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
           }
         },
         "Navigation": {
@@ -8803,9 +8767,6 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
-          },
-          "hoc_wrapper_recognition": {
             "status": "missing"
           }
         },
@@ -8955,13 +8916,7 @@
           "context_extraction": {
             "status": "missing"
           },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
-          },
           "hook_recognition": {
-            "status": "missing"
-          },
-          "jsx_template": {
             "status": "missing"
           }
         },
@@ -9844,13 +9799,7 @@
           "context_extraction": {
             "status": "missing"
           },
-          "hoc_wrapper_recognition": {
-            "status": "missing"
-          },
           "hook_recognition": {
-            "status": "missing"
-          },
-          "jsx_template": {
             "status": "missing"
           }
         },
@@ -10566,15 +10515,7 @@
             "issue": "https://github.com/cajasmota/archigraph/issues/2751",
             "verified_at": "2026-05-28"
           },
-          "hoc_wrapper_recognition": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2854",
-            "verified_at": "2026-05-28"
-          },
           "hook_recognition": {
-            "status": "not_applicable"
-          },
-          "jsx_template": {
             "status": "not_applicable"
           }
         },
@@ -10899,11 +10840,6 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
-          },
-          "hoc_wrapper_recognition": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
-            "verified_at": "2026-05-28"
           }
         },
         "Navigation": {
@@ -11017,6 +10953,13 @@
           "expo_router_specifics": {
             "status": "full",
             "cites": ["internal/extractors/javascript/navigation.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Expo Internals": {
+          "hoc_wrapper_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         }
@@ -11649,11 +11592,6 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2751"
-          },
-          "hoc_wrapper_recognition": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         },
         "Navigation": {
@@ -11745,6 +11683,15 @@
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go","internal/substrate/uimm_substrate_test.go","testdata/fixtures/typescript/substrate_mobile/App.tsx"],
             "verified_at": "2026-05-28"
+          }
+        }
+      },
+      "framework_specific": {
+        "Ionic Internals": {
+          "hoc_wrapper_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_ionic/SessionContext.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         }
       }
@@ -11979,11 +11926,6 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2859"
-          },
-          "hoc_wrapper_recognition": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2859"
           }
         },
         "Navigation": {
@@ -12079,6 +12021,16 @@
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go","internal/substrate/uimm_substrate_test.go","testdata/fixtures/typescript/substrate_mobile/App.tsx"],
             "verified_at": "2026-05-28"
+          }
+        }
+      },
+      "framework_specific": {
+        "NativeScript Internals": {
+          "hoc_wrapper_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/testdata/mobile_nativescript/AppShell.tsx"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2859",
+            "notes": "Genuine HOC signal only for the react-nativescript flavor (memo/withOrientation, recognised by the framework-agnostic React HOC detector in extractor.go). Core/Angular/Vue NativeScript flavors have no HOC equivalent; re-homed out of the shared mobile Structure column so it no longer reads as a paradigm-wide claim."
           }
         }
       }
@@ -12518,20 +12470,10 @@
             "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           },
-          "hoc_wrapper_recognition": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
-            "verified_at": "2026-05-28"
-          },
           "hook_recognition": {
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/issue2854_react_test.go","internal/extractors/javascript/react.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-            "verified_at": "2026-05-28"
-          },
-          "jsx_template": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
           }
         },
@@ -12752,10 +12694,20 @@
             "issue": "https://github.com/cajasmota/archigraph/issues/2875",
             "notes": "Covered by generic Structure/context_extraction (createContext, #611) and Structure/hoc_wrapper_recognition (forwardRef/memo/lazy/connect/withX, extractor.go). Not duplicated here to avoid double-counting."
           },
+          "hoc_wrapper_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
           "hooks": {
             "status": "not_applicable",
             "issue": "https://github.com/cajasmota/archigraph/issues/2875",
             "notes": "Covered by generic Structure/hook_recognition (react.go USES_HOOK + custom-hook subtype). Not duplicated here to avoid double-counting."
+          },
+          "jsx_template": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
           },
           "lazy_code_splitting": {
             "status": "partial",
@@ -12790,11 +12742,6 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go"],
-            "verified_at": "2026-05-28"
-          },
-          "hoc_wrapper_recognition": {
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
@@ -12959,6 +12906,13 @@
             "cites": ["internal/extractors/config/discover.go","internal/extractors/config/testdata/mobile/rn_cli/react-native.config.js"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2879",
             "verified_at": "2026-05-29"
+          }
+        },
+        "React Native Internals": {
+          "hoc_wrapper_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
           }
         }
       }
@@ -13294,15 +13248,7 @@
             "issue": "https://github.com/cajasmota/archigraph/issues/2751",
             "verified_at": "2026-05-28"
           },
-          "hoc_wrapper_recognition": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2854",
-            "verified_at": "2026-05-28"
-          },
           "hook_recognition": {
-            "status": "not_applicable"
-          },
-          "jsx_template": {
             "status": "not_applicable"
           }
         },
@@ -13652,18 +13598,10 @@
             "issue": "https://github.com/cajasmota/archigraph/issues/2751",
             "verified_at": "2026-05-28"
           },
-          "hoc_wrapper_recognition": {
-            "status": "not_applicable",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2854",
-            "verified_at": "2026-05-28"
-          },
           "hook_recognition": {
             "status": "full",
             "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2854_test.go"],
             "verified_at": "2026-05-28"
-          },
-          "jsx_template": {
-            "status": "not_applicable"
           }
         },
         "Data Flow": {
@@ -14159,9 +14097,6 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
-          },
-          "hoc_wrapper_recognition": {
             "status": "missing"
           }
         },
@@ -14773,9 +14708,6 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
-          },
-          "hoc_wrapper_recognition": {
             "status": "missing"
           }
         },

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -135,9 +135,7 @@ subcategories:
       - state_management
       - data_fetching
       - router_pattern
-      - jsx_template
       - context_extraction
-      - hoc_wrapper_recognition
       - branch_conditions
       - interface_extraction
       - type_alias_extraction
@@ -167,7 +165,7 @@ subcategories:
       - template_pattern_catalog
     groups:
       - name: Structure
-        keys: [component_extraction, hook_recognition, jsx_template, context_extraction, hoc_wrapper_recognition]
+        keys: [component_extraction, hook_recognition, context_extraction]
       - name: Data Flow
         keys: [prop_extraction, state_management, data_fetching, branch_conditions]
       - name: Navigation
@@ -250,7 +248,6 @@ subcategories:
       - deep_link_extraction
       - state_management
       - context_extraction
-      - hoc_wrapper_recognition
       - branch_conditions
       - interface_extraction
       - type_alias_extraction
@@ -280,7 +277,7 @@ subcategories:
       - template_pattern_catalog
     groups:
       - name: Structure
-        keys: [context_extraction, hoc_wrapper_recognition]
+        keys: [context_extraction]
       - name: Navigation
         keys: [navigation_extraction, deep_link_extraction, screen_detection]
       - name: Platform

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -257,28 +257,12 @@ records:
               functions: [isZustandHookName, isReactQueryHook]
           issues_implemented: ["2735"]
           verified_at: "2026-05-28"
-        jsx_template:
-          status: full
-          symbols:
-            - file: internal/extractors/javascript/extractor.go
-              functions: [extractJSXRendersRelationships]
-          tests:
-            - file: internal/extractors/javascript/issue610_jsx_renders_test.go
-          issues_implemented: ["610", "2665", "2735"]
-          verified_at: "2026-05-28"
         context_extraction:
           status: full
           symbols:
             - file: internal/extractors/javascript/extractor.go
               functions: [isContextFactory]
           issues_implemented: ["611"]
-          verified_at: "2026-05-28"
-        hoc_wrapper_recognition:
-          status: full
-          symbols:
-            - file: internal/extractors/javascript/extractor.go
-              functions: [isFunctionWrapperCall]
-          issues_implemented: []
           verified_at: "2026-05-28"
       Data Flow:
         state_management:

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -80,12 +80,12 @@ func TestSubcategoryRenderKeysExcludesCategoryUnion(t *testing.T) {
 		"enum_extraction",
 		"env_fallback_recognition",
 		"fs_effect",
-		"hoc_wrapper_recognition",
+		// #2938 jsx_template + hoc_wrapper_recognition removed from the shared
+		// ui_frontend Structure group; re-homed to React framework_specific.
 		"hook_recognition",
 		"http_effect",
 		"import_resolution_quality",
 		"interface_extraction",
-		"jsx_template",
 		// #2774 Phase 3B module cycles.
 		"module_cycle_detection",
 		"mutation_effect",
@@ -140,12 +140,11 @@ func TestSubcategoryCapabilityKeysSorted(t *testing.T) {
 		"env_fallback_recognition",
 		"fs_effect",
 		"handler_attribution",
-		"hoc_wrapper_recognition",
+		// #2938 jsx_template + hoc_wrapper_recognition removed from ui_frontend.
 		"hook_recognition",
 		"http_effect",
 		"import_resolution_quality",
 		"interface_extraction",
-		"jsx_template",
 		"middleware_coverage",
 		// #2774 Phase 3B module cycles.
 		"module_cycle_detection",


### PR DESCRIPTION
## What

Removes the React-paradigm-only capability keys `jsx_template` and `hoc_wrapper_recognition` from the shared `ui_frontend` and `mobile` Structure groups in `capability-dictionary.yaml`, and atomically re-homes / deletes every record cell that carried them so `validate` stays at 0 errors.

These keys were mandatory columns for EVERY framework in those subcategories across all languages, so non-React frameworks (Angular/Vue/Svelte, Blazor, Qt, GWT/Vaadin, MAUI/Xamarin/Android/Compose/KMP, gomobile) were forced to carry them as `not_applicable`/`missing` noise. "Correct N/A" != "worth showing."

`hook_recognition` is **kept** — it is genuinely shared (React hooks + Vue composables both real).

## Dictionary

- `ui_frontend` Structure group: removed `jsx_template` + `hoc_wrapper_recognition` (and from the subcategory capability list).
- `mobile` Structure group: removed `hoc_wrapper_recognition`.

## Records — re-homed `full` -> `framework_specific` (cites/verified_at/issue preserved)

| Record | Keys | New fwspec group |
|---|---|---|
| `lang.jsts.framework.react` | `jsx_template`, `hoc_wrapper_recognition` | React Internals |
| `lang.jsts.framework.react-native` | `hoc_wrapper_recognition` | React Native Internals |
| `lang.jsts.framework.expo` | `hoc_wrapper_recognition` | Expo Internals |
| `lang.jsts.framework.ionic` | `hoc_wrapper_recognition` | Ionic Internals |
| `lang.jsts.framework.nativescript` | `hoc_wrapper_recognition` | NativeScript Internals (scoped — see honesty note) |

Meaning of the re-homed React cells: `jsx_template` = JSX `renders` relationship extraction; `hoc_wrapper_recognition` = recognition of `forwardRef`/`memo`/`lazy`/`connect`/`with<X>` higher-order-component wrapper calls. Both remain documented under React's framework_specific block instead of polluting the shared column set.

## Records — deleted `missing`/`not_applicable` cells (no longer appear)

`qt`, `blazor`, `blazor-server`, `blazor-wasm` (jsx+hoc); `gwt`, `vaadin` (jsx+hoc); `angular`, `svelte`, `vue` (jsx+hoc, were N/A); `net-maui`, `xamarin`, `gomobile`, `android-jetpack`, `android-sdk`, `compose`, `kmp` (hoc).

## NativeScript honesty finding

`lang.jsts.framework.nativescript` claimed `hoc_wrapper_recognition=full`. Verified against the extractor: the claim is **fixture-backed but React-flavor-only**. The fixture (`testdata/mobile_nativescript/AppShell.tsx`) uses `react-nativescript` (`memo` + `withOrientation`), picked up by the framework-agnostic React HOC detector (`isFunctionWrapperCall`/`isHOCName` in `extractor.go`). Core/Angular/Vue NativeScript flavors have **no** HOC equivalent. Rather than drop a fixture-proven signal, it is re-homed to "NativeScript Internals" with an explicit note scoping it to the react-nativescript flavor, so it no longer reads as a paradigm-wide mobile column.

## Supporting edits

- `capability-map.yaml`: removed the React Structure `jsx_template` + `hoc_wrapper_recognition` map entries (those cells are no longer canonical registry cells; framework_specific cells carry their own cites). Map integrity check passes.
- `subcategory_test.go`: updated the two expected key-set assertions (`TestSubcategoryRenderKeysExcludesCategoryUnion`, `TestSubcategoryCapabilityKeysSorted`) to the new `ui_frontend` vocabulary.

## Verification

- `go run ./tools/coverage validate` -> **0 errors**
- `go run ./tools/coverage fmt --check` -> canonical
- `go run ./tools/coverage gen` -> byte-stable
- `go test ./tools/coverage/` -> pass
- `go build ./...` -> clean
- Render check: Angular/Vue/Svelte/Blazor/Qt/GWT/Vaadin/MAUI/Android no longer show the two columns; React + react-native/expo/ionic/nativescript still document them under framework_specific.

No extractor code changes. Dictionary + registry + regenerated docs committed together (CI coverage-docs gate).

Closes #2938

🤖 Generated with [Claude Code](https://claude.com/claude-code)