### PR TITLE
coverage: task_queue subcategory (re-home Celery/Dramatiq, create RQ)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 182 records · **C/C++**: 17 · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 12 · **lua**: 2 · **php**: 12 · **python**: 20 · **ruby**: 8 · **rust**: 11 · **scala**: 9 · **swift**: 1
+**Total**: 183 records · **C/C++**: 17 · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 12 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 11 · **scala**: 9 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -81,11 +81,9 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ⚠️ 0/2 | ❌ 0/1 | ⚠️ 8/17 | ❌ 0/1 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | ⚠️ 5/6 | — 0/1 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ⚠️ 0/1 | |
 | [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 7/20 | ❌ 0/3 | |
-| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 5/6 | — 0/1 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
@@ -235,3 +233,12 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/3 | |
 | [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ✅ 3/3 | |
 | [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/3 | |
+
+
+## Task Queue
+
+| Language | Name | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ❌ 0/1 | ❌ 5/21 | ❌ 4/6 | |
+| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
+| [python](../by-language/python.md) | [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # python
 
-**Frameworks**: 20 · **Tools**: 15 · **ORMs**: 17 · **Other**: 3
+**Frameworks**: 21 · **Tools**: 15 · **ORMs**: 17 · **Other**: 3
 
 Back to [summary](../summary.md).
 
@@ -13,11 +13,9 @@ Back to [summary](../summary.md).
 | Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
 | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
-| [Celery (task queue)](../detail/lang.python.framework.celery.md) | ✅ 1/2 | — 0/1 | ⚠️ 5/6 | — 0/1 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ⚠️ 0/1 | |
 | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 2/2 | ✅ 1/1 | ⚠️ 7/20 | ❌ 0/3 | |
-| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/2 | — 0/1 | ⚠️ 5/6 | — 0/1 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 2/2 | ⚠️ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
 | [Flask](../detail/lang.python.framework.flask.md) | ✅ 2/2 | ❌ 0/1 | ⚠️ 5/6 | ❌ 0/1 | |
@@ -38,6 +36,15 @@ Back to [summary](../summary.md).
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/3 | |
+
+
+### Task Queue
+
+| Name | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|
+| [Celery (task queue)](../detail/lang.python.framework.celery.md) | ❌ 0/1 | ❌ 5/21 | ❌ 4/6 | |
+| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
+| [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -5,66 +5,69 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Backend HTTP
-- **Capability cells:** 10
+- **Subcategory:** Task Queue
+- **Capability cells:** 28
 
 ## Capabilities
 
 
-### Routing
+### Tasks
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Endpoint synthesis | — `not_applicable` | — | — | — | — | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/celery.yaml`<br>`internal/extractors/python/celery.go` | — |
+| Task extraction | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/python/frameworks/celery.yaml`<br>`internal/extractors/python/celery.go` | — |
+| Task routing | ✅ `full` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/python/celery.go`<br>`internal/extractors/python/celery.go` | — |
 
-### Auth
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-| Auth coverage | — `not_applicable` | — | — | — | — | — |
-
-### Validation
+### Schedule
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| Schedule extraction | ✅ `full` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/python/celery.go`<br>`internal/engine/scheduled_jobs_edges.go` | — |
 
-### Middleware
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-| Middleware coverage | — `not_applicable` | — | — | — | — | — |
-
-### Type System
+### Broker
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| Broker binding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Result backend binding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+
+### Reliability
+
+| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
+|------------|--------|-------------|--------------|-------|-------|-------|
+| Retry policy extraction | ✅ `full` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/extractors/python/celery.go` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-
-### Observability
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-
-### Data
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.rq.md
+++ b/docs/coverage/detail/lang.python.framework.rq.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `lang.python.framework.dramatiq` — Dramatiq (task queue)
+# `lang.python.framework.rq` — RQ (Redis Queue)
 
 Auto-generated. Back to [summary](../summary.md).
 
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Task extraction | ⚠️ `partial` | `2026-05-28` | — | — | `internal/custom/python/dramatiq.go`<br>`internal/engine/rules/python/frameworks/dramatiq.yaml` | — |
-| Task routing | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Task extraction | ⚠️ `partial` | `2026-05-28` | — | — | `internal/custom/python/rq.go` | — |
+| Task routing | ⚠️ `partial` | `2026-05-28` | — | — | `internal/custom/python/rq.go` | — |
 
 ### Schedule
 
@@ -48,22 +48,22 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
-| Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
+| Constant propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
-| Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
+| Env fallback recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
-| Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
+| Import resolution quality | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
-| Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
+| Request shape extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
-| Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
+| Schema drift detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
@@ -72,7 +72,7 @@ Auto-generated. Back to [summary](../summary.md).
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
-(or use `go run ./tools/coverage update lang.python.framework.dramatiq ...`) then regenerate:
+(or use `go run ./tools/coverage update lang.python.framework.rq ...`) then regenerate:
 
 ```
 go run ./tools/coverage validate

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -20430,45 +20430,110 @@
     {
       "id": "lang.python.framework.celery",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "task_queue",
       "language": "python",
       "label": "Celery (task queue)",
       "capabilities": {
-        "Routing": {
-          "endpoint_synthesis": {
-            "status": "not_applicable"
-          },
-          "handler_attribution": {
+        "Tasks": {
+          "task_extraction": {
             "status": "full",
             "cites": ["internal/engine/rules/python/frameworks/celery.yaml","internal/extractors/python/celery.go"],
             "verified_at": "2026-05-28"
+          },
+          "task_routing": {
+            "status": "full",
+            "cites": ["internal/custom/python/celery.go","internal/extractors/python/celery.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
           }
         },
-        "Auth": {
-          "auth_coverage": {
-            "status": "not_applicable"
+        "Schedule": {
+          "schedule_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/python/celery.go","internal/engine/scheduled_jobs_edges.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
           }
         },
-        "Middleware": {
-          "middleware_coverage": {
-            "status": "not_applicable"
+        "Broker": {
+          "broker_binding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "result_backend_binding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Reliability": {
+          "retry_policy_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/python/celery.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -20480,10 +20545,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -20767,45 +20852,104 @@
     {
       "id": "lang.python.framework.dramatiq",
       "category": "http_framework",
-      "subcategory": "http_backend",
+      "subcategory": "task_queue",
       "language": "python",
       "label": "Dramatiq (task queue)",
       "capabilities": {
-        "Routing": {
-          "endpoint_synthesis": {
-            "status": "not_applicable"
-          },
-          "handler_attribution": {
+        "Tasks": {
+          "task_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/python/frameworks/dramatiq.yaml"],
+            "cites": ["internal/custom/python/dramatiq.go","internal/engine/rules/python/frameworks/dramatiq.yaml"],
             "verified_at": "2026-05-28"
+          },
+          "task_routing": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
-        "Auth": {
-          "auth_coverage": {
-            "status": "not_applicable"
+        "Schedule": {
+          "schedule_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
-        "Middleware": {
-          "middleware_coverage": {
-            "status": "not_applicable"
+        "Broker": {
+          "broker_binding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "result_backend_binding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Reliability": {
+          "retry_policy_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         },
         "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "constant_propagation": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "env_fallback_recognition": {
             "status": "full",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
           },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "import_resolution_quality": {
             "status": "partial",
             "cites": ["internal/links/constant_propagation.go","internal/substrate/python.go","internal/substrate/substrate.go"],
             "verified_at": "2026-05-28"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -20817,10 +20961,30 @@
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
             "verified_at": "2026-05-27"
           },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
           "schema_drift_detection": {
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
             "verified_at": "2026-05-27"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }
@@ -21337,6 +21501,141 @@
             "status": "full",
             "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_python.go"],
             "verified_at": "2026-05-27"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.python.framework.rq",
+      "category": "http_framework",
+      "subcategory": "task_queue",
+      "language": "python",
+      "label": "RQ (Redis Queue)",
+      "capabilities": {
+        "Tasks": {
+          "task_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/python/rq.go"],
+            "verified_at": "2026-05-28"
+          },
+          "task_routing": {
+            "status": "partial",
+            "cites": ["internal/custom/python/rq.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Schedule": {
+          "schedule_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Broker": {
+          "broker_binding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "result_backend_binding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Reliability": {
+          "retry_policy_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,14 +1,14 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 182 · **ORMs**: 150 · **Tools**: 110 · **Other**: 110
+**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 183 · **ORMs**: 150 · **Tools**: 110 · **Other**: 110
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
 | [JS/TS](by-language/jsts.md) | 30 | 21 | 18 | 2 |
-| [python](by-language/python.md) | 20 | 15 | 17 | 3 |
+| [python](by-language/python.md) | 21 | 15 | 17 | 3 |
 | [java](by-language/java.md) | 19 | 10 | 13 | 2 |
 | [C/C++](by-language/c-cpp.md) | 17 | 16 | 7 | 0 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
@@ -66,4 +66,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 182 frameworks · 110 tools · 150 ORMs · 110 other
+Total: 183 frameworks · 110 tools · 150 ORMs · 110 other

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -50,7 +50,7 @@ categories:
     capabilities: [call_line_precision, discriminates_on, navigates_to, core_extraction, import_resolution_quality, db_effect, fs_effect, http_effect]
   http_framework:
     capabilities: [endpoint_synthesis, handler_attribution, auth_coverage, middleware_coverage]
-    subcategory_order: [http_backend, jvm_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration]
+    subcategory_order: [http_backend, jvm_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration, task_queue]
   orm:
     capabilities: [model_extraction, query_attribution, migration_parsing]
   message_broker:
@@ -477,3 +477,49 @@ subcategories:
         keys: [chain_composition, tool_use_detection]
       - name: Tracking
         keys: []
+
+  task_queue:
+    display: "Task Queue"
+    parent_category: http_framework
+    capabilities:
+      - task_extraction
+      - task_routing
+      - schedule_extraction
+      - broker_binding
+      - result_backend_binding
+      - retry_policy_extraction
+      - tests_linkage
+      - constant_propagation
+      - env_fallback_recognition
+      - import_resolution_quality
+      - confidence_overlay
+      - reachability_analysis
+      - dead_code_detection
+      - db_effect
+      - http_effect
+      - fs_effect
+      - mutation_effect
+      - request_shape_extraction
+      - response_shape_extraction
+      - schema_drift_detection
+      - taint_source_detection
+      - taint_sink_detection
+      - sanitizer_recognition
+      - vulnerability_finding
+      - pure_function_tagging
+      - module_cycle_detection
+      - def_use_chain_extraction
+      - template_pattern_catalog
+    groups:
+      - name: Tasks
+        keys: [task_extraction, task_routing]
+      - name: Schedule
+        keys: [schedule_extraction]
+      - name: Broker
+        keys: [broker_binding, result_backend_binding]
+      - name: Reliability
+        keys: [retry_policy_extraction]
+      - name: Testing
+        keys: [tests_linkage]
+      - name: Substrate
+        keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]

--- a/tools/coverage/capability_dictionary_test.go
+++ b/tools/coverage/capability_dictionary_test.go
@@ -50,7 +50,7 @@ func TestLoadCapabilityDictionaryFromDisk(t *testing.T) {
 	}
 	// Subcategory render order — http_framework subcategories must
 	// follow the explicit subcategory_order from the dictionary.
-	wantOrder := []string{"http_backend", "jvm_backend", "ui_frontend", "meta_framework", "mobile", "desktop", "rpc_framework", "static_site", "ai_integration"}
+	wantOrder := []string{"http_backend", "jvm_backend", "ui_frontend", "meta_framework", "mobile", "desktop", "rpc_framework", "static_site", "ai_integration", "task_queue"}
 	if got := d.SubcategoriesByCategory("http_framework"); !reflect.DeepEqual(got, wantOrder) {
 		t.Errorf("SubcategoriesByCategory(http_framework) = %v, want %v", got, wantOrder)
 	}


### PR DESCRIPTION
## Foundation Wave 2, PR-C — Closes #2954

Adds a `task_queue` subcategory under `http_framework` and migrates the Python task-queue frameworks onto it. No extractor code — authoring = citing existing extractors. Uses `coverage backfill` (PR-A #2943) + `coverage delta` (#2949).

### Dictionary (`tools/coverage/capability-dictionary.yaml`)
- New **`task_queue`** subcategory (after `ai_integration` in `subcategory_order`). Groups: `Tasks [task_extraction, task_routing]`, `Schedule [schedule_extraction]`, `Broker [broker_binding, result_backend_binding]`, `Reliability [retry_policy_extraction]`, `Testing [tests_linkage]`, `Substrate [21 canonical universal-core keys]`. Testing + Substrate spelled canonically (universal-core).

### Records
- Reassigned **`lang.python.framework.celery`** and **`lang.python.framework.dramatiq`** `http_backend → task_queue` (surgical subcategory edit). Their task-discovery cell (`Routing.handler_attribution`) re-homed to **`Tasks.task_extraction`**, carrying over status + cites. The http_backend-only `Routing/Auth/Middleware` lanes were dropped; `Substrate` cells preserved.
- **Created `lang.python.framework.rq`** (RQ / Redis Queue), grouped on `task_queue`.
- `backfill --subcategory task_queue` seeded the remaining lanes as `missing` (68 cells).
- `msg.celery` / `msg.dramatiq` message_broker records **left untouched** (different surface).

### Honest authoring (cites = existing extractors)
- **Celery:** `task_extraction` **full**, `task_routing` **full** (`queue`/`routing_key` kwargs + `task_routes` + canvas chain/group/chord), `schedule_extraction` **full** (`beat_schedule`), `retry_policy_extraction` **full** (`max_retries`/`default_retry_delay`/`autoretry_for`/`retry_backoff`). `broker_binding`/`result_backend_binding` **missing** — detection-only metadata in the rules YAML, no binding edge is extracted.
- **Dramatiq:** `task_extraction` **partial** (`@dramatiq.actor` + `.send`/`.send_with_options` sites), re-cited to the real custom extractor. Schedule/broker/retry **missing** (not extracted).
- **RQ:** `task_extraction` **partial** (`.enqueue`/`.enqueue_call` callables + `Worker(...)` consumers), `task_routing` **partial** (`queue_var` + Worker queue list). Schedule/broker/retry/substrate **missing**.

### Acceptance
- `validate` **0 errors** (warnings advisory).
- `gen` **byte-stable** (verified twice, identical).
- `fmt --check` canonical.
- `go test ./tools/coverage/` + `go build ./...` green. (Updated the one affected test: `subcategory_order` expectation.)
- Render-checked Celery + RQ detail pages — task_queue lanes render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)