### PR TITLE
coverage: jvm_backend subcategory (DI/Tx/AOP) + Type System lane on http_backend

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -54,19 +54,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 7/20 | ❌ 0/4 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
@@ -79,14 +66,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ✅ 2/2 | ✅ 1/1 | ✅ 7/7 | ✅ 5/6 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/1 | — | — 0/4 | — | |
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/1 | — | — 0/4 | — | |
 | [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
@@ -138,15 +117,42 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/1 | — | ⚠️ 0/8 | — | |
+
+
+## JVM Backend
+
+| Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ 2/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ❌ 2/3 | ✅ 1/1 | ❌ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
 
 
 ## UI Frontend

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -8,23 +8,23 @@ Back to [summary](../summary.md).
 ## Frameworks
 
 
-### Backend HTTP
+### JVM Backend
 
-| Name | Routing | Auth | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Quarkus](../detail/lang.java.framework.quarkus.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 7/20 | ❌ 0/4 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ 2/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ❌ 2/3 | ✅ 1/1 | ❌ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 
 
 ### UI Frontend

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -8,18 +8,18 @@ Back to [summary](../summary.md).
 ## Frameworks
 
 
-### Backend HTTP
+### JVM Backend
 
-| Name | Routing | Auth | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 6/17 | ❌ 0/1 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/15 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
 
 
 ### Mobile

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -8,18 +8,18 @@ Back to [summary](../summary.md).
 ## Frameworks
 
 
-### Backend HTTP
+### JVM Backend
 
-| Name | Routing | Auth | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 8/17 | — 0/1 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
 
 
 ### Meta Framework

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/aspnet_core_routes.go` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/dropwizard.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| `di_injection_point` | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/micronaut.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/micronaut.go` | — |
+| `di_injection_point` | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/micronaut.go` | — |
+| `di_scope_resolution` | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/micronaut.go` | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/quarkus.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 24
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/java/frameworks/spring_boot.yaml`<br>`internal/engine/rules/java/frameworks/spring_mvc.yaml`<br>`internal/engine/spring_routes.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/spring_boot.go` | — |
+| `di_injection_point` | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/spring_boot.go` | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -54,6 +94,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,27 +42,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `interface_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `db_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `confidence_overlay` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `constant_propagation` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `dead_code_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `fs_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `http_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `mutation_effect` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `reachability_analysis` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `sanitizer_recognition` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `schema_drift_detection` | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
+| `taint_sink_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `taint_source_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `vulnerability_finding` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/adonisjs_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/express_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/fastify_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/feathers_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/hapi_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/hono_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/koa_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/marblejs_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/nestjs_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/polka_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ✅ `full` | — | — | — | `internal/engine/http_endpoint_jsts_middleware.go`<br>`internal/engine/http_endpoint_jsts_middleware_test.go`<br>`testdata/fixtures/typescript/restify_middleware.ts` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -36,6 +36,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | — `not_applicable` | — | — | — | — | Sails does not attach middleware to individual endpoints; its global middleware pipeline is the declarative `order` array under `middleware` in config/http.js. Covered by the framework_specific Middleware Pipeline / middleware_order_recognition cell (ParseSailsMiddlewareOrder). |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -15,35 +15,75 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml` | — |
+| `route_extraction` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `auth_coverage` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Validation
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+| `request_validation` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+| `di_injection_point` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+| `di_scope_resolution` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+| `transaction_propagation` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+| `transaction_rollback_rules` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+| `aspect_extraction` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
+| `pointcut_resolution` | — `not_applicable` | — | — | — | — | Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -15,35 +15,75 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml` | — |
+| `route_extraction` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `auth_coverage` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Validation
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `request_validation` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `di_injection_point` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `di_scope_resolution` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `transaction_propagation` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `transaction_rollback_rules` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `aspect_extraction` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `pointcut_resolution` | — `not_applicable` | — | — | — | — | kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` | — |
 | `handler_attribution` | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes_kotlin.go` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `dead_code_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -32,6 +32,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -32,6 +32,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/django_imports_rewrite.go` | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.dramatiq.md
+++ b/docs/coverage/detail/lang.python.framework.dramatiq.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `middleware_coverage` | ❌ `missing` | — | — | — | — | — |
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ❌ `missing` | — | — | — | — | — |
 | `handler_attribution` | ❌ `missing` | — | — | — | — | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -15,35 +15,75 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | — |
+| `endpoint_synthesis` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/cats_effect.yaml` | — |
+| `route_extraction` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Auth
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `auth_coverage` | — `not_applicable` | — | — | — | — | — |
+| `auth_coverage` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Validation
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `request_validation` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| `middleware_coverage` | — `not_applicable` | — | — | — | — | — |
+| `middleware_coverage` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `di_injection_point` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `di_scope_resolution` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `transaction_propagation` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `transaction_rollback_rules` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `aspect_extraction` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
+| `pointcut_resolution` | — `not_applicable` | — | — | — | — | Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container. |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -5,8 +5,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 21
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
 
 ## Capabilities
 
@@ -17,6 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | `endpoint_synthesis` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
 | `handler_attribution` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
+| `route_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Auth
 
@@ -28,6 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `dto_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `request_validation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Middleware
 
@@ -39,11 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `tests_linkage` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `enum_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `interface_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_alias_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `type_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `di_binding_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_injection_point` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `di_scope_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `transaction_boundary_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_propagation` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `transaction_rollback_rules` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| `advice_attribution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `aspect_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `pointcut_resolution` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| `log_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `metric_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| `trace_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 
 ### Data
 
@@ -58,11 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | `constant_propagation` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `db_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `dead_code_detection` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
+| `def_use_chain_extraction` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `env_fallback_recognition` | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | `fs_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `http_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | `import_resolution_quality` | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
+| `module_cycle_detection` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `mutation_effect` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
+| `pure_function_tagging` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `reachability_analysis` | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | `request_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `response_shape_extraction` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -70,6 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | `schema_drift_detection` | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | `taint_sink_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | `taint_source_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
+| `template_pattern_catalog` | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
 | `vulnerability_finding` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.swift.framework.vapor.md
+++ b/docs/coverage/detail/lang.swift.framework.vapor.md
@@ -32,6 +32,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -8621,7 +8621,7 @@
     {
       "id": "lang.java.framework.akka-http",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Akka HTTP (Java DSL)",
       "capabilities": {
@@ -8631,6 +8631,10 @@
           },
           "handler_attribution": {
             "status": "missing"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -8638,26 +8642,161 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -8669,10 +8808,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -8842,7 +9001,7 @@
     {
       "id": "lang.java.framework.dropwizard",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Dropwizard",
       "capabilities": {
@@ -8856,6 +9015,10 @@
             "status": "full",
             "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -8863,26 +9026,161 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -8894,10 +9192,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -8982,7 +9300,7 @@
     {
       "id": "lang.java.framework.helidon",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Helidon",
       "capabilities": {
@@ -8992,6 +9310,10 @@
           },
           "handler_attribution": {
             "status": "missing"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -8999,26 +9321,161 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9030,10 +9487,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9041,7 +9518,7 @@
     {
       "id": "lang.java.framework.jakarta-ee",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Jakarta EE (Servlet / EE Platform)",
       "capabilities": {
@@ -9055,6 +9532,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/java/frameworks/jakarta_ee.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9062,26 +9543,165 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/java/jakarta_ee_advanced.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
+          },
+          "di_injection_point": {
+            "status": "partial",
+            "cites": ["internal/custom/java/jakarta_ee_advanced.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9093,10 +9713,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9104,7 +9744,7 @@
     {
       "id": "lang.java.framework.javalin",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Javalin",
       "capabilities": {
@@ -9114,6 +9754,10 @@
           },
           "handler_attribution": {
             "status": "missing"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9121,26 +9765,161 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9152,10 +9931,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9163,7 +9962,7 @@
     {
       "id": "lang.java.framework.jaxrs",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "JAX-RS / Jakarta REST",
       "capabilities": {
@@ -9177,6 +9976,10 @@
             "status": "full",
             "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9186,26 +9989,161 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9217,10 +10155,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9250,7 +10208,7 @@
     {
       "id": "lang.java.framework.micronaut",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Micronaut",
       "capabilities": {
@@ -9264,6 +10222,10 @@
             "status": "full",
             "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9273,26 +10235,167 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/java/micronaut.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
+          },
+          "di_injection_point": {
+            "status": "partial",
+            "cites": ["internal/custom/java/micronaut.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
+          },
+          "di_scope_resolution": {
+            "status": "partial",
+            "cites": ["internal/custom/java/micronaut.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9304,10 +10407,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9315,7 +10438,7 @@
     {
       "id": "lang.java.framework.microprofile",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Eclipse MicroProfile",
       "capabilities": {
@@ -9329,6 +10452,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/java/frameworks/microprofile.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9336,26 +10463,161 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9367,10 +10629,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9442,7 +10724,7 @@
     {
       "id": "lang.java.framework.quarkus",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Quarkus",
       "capabilities": {
@@ -9456,6 +10738,10 @@
             "status": "full",
             "cites": ["internal/engine/java_annotation_routes.go"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9465,26 +10751,161 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9496,10 +10917,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9507,7 +10948,7 @@
     {
       "id": "lang.java.framework.spring-boot",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Spring Boot / Spring MVC",
       "capabilities": {
@@ -9521,6 +10962,10 @@
             "status": "full",
             "cites": ["internal/engine/java_annotation_routes.go","internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9530,6 +10975,16 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
@@ -9537,7 +10992,98 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_boot.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
+          },
+          "di_injection_point": {
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_boot.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
@@ -9660,7 +11206,7 @@
     {
       "id": "lang.java.framework.spring-webflux",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Spring WebFlux (reactive)",
       "capabilities": {
@@ -9674,6 +11220,10 @@
             "status": "full",
             "cites": ["internal/engine/spring_routes.go"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9683,26 +11233,161 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9714,10 +11399,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9725,7 +11430,7 @@
     {
       "id": "lang.java.framework.struts",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Apache Struts",
       "capabilities": {
@@ -9739,6 +11444,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/java/frameworks/apache_struts.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9746,26 +11455,161 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9777,10 +11621,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -9865,7 +11729,7 @@
     {
       "id": "lang.java.framework.vertx",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "java",
       "label": "Vert.x",
       "capabilities": {
@@ -9879,6 +11743,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/java/frameworks/vert_x.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -9886,26 +11754,161 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
           }
         },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/java.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -9917,10 +11920,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -13972,28 +15995,125 @@
     {
       "id": "lang.kotlin.framework.arrow",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "kotlin",
       "label": "Arrow (functional Kotlin)",
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
           },
           "handler_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/kotlin/frameworks/arrow_functional_kotlin.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "request_validation": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "di_injection_point": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "di_scope_resolution": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "transaction_propagation": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "transaction_rollback_rules": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "aspect_extraction": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "pointcut_resolution": {
+            "status": "not_applicable",
+            "notes": "Arrow is a functional-programming library, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -14017,6 +16137,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
@@ -14037,10 +16161,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -14079,6 +16211,10 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -14345,28 +16481,125 @@
     {
       "id": "lang.kotlin.framework.coroutines",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "kotlin",
       "label": "kotlinx.coroutines (structured concurrency)",
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
           },
           "handler_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/kotlin/frameworks/kotlinx_coroutines.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "request_validation": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "di_injection_point": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "di_scope_resolution": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "transaction_propagation": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "transaction_rollback_rules": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "aspect_extraction": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "pointcut_resolution": {
+            "status": "not_applicable",
+            "notes": "kotlinx.coroutines is a concurrency runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -14390,6 +16623,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
@@ -14410,10 +16647,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -14453,6 +16698,10 @@
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "vulnerability_finding": {
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
@@ -14464,7 +16713,7 @@
     {
       "id": "lang.kotlin.framework.http4k",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "kotlin",
       "label": "http4k",
       "capabilities": {
@@ -14478,6 +16727,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/kotlin/frameworks/http4k.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -14485,9 +16738,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -14511,6 +16854,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
@@ -14531,10 +16878,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -14573,6 +16928,10 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -14585,7 +16944,7 @@
     {
       "id": "lang.kotlin.framework.javalin",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "kotlin",
       "label": "Javalin (Kotlin)",
       "capabilities": {
@@ -14595,6 +16954,10 @@
           },
           "handler_attribution": {
             "status": "missing"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -14602,9 +16965,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -14628,6 +17081,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
@@ -14648,10 +17105,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -14690,6 +17155,10 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -14838,7 +17307,7 @@
     {
       "id": "lang.kotlin.framework.ktor",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "kotlin",
       "label": "Ktor",
       "capabilities": {
@@ -14852,6 +17321,10 @@
             "status": "full",
             "cites": ["internal/engine/rules/kotlin/frameworks/ktor.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -14859,9 +17332,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -14885,6 +17448,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
@@ -14905,10 +17472,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -14948,6 +17523,10 @@
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "vulnerability_finding": {
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
@@ -14959,7 +17538,7 @@
     {
       "id": "lang.kotlin.framework.micronaut",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "kotlin",
       "label": "Micronaut (Kotlin)",
       "capabilities": {
@@ -14973,6 +17552,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -14980,9 +17563,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -15006,6 +17679,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
@@ -15026,10 +17703,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -15069,6 +17754,10 @@
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "vulnerability_finding": {
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
@@ -15080,7 +17769,7 @@
     {
       "id": "lang.kotlin.framework.quarkus",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "kotlin",
       "label": "Quarkus (Kotlin)",
       "capabilities": {
@@ -15094,6 +17783,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -15101,9 +17794,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -15127,6 +17910,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
@@ -15147,10 +17934,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -15190,6 +17985,10 @@
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "vulnerability_finding": {
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
@@ -15201,7 +18000,7 @@
     {
       "id": "lang.kotlin.framework.spring-boot",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "kotlin",
       "label": "Spring Boot (Kotlin)",
       "capabilities": {
@@ -15215,6 +18014,10 @@
             "status": "full",
             "cites": ["internal/engine/spring_routes_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -15224,9 +18027,99 @@
             "verified_at": "2026-05-28"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -15250,6 +18143,10 @@
             "cites": ["internal/links/reachability.go","internal/substrate/entry_points_kotlin.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
@@ -15270,10 +18167,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/kotlin.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "partial",
@@ -15312,6 +18217,10 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -21628,7 +24537,7 @@
     {
       "id": "lang.scala.framework.akka-http",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "scala",
       "label": "Akka HTTP / Pekko HTTP",
       "capabilities": {
@@ -21642,6 +24551,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -21649,9 +24562,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -21675,6 +24678,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
@@ -21695,10 +24702,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -21737,6 +24752,10 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -21749,7 +24768,7 @@
     {
       "id": "lang.scala.framework.cask",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "scala",
       "label": "Cask",
       "capabilities": {
@@ -21759,6 +24778,10 @@
           },
           "handler_attribution": {
             "status": "missing"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -21766,9 +24789,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -21792,6 +24905,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
@@ -21812,10 +24929,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -21854,6 +24979,10 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -21866,28 +24995,125 @@
     {
       "id": "lang.scala.framework.cats-effect",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "scala",
       "label": "Cats Effect (concurrency runtime)",
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
           },
           "handler_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/scala/frameworks/cats_effect.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "request_validation": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "not_applicable"
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "di_injection_point": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "di_scope_resolution": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "transaction_propagation": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "transaction_rollback_rules": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "aspect_extraction": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          },
+          "pointcut_resolution": {
+            "status": "not_applicable",
+            "notes": "Cats Effect is an effect-system runtime, not a web backend — no routing/DI/transaction/AOP container."
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -21911,6 +25137,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
@@ -21931,10 +25161,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -21974,6 +25212,10 @@
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "vulnerability_finding": {
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
@@ -21985,7 +25227,7 @@
     {
       "id": "lang.scala.framework.finatra",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "scala",
       "label": "Finatra (Twitter Finagle)",
       "capabilities": {
@@ -21999,6 +25241,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/scala/frameworks/finatra.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -22006,9 +25252,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -22032,6 +25368,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
@@ -22052,10 +25392,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -22095,6 +25443,10 @@
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "vulnerability_finding": {
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
@@ -22106,7 +25458,7 @@
     {
       "id": "lang.scala.framework.http4s",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "scala",
       "label": "http4s",
       "capabilities": {
@@ -22120,6 +25472,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/scala/frameworks/http4s.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -22127,9 +25483,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -22153,6 +25599,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
@@ -22173,10 +25623,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -22216,6 +25674,10 @@
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "vulnerability_finding": {
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
@@ -22227,7 +25689,7 @@
     {
       "id": "lang.scala.framework.lagom",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "scala",
       "label": "Lagom",
       "capabilities": {
@@ -22241,6 +25703,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/scala/frameworks/lagom.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -22248,9 +25714,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -22274,6 +25830,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
@@ -22294,10 +25854,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -22336,6 +25904,10 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -22484,7 +26056,7 @@
     {
       "id": "lang.scala.framework.scalatra",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "scala",
       "label": "Scalatra",
       "capabilities": {
@@ -22498,6 +26070,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/scala/frameworks/scalatra.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -22505,9 +26081,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -22531,6 +26197,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
@@ -22551,10 +26221,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -22594,6 +26272,10 @@
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "vulnerability_finding": {
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
@@ -22605,7 +26287,7 @@
     {
       "id": "lang.scala.framework.zio-http",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "jvm_backend",
       "language": "scala",
       "label": "ZIO HTTP / ZIO",
       "capabilities": {
@@ -22619,6 +26301,10 @@
             "status": "partial",
             "cites": ["internal/engine/rules/scala/frameworks/zio.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Auth": {
@@ -22626,9 +26312,99 @@
             "status": "missing"
           }
         },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
         "Middleware": {
           "middleware_coverage": {
             "status": "missing"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
@@ -22652,6 +26428,10 @@
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_scala.go"],
             "verified_at": "2026-05-28"
           },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
@@ -22672,10 +26452,18 @@
             "cites": ["internal/links/constant_propagation.go","internal/substrate/scala.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-27"
           },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "mutation_effect": {
             "status": "partial",
             "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
             "status": "full",
@@ -22714,6 +26502,10 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "vulnerability_finding": {
             "status": "partial",

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -50,7 +50,7 @@ categories:
     capabilities: [call_line_precision, discriminates_on, navigates_to, core_extraction, import_resolution_quality, db_effect, fs_effect, http_effect]
   http_framework:
     capabilities: [endpoint_synthesis, handler_attribution, auth_coverage, middleware_coverage]
-    subcategory_order: [http_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration]
+    subcategory_order: [http_backend, jvm_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration]
   orm:
     capabilities: [model_extraction, query_attribution, migration_parsing]
   message_broker:
@@ -94,6 +94,79 @@ subcategories:
       - request_validation
       - tests_linkage
       - dto_extraction
+      - interface_extraction
+      - type_alias_extraction
+      - enum_extraction
+      - type_extraction
+      - constant_propagation
+      - env_fallback_recognition
+      - import_resolution_quality
+      - confidence_overlay
+      - reachability_analysis
+      - dead_code_detection
+      - db_effect
+      - http_effect
+      - fs_effect
+      - mutation_effect
+      - request_shape_extraction
+      - response_shape_extraction
+      - schema_drift_detection
+      - taint_source_detection
+      - taint_sink_detection
+      - sanitizer_recognition
+      - vulnerability_finding
+      - pure_function_tagging
+      - module_cycle_detection
+      - def_use_chain_extraction
+      - template_pattern_catalog
+      - trace_extraction
+      - log_extraction
+      - metric_extraction
+    groups:
+      - name: Routing
+        keys: [endpoint_synthesis, handler_attribution, route_extraction]
+      - name: Auth
+        keys: [auth_coverage]
+      - name: Validation
+        keys: [request_validation, dto_extraction]
+      - name: Middleware
+        keys: [middleware_coverage]
+      - name: Type System
+        keys: [interface_extraction, type_alias_extraction, enum_extraction, type_extraction]
+      - name: Testing
+        keys: [tests_linkage]
+      - name: Observability
+        keys: [trace_extraction, log_extraction, metric_extraction]
+      - name: Data
+        keys: [db_effect]
+      - name: Substrate
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
+
+  jvm_backend:
+    display: "JVM Backend"
+    parent_category: http_framework
+    capabilities:
+      - endpoint_synthesis
+      - handler_attribution
+      - auth_coverage
+      - middleware_coverage
+      - route_extraction
+      - request_validation
+      - tests_linkage
+      - dto_extraction
+      - interface_extraction
+      - type_alias_extraction
+      - enum_extraction
+      - type_extraction
+      - di_binding_extraction
+      - di_injection_point
+      - di_scope_resolution
+      - transaction_boundary_extraction
+      - transaction_propagation
+      - transaction_rollback_rules
+      - aspect_extraction
+      - pointcut_resolution
+      - advice_attribution
       - constant_propagation
       - env_fallback_recognition
       - import_resolution_quality
@@ -129,6 +202,14 @@ subcategories:
         keys: [middleware_coverage]
       - name: Testing
         keys: [tests_linkage]
+      - name: Type System
+        keys: [interface_extraction, type_alias_extraction, enum_extraction, type_extraction]
+      - name: DI
+        keys: [di_binding_extraction, di_injection_point, di_scope_resolution]
+      - name: Transactions
+        keys: [transaction_boundary_extraction, transaction_propagation, transaction_rollback_rules]
+      - name: AOP
+        keys: [aspect_extraction, pointcut_resolution, advice_attribution]
       - name: Observability
         keys: [trace_extraction, log_extraction, metric_extraction]
       - name: Data

--- a/tools/coverage/capability_dictionary_test.go
+++ b/tools/coverage/capability_dictionary_test.go
@@ -50,7 +50,7 @@ func TestLoadCapabilityDictionaryFromDisk(t *testing.T) {
 	}
 	// Subcategory render order — http_framework subcategories must
 	// follow the explicit subcategory_order from the dictionary.
-	wantOrder := []string{"http_backend", "ui_frontend", "meta_framework", "mobile", "desktop", "rpc_framework", "static_site", "ai_integration"}
+	wantOrder := []string{"http_backend", "jvm_backend", "ui_frontend", "meta_framework", "mobile", "desktop", "rpc_framework", "static_site", "ai_integration"}
 	if got := d.SubcategoriesByCategory("http_framework"); !reflect.DeepEqual(got, wantOrder) {
 		t.Errorf("SubcategoriesByCategory(http_framework) = %v, want %v", got, wantOrder)
 	}

--- a/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.jsts.framework.nestjs.md
@@ -35,6 +35,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 
+### Type System
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |


### PR DESCRIPTION
## Foundation Wave 2, PR-B — Closes #2944

Adds a JVM-aware backend subcategory and a language-neutral Type System lane, migrates the 29 JVM web-framework records, and authors the genuinely-extracted DI / Type-System cells. Uses the `coverage backfill` tool from PR-A (#2943). No extractor code — authoring = citing existing extractors.

### Dictionary (`tools/coverage/capability-dictionary.yaml`)
- **`Type System` group on `http_backend`** with keys `[interface_extraction, type_alias_extraction, enum_extraction, type_extraction]`; `type_extraction` is a NEW language-neutral key. Type System is universal-core → its own overview column (renders for jvm_backend, all-"—" suppressed on non-JVM http_backend).
- **`jvm_backend` subcategory** (after `http_backend` in `subcategory_order`), groups `Routing, Auth, Validation, Middleware, Testing, Type System, DI, Transactions, AOP, Observability, Data, Substrate`. New lanes: DI (`di_binding_extraction/di_injection_point/di_scope_resolution`), Transactions (`transaction_boundary_extraction/transaction_propagation/transaction_rollback_rules`), AOP (`aspect_extraction/pointcut_resolution/advice_attribution`); carries over all http_backend lanes + 22-key Substrate.

### Registry
- Reassigned **29 JVM records** `http_backend → jvm_backend` (surgical subcategory field edit).
- `backfill --subcategory jvm_backend` seeded the new lanes as `missing` (825 cells). **http_backend NOT backfilled** (deferred to PR-F).

### Honest authoring
- **Type System (Java):** `interface_extraction`/`enum_extraction`/`type_extraction` = **full** on all 13 java records (`internal/extractors/java/java.go` emits class/interface/enum/record decls). `type_alias_extraction` left **missing** (Java has no type aliases).
- **DI:** **partial** on `spring-boot` (`spring_boot.go`), `jakarta-ee` (`jakarta_ee_advanced.go`), `micronaut` (`micronaut.go`) — extractors emit SCOPE entities + `DEPENDS_ON` edges, not yet PROVIDES/INJECTS. `micronaut.di_scope_resolution` = **partial** (captures `@Singleton/@Prototype` scope). Spring/CDI scope left missing.
- **Transactions & AOP:** left **missing** — `@Transactional`/`@Aspect`/`@Around` are not extracted today (honest gap).
- **not_applicable:** `arrow`, `coroutines`, `cats-effect` web-backend lanes (Routing/Auth/Validation/Middleware/DI/Tx/AOP) marked `not_applicable` with one-line reasons (functional library / concurrency runtime / effect-system runtime, not web backends).

### Acceptance
- `validate` **0 errors** (7299 advisory warnings, warning-mode); `fmt --check` canonical; `gen` byte-stable (ran twice); `go test ./tools/coverage/` + `go build ./...` green.
- Golden `testdata/fixture-out/` (nestjs detail) + `capability_dictionary_test.go` subcategory-order refreshed.
- Render check: spring-boot overview shows universal cols incl. **Type System** + **Other capabilities** digest; detail shows full Type System lanes + red DI/Tx/AOP reds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)