### PR TITLE
coverage: backfill helper + grouped-completeness check (warning mode)

### DIFF
--- a/tools/coverage/backfill.go
+++ b/tools/coverage/backfill.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// defaultBackfillIssue is the tracking tag stamped on every cell seeded
+// by `coverage backfill` when --issue is not supplied. It marks the cell
+// as a dictionary-completeness placeholder rather than a hand-triaged
+// gap so later sweeps can distinguish auto-seeded rows from real
+// known-limitation tickets.
+const defaultBackfillIssue = "backfill:dictionary-completeness"
+
+// seedPlan is a single (record, group, key) cell that backfill would
+// seed. Slices of seedPlan are sorted deterministically before any
+// output or write so dry-run reports and registry writes are stable.
+type seedPlan struct {
+	RecordID string
+	Language string
+	Group    string
+	Key      string
+}
+
+// planBackfill computes the set of lane cells that are declared by each
+// grouped record's subcategory group taxonomy but absent from the
+// record's cells. It mutates nothing — callers decide whether to seed.
+//
+// Only GROUPED records whose subcategory carries a group taxonomy are
+// considered. A lane key is "declared" if it appears in the subcategory's
+// group taxonomy; its canonical owning group is groupForCapability (the
+// first group in render order that lists the key), mirroring the
+// auto-placement in cmdUpdate. A key already present anywhere on the
+// record (any group) is never re-seeded — this is the no-clobber
+// guarantee. framework_specific cells are deliberately ignored: the
+// completeness denominator here is the canonical lane set only.
+//
+// langFilter / subFilter, when non-empty, scope the plan to a single
+// language slug / subcategory slug.
+func planBackfill(reg *Registry, langFilter, subFilter string) []seedPlan {
+	var plans []seedPlan
+	for i := range reg.Records {
+		rec := &reg.Records[i]
+		if !rec.IsGrouped() {
+			continue
+		}
+		if rec.Subcategory == "" || !validSubcategory(rec.Category, rec.Subcategory) {
+			continue
+		}
+		if langFilter != "" && rec.Language != langFilter {
+			continue
+		}
+		if subFilter != "" && rec.Subcategory != subFilter {
+			continue
+		}
+		groups := groupsForSubcategory(rec.Subcategory)
+		if len(groups) == 0 {
+			continue
+		}
+		existing := rec.AllCapabilities()
+		// Walk the taxonomy in canonical render order and seed each
+		// declared key exactly once, into its canonical owning group.
+		// A key declared under multiple groups (e.g. db_effect) is owned
+		// by the first group in render order — groupForCapability returns
+		// precisely that group, so seeding stays deterministic.
+		seeded := map[string]struct{}{}
+		for _, g := range groups {
+			for _, key := range g.Keys {
+				if _, ok := existing[key]; ok {
+					continue
+				}
+				if _, done := seeded[key]; done {
+					continue
+				}
+				owner := groupForCapability(rec.Subcategory, key)
+				if owner == "" {
+					owner = uncategorizedGroup
+				}
+				if owner != g.Name {
+					// Defer to the canonical owning group; we'll reach it
+					// later in the render-order walk.
+					continue
+				}
+				seeded[key] = struct{}{}
+				plans = append(plans, seedPlan{
+					RecordID: rec.ID,
+					Language: rec.Language,
+					Group:    owner,
+					Key:      key,
+				})
+			}
+		}
+	}
+	sortSeedPlans(plans)
+	return plans
+}
+
+// sortSeedPlans orders plans by (RecordID, Group, Key) so dry-run output
+// and the resulting registry write are byte-stable across runs.
+func sortSeedPlans(plans []seedPlan) {
+	sort.Slice(plans, func(i, j int) bool {
+		if plans[i].RecordID != plans[j].RecordID {
+			return plans[i].RecordID < plans[j].RecordID
+		}
+		if plans[i].Group != plans[j].Group {
+			return plans[i].Group < plans[j].Group
+		}
+		return plans[i].Key < plans[j].Key
+	})
+}
+
+// applyBackfill inserts every planned cell into reg as a {missing, issue}
+// placeholder. It assumes plans were produced by planBackfill against the
+// same reg (no-clobber already enforced there) but re-checks presence
+// defensively so an existing cell is never overwritten.
+func applyBackfill(reg *Registry, plans []seedPlan, issue string) int {
+	byID := map[string]*Record{}
+	for i := range reg.Records {
+		byID[reg.Records[i].ID] = &reg.Records[i]
+	}
+	seeded := 0
+	for _, p := range plans {
+		rec := byID[p.RecordID]
+		if rec == nil {
+			continue
+		}
+		if rec.Groups == nil {
+			rec.Groups = map[string]map[string]Capability{}
+		}
+		if rec.Groups[p.Group] == nil {
+			rec.Groups[p.Group] = map[string]Capability{}
+		}
+		if _, exists := rec.Groups[p.Group][p.Key]; exists {
+			continue
+		}
+		// Defensive cross-group no-clobber: a key present in any other
+		// group must never be duplicated here.
+		if _, anywhere := rec.AllCapabilities()[p.Key]; anywhere {
+			continue
+		}
+		rec.Groups[p.Group][p.Key] = Capability{Status: StatusMissing, Issue: issue}
+		seeded++
+	}
+	return seeded
+}
+
+// cmdBackfill seeds missing lane cells declared by each grouped record's
+// subcategory group taxonomy but absent from the record. See planBackfill
+// for the placement / no-clobber rules.
+func cmdBackfill(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("backfill", flag.ContinueOnError)
+	path := registryFlag(fs)
+	issue := fs.String("issue", defaultBackfillIssue, "tracking tag stamped on each seeded cell")
+	lang := fs.String("language", "", "scope to a single language slug")
+	sub := fs.String("subcategory", "", "scope to a single subcategory slug")
+	dryRun := fs.Bool("dry-run", false, "print (record, group, key) tuples + per-language counts; write nothing")
+	check := fs.Bool("check", false, "exit non-zero if any cell would be seeded (CI guard); write nothing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	plans := planBackfill(reg, *lang, *sub)
+
+	if *dryRun || *check {
+		printBackfillReport(out, plans)
+	}
+	if *check {
+		if len(plans) > 0 {
+			return fmt.Errorf("backfill --check: %d cell(s) would be seeded", len(plans))
+		}
+		return nil
+	}
+	if *dryRun {
+		return nil
+	}
+
+	seeded := applyBackfill(reg, plans, *issue)
+	if seeded == 0 {
+		fmt.Fprintln(out, "backfill: nothing to seed (registry already complete)")
+		return nil
+	}
+	if err := saveRegistry(*path, reg); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "backfill: seeded %d cell(s)\n", seeded)
+	return nil
+}
+
+// printBackfillReport writes the (record, group, key) tuples in sorted
+// order followed by per-language counts and a grand total. Shared by
+// --dry-run and --check.
+func printBackfillReport(out io.Writer, plans []seedPlan) {
+	for _, p := range plans {
+		fmt.Fprintf(out, "%s\t%s\t%s\n", p.RecordID, p.Group, p.Key)
+	}
+	perLang := map[string]int{}
+	for _, p := range plans {
+		perLang[p.Language]++
+	}
+	langs := make([]string, 0, len(perLang))
+	for l := range perLang {
+		langs = append(langs, l)
+	}
+	sort.Strings(langs)
+	fmt.Fprintln(out, "per-language pending-seed counts:")
+	for _, l := range langs {
+		fmt.Fprintf(out, "  %-14s %d\n", l, perLang[l])
+	}
+	fmt.Fprintf(out, "total: %d cell(s) would be seeded\n", len(plans))
+}

--- a/tools/coverage/backfill_test.go
+++ b/tools/coverage/backfill_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestBackfillSeedsMissingLaneCells confirms backfill seeds at least one
+// declared-but-absent lane cell and stamps it {missing, default issue}.
+func TestBackfillSeedsMissingLaneCells(t *testing.T) {
+	dst := copyFixture(t)
+	if _, _, err := runCmd(t, "backfill", "--file", dst); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	reg, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	rec := findRecord(reg, "lang.jsts.framework.nestjs")
+	if rec == nil {
+		t.Fatal("nestjs record missing after backfill")
+	}
+	// route_extraction is declared under Routing in the http_backend
+	// taxonomy but absent from the fixture — it must now exist as a
+	// missing placeholder.
+	seeded, ok := rec.Groups["Routing"]["route_extraction"]
+	if !ok {
+		t.Fatal("expected route_extraction seeded under Routing")
+	}
+	if seeded.Status != StatusMissing {
+		t.Errorf("seeded status = %q, want %q", seeded.Status, StatusMissing)
+	}
+	if seeded.Issue != defaultBackfillIssue {
+		t.Errorf("seeded issue = %q, want %q", seeded.Issue, defaultBackfillIssue)
+	}
+}
+
+// TestBackfillIdempotent confirms a second backfill run produces no
+// byte-level change to the registry.
+func TestBackfillIdempotent(t *testing.T) {
+	dst := copyFixture(t)
+	if _, _, err := runCmd(t, "backfill", "--file", dst); err != nil {
+		t.Fatalf("first backfill: %v", err)
+	}
+	after1, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+	if _, _, err := runCmd(t, "backfill", "--file", dst); err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	after2, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+	if string(after1) != string(after2) {
+		t.Error("second backfill changed the registry; expected idempotent no-op")
+	}
+}
+
+// TestBackfillNoClobber confirms an existing cell (any status, cites,
+// verified_at) survives backfill untouched.
+func TestBackfillNoClobber(t *testing.T) {
+	dst := copyFixture(t)
+	// endpoint_synthesis is a pre-set `full` cell with cites + verified_at
+	// in the fixture; backfill must never touch it.
+	before, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load before: %v", err)
+	}
+	preset := findRecord(before, "lang.jsts.framework.nestjs").Groups["Routing"]["endpoint_synthesis"]
+	if preset.Status != StatusFull {
+		t.Fatalf("fixture precondition: endpoint_synthesis status = %q, want full", preset.Status)
+	}
+
+	if _, _, err := runCmd(t, "backfill", "--file", dst); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	after, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load after: %v", err)
+	}
+	got := findRecord(after, "lang.jsts.framework.nestjs").Groups["Routing"]["endpoint_synthesis"]
+	if got.Status != StatusFull {
+		t.Errorf("endpoint_synthesis status changed to %q", got.Status)
+	}
+	if len(got.Cites) != len(preset.Cites) || (len(got.Cites) > 0 && got.Cites[0] != preset.Cites[0]) {
+		t.Errorf("endpoint_synthesis cites changed: %v -> %v", preset.Cites, got.Cites)
+	}
+	if got.VerifiedAt != preset.VerifiedAt {
+		t.Errorf("endpoint_synthesis verified_at changed: %q -> %q", preset.VerifiedAt, got.VerifiedAt)
+	}
+}
+
+// TestBackfillCheckReportsPending confirms --check exits non-zero when
+// cells would be seeded and prints the per-language report.
+func TestBackfillCheckReportsPending(t *testing.T) {
+	dst := copyFixture(t)
+	out, _, err := runCmd(t, "backfill", "--file", dst, "--check")
+	if err == nil {
+		t.Fatal("expected non-zero exit from --check with pending seeds")
+	}
+	if !strings.Contains(out, "per-language pending-seed counts:") {
+		t.Errorf("expected per-language report in output, got:\n%s", out)
+	}
+	// --check must not have written anything.
+	out2, _, err := runCmd(t, "backfill", "--file", dst, "--check")
+	if err == nil || out2 != out {
+		t.Error("--check mutated the registry or behaved nondeterministically")
+	}
+}
+
+// TestBackfillDryRunWritesNothing confirms --dry-run leaves the file
+// byte-identical while still printing the tuples + counts.
+func TestBackfillDryRunWritesNothing(t *testing.T) {
+	dst := copyFixture(t)
+	before, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+	out, _, err := runCmd(t, "backfill", "--file", dst, "--dry-run")
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	after, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("--dry-run wrote to the registry")
+	}
+	if !strings.Contains(out, "total:") {
+		t.Errorf("expected total line in dry-run output, got:\n%s", out)
+	}
+}
+
+// TestCompletenessWarningsZeroAfterBackfill confirms that once backfill
+// has seeded every declared lane cell, validateRegistry emits zero
+// grouped-completeness warnings.
+func TestCompletenessWarningsZeroAfterBackfill(t *testing.T) {
+	dst := copyFixture(t)
+
+	// Before: the fixture's grouped nestjs record is incomplete, so at
+	// least one completeness warning must be present.
+	before, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load before: %v", err)
+	}
+	if n := countCompletenessWarnings(validateRegistry(before, repoRoot(t))); n == 0 {
+		t.Fatal("fixture precondition: expected completeness warnings before backfill")
+	}
+
+	if _, _, err := runCmd(t, "backfill", "--file", dst); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	after, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load after: %v", err)
+	}
+	if n := countCompletenessWarnings(validateRegistry(after, repoRoot(t))); n != 0 {
+		t.Errorf("expected 0 completeness warnings after backfill, got %d", n)
+	}
+}
+
+// countCompletenessWarnings counts warnings emitted by
+// validateGroupedCompleteness (identified by their stable message stem).
+func countCompletenessWarnings(res *ValidationResult) int {
+	n := 0
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "declared by subcategory") {
+			n++
+		}
+	}
+	return n
+}

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -39,6 +39,8 @@ func run(argv []string, stdout, stderr io.Writer) error {
 		return cmdAdd(rest, stdout)
 	case "update":
 		return cmdUpdate(rest, stdout)
+	case "backfill":
+		return cmdBackfill(rest, stdout)
 	case "remove":
 		return cmdRemove(rest, stdout)
 	case "gaps":
@@ -72,6 +74,7 @@ subcommands:
   get       show one record by id (--json)
   add       insert a new record (--id, --category, [--subcategory], --language, --label)
   update    update one capability cell (id positional, --capability, --status, --cites, --verified-now, --issue)
+  backfill  seed missing lane cells declared by the group taxonomy (--file, --issue, --language, --subcategory, --dry-run, --check)
   remove    delete a record by id
   gaps      list missing/partial records (--language, --category, --json)
   stats     counters across the registry (--json)

--- a/tools/coverage/validate.go
+++ b/tools/coverage/validate.go
@@ -20,6 +20,16 @@ var frameworkSpecificKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 // stale-verification warning.
 const staleDays = 90
 
+// completenessGateIsError controls the severity of the grouped-
+// completeness check (validateGroupedCompleteness): a lane key declared
+// by a record's subcategory group taxonomy but absent from the record's
+// cells. While false (this PR, #2942) these surface as WARNINGS, which
+// never fail CI — the `backfill` subcommand exists to seed those cells so
+// they become explicit `missing` placeholders. A later PR flips this to
+// true once the registry is backfilled, turning dictionary completeness
+// into a hard gate.
+const completenessGateIsError = false
+
 // ValidationResult collects errors (block) and warnings (advisory).
 type ValidationResult struct {
 	Errors   []string
@@ -183,6 +193,54 @@ func validateGroupedRecord(res *ValidationResult, prefix string, rec Record, rep
 			}
 			validateCapabilityCell(res, capPrefix, caps[k], repoRoot)
 		}
+	}
+	validateGroupedCompleteness(res, prefix, rec)
+}
+
+// validateGroupedCompleteness reports lane cells declared by the record's
+// subcategory group taxonomy but absent from the record. It is the
+// validate-time mirror of the `backfill` subcommand: every key the
+// taxonomy promises should have an explicit cell. AllCapabilities (lane
+// cells only — framework_specific is deliberately excluded) is the
+// presence set. Messages are appended in SORTED order so output is
+// deterministic regardless of map iteration. Subcategories without a
+// group taxonomy are skipped (nothing to be complete against).
+//
+// Severity is governed by completenessGateIsError: while false these are
+// warnings (advisory, never fail CI). validateRegistry sorts Errors and
+// Warnings globally afterward, so local ordering here is for readability.
+func validateGroupedCompleteness(res *ValidationResult, prefix string, rec Record) {
+	if rec.Subcategory == "" || !validSubcategory(rec.Category, rec.Subcategory) {
+		return
+	}
+	groups := groupsForSubcategory(rec.Subcategory)
+	if len(groups) == 0 {
+		return
+	}
+	present := rec.AllCapabilities()
+	var msgs []string
+	seen := map[string]struct{}{}
+	for _, g := range groups {
+		for _, key := range g.Keys {
+			if _, ok := present[key]; ok {
+				continue
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			owner := groupForCapability(rec.Subcategory, key)
+			if owner == "" {
+				owner = uncategorizedGroup
+			}
+			msgs = append(msgs, fmt.Sprintf("%s: lane key %q (group %q) declared by subcategory %q taxonomy but absent from record", prefix, key, owner, rec.Subcategory))
+		}
+	}
+	sort.Strings(msgs)
+	if completenessGateIsError {
+		res.Errors = append(res.Errors, msgs...)
+	} else {
+		res.Warnings = append(res.Warnings, msgs...)
 	}
 }
 


### PR DESCRIPTION
## Foundation Wave 2, PR-A — Go-only tooling

Closes #2942. Adds the coverage-completeness mechanism; later PRs use it. No registry/dictionary/docs change (tooling-only).

### What
- **`tools/coverage/backfill.go`** + `backfill` dispatch + usage line. For each GROUPED record whose subcategory carries a group taxonomy, seeds every declared lane key ABSENT from the record's cells as `{status: missing, issue: <--issue default "backfill:dictionary-completeness">}`, auto-placed into its canonical owning group (mirrors the placement in `cmdUpdate`). No-clobber / idempotent — an existing cell (status, cites, verified_at) is never touched; a 2nd run is a byte-level no-op. Flags: `--file --issue --language --subcategory --dry-run --check`. `--dry-run` prints `(record, group, key)` tuples + per-language counts and writes nothing; `--check` exits non-zero if any cell would be seeded (CI guard) and writes nothing. All writes go through `saveRegistry` (canonical, byte-stable) with a deterministic `(record, group, key)` sort.
- **`tools/coverage/validate.go`**: `validateGroupedCompleteness(res, prefix, rec)` called from `validateGroupedRecord`. For each lane key declared by the subcategory taxonomy but absent from `rec.AllCapabilities()` (lane cells only — `framework_specific` deliberately excluded), emits a SORTED message. Severity is governed by the package const `completenessGateIsError`, set **`false` (WARNING mode)** in this PR — warnings never fail CI. Subcategories with no group taxonomy are skipped.
- **`tools/coverage/backfill_test.go`**: idempotency (2nd run no diff), no-clobber (pre-set `full` cell survives), `--dry-run`/`--check` write nothing, and post-backfill completeness warnings == 0.

### Verification
- `go build ./...`, `go test ./tools/coverage/`, `go vet ./tools/coverage/` — all green.
- `coverage validate` still exits 0 (the 2613 new completeness messages are warnings).
- `coverage fmt --check` clean. No diff under `docs/coverage/` (no backfilled `registry.json`, no regenerated docs).

### Blast radius — `coverage backfill --check` per-language pending-seed counts
Total: **2613** cells would be seeded.

| language | pending seeds |
|---|---|
| c-cpp | 167 |
| csharp | 118 |
| elixir | 95 |
| go | 344 |
| java | 365 |
| jsts | 507 |
| kotlin | 108 |
| lua | 54 |
| php | 132 |
| python | 404 |
| ruby | 88 |
| rust | 113 |
| scala | 95 |
| swift | 23 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)