### PR TITLE
coverage update: auto-clear issue on full/N-A, add --notes and --clear-issue

### DIFF
--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -75,7 +75,9 @@ subcommands:
   list      list records (filters: --status, --by-language, --by-category, --stale-days, --json)
   get       show one record by id (--json)
   add       insert a new record (--id, --category, [--subcategory], --language, --label)
-  update    update one capability cell (id positional, --capability, --status, --cites, --verified-now, --issue)
+  update    update one capability cell (flags must precede <record-id>)
+            --capability, --status (required); --cites, --verified-now, --issue, --notes, --clear-issue
+            when status=full or not_applicable the issue field is auto-cleared unless --issue is given
   backfill  seed missing lane cells declared by the group taxonomy (--file, --issue, --language, --subcategory, --dry-run, --check)
   remove    delete a record by id
   gaps      list missing/partial records (--language, --category, --json)
@@ -199,12 +201,14 @@ func cmdUpdate(args []string, out io.Writer) error {
 	status := fs.String("status", "", "status: full|partial|missing|not_applicable (required)")
 	cites := fs.String("cites", "", "comma-separated repo-relative paths")
 	verifiedNow := fs.Bool("verified-now", false, "set verified_at to today")
-	issue := fs.String("issue", "", "tracking issue URL")
+	issue := fs.String("issue", "", "tracking issue URL (overrides auto-clear when status=full/not_applicable)")
+	notes := fs.String("notes", "", "free-form scope clarification written to Capability.Notes")
+	clearIssue := fs.Bool("clear-issue", false, "explicitly remove the issue field regardless of status")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return fmt.Errorf("update: expected exactly one ID argument")
+		return fmt.Errorf("update: expected exactly one ID argument (flags must precede <record-id>)")
 	}
 	id := fs.Arg(0)
 	if *cap == "" || *status == "" {
@@ -213,6 +217,14 @@ func cmdUpdate(args []string, out io.Writer) error {
 	if _, ok := validStatuses[*status]; !ok {
 		return fmt.Errorf("update: invalid status %q", *status)
 	}
+	// Track whether --issue was explicitly supplied by the caller so
+	// applyUpdateFlags can distinguish "not passed" from "passed as empty".
+	issueExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "issue" {
+			issueExplicit = true
+		}
+	})
 	reg, err := loadRegistry(*path)
 	if err != nil {
 		return err
@@ -241,14 +253,14 @@ func cmdUpdate(args []string, out io.Writer) error {
 			rec.Groups[group] = map[string]Capability{}
 		}
 		cell := rec.Groups[group][*cap]
-		applyUpdateFlags(&cell, *status, *cites, *issue, *verifiedNow)
+		applyUpdateFlags(&cell, *status, *cites, *issue, *notes, *verifiedNow, issueExplicit, *clearIssue)
 		rec.Groups[group][*cap] = cell
 	} else {
 		if rec.Capabilities == nil {
 			rec.Capabilities = map[string]Capability{}
 		}
 		cell := rec.Capabilities[*cap]
-		applyUpdateFlags(&cell, *status, *cites, *issue, *verifiedNow)
+		applyUpdateFlags(&cell, *status, *cites, *issue, *notes, *verifiedNow, issueExplicit, *clearIssue)
 		rec.Capabilities[*cap] = cell
 	}
 	if err := saveRegistry(*path, reg); err != nil {
@@ -395,7 +407,13 @@ func cmdValidate(args []string, out, errw io.Writer) error {
 // applyUpdateFlags mutates cell with the non-empty CLI flags from
 // cmdUpdate. Shared between the flat and grouped write paths so cell
 // semantics stay identical regardless of capability shape.
-func applyUpdateFlags(cell *Capability, status, cites, issue string, verifiedNow bool) {
+//
+// Auto-clear semantics: when status is "full" or "not_applicable" the
+// issue field is cleared UNLESS --issue was explicitly provided by the
+// caller (issueExplicit=true). This prevents stale backfill issue tags
+// from lingering after a cell is marked done. --clear-issue forces
+// removal regardless of status.
+func applyUpdateFlags(cell *Capability, status, cites, issue, notes string, verifiedNow, issueExplicit, clearIssue bool) {
 	cell.Status = status
 	if cites != "" {
 		parts := strings.Split(cites, ",")
@@ -408,8 +426,22 @@ func applyUpdateFlags(cell *Capability, status, cites, issue string, verifiedNow
 		}
 		cell.Cites = clean
 	}
-	if issue != "" {
+	switch {
+	case issueExplicit:
+		// Caller explicitly passed --issue: honour the value (even if empty).
 		cell.Issue = issue
+	case clearIssue:
+		// Caller explicitly requested removal.
+		cell.Issue = ""
+	case status == StatusFull || status == StatusNotApplicable:
+		// Auto-clear: a resolved cell needs no tracking issue.
+		cell.Issue = ""
+	case issue != "":
+		// Non-resolved status with a new issue value.
+		cell.Issue = issue
+	}
+	if notes != "" {
+		cell.Notes = notes
 	}
 	if verifiedNow {
 		cell.VerifiedAt = time.Now().UTC().Format("2006-01-02")

--- a/tools/coverage/main_test.go
+++ b/tools/coverage/main_test.go
@@ -265,6 +265,148 @@ func TestUnknownSubcommand(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Tests for auto-clear issue, --notes, and --clear-issue (#2952)
+// ---------------------------------------------------------------------------
+
+// TestUpdateFullAutoClearsIssue verifies that flipping a partial cell
+// (which carries an issue tag) to "full" removes the issue automatically.
+func TestUpdateFullAutoClearsIssue(t *testing.T) {
+	tmp := copyFixture(t)
+	// django-drf auth_coverage is partial with an issue; flip to full.
+	if _, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "auth_coverage",
+		"--status", "full",
+		"lang.python.framework.django-drf"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	out, _, err := runCmd(t, "get", "--file", tmp, "--json", "lang.python.framework.django-drf")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// The issue should have been cleared automatically.
+	if strings.Contains(out, "https://github.com/cajasmota/archigraph/issues/1942") {
+		t.Errorf("expected issue to be auto-cleared on flip to full, but it persists:\n%s", out)
+	}
+}
+
+// TestUpdateNotApplicableAutoClearsIssue verifies auto-clear for not_applicable.
+func TestUpdateNotApplicableAutoClearsIssue(t *testing.T) {
+	tmp := copyFixture(t)
+	if _, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "auth_coverage",
+		"--status", "not_applicable",
+		"lang.python.framework.django-drf"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	out, _, err := runCmd(t, "get", "--file", tmp, "--json", "lang.python.framework.django-drf")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if strings.Contains(out, "https://github.com/cajasmota/archigraph/issues/1942") {
+		t.Errorf("expected issue to be auto-cleared on flip to not_applicable, but it persists:\n%s", out)
+	}
+}
+
+// TestUpdateFullWithExplicitIssuePreservesIssue verifies that --issue overrides
+// the auto-clear so a caller can intentionally keep or set an issue on a full cell.
+func TestUpdateFullWithExplicitIssuePreservesIssue(t *testing.T) {
+	tmp := copyFixture(t)
+	const keepIssue = "https://example.com/i/override"
+	if _, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "auth_coverage",
+		"--status", "full",
+		"--issue", keepIssue,
+		"lang.python.framework.django-drf"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	out, _, err := runCmd(t, "get", "--file", tmp, "--json", "lang.python.framework.django-drf")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.Contains(out, keepIssue) {
+		t.Errorf("expected explicit --issue to be preserved on full cell, got:\n%s", out)
+	}
+}
+
+// TestUpdatePartialKeepsIssue verifies that a partial/missing flip does NOT
+// auto-clear the issue — only full/not_applicable cells are cleared.
+func TestUpdatePartialKeepsIssue(t *testing.T) {
+	tmp := copyFixture(t)
+	// Start: django-drf auth_coverage is partial with an issue.
+	// Update to missing (still a gap) without passing --issue.
+	if _, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "auth_coverage",
+		"--status", "missing",
+		"lang.python.framework.django-drf"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	out, _, err := runCmd(t, "get", "--file", tmp, "--json", "lang.python.framework.django-drf")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// Issue should remain — the cell is still a gap.
+	if !strings.Contains(out, "https://github.com/cajasmota/archigraph/issues/1942") {
+		t.Errorf("expected issue to be preserved on partial→missing flip, got:\n%s", out)
+	}
+}
+
+// TestUpdateNotesFlag verifies that --notes writes Capability.Notes.
+func TestUpdateNotesFlag(t *testing.T) {
+	tmp := copyFixture(t)
+	const notesText = "JSX navigation only; class components not supported"
+	if _, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "endpoint_synthesis",
+		"--status", "full",
+		"--notes", notesText,
+		"lang.python.framework.flask"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	out, _, err := runCmd(t, "get", "--file", tmp, "--json", "lang.python.framework.flask")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.Contains(out, notesText) {
+		t.Errorf("expected notes to be written, got:\n%s", out)
+	}
+}
+
+// TestUpdateClearIssueFlag verifies that --clear-issue removes the issue field
+// regardless of the new status.
+func TestUpdateClearIssueFlag(t *testing.T) {
+	tmp := copyFixture(t)
+	// django-drf auth_coverage is partial with an issue; keep partial but drop issue.
+	if _, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "auth_coverage",
+		"--status", "partial",
+		"--clear-issue",
+		"lang.python.framework.django-drf"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	out, _, err := runCmd(t, "get", "--file", tmp, "--json", "lang.python.framework.django-drf")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if strings.Contains(out, "https://github.com/cajasmota/archigraph/issues/1942") {
+		t.Errorf("expected --clear-issue to remove issue on partial cell, but it persists:\n%s", out)
+	}
+}
+
+// TestUpdatePositionalAfterFlagsError verifies the "flags must precede record-id"
+// error message is emitted when the positional arg count is wrong.
+func TestUpdateMissingPositional(t *testing.T) {
+	tmp := copyFixture(t)
+	_, _, err := runCmd(t, "update", "--file", tmp,
+		"--capability", "endpoint_synthesis",
+		"--status", "full")
+	if err == nil {
+		t.Fatal("expected error when record-id positional is missing")
+	}
+	if !strings.Contains(err.Error(), "expected exactly one ID argument") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 // TestGenDispatch exercises the gen subcommand through the top-level
 // run() dispatcher so the wiring in main.go is covered alongside the
 // generator itself. Deeper rendering behaviour lives in gen_test.go.


### PR DESCRIPTION
## Summary

- **Auto-clear issue on resolved status**: `coverage update --status full` (or `not_applicable`) now automatically clears the `issue` field unless `--issue` is explicitly passed. Prevents stale backfill issue tags from persisting after a cell is marked done — previously required manual JSON edits (PR #2950 stripped 39 by hand).
- **`--notes "<text>"` flag**: writes `Capability.Notes` directly from the CLI; no hand-edit needed for `not_applicable`-with-reason or authoring notes.
- **`--clear-issue` flag**: explicitly removes the issue field regardless of status.
- **Usage doc update**: clarifies that flags must precede the positional `<record-id>` (Go flag parsing stops at first positional).

## Changes

- `tools/coverage/main.go` — `cmdUpdate` (new flags + explicit-issue tracking via `flag.Visit`) + `applyUpdateFlags` (extended signature, auto-clear logic)
- `tools/coverage/main_test.go` — 7 new tests covering all new behaviours

## Test plan

- [x] `TestUpdateFullAutoClearsIssue` — partial→full auto-clears issue
- [x] `TestUpdateNotApplicableAutoClearsIssue` — partial→not_applicable auto-clears issue
- [x] `TestUpdateFullWithExplicitIssuePreservesIssue` — explicit `--issue` overrides auto-clear
- [x] `TestUpdatePartialKeepsIssue` — partial→missing does NOT clear issue
- [x] `TestUpdateNotesFlag` — `--notes` writes `Capability.Notes`
- [x] `TestUpdateClearIssueFlag` — `--clear-issue` removes issue on partial cell
- [x] `TestUpdateMissingPositional` — missing record-id produces clear error
- [x] `go build ./...`, `go test ./tools/coverage/`, `go vet ./tools/coverage/` all green
- [x] No diff under `docs/coverage/` or registry (tooling-only change)

Closes #2952

🤖 Generated with [Claude Code](https://claude.com/claude-code)