### PR TITLE
coverage: count framework_specific toward completeness + per-framework overview (#2940)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -9,223 +9,223 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 ## Backend HTTP
 
-| Language | Name | Routing | Security | Validation | Middleware | Observability | Data | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 3/17 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/17 | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | — | ⚠️ 0/1 | — | — | ⚠️ 6/17 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | ⚠️ 8/17 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | ⚠️ 8/17 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 6/17 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 7/20 | |
-| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | — | ⚠️ 0/1 | — | — | ⚠️ 7/20 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | — 0/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | ⚠️ 8/17 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 6/17 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | ⚠️ 8/17 | |
-| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — | — | — | — | — 0/4 | |
-| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — | — | — | — | — 0/4 | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 6/17 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — | — 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | — | ⚠️ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ✅ 1/1 | — | ❌ 0/1 | — | — | ⚠️ 7/20 | |
-| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 5/6 | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 6/17 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 6/17 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — | — 0/1 | — | — | ⚠️ 8/17 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | — | ❌ 0/1 | — | — | ⚠️ 8/17 | |
-| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | — | — | — | — | ⚠️ 0/8 | |
+| Language | Name | Routing | Auth | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ⚠️ 0/1 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 7/20 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 7/20 | ❌ 0/4 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 5/6 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — 0/4 | — | |
+| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — 0/4 | — | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | ⚠️ 5/6 | — 0/1 | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ⚠️ 0/1 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 7/20 | ❌ 0/3 | |
+| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 5/6 | — 0/1 | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | ⚠️ 0/8 | — | |
 
 
 ## UI Frontend
 
-| Language | Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 18/18 | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
+| Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 17/18 | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | ✅ 18/18 | ⚠️ 20/23 | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 16/18 | |
+| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 18/20 | |
 
 
 ## Meta Framework
 
-| Language | Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | — 0/1 | ✅ 1/1 | ✅ 4/4 | |
-| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 4/4 | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 3/14 | |
+| Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/7 | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | — | ❌ 0/7 | |
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 7/9 | |
+| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | — | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | — | ✅ 11/11 | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | — | ✅ 8/9 | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | — | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 8/9 | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ⚠️ 3/14 | ❌ 0/7 | |
 
 
 ## Mobile
 
-| Language | Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
+| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
+| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
+| [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 13/13 | |
+| [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 10/10 | |
+| [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 10/10 | |
+| [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 19/19 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
 
 
 ## Desktop
 
-| Language | Name | Process | Native | Substrate | Notes |
-|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/2 | ❌ 0/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ✅ 2/2 | ✅ 1/1 | — | |
-| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
+| Language | Name | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | — | ❌ 0/3 | |
+| [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | — | ✅ 3/3 | |
+| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ⚠️ 3/7 | ❌ 0/3 | |
 
 
 ## RPC Framework
 
-| Language | Name | Schema | Codegen | Transport | Substrate | Notes |
-|---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | — | ⚠️ 5/14 | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | — 0/1 | ✅ 1/1 | — | |
-| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | — | |
+| Language | Name | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ⚠️ 5/14 | ❌ 0/3 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | — | ✅ 3/4 | |
+| [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | — | ✅ 4/4 | |
 
 
 ## AI Integration
 
-| Language | Name | Prompts | Composition | Notes |
-|---|---|---|---|---|
-| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/1 | ❌ 0/2 | |
-| [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ✅ 1/1 | ✅ 2/2 | |
-| [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/1 | ❌ 0/2 | |
+| Language | Name | Other capabilities | Notes |
+|---|---|---|---|
+| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/3 | |
+| [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ✅ 3/3 | |
+| [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/3 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -10,37 +10,37 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 3/17 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/17 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/17 | ❌ 0/1 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/17 | ❌ 0/1 | |
 
 
 ### UI Frontend
 
-| Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
 
 
 ### Desktop
 
-| Name | Process | Native | Substrate | Notes |
-|---|---|---|---|---|
-| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
+| Name | Substrate | Other capabilities | Notes |
+|---|---|---|---|
+| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ⚠️ 3/7 | ❌ 0/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -10,47 +10,47 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 0/1 | ⚠️ 6/17 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ⚠️ 0/1 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 
 
 ### UI Frontend
 
-| Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
 
 
 ### Mobile
 
-| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
 
 
 ### Desktop
 
-| Name | Process | Native | Substrate | Notes |
-|---|---|---|---|---|
-| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
+| Name | Substrate | Other capabilities | Notes |
+|---|---|---|---|
+| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [WPF](../detail/lang.csharp.framework.wpf.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ⚠️ 3/7 | ❌ 0/3 | |
 
 
 ### RPC Framework
 
-| Name | Schema | Codegen | Substrate | Notes |
-|---|---|---|---|---|
-| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/14 | |
+| Name | Substrate | Other capabilities | Notes |
+|---|---|---|---|
+| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ⚠️ 5/14 | ❌ 0/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -10,23 +10,23 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | — 0/1 | ⚠️ 8/17 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | — 0/1 | ⚠️ 8/17 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 6/17 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 
 
 ### Meta Framework
 
-| Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/7 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -10,37 +10,37 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 7/20 | |
-| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Iris](../detail/lang.go.framework.iris.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Revel](../detail/lang.go.framework.revel.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [chi](../detail/lang.go.framework.chi.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [go-zero](../detail/lang.go.framework.go-zero.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [Beego](../detail/lang.go.framework.beego.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Echo](../detail/lang.go.framework.echo.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Fiber](../detail/lang.go.framework.fiber.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Gin](../detail/lang.go.framework.gin.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 7/20 | ❌ 0/1 | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Huma](../detail/lang.go.framework.huma.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Iris](../detail/lang.go.framework.iris.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Revel](../detail/lang.go.framework.revel.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [chi](../detail/lang.go.framework.chi.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [go-zero](../detail/lang.go.framework.go-zero.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 
 
 ### Mobile
 
-| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
 
 
 ### Desktop
 
-| Name | Process | Native | Notes |
-|---|---|---|---|
-| [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/2 | ❌ 0/1 | |
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -10,51 +10,51 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ✅ 2/2 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 0/1 | ⚠️ 7/20 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 7/20 | ❌ 0/4 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 
 
 ### UI Frontend
 
-| Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/4 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
 
 
 ### Meta Framework
 
-| Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | |
+| Name | Routing | Type System | Testing | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/7 | |
 
 
 ### Mobile
 
-| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
-| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 2/3 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
+| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
 
 
 ### AI Integration
 
-| Name | Prompts | Composition | Notes |
-|---|---|---|---|
-| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/1 | ❌ 0/2 | |
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -10,74 +10,74 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Validation | Middleware | Observability | Data | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Feathers](../detail/lang.jsts.framework.feathers.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Hapi](../detail/lang.jsts.framework.hapi.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | — 0/1 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Feathers](../detail/lang.jsts.framework.feathers.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Hapi](../detail/lang.jsts.framework.hapi.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Hono](../detail/lang.jsts.framework.hono.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Koa](../detail/lang.jsts.framework.koa.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
+| [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 5/6 | |
 
 
 ### UI Frontend
 
-| Name | Structure | Data Flow | Navigation | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|
-| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 2/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 18/18 | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 2/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
-| [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 4/4 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 7/7 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 17/18 | |
+| [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | ✅ 18/18 | ⚠️ 20/23 | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 16/18 | |
+| [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 18/20 | |
 
 
 ### Meta Framework
 
-| Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | — 0/1 | ✅ 1/1 | ✅ 4/4 | |
-| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | — | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 1/2 | ✅ 1/1 | ✅ 2/2 | ✅ 2/2 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 4/4 | |
+| Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 7/9 | |
+| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | — | ✅ 8/8 | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | — | ✅ 11/11 | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | — | ✅ 8/9 | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | — | ✅ 8/8 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 8/9 | |
 
 
 ### Mobile
 
-| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
-| [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | ✅ 3/3 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 13/13 | |
+| [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 10/10 | |
+| [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 10/10 | |
+| [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 19/19 | |
 
 
 ### Desktop
 
-| Name | Process | Native | Notes |
-|---|---|---|---|
-| [Electron](../detail/lang.jsts.framework.electron.md) | ✅ 2/2 | ✅ 1/1 | |
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [Electron](../detail/lang.jsts.framework.electron.md) | ✅ 3/3 | |
 
 
 ### RPC Framework
 
-| Name | Schema | Codegen | Transport | Notes |
-|---|---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 2/2 | — 0/1 | ✅ 1/1 | |
-| [tRPC](../detail/lang.jsts.framework.trpc.md) | ✅ 2/2 | ✅ 1/1 | ✅ 1/1 | |
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ✅ 3/4 | |
+| [tRPC](../detail/lang.jsts.framework.trpc.md) | ✅ 4/4 | |
 
 
 ### AI Integration
 
-| Name | Prompts | Composition | Notes |
-|---|---|---|---|
-| [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ✅ 1/1 | ✅ 2/2 | |
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ✅ 3/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -10,32 +10,32 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | — 0/1 | ⚠️ 8/17 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 6/17 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | — 0/1 | ⚠️ 8/17 | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
 
 
 ### Mobile
 
-| Name | Structure | Navigation | Platform | Native Bridge | Data Flow | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/14 | |
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
 
 
 ### Desktop
 
-| Name | Process | Native | Substrate | Notes |
-|---|---|---|---|---|
-| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
-| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
+| Name | Substrate | Other capabilities | Notes |
+|---|---|---|---|
+| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ⚠️ 3/7 | ❌ 0/3 | |
+| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ⚠️ 3/7 | ❌ 0/3 | |
 
 
 ## ORMs

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -10,20 +10,20 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 6/17 | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Magento](../detail/lang.php.framework.magento.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Slim](../detail/lang.php.framework.slim.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -10,34 +10,34 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | — 0/1 | ⚠️ 5/6 | |
-| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 0/1 | ⚠️ 5/6 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ✅ 1/1 | ❌ 0/1 | ⚠️ 7/20 | |
-| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | — 0/1 | ⚠️ 5/6 | |
-| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Flask](../detail/lang.python.framework.flask.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 5/6 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | ⚠️ 5/6 | — 0/1 | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ⚠️ 0/1 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 7/20 | ❌ 0/3 | |
+| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 5/6 | — 0/1 | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Flask](../detail/lang.python.framework.flask.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 
 
 ### AI Integration
 
-| Name | Prompts | Composition | Notes |
-|---|---|---|---|
-| [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/1 | ❌ 0/2 | |
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -10,16 +10,16 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 6/17 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | — 0/1 | ⚠️ 8/17 | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -10,25 +10,25 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 6/17 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 
 
 ### Desktop
 
-| Name | Process | Native | Substrate | Notes |
-|---|---|---|---|---|
-| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 3/7 | |
+| Name | Substrate | Other capabilities | Notes |
+|---|---|---|---|
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ⚠️ 3/7 | ❌ 0/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -10,23 +10,23 @@ Back to [summary](../summary.md).
 
 ### Backend HTTP
 
-| Name | Routing | Security | Middleware | Substrate | Notes |
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | — 0/1 | ⚠️ 8/17 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | ❌ 0/1 | ⚠️ 8/17 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 
 
 ### Meta Framework
 
-| Name | Structure | Data Flow | Server | Routing | Build | Type System | Lifecycle | Testing | Substrate | Notes |
-|---|---|---|---|---|---|---|---|---|---|---|
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/1 | ❌ 0/2 | ❌ 0/2 | ❌ 0/1 | ❌ 0/3 | ❌ 0/1 | ❌ 0/1 | ⚠️ 3/14 | |
+| Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ⚠️ 3/14 | ❌ 0/7 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go`<br>`internal/engine/rules/csharp/frameworks/asp_net_core.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/csharp/frameworks/asp_net_mvc.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml`<br>`internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/ash_framework.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/nerves.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/elixir/frameworks/oban.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go`<br>`internal/engine/rules/elixir/frameworks/phoenix.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/phoenix_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/beego.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/beego.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/buffalo.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/buffalo.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/chi.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/echo.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/fiber.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gin.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/go_zero.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/go_zero.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gorilla_mux.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/hertz.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/hertz.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_go_trio.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/iris.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/iris.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/kratos.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/kratos.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/net_http_stdlib.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/go_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/revel.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/go/frameworks/revel.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/dropwizard.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/micronaut.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/quarkus.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/java/frameworks/spring_boot.yaml`<br>`internal/engine/rules/java/frameworks/spring_mvc.yaml`<br>`internal/engine/spring_routes.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/http_endpoint_jsts_backend_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml`<br>`testdata/fixtures/typescript/adonisjs_group_prefix.ts`<br>`testdata/fixtures/typescript/adonisjs_routes.ts` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/adonisjs.yaml`<br>`testdata/fixtures/typescript/adonisjs_routes.ts` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/feathers.yaml`<br>`testdata/fixtures/typescript/feathers_routes.ts` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/feathers.yaml`<br>`testdata/fixtures/typescript/feathers_routes.ts` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/hapi.yaml`<br>`testdata/fixtures/typescript/hapi_routes.ts` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/hapi.yaml`<br>`testdata/fixtures/typescript/hapi_routes.ts` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/framework_dsl.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/marblejs.yaml`<br>`testdata/fixtures/typescript/marblejs_routes.ts` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/marblejs.yaml`<br>`testdata/fixtures/typescript/marblejs_routes.ts` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/polka.yaml`<br>`testdata/fixtures/typescript/polka_routes.ts` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/polka.yaml`<br>`testdata/fixtures/typescript/polka_routes.ts` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/restify.yaml`<br>`testdata/fixtures/typescript/restify_routes.ts` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/restify.yaml`<br>`testdata/fixtures/typescript/restify_routes.ts` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/sails.yaml`<br>`testdata/fixtures/typescript/sails_routes.ts` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2851) | `internal/engine/http_endpoint_jsts_backend.go`<br>`internal/engine/rules/javascript_typescript/frameworks/sails.yaml`<br>`testdata/fixtures/typescript/sails_routes.ts` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes_kotlin.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/cakephp.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/cakephp.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/codeigniter.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/drupal.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/drupal.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/laminas.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/laminas.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/laravel.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/magento.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/magento.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/slim.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/slim.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go`<br>`internal/engine/rules/php/frameworks/symfony.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_php_producer.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/wordpress.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/wordpress.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/yii.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/php/frameworks/yii.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/celery.yaml`<br>`internal/extractors/python/celery.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/django_drf_actions.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/drf_serializer_fields.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go`<br>`internal/engine/rules/python/frameworks/django.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/django_admin_routes.go`<br>`internal/engine/django_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.dramatiq.md
+++ b/docs/coverage/detail/lang.python.framework.dramatiq.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/dramatiq.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/fastapi.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/fastapi.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/flask.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/flask.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pyramid.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/pyramid.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/starlette.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/starlette.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/graphql/frameworks/strawberry_python.yaml`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/tornado.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/tornado.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/dry_rb.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/grape.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/grape.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/hanami.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/padrino.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/ruby_on_rails.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/roda.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/ruby/frameworks/roda.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/sinatra.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_ruby_producer.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go`<br>`internal/engine/rules/rust/frameworks/axum.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_axum.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/gotham.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/gotham.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/hyper.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/hyper.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/poem.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/poem.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go`<br>`internal/engine/rules/rust/frameworks/rocket.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rocket_routes.go` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tide.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/tide.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/warp.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/rust/frameworks/warp.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/cats_effect.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -18,7 +18,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/detail/lang.swift.framework.vapor.md
+++ b/docs/coverage/detail/lang.swift.framework.vapor.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 
-### Security
+### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1796,7 +1796,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -1913,7 +1913,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2030,7 +2030,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2147,7 +2147,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2264,7 +2264,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2381,7 +2381,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2498,7 +2498,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2615,7 +2615,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2732,7 +2732,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2849,7 +2849,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -2966,7 +2966,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -3083,7 +3083,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -3332,7 +3332,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -3449,7 +3449,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -4154,7 +4154,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -4277,7 +4277,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -4790,7 +4790,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -4907,7 +4907,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -5118,7 +5118,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -5371,7 +5371,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -6058,7 +6058,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -6179,7 +6179,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -6296,7 +6296,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -6413,7 +6413,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -6532,7 +6532,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
           }
@@ -6651,7 +6651,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
           }
@@ -6772,7 +6772,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7025,7 +7025,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7340,7 +7340,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7403,7 +7403,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7466,7 +7466,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7529,7 +7529,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7592,7 +7592,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7655,7 +7655,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7740,7 +7740,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -7873,7 +7873,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8017,7 +8017,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8080,7 +8080,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8143,7 +8143,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8206,7 +8206,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8269,7 +8269,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8332,7 +8332,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8395,7 +8395,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8633,7 +8633,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8858,7 +8858,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -8994,7 +8994,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -9057,7 +9057,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -9116,7 +9116,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -9179,7 +9179,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "partial",
             "cites": ["internal/engine/java_auth_policy.go"],
@@ -9266,7 +9266,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "partial",
             "cites": ["internal/engine/java_auth_policy.go"],
@@ -9331,7 +9331,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -9458,7 +9458,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "partial",
             "cites": ["internal/engine/java_auth_policy.go"],
@@ -9523,7 +9523,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["internal/engine/java_auth_policy.go"],
@@ -9676,7 +9676,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "partial",
             "cites": ["internal/engine/java_auth_policy.go"],
@@ -9741,7 +9741,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -9881,7 +9881,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -10422,7 +10422,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/adonisjs_auth.ts"],
@@ -10986,7 +10986,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/express_auth.ts"],
@@ -11081,7 +11081,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/fastify_auth.ts"],
@@ -11176,7 +11176,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/feathers_auth.ts"],
@@ -11413,7 +11413,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/hapi_auth.ts"],
@@ -11506,7 +11506,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/hono_auth.ts"],
@@ -11715,7 +11715,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/koa_auth.ts"],
@@ -11840,7 +11840,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/marblejs_auth.ts"],
@@ -12056,7 +12056,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["cmd/archigraph/audit2852_jsauth_test.go","internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/nestjs_auth.ts"],
@@ -12377,7 +12377,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/polka_auth.ts"],
@@ -13041,7 +13041,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","testdata/fixtures/typescript/restify_auth.ts"],
@@ -13136,7 +13136,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["internal/engine/http_endpoint_jsts_auth.go","internal/engine/http_endpoint_jsts_auth_test.go","internal/engine/http_endpoint_jsts_sails_auth.go","testdata/fixtures/typescript/sails_policies.ts","testdata/fixtures/typescript/sails_routes.ts"],
@@ -13986,7 +13986,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
           }
@@ -14359,7 +14359,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
           }
@@ -14480,7 +14480,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -14597,7 +14597,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -14854,7 +14854,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -14975,7 +14975,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -15096,7 +15096,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -15217,7 +15217,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "partial",
             "cites": ["internal/engine/java_auth_policy.go"],
@@ -15714,7 +15714,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -15835,7 +15835,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -15956,7 +15956,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -16077,7 +16077,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -16198,7 +16198,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -16315,7 +16315,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -16436,7 +16436,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -16553,7 +16553,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -16674,7 +16674,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -16795,7 +16795,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -16916,7 +16916,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -17037,7 +17037,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -17411,7 +17411,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -17474,7 +17474,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -17535,7 +17535,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
           }
@@ -17594,7 +17594,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -17657,7 +17657,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "partial",
             "cites": ["internal/engine/django_drf_actions.go"],
@@ -17724,7 +17724,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "full",
             "cites": ["internal/extractors/python/config_module.go","internal/extractors/python/django_drf_permissions.go","internal/mcp/auth_coverage.go"],
@@ -17872,7 +17872,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
           }
@@ -17931,7 +17931,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -17994,7 +17994,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "partial",
             "cites": ["internal/engine/rules/python/frameworks/fastapi.yaml"],
@@ -18059,7 +18059,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18118,7 +18118,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18203,7 +18203,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18266,7 +18266,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18325,7 +18325,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18388,7 +18388,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18451,7 +18451,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18514,7 +18514,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18577,7 +18577,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -18640,7 +18640,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -19042,7 +19042,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -19161,7 +19161,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
           }
@@ -19282,7 +19282,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -19403,7 +19403,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -19524,7 +19524,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -19645,7 +19645,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -19766,7 +19766,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -19887,7 +19887,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -20284,7 +20284,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -20405,7 +20405,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -20526,7 +20526,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -20647,7 +20647,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -20768,7 +20768,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -20889,7 +20889,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -21006,7 +21006,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -21186,7 +21186,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -21303,7 +21303,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -21424,7 +21424,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -21644,7 +21644,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -21761,7 +21761,7 @@
             "status": "missing"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -21880,7 +21880,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "not_applicable"
           }
@@ -22001,7 +22001,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -22122,7 +22122,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -22243,7 +22243,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -22500,7 +22500,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }
@@ -22621,7 +22621,7 @@
             "verified_at": "2026-05-28"
           }
         },
-        "Security": {
+        "Auth": {
           "auth_coverage": {
             "status": "missing"
           }

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -13,6 +13,17 @@
 
 $schema_version: 1
 
+# Universal core (#2940). These group names are the cross-framework lanes
+# that count on every framework's by-language overview row. `order` fixes
+# their left-to-right render order in the per-subcategory pivot; only the
+# universal-core groups a subcategory actually declares are shown (omit-if-
+# absent — we never fabricate a column). Any subcategory group whose name
+# also appears here MUST be spelled identically (load-time consistency
+# check in capability_dictionary.go + validate.go); that is why the
+# http_backend auth lane is named "Auth" rather than "Security".
+universal_core:
+  order: [Routing, Auth, Type System, Testing, Substrate]
+
 # Buckets group registry categories into the four rendering lanes used
 # by summary.md and the per-language pages. Order governs display order
 # across the registry.
@@ -110,7 +121,7 @@ subcategories:
     groups:
       - name: Routing
         keys: [endpoint_synthesis, handler_attribution, route_extraction]
-      - name: Security
+      - name: Auth
         keys: [auth_coverage]
       - name: Validation
         keys: [request_validation, dto_extraction]

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -604,7 +604,7 @@ records:
             - file: internal/extractors/python/drf_serializer_fields_test.go
           issues_implemented: ["2677"]
           verified_at: "2026-05-28"
-      Security:
+      Auth:
         auth_coverage:
           status: full
           symbols:
@@ -823,7 +823,7 @@ records:
             - file: internal/engine/rules/python/frameworks/fastapi.yaml
           issues_implemented: ["2681"]
           verified_at: "2026-05-28"
-      Security:
+      Auth:
         auth_coverage:
           status: partial
           symbols:
@@ -924,7 +924,7 @@ records:
             - file: internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml
           issues_implemented: ["2687"]
           verified_at: "2026-05-28"
-      Security:
+      Auth:
         auth_coverage:
           status: partial
           symbols:
@@ -1399,7 +1399,7 @@ records:
                 - containsAnyHTTPAnnotation
           issues_implemented: ["2680"]
           verified_at: "2026-05-28"
-      Security:
+      Auth:
         auth_coverage:
           status: full
           symbols:

--- a/tools/coverage/capability_dictionary.go
+++ b/tools/coverage/capability_dictionary.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 
 	"gopkg.in/yaml.v3"
@@ -34,6 +35,7 @@ var embeddedDictionary embed.FS
 // and for callers that want a fresh load from a specific path.
 type CapabilityDictionary struct {
 	SchemaVersion int                         `yaml:"$schema_version"`
+	UniversalCore UniversalCoreEntry          `yaml:"universal_core"`
 	Buckets       map[string]BucketEntry      `yaml:"buckets"`
 	Categories    map[string]CategoryEntry    `yaml:"categories"`
 	Subcategories map[string]SubcategoryEntry `yaml:"subcategories"`
@@ -44,6 +46,14 @@ type CapabilityDictionary struct {
 	subcatsByCat     map[string][]string            // category → ordered subcategory slugs
 	groupsBySubcat   map[string][]capabilityGroup   // subcategory → ordered groups
 	groupIndex       map[string]map[string][]string // subcategory → group name → keys
+	universalCoreSet map[string]struct{}            // membership set over UniversalCore.Order
+}
+
+// UniversalCoreEntry declares the cross-framework "universal core" group
+// lanes (#2940). Order fixes the left-to-right render sequence of the
+// universal columns on every per-subcategory pivot table.
+type UniversalCoreEntry struct {
+	Order []string `yaml:"order"`
 }
 
 // BucketEntry is one bucket definition (render order + category list).
@@ -111,11 +121,50 @@ func parseCapabilityDictionary(data []byte, path string) (*CapabilityDictionary,
 		return nil, fmt.Errorf("capability dictionary %s: unsupported $schema_version %d (want 1)", path, d.SchemaVersion)
 	}
 	d.indexDerived()
+	if err := d.checkUniversalCoreConsistency(); err != nil {
+		return nil, fmt.Errorf("capability dictionary %s: %w", path, err)
+	}
 	return d, nil
+}
+
+// checkUniversalCoreConsistency enforces the #2940 spelling invariant:
+// any subcategory group name that case-insensitively matches a
+// universal_core lane MUST be spelled identically. This guarantees the
+// pivot's `universal_core.order ∩ groups` intersection (an exact-string
+// set membership) actually picks the lane up rather than silently
+// dropping it because of a "Security" vs "Auth" / casing divergence.
+func (d *CapabilityDictionary) checkUniversalCoreConsistency() error {
+	if len(d.universalCoreSet) == 0 {
+		return nil
+	}
+	canonByLower := map[string]string{}
+	for _, name := range d.UniversalCore.Order {
+		canonByLower[strings.ToLower(name)] = name
+	}
+	subs := make([]string, 0, len(d.groupsBySubcat))
+	for s := range d.groupsBySubcat {
+		subs = append(subs, s)
+	}
+	sort.Strings(subs)
+	for _, sub := range subs {
+		for _, g := range d.groupsBySubcat[sub] {
+			if _, exact := d.universalCoreSet[g.Name]; exact {
+				continue
+			}
+			if canon, ok := canonByLower[strings.ToLower(g.Name)]; ok {
+				return fmt.Errorf("subcategory %q group %q must be spelled %q to match universal_core", sub, g.Name, canon)
+			}
+		}
+	}
+	return nil
 }
 
 // indexDerived populates the read-only derived indexes used by helpers.
 func (d *CapabilityDictionary) indexDerived() {
+	d.universalCoreSet = map[string]struct{}{}
+	for _, name := range d.UniversalCore.Order {
+		d.universalCoreSet[name] = struct{}{}
+	}
 	// bucketOrder by ascending Order then name for ties.
 	names := make([]string, 0, len(d.Buckets))
 	for n := range d.Buckets {
@@ -183,6 +232,22 @@ func (d *CapabilityDictionary) indexDerived() {
 		d.groupsBySubcat[slug] = groups
 		d.groupIndex[slug] = inner
 	}
+}
+
+// UniversalCoreOrder returns the universal-core group lane names in
+// canonical render order (#2940). The returned slice is a fresh copy so
+// callers cannot mutate the dictionary's backing array.
+func (d *CapabilityDictionary) UniversalCoreOrder() []string {
+	out := make([]string, len(d.UniversalCore.Order))
+	copy(out, d.UniversalCore.Order)
+	return out
+}
+
+// IsUniversalCore reports whether group is a universal-core lane name
+// (exact match — spelling is enforced canonical at load time).
+func (d *CapabilityDictionary) IsUniversalCore(group string) bool {
+	_, ok := d.universalCoreSet[group]
+	return ok
 }
 
 // BucketOrder returns the render order of bucket names.

--- a/tools/coverage/capability_dictionary_test.go
+++ b/tools/coverage/capability_dictionary_test.go
@@ -102,3 +102,98 @@ func TestDictionarySingletonStable(t *testing.T) {
 		t.Errorf("dict() returned distinct pointers across calls: a=%p b=%p", a, b)
 	}
 }
+
+// TestUniversalCoreOrder pins the #2940 universal-core lane ordering and
+// membership query against the shipped dictionary.
+func TestUniversalCoreOrder(t *testing.T) {
+	d, err := LoadCapabilityDictionary(filepath.Join(repoRoot(t), defaultDictionaryPath))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	want := []string{"Routing", "Auth", "Type System", "Testing", "Substrate"}
+	if got := d.UniversalCoreOrder(); !reflect.DeepEqual(got, want) {
+		t.Errorf("UniversalCoreOrder = %v, want %v", got, want)
+	}
+	for _, name := range want {
+		if !d.IsUniversalCore(name) {
+			t.Errorf("IsUniversalCore(%q) = false, want true", name)
+		}
+	}
+	// "Security" was renamed to "Auth" (#2940): the http_backend auth lane
+	// must now be spelled canonically so the universal column picks it up.
+	if d.IsUniversalCore("Security") {
+		t.Errorf("IsUniversalCore(Security) = true; lane should be renamed to Auth")
+	}
+	if g := d.GroupForCapability("http_backend", "auth_coverage"); g != "Auth" {
+		t.Errorf("http_backend auth_coverage group = %q, want Auth", g)
+	}
+}
+
+// TestUniversalCoreConsistencyRejectsDivergentSpelling proves the load-
+// time guard: a subcategory group whose name case-insensitively matches a
+// universal_core lane but is spelled differently (here "auth" vs the
+// canonical "Auth") fails to load. This is what keeps the pivot's exact-
+// string `universal_core ∩ groups` intersection from silently dropping a
+// lane because of a casing divergence.
+func TestUniversalCoreConsistencyRejectsDivergentSpelling(t *testing.T) {
+	src := `$schema_version: 1
+universal_core:
+  order: [Auth]
+buckets:
+  Frameworks: {order: 1, categories: [http_framework]}
+categories:
+  http_framework: {capabilities: [auth_coverage], subcategory_order: [http_backend]}
+subcategories:
+  http_backend:
+    display: Backend
+    parent_category: http_framework
+    capabilities: [auth_coverage]
+    groups:
+      - {name: auth, keys: [auth_coverage]}
+`
+	tmp := filepath.Join(t.TempDir(), "dict.yaml")
+	if err := os.WriteFile(tmp, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadCapabilityDictionary(tmp)
+	if err == nil {
+		t.Fatalf("expected consistency error for divergent universal-core spelling, got nil")
+	}
+	if !containsStr(err.Error(), `must be spelled "Auth"`) {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestOtherCapabilitiesDigest verifies the #2940 merged digest: non-
+// universal canonical group cells UNION all framework_specific cells,
+// excluding universal-core lanes.
+func TestOtherCapabilitiesDigest(t *testing.T) {
+	rec := Record{
+		ID: "lang.jsts.framework.nestjs", Category: "http_framework",
+		Subcategory: "http_backend", Language: "jsts", Label: "NestJS",
+		Groups: map[string]map[string]Capability{
+			"Routing":    {"endpoint_synthesis": {Status: StatusFull}}, // universal — excluded
+			"Validation": {"request_validation": {Status: StatusMissing}},
+		},
+		FrameworkSpecific: map[string]map[string]Capability{
+			"NestJS Internals": {
+				"dependency_injection": {Status: StatusMissing},
+				"module_graph":         {Status: StatusPartial},
+			},
+		},
+	}
+	cells := otherCapabilitiesCells(rec)
+	if _, ok := cells["endpoint_synthesis"]; ok {
+		t.Errorf("universal-core cell leaked into Other digest set")
+	}
+	want := []string{"dependency_injection", "module_graph", "request_validation"}
+	got := sortedCapKeys(cells)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Other cells = %v, want %v", got, want)
+	}
+	// 3 cells, 0 full, worst = missing → ❌ 0/3.
+	view := recordToView(rec)
+	if d := view.GroupDigestByName[OtherCapabilitiesColumn]; d != "❌ 0/3" {
+		t.Errorf("Other digest = %q, want ❌ 0/3", d)
+	}
+}

--- a/tools/coverage/gen_test.go
+++ b/tools/coverage/gen_test.go
@@ -237,13 +237,16 @@ func TestGenSummaryIncludesExtractorSupportedLanguages(t *testing.T) {
 }
 
 // TestGenHidesStrandedGroupColumns is the gen-level snapshot of the
-// don't-strand render guard (#2902). It builds a minimal in-memory
-// registry of grouped ui_frontend records where the Navigation / Type
-// System / Lifecycle / Testing / Substrate groups are all-"—" (no record
-// carries a cell), then asserts the rendered by-language and by-category
-// tables drop those column headers while keeping the populated Structure
-// and Data Flow columns — and that a tracked-but-missing ("❌") cell keeps
-// its column (only truly-N/A all-"—" columns are hidden).
+// don't-strand render guard (#2902) under the #2940 per-framework column
+// model. Columns are the universal-core lanes the subcategory declares
+// (universal_core ∩ declared, don't-strand filtered) plus the merged
+// "Other capabilities" digest. Here Vue carries a Testing cell (a
+// universal lane) plus non-universal Structure/Data Flow cells, and
+// Svelte carries only Structure. The Testing column survives (Vue has a
+// cell); the other universal lanes (Type System / Substrate) are all-"—"
+// and are dropped; non-universal Structure/Data Flow roll into the always-
+// present "Other capabilities" column, so no Structure/Data Flow/
+// Navigation/Lifecycle column headers appear.
 func TestGenHidesStrandedGroupColumns(t *testing.T) {
 	reg := &Registry{
 		SchemaVersion: SchemaVersion,
@@ -252,6 +255,7 @@ func TestGenHidesStrandedGroupColumns(t *testing.T) {
 				Groups: map[string]map[string]Capability{
 					"Structure": {"component_extraction": {Status: StatusFull}},
 					"Data Flow": {"prop_flow": {Status: StatusMissing, Issue: "x"}},
+					"Testing":   {"tests_linkage": {Status: StatusFull}},
 				}},
 			{ID: "lang.jsts.framework.svelte", Category: "http_framework", Subcategory: "ui_frontend", Language: "jsts", Label: "Svelte",
 				Groups: map[string]map[string]Capability{
@@ -272,16 +276,17 @@ func TestGenHidesStrandedGroupColumns(t *testing.T) {
 			t.Fatalf("read %s: %v", rel, err)
 		}
 		body := string(data)
-		// Populated columns survive (Data Flow has a tracked ❌ cell).
-		for _, keep := range []string{"| Structure |", "| Data Flow |"} {
+		// The populated universal lane and the merged digest survive.
+		for _, keep := range []string{"| Testing |", "| Other capabilities |"} {
 			if !strings.Contains(body, keep) {
 				t.Errorf("%s: expected column %q to be kept, got:\n%s", rel, keep, body)
 			}
 		}
-		// All-"—" columns are dropped.
-		for _, drop := range []string{"| Navigation |", "| Type System |", "| Lifecycle |", "| Testing |", "| Substrate |"} {
+		// All-"—" universal columns are dropped; non-universal lanes never
+		// get their own column (they fold into "Other capabilities").
+		for _, drop := range []string{"| Structure |", "| Data Flow |", "| Navigation |", "| Type System |", "| Lifecycle |", "| Substrate |"} {
 			if strings.Contains(body, drop) {
-				t.Errorf("%s: stranded column %q should be hidden, got:\n%s", rel, drop, body)
+				t.Errorf("%s: stranded/folded column %q should be hidden, got:\n%s", rel, drop, body)
 			}
 		}
 	}

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -295,7 +295,49 @@ func recordToView(rec Record) recordView {
 			view.GroupDigestByName[g.Name] = g.Digest
 		}
 	}
+	// "Other capabilities" merged digest (#2940): everything outside the
+	// universal-core lanes — non-universal canonical group cells UNION all
+	// framework_specific cells — rolled into a single digest column so a
+	// framework's unique idioms render (and count) on the overview. The set
+	// is built order-independently (map union) so the digest is
+	// deterministic regardless of group/key iteration order.
+	if other := otherCapabilitiesCells(rec); len(other) > 0 {
+		view.GroupDigestByName[OtherCapabilitiesColumn] = groupDigest(other)
+	} else {
+		view.GroupDigestByName[OtherCapabilitiesColumn] = "—"
+	}
 	return view
+}
+
+// otherCapabilitiesCells returns the union of the record's non-universal-
+// core canonical group cells and all of its framework_specific cells,
+// keyed by capability slug (#2940). Universal-core group cells are
+// excluded — they own their own pivot columns. For non-grouped records
+// (no subcategory taxonomy) every canonical cell is "other" since none of
+// them belongs to a universal-core lane. Keys are collision-free across
+// tiers (validate.go), so the union never silently overwrites.
+func otherCapabilitiesCells(rec Record) map[string]Capability {
+	out := map[string]Capability{}
+	if rec.IsGrouped() {
+		for gname, caps := range rec.Groups {
+			if isUniversalCore(gname) {
+				continue
+			}
+			for k, c := range caps {
+				out[k] = c
+			}
+		}
+	} else {
+		for k, c := range rec.Capabilities {
+			out[k] = c
+		}
+	}
+	for _, caps := range rec.FrameworkSpecific {
+		for k, c := range caps {
+			out[k] = c
+		}
+	}
+	return out
 }
 
 // buildGroupViews materialises one groupView per declared group in the
@@ -819,6 +861,41 @@ func nonStrandedGroupNames(candidates []string, records int, digestFor func(rec 
 	return out
 }
 
+// universalPivotColumns returns the per-subcategory pivot column headers
+// under the #2940 model: the universal-core lanes the subcategory actually
+// declares (universal_core.order ∩ knownGroupNames(sub), omit-if-absent,
+// in universal-core render order) followed by the synthetic
+// OtherCapabilitiesColumn, always last.
+//
+// The universal columns are subject to the don't-strand guard
+// (nonStrandedGroupNames): a lane that is all-"—" across every record in
+// the table is dropped. The OtherCapabilitiesColumn is EXEMPT from that
+// over-suppression — it is kept whenever any record carries a non-"—"
+// digest for it, and dropped only when it is "—" for every record (which
+// the guard already does, applied to the single-element tail). Iteration
+// is over the ordered universal_core list and the explicitly-ordered
+// record slice, so no map ranging leaks here.
+func universalPivotColumns(sub string, records int, digestFor func(rec int, group string) string) []string {
+	declared := knownGroupNames(sub)
+	declaredSet := map[string]bool{}
+	for _, g := range declared {
+		declaredSet[g] = true
+	}
+	universal := make([]string, 0, len(declared))
+	for _, name := range universalCoreOrder() {
+		if declaredSet[name] {
+			universal = append(universal, name)
+		}
+	}
+	cols := nonStrandedGroupNames(universal, records, digestFor)
+	// The merged digest column: keep unless its digest is "—" for every
+	// record (same all-"—" suppression, never the broader over-suppression).
+	if len(nonStrandedGroupNames([]string{OtherCapabilitiesColumn}, records, digestFor)) > 0 {
+		cols = append(cols, OtherCapabilitiesColumn)
+	}
+	return cols
+}
+
 // buildBucketSection produces a bucketSection for a per-language page.
 // When any record in recs declares a subcategory, the section is split
 // into one subSection per subcategory (ordered by subcategoryOrder)
@@ -887,7 +964,7 @@ func buildBucketSection(bucket string, recs []recordView) bucketSection {
 			Records:     recsForSub,
 		}
 		if len(groupNames) > 0 {
-			sec.GroupNames = nonStrandedGroupNames(groupNames, len(recsForSub), func(r int, g string) string {
+			sec.GroupNames = universalPivotColumns(s, len(recsForSub), func(r int, g string) string {
 				return groupCell(recsForSub[r].GroupDigestByName, g)
 			})
 		} else {
@@ -935,7 +1012,7 @@ func splitCategoryRowsBySubcategory(category string, rows []categoryRow) ([]cate
 			Records:     recsForSub,
 		}
 		if len(groupNames) > 0 {
-			sec.GroupNames = nonStrandedGroupNames(groupNames, len(recsForSub), func(r int, g string) string {
+			sec.GroupNames = universalPivotColumns(s, len(recsForSub), func(r int, g string) string {
 				return groupCell(recsForSub[r].GroupDigestByName, g)
 			})
 		} else {

--- a/tools/coverage/schema.go
+++ b/tools/coverage/schema.go
@@ -71,6 +71,13 @@ const SchemaVersion = 1
 // key here so the taxonomy can be extended deliberately.
 const uncategorizedGroup = "Uncategorized"
 
+// OtherCapabilitiesColumn is the synthetic pivot-column header under
+// which a record's non-universal-core canonical groups and all of its
+// framework_specific cells are rolled up into a single digest (#2940).
+// It is reserved: validate.go rejects any real group name or
+// framework_specific group name that collides with it.
+const OtherCapabilitiesColumn = "Other capabilities"
+
 // Status enum values for a capability cell.
 const (
 	StatusFull          = "full"
@@ -179,6 +186,24 @@ func (r *Record) AllCapabilities() map[string]Capability {
 	}
 	out := map[string]Capability{}
 	for _, g := range r.Groups {
+		for k, v := range g {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// AllCapabilitiesIncludingFrameworkSpecific returns every capability cell
+// on the record — the canonical capabilities (flat or grouped) UNION all
+// framework_specific cells — as a flat map keyed by capability slug. This
+// is the completeness denominator (#2940): a framework's framework_specific
+// idioms COUNT toward stats/gaps so a framework can no longer look "green"
+// while its real idioms go unextracted. Keys are collision-free across the
+// canonical and framework_specific tiers (enforced by validate.go), so the
+// flatten never silently overwrites.
+func (r *Record) AllCapabilitiesIncludingFrameworkSpecific() map[string]Capability {
+	out := r.AllCapabilities()
+	for _, g := range r.FrameworkSpecific {
 		for k, v := range g {
 			out[k] = v
 		}
@@ -388,6 +413,17 @@ func groupAllowedKeys(sub, group string) []string {
 // render order, or nil when sub has no group taxonomy.
 func knownGroupNames(sub string) []string {
 	return dict().GroupNames(sub)
+}
+
+// universalCoreOrder returns the universal-core lane names in canonical
+// render order (#2940).
+func universalCoreOrder() []string {
+	return dict().UniversalCoreOrder()
+}
+
+// isUniversalCore reports whether group is a universal-core lane name.
+func isUniversalCore(group string) bool {
+	return dict().IsUniversalCore(group)
 }
 
 // validGroupName reports whether group is part of sub's taxonomy. The

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -281,14 +281,18 @@ func TestBuildBucketSectionGroupsBySubcategory(t *testing.T) {
 		t.Errorf("legacy record should fall through to flat Records, got %+v", sec.Records)
 	}
 	// ui_frontend has a declared group taxonomy (#2737), so the
-	// subsection now renders group-digest columns rather than per-
-	// capability columns. CapabilityKeys is unset; GroupNames carries
-	// the canonical group render order.
+	// subsection renders group-digest columns rather than per-capability
+	// columns. Under the #2940 per-framework model the columns are the
+	// universal-core lanes the subcategory declares (universal_core.order ∩
+	// {Structure, Data Flow, Navigation, Type System, Lifecycle, Testing,
+	// Substrate} = Type System, Testing, Substrate) followed by the merged
+	// "Other capabilities" digest (which rolls up Structure/Data Flow/
+	// Navigation/Lifecycle). CapabilityKeys is unset.
 	uiSec := sec.Subsections[1]
 	if len(uiSec.CapabilityKeys) != 0 {
 		t.Errorf("ui_frontend should use group columns, got CapabilityKeys=%v", uiSec.CapabilityKeys)
 	}
-	wantGroups := []string{"Structure", "Data Flow", "Navigation", "Type System", "Lifecycle", "Testing", "Substrate"}
+	wantGroups := []string{"Type System", "Testing", "Substrate", OtherCapabilitiesColumn}
 	if !reflect.DeepEqual(uiSec.GroupNames, wantGroups) {
 		t.Errorf("ui_frontend GroupNames = %v, want %v", uiSec.GroupNames, wantGroups)
 	}
@@ -327,16 +331,22 @@ func TestNonStrandedGroupNames(t *testing.T) {
 }
 
 // TestBuildBucketSectionHidesStrandedGroups proves the guard wired into
-// buildBucketSection drops an all-"—" group column from the rendered
-// subsection while keeping populated columns in canonical order.
+// buildBucketSection drops an all-"—" universal-core column from the
+// rendered subsection while keeping a populated universal lane — and that
+// the synthetic "Other capabilities" digest column is always present once
+// any record carries non-universal cells. Under the #2940 model the column
+// set is (universal_core ∩ declared) [don't-strand filtered] + Other.
 func TestBuildBucketSectionHidesStrandedGroups(t *testing.T) {
-	// Two ui_frontend records, neither carrying Navigation / Type System /
-	// Lifecycle / Testing / Substrate cells, so those columns are all-"—".
+	// Two ui_frontend records: Vue carries a Testing cell (a universal lane)
+	// plus non-universal Structure/Data Flow; Svelte carries only Structure.
+	// Type System / Substrate universal lanes are all-"—" → dropped. Testing
+	// survives (Vue has a cell). Structure/Data Flow roll into Other.
 	recs := []recordView{
 		recordToView(Record{ID: "lang.jsts.framework.vue", Category: "http_framework", Subcategory: "ui_frontend", Label: "Vue",
 			Groups: map[string]map[string]Capability{
 				"Structure": {"component_extraction": {Status: StatusFull}},
 				"Data Flow": {"prop_flow": {Status: StatusPartial, Issue: "x"}},
+				"Testing":   {"tests_linkage": {Status: StatusFull}},
 			}}),
 		recordToView(Record{ID: "lang.jsts.framework.svelte", Category: "http_framework", Subcategory: "ui_frontend", Label: "Svelte",
 			Groups: map[string]map[string]Capability{
@@ -348,7 +358,7 @@ func TestBuildBucketSectionHidesStrandedGroups(t *testing.T) {
 		t.Fatalf("want 1 subsection, got %d", len(sec.Subsections))
 	}
 	got := sec.Subsections[0].GroupNames
-	want := []string{"Structure", "Data Flow"}
+	want := []string{"Testing", OtherCapabilitiesColumn}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("stranded groups not hidden: GroupNames = %v, want %v", got, want)
 	}
@@ -663,6 +673,45 @@ func TestValidateFrameworkSpecific(t *testing.T) {
 	}
 	if !hasError("also appears in canonical capabilities") {
 		t.Errorf("expected canonical-clash error; got: %v", res.Errors)
+	}
+}
+
+// TestValidateRejectsReservedOtherCapabilitiesGroup pins the #2940
+// reserved-name guard: neither a canonical grouped record nor a
+// framework_specific block may use the reserved "Other capabilities"
+// group name (it is the synthetic merged pivot column).
+func TestValidateRejectsReservedOtherCapabilitiesGroup(t *testing.T) {
+	reg := &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			{
+				ID: "lang.jsts.framework.reserved-canon", Category: "http_framework",
+				Subcategory: "http_backend", Language: "jsts", Label: "Reserved",
+				Groups: map[string]map[string]Capability{
+					OtherCapabilitiesColumn: {"endpoint_synthesis": {Status: StatusFull}},
+				},
+			},
+			{
+				ID: "lang.jsts.framework.reserved-fs", Category: "http_framework",
+				Subcategory: "http_backend", Language: "jsts", Label: "ReservedFS",
+				Groups: map[string]map[string]Capability{
+					"Routing": {"endpoint_synthesis": {Status: StatusFull}},
+				},
+				FrameworkSpecific: map[string]map[string]Capability{
+					OtherCapabilitiesColumn: {"reservedfs_thing": {Status: StatusMissing, Issue: "x"}},
+				},
+			},
+		},
+	}
+	res := validateRegistry(reg, ".")
+	count := 0
+	for _, e := range res.Errors {
+		if containsStr(e, "is reserved (the synthetic merged pivot column)") {
+			count++
+		}
+	}
+	if count < 2 {
+		t.Errorf("expected reserved-name errors for both canonical and framework_specific groups; got %d in: %v", count, res.Errors)
 	}
 }
 

--- a/tools/coverage/testdata/fixture-out/by-category/http_framework.md
+++ b/tools/coverage/testdata/fixture-out/by-category/http_framework.md
@@ -6,10 +6,19 @@
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 
+
+## Backend HTTP
+
+| Language | Name | Routing | Auth | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 0/1 | ✅ 1/1 | ❌ 0/3 | |
+
+
+## Other
+
 | Language | Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|---|
 | [JS/TS](../by-language/jsts.md) | [Express.js](../detail/lang.jsts.framework.express.md) | — | ✅ | — | — | |
-| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | — | ✅ | — | — | |
 | [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | — | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | — | ✅ | — | — | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | — | ✅ | — | — | |

--- a/tools/coverage/testdata/fixture-out/by-language/jsts.md
+++ b/tools/coverage/testdata/fixture-out/by-language/jsts.md
@@ -7,7 +7,16 @@ Back to [summary](../summary.md).
 
 ## Frameworks
 
+
+### Backend HTTP
+
+| Name | Routing | Auth | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 0/1 | ✅ 1/1 | ❌ 0/3 | |
+
+
+### Other
+
 | Name | Auth Coverage | Endpoint Synthesis | Handler Attribution | Middleware Coverage | Notes |
 |---|---|---|---|---|---|
 | [Express.js](../detail/lang.jsts.framework.express.md) | — | ✅ | — | — | |
-| [NestJS](../detail/lang.jsts.framework.nestjs.md) | — | ✅ | — | — | |

--- a/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
@@ -5,13 +5,65 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Capability cells:** 1
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 5
 
 ## Capabilities
+
+
+### Routing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` | — |
+| `handler_attribution` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `auth_coverage` | ⚠️ `partial` | `2026-05-27` | — | [link](https://github.com/cajasmota/archigraph/issues/2940) | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `request_validation` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2940) | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+### Testing
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+### Observability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+### Data
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
+### Substrate
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `import_resolution_quality` | ✅ `full` | `2026-05-27` | — | — | `internal/engine/http_endpoint_synthesis.go` | — |
+
+## Framework-specific
+
+### NestJS Internals
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `dependency_injection` | ❌ `missing` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2940) | — | — |
+| `module_graph` | ⚠️ `partial` | — | — | [link](https://github.com/cajasmota/archigraph/issues/2940) | — | — |
 
 ## Provenance
 

--- a/tools/coverage/testdata/fixture.json
+++ b/tools/coverage/testdata/fixture.json
@@ -17,13 +17,53 @@
     {
       "id": "lang.jsts.framework.nestjs",
       "category": "http_framework",
+      "subcategory": "http_backend",
       "language": "jsts",
       "label": "NestJS",
       "capabilities": {
-        "endpoint_synthesis": {
-          "status": "full",
-          "cites": ["internal/engine/http_endpoint_synthesis.go"],
-          "verified_at": "2026-05-27"
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
+            "verified_at": "2026-05-27"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
+            "verified_at": "2026-05-27"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "partial",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2940",
+            "verified_at": "2026-05-27"
+          }
+        },
+        "Validation": {
+          "request_validation": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2940"
+          }
+        },
+        "Substrate": {
+          "import_resolution_quality": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
+            "verified_at": "2026-05-27"
+          }
+        }
+      },
+      "framework_specific": {
+        "NestJS Internals": {
+          "dependency_injection": {
+            "status": "missing",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2940"
+          },
+          "module_graph": {
+            "status": "partial",
+            "issue": "https://github.com/cajasmota/archigraph/issues/2940"
+          }
         }
       }
     },

--- a/tools/coverage/validate.go
+++ b/tools/coverage/validate.go
@@ -37,6 +37,7 @@ func validateRegistry(reg *Registry, repoRoot string) *ValidationResult {
 	if reg.SchemaVersion != SchemaVersion {
 		res.Errors = append(res.Errors, fmt.Sprintf("schema_version %d unsupported (want %d)", reg.SchemaVersion, SchemaVersion))
 	}
+	validateUniversalCoreConsistency(res)
 
 	seen := map[string]int{}
 	for i, rec := range reg.Records {
@@ -151,6 +152,10 @@ func validateGroupedRecord(res *ValidationResult, prefix string, rec Record, rep
 	sort.Strings(groupNames)
 	for _, gname := range groupNames {
 		gPrefix := fmt.Sprintf("%s.capabilities[%s]", prefix, gname)
+		if gname == OtherCapabilitiesColumn {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: group name %q is reserved (the synthetic merged pivot column)", gPrefix, OtherCapabilitiesColumn))
+			continue
+		}
 		if !validGroupName(rec.Subcategory, gname) {
 			res.Errors = append(res.Errors, fmt.Sprintf("%s: unknown group %q for subcategory %q (known: %v)", gPrefix, gname, rec.Subcategory, known))
 			continue
@@ -236,6 +241,10 @@ func validateFrameworkSpecific(res *ValidationResult, prefix string, rec Record,
 			res.Errors = append(res.Errors, fmt.Sprintf("%s: group name is empty or whitespace-only", gPrefix))
 			continue
 		}
+		if gname == OtherCapabilitiesColumn {
+			res.Errors = append(res.Errors, fmt.Sprintf("%s: group name %q is reserved (the synthetic merged pivot column)", gPrefix, OtherCapabilitiesColumn))
+			continue
+		}
 		if rec.Label != "" && !strings.Contains(strings.ToLower(gname), strings.ToLower(firstLabelToken(rec.Label))) {
 			res.Warnings = append(res.Warnings, fmt.Sprintf("%s: group name %q does not reference framework label %q", gPrefix, gname, rec.Label))
 		}
@@ -257,6 +266,43 @@ func validateFrameworkSpecific(res *ValidationResult, prefix string, rec Record,
 			}
 			seenKeys[k] = gname
 			validateCapabilityCell(res, capPrefix, caps[k], repoRoot)
+		}
+	}
+}
+
+// validateUniversalCoreConsistency surfaces the #2940 dictionary
+// invariant at validate time: a subcategory group whose name
+// case-insensitively matches a universal_core lane MUST be spelled
+// identically, and no real group may be named OtherCapabilitiesColumn.
+// The dictionary loader (capability_dictionary.go) already rejects a
+// divergent dictionary outright, so this is a defensive second gate that
+// keeps the validate subcommand authoritative on its own.
+func validateUniversalCoreConsistency(res *ValidationResult) {
+	d := dict()
+	core := d.UniversalCoreOrder()
+	if len(core) == 0 {
+		return
+	}
+	canonByLower := map[string]string{}
+	for _, name := range core {
+		if name == OtherCapabilitiesColumn {
+			res.Errors = append(res.Errors, fmt.Sprintf("universal_core lane %q collides with the reserved merged-pivot column name", OtherCapabilitiesColumn))
+		}
+		canonByLower[strings.ToLower(name)] = name
+	}
+	for _, cat := range knownCategories() {
+		for _, sub := range knownSubcategories(cat) {
+			for _, g := range knownGroupNames(sub) {
+				if g == OtherCapabilitiesColumn {
+					res.Errors = append(res.Errors, fmt.Sprintf("subcategory %q declares a group named %q, which is reserved for the merged pivot column", sub, OtherCapabilitiesColumn))
+				}
+				if d.IsUniversalCore(g) {
+					continue
+				}
+				if canon, ok := canonByLower[strings.ToLower(g)]; ok {
+					res.Errors = append(res.Errors, fmt.Sprintf("subcategory %q group %q must be spelled %q to match universal_core", sub, g, canon))
+				}
+			}
 		}
 	}
 }

--- a/tools/coverage/views.go
+++ b/tools/coverage/views.go
@@ -30,7 +30,7 @@ func listRecords(reg *Registry, f ListFilter) []Record {
 		if f.Category != "" && rec.Category != f.Category {
 			continue
 		}
-		caps := rec.AllCapabilities()
+		caps := rec.AllCapabilitiesIncludingFrameworkSpecific()
 		if f.Status != "" {
 			match := false
 			for _, cap := range caps {
@@ -105,7 +105,7 @@ func computeStats(reg *Registry) Stats {
 		s.ByCategory[rec.Category]++
 		ls := s.ByLanguage[rec.Language]
 		ls.Records++
-		for _, cap := range rec.AllCapabilities() {
+		for _, cap := range rec.AllCapabilitiesIncludingFrameworkSpecific() {
 			s.Capabilities++
 			s.ByStatus[cap.Status]++
 			switch cap.Status {
@@ -136,7 +136,7 @@ func gapsRecords(reg *Registry, language, category string) []Record {
 			continue
 		}
 		hit := false
-		for _, cap := range rec.AllCapabilities() {
+		for _, cap := range rec.AllCapabilitiesIncludingFrameworkSpecific() {
 			if cap.Status == StatusMissing || cap.Status == StatusPartial {
 				hit = true
 				break
@@ -156,7 +156,7 @@ func gapsRecords(reg *Registry, language, category string) []Record {
 func printRecordsText(w io.Writer, recs []Record) {
 	for _, rec := range recs {
 		fmt.Fprintf(w, "%-50s  %-18s  %-12s  %s\n", rec.ID, rec.Category, rec.Language, rec.Label)
-		caps := rec.AllCapabilities()
+		caps := rec.AllCapabilitiesIncludingFrameworkSpecific()
 		keys := sortedCapKeys(caps)
 		for _, k := range keys {
 			fmt.Fprintf(w, "    %-30s  %s\n", k, caps[k].Status)


### PR DESCRIPTION
## Summary

Foundation tooling for the per-framework capability model (epic #2847). `Record` completeness now **counts** `framework_specific` cells, and each framework's surface renders honestly via a **universal-core + "Other capabilities" digest** pivot. **registry.json shape is UNCHANGED** — this reuses the existing `framework_specific` field. No extractor code; per-framework authoring is a follow-up.

Implements steps 1–8 of #2940 exactly.

## Universal-core wiring

- `universal_core.order: [Routing, Auth, Type System, Testing, Substrate]` added to `capability-dictionary.yaml`.
- The http_backend auth lane was renamed **Security → Auth** so the universal-core lane is picked up by the exact-string `universal_core ∩ groups` intersection (the only rename needed for consistency).
- Load-time canonical-spelling consistency check in `capability_dictionary.go` (+ a defensive validate-time gate) rejects any subcategory group whose name case-folds to a universal-core lane but is spelled differently.
- Per-subcategory pivot columns = `(universal_core.order ∩ knownGroupNames(sub))` (omit-if-absent, don't-strand filtered) + `OtherCapabilitiesColumn` (always last). The digest column is exempt from non-stranded over-suppression — dropped only when its digest is `—` for every record.
- The "Other capabilities" digest = `groupDigest` over (non-universal canonical group cells) ∪ (all `framework_specific` cells), computed order-independently for determinism.

## Counting change

`AllCapabilitiesIncludingFrameworkSpecific()` is wired into the 4 counting sites (`computeStats`, `gapsRecords`, `listRecords`, `printRecordsText`). `generate.go recordToView` and `discover.go` deliberately stay on canonical `AllCapabilities()`.

## Records that auto-flipped green → partially-red

23 records carry `framework_specific`. 3 had all-clean canonical capabilities but `framework_specific` reds, so they now show honest red in the completeness metric:

- `lang.jsts.framework.react`
- `lang.jsts.framework.svelte`
- `lang.jsts.framework.vue`

## Verification

- `validate` → **0 errors**
- `fmt --check` → canonical
- `gen` run twice → **byte-identical**
- `go test ./tools/coverage/` + `go build ./...` → green
- Render check: react's by-language overview shows the `Other capabilities` digest column (`⚠️ 20/23`) with universal columns in fixed order; the detail page shows the full framework-specific set with reds visible.
- Golden `tools/coverage/testdata/fixture-out/` refreshed; `fixture.json` nestjs record now exercises universal + non-universal group + `framework_specific`.

Closes #2940

🤖 Generated with [Claude Code](https://claude.com/claude-code)