### PR TITLE
coverage: render non-URL issue tags as plain text

### DIFF
--- a/docs/coverage/detail/config.tsconfig.md
+++ b/docs/coverage/detail/config.tsconfig.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| File parsing | ✅ `full` | `2026-05-28` | — | [link](2865) | `internal/extractors/config/discover.go`<br>`internal/extractors/config/discover_test.go` | — |
+| File parsing | ✅ `full` | `2026-05-28` | — | 2865 | `internal/extractors/config/discover.go`<br>`internal/extractors/config/discover_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.assembly.toolchain.armasm.md
+++ b/docs/coverage/detail/lang.assembly.toolchain.armasm.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Call line precision | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
-| Core extraction | ⚠️ `partial` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go` | — |
-| Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go` | — |
+| Call line precision | ✅ `full` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| Core extraction | ⚠️ `partial` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go` | — |
+| Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.assembly.toolchain.gnu-as.md
+++ b/docs/coverage/detail/lang.assembly.toolchain.gnu-as.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Call line precision | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
-| Core extraction | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
-| Import resolution quality | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| Call line precision | ✅ `full` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| Core extraction | ✅ `full` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| Import resolution quality | ✅ `full` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.assembly.toolchain.masm.md
+++ b/docs/coverage/detail/lang.assembly.toolchain.masm.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Call line precision | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
-| Core extraction | ⚠️ `partial` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go` | — |
-| Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go` | — |
+| Call line precision | ✅ `full` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| Core extraction | ⚠️ `partial` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go` | — |
+| Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.assembly.toolchain.nasm.md
+++ b/docs/coverage/detail/lang.assembly.toolchain.nasm.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Call line precision | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
-| Core extraction | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
-| Import resolution quality | ✅ `full` | `2026-05-28` | — | [link](2744) | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| Call line precision | ✅ `full` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| Core extraction | ✅ `full` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
+| Import resolution quality | ✅ `full` | `2026-05-28` | — | 2744 | `internal/extractors/assembly/extractor.go`<br>`internal/extractors/assembly/extractor_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.cobol.embedded.cics.md
+++ b/docs/coverage/detail/lang.cobol.embedded.cics.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Fs effect | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/substrate/effect_sinks_cobol.go` | — |
-| HTTP effect | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/extractors/cobol/depth.go`<br>`internal/substrate/effect_sinks_cobol.go` | — |
+| Fs effect | ✅ `full` | `2026-05-28` | — | 2838 | `internal/substrate/effect_sinks_cobol.go` | — |
+| HTTP effect | ✅ `full` | `2026-05-28` | — | 2838 | `internal/extractors/cobol/depth.go`<br>`internal/substrate/effect_sinks_cobol.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.cobol.embedded.db2-sql.md
+++ b/docs/coverage/detail/lang.cobol.embedded.db2-sql.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/extractors/cobol/depth.go`<br>`internal/substrate/effect_sinks_cobol.go` | — |
+| DB effect | ✅ `full` | `2026-05-28` | — | 2838 | `internal/extractors/cobol/depth.go`<br>`internal/substrate/effect_sinks_cobol.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.cobol.runtime.gnucobol.md
+++ b/docs/coverage/detail/lang.cobol.runtime.gnucobol.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Call line precision | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/extractors/cobol/extractor.go` | — |
-| Core extraction | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/classifier/classifier.go`<br>`internal/extractors/cobol/extractor.go` | — |
-| Import resolution quality | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/extractors/cobol/depth.go`<br>`internal/extractors/cobol/extractor.go` | — |
+| Call line precision | ✅ `full` | `2026-05-28` | — | 2743 | `internal/extractors/cobol/extractor.go` | — |
+| Core extraction | ✅ `full` | `2026-05-28` | — | 2743 | `internal/classifier/classifier.go`<br>`internal/extractors/cobol/extractor.go` | — |
+| Import resolution quality | ✅ `full` | `2026-05-28` | — | 2838 | `internal/extractors/cobol/depth.go`<br>`internal/extractors/cobol/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.cobol.runtime.ibm-enterprise.md
+++ b/docs/coverage/detail/lang.cobol.runtime.ibm-enterprise.md
@@ -11,12 +11,12 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Call line precision | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/extractors/cobol/extractor.go` | — |
-| Core extraction | ✅ `full` | `2026-05-28` | — | [link](2743) | `internal/classifier/classifier.go`<br>`internal/extractors/cobol/extractor.go` | — |
-| DB effect | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/extractors/cobol/depth.go`<br>`internal/substrate/effect_sinks_cobol.go` | — |
-| Fs effect | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/substrate/effect_sinks_cobol.go` | — |
-| HTTP effect | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/extractors/cobol/depth.go`<br>`internal/substrate/effect_sinks_cobol.go` | — |
-| Import resolution quality | ✅ `full` | `2026-05-28` | — | [link](2838) | `internal/extractors/cobol/depth.go`<br>`internal/extractors/cobol/extractor.go` | — |
+| Call line precision | ✅ `full` | `2026-05-28` | — | 2743 | `internal/extractors/cobol/extractor.go` | — |
+| Core extraction | ✅ `full` | `2026-05-28` | — | 2743 | `internal/classifier/classifier.go`<br>`internal/extractors/cobol/extractor.go` | — |
+| DB effect | ✅ `full` | `2026-05-28` | — | 2838 | `internal/extractors/cobol/depth.go`<br>`internal/substrate/effect_sinks_cobol.go` | — |
+| Fs effect | ✅ `full` | `2026-05-28` | — | 2838 | `internal/substrate/effect_sinks_cobol.go` | — |
+| HTTP effect | ✅ `full` | `2026-05-28` | — | 2838 | `internal/extractors/cobol/depth.go`<br>`internal/substrate/effect_sinks_cobol.go` | — |
+| Import resolution quality | ✅ `full` | `2026-05-28` | — | 2838 | `internal/extractors/cobol/depth.go`<br>`internal/extractors/cobol/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ❌ `missing` | — | — | — | — | — |
 | Handler attribution | ❌ `missing` | — | — | — | — | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/dropwizard.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ❌ `missing` | — | — | — | — | — |
 | Handler attribution | ❌ `missing` | — | — | — | — | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/jakarta_ee_advanced.go` | — |
-| DI injection point | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/jakarta_ee_advanced.go` | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ⚠️ `partial` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI injection point | ⚠️ `partial` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/java/jakarta_ee_advanced.go` | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ❌ `missing` | — | — | — | — | — |
 | Handler attribution | ❌ `missing` | — | — | — | — | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/jakarta_ee.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/micronaut.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/micronaut.go` | — |
-| DI injection point | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/micronaut.go` | — |
-| DI scope resolution | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/micronaut.go` | — |
+| DI binding extraction | ⚠️ `partial` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/java/micronaut.go` | — |
+| DI injection point | ⚠️ `partial` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/java/micronaut.go` | — |
+| DI scope resolution | ⚠️ `partial` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/java/micronaut.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/microprofile.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/rules/java/frameworks/quarkus.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/java/frameworks/spring_boot.yaml`<br>`internal/engine/rules/java/frameworks/spring_mvc.yaml`<br>`internal/engine/spring_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,40 +50,40 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/spring_boot.go` | — |
-| DI injection point | ⚠️ `partial` | `2026-05-28` | — | [link](backfill:dictionary-completeness) | `internal/custom/java/spring_boot.go` | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ⚠️ `partial` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/java/spring_boot.go` | — |
+| DI injection point | ⚠️ `partial` | `2026-05-28` | — | backfill:dictionary-completeness | `internal/custom/java/spring_boot.go` | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -94,7 +94,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_java.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_java.go` | — |

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes.go` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
@@ -50,71 +50,71 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Type extraction | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/java/java.go` | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DB effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Confidence overlay | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Dead code detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Dead code detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| HTTP effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Fs effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Mutation effect | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Reachability analysis | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Sanitizer recognition | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | — |
-| Taint sink detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Taint source detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Vulnerability finding | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Taint sink detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jcl.runtime.zos.md
+++ b/docs/coverage/detail/lang.jcl.runtime.zos.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Call line precision | ✅ `full` | `2026-05-28` | — | [link](2843) | `internal/extractors/jcl/extractor.go`<br>`internal/extractors/jcl/extractor_test.go` | — |
-| Core extraction | ✅ `full` | `2026-05-28` | — | [link](2843) | `internal/extractors/jcl/extractor.go`<br>`internal/extractors/jcl/testdata/payjob.jcl` | — |
+| Call line precision | ✅ `full` | `2026-05-28` | — | 2843 | `internal/extractors/jcl/extractor.go`<br>`internal/extractors/jcl/extractor_test.go` | — |
+| Core extraction | ✅ `full` | `2026-05-28` | — | 2843 | `internal/extractors/jcl/extractor.go`<br>`internal/extractors/jcl/testdata/payjob.jcl` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.framework.adonisjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.adonisjs.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/adonisjs_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/adonisjs_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/adonisjs.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/adonisjs.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/adonisjs.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/adonisjs.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.electron.md
+++ b/docs/coverage/detail/lang.jsts.framework.electron.md
@@ -15,14 +15,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| IPC extraction | ✅ `full` | — | — | [link](2865) | `internal/engine/electron_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/electron.yaml`<br>`testdata/fixtures/typescript/electron_ipc.ts`<br>`testdata/fixtures/typescript/electron_preload.ts` | — |
-| Main renderer split | ✅ `full` | `2026-05-28` | — | [link](2865) | `internal/engine/electron_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/electron.yaml`<br>`testdata/fixtures/typescript/electron_ipc.ts`<br>`testdata/fixtures/typescript/electron_preload.ts` | — |
+| IPC extraction | ✅ `full` | — | — | 2865 | `internal/engine/electron_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/electron.yaml`<br>`testdata/fixtures/typescript/electron_ipc.ts`<br>`testdata/fixtures/typescript/electron_preload.ts` | — |
+| Main renderer split | ✅ `full` | `2026-05-28` | — | 2865 | `internal/engine/electron_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/electron.yaml`<br>`testdata/fixtures/typescript/electron_ipc.ts`<br>`testdata/fixtures/typescript/electron_preload.ts` | — |
 
 ### Native
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Native module imports | ✅ `full` | — | — | [link](2865) | `internal/engine/electron_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/electron.yaml`<br>`testdata/fixtures/typescript/electron_ipc.ts`<br>`testdata/fixtures/typescript/electron_preload.ts` | — |
+| Native module imports | ✅ `full` | — | — | 2865 | `internal/engine/electron_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/electron.yaml`<br>`testdata/fixtures/typescript/electron_ipc.ts`<br>`testdata/fixtures/typescript/electron_preload.ts` | — |
 
 ### Updates
 

--- a/docs/coverage/detail/lang.jsts.framework.expo.md
+++ b/docs/coverage/detail/lang.jsts.framework.expo.md
@@ -21,7 +21,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Deep link extraction | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_expo/linking.ts`<br>`testdata/fixtures/real-world/typescript/react_native_navigator.tsx` | — |
+| Deep link extraction | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_expo/linking.ts`<br>`testdata/fixtures/real-world/typescript/react_native_navigator.tsx` | — |
 | Navigation extraction | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` | — |
 | Screen detection | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/expo.yaml` | — |
 
@@ -29,13 +29,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Platform branching | ✅ `full` | `2026-05-28` | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/platform_variants.go`<br>`internal/extractors/javascript/testdata/mobile_expo/StatusBar.ios.tsx` | — |
+| Platform branching | ✅ `full` | `2026-05-28` | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/platform_variants.go`<br>`internal/extractors/javascript/testdata/mobile_expo/StatusBar.ios.tsx` | — |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Native module imports | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_expo/linking.ts`<br>`internal/extractors/javascript/testdata/mobile_react_native/AppNavigator.tsx`<br>`testdata/fixtures/real-world/typescript/react_native_navigator.tsx` | — |
+| Native module imports | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_expo/linking.ts`<br>`internal/extractors/javascript/testdata/mobile_react_native/AppNavigator.tsx`<br>`testdata/fixtures/real-world/typescript/react_native_navigator.tsx` | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.express.md
+++ b/docs/coverage/detail/lang.jsts.framework.express.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | 2932 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml`<br>`internal/extractors/javascript/framework_dsl.go` | — |
+| Handler attribution | ✅ `full` | `2026-05-28` | — | 2932 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/express.yaml` | — |
 
 ### Auth
 
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/express_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/express_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/express.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/express.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/express.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/express.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.fastify.md
+++ b/docs/coverage/detail/lang.jsts.framework.fastify.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | 2932 | `internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/http_endpoint_synthesis_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/fastify.yaml` | — |
 
 ### Auth
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/fastify_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/fastify_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/fastify.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/fastify.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/fastify.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/fastify.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.feathers.md
+++ b/docs/coverage/detail/lang.jsts.framework.feathers.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/feathers_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/feathers_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/feathers.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/feathers.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/feathers.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/feathers.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
+++ b/docs/coverage/detail/lang.jsts.framework.graphql-resolvers.md
@@ -15,20 +15,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Procedure extraction | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml`<br>`internal/extractors/graphql/graphql.go` | — |
-| Schema extraction | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml`<br>`internal/extractors/graphql/graphql.go` | — |
+| Procedure extraction | ✅ `full` | `2026-05-28` | — | 2932 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/graphql/frameworks/apollo_server.yaml`<br>`internal/engine/rules/graphql/frameworks/graphql_yoga.yaml`<br>`internal/extractors/graphql/graphql.go` | — |
+| Schema extraction | ✅ `full` | `2026-05-28` | — | 2932 | `internal/engine/rules/graphql/frameworks/graphql_schema.yaml`<br>`internal/extractors/graphql/graphql.go` | — |
 
 ### Codegen
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Client codegen | — `not_applicable` | — | — | [link](2865) | — | Server-side resolver record: client codegen (graphql-codegen/Apollo) generates a typed CLIENT elsewhere, not in resolver source. |
+| Client codegen | — `not_applicable` | — | — | 2865 | — | Server-side resolver record: client codegen (graphql-codegen/Apollo) generates a typed CLIENT elsewhere, not in resolver source. |
 
 ### Transport
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transport binding | ✅ `full` | `2026-05-28` | — | [link](2906) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_transport_binding.go`<br>`internal/engine/http_endpoint_transport_binding_test.go`<br>`testdata/fixtures/typescript/graphql_transport_http.ts`<br>`testdata/fixtures/typescript/graphql_transport_http_ws.ts` | — |
+| Transport binding | ✅ `full` | `2026-05-28` | — | 2906 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_transport_binding.go`<br>`internal/engine/http_endpoint_transport_binding_test.go`<br>`testdata/fixtures/typescript/graphql_transport_http.ts`<br>`testdata/fixtures/typescript/graphql_transport_http_ws.ts` | — |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.jsts.framework.hapi.md
+++ b/docs/coverage/detail/lang.jsts.framework.hapi.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/hapi_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/hapi_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/hapi.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/hapi.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/hapi.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/hapi.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.hono.md
+++ b/docs/coverage/detail/lang.jsts.framework.hono.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/hono_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/hono_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/hono.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/hono.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/hono.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/hono.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.ionic.md
+++ b/docs/coverage/detail/lang.jsts.framework.ionic.md
@@ -21,21 +21,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Deep link extraction | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/deepLinks.ts` | — |
-| Navigation extraction | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/AppRouter.tsx` | — |
-| Screen detection | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/AppRouter.tsx` | — |
+| Deep link extraction | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/deepLinks.ts` | — |
+| Navigation extraction | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/AppRouter.tsx` | — |
+| Screen detection | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/AppRouter.tsx` | — |
 
 ### Platform
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Platform branching | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/AppRouter.tsx` | — |
+| Platform branching | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/AppRouter.tsx` | — |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Native module imports | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/AppRouter.tsx`<br>`internal/extractors/javascript/testdata/mobile_ionic/deepLinks.ts` | — |
+| Native module imports | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_ionic/AppRouter.tsx`<br>`internal/extractors/javascript/testdata/mobile_ionic/deepLinks.ts` | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.koa.md
+++ b/docs/coverage/detail/lang.jsts.framework.koa.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/koa_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/koa_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/koa.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/koa.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/koa.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/koa.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.langchain.md
+++ b/docs/coverage/detail/lang.jsts.framework.langchain.md
@@ -15,14 +15,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Prompt template extraction | ✅ `full` | `2026-05-28` | — | [link](2865) | `internal/engine/langchain_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/langchain.yaml`<br>`testdata/fixtures/typescript/langchain_chain.ts` | — |
+| Prompt template extraction | ✅ `full` | `2026-05-28` | — | 2865 | `internal/engine/langchain_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/langchain.yaml`<br>`testdata/fixtures/typescript/langchain_chain.ts` | — |
 
 ### Composition
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Chain composition | ✅ `full` | `2026-05-28` | — | [link](2865) | `internal/engine/langchain_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/langchain.yaml`<br>`testdata/fixtures/typescript/langchain_chain.ts` | — |
-| Tool use detection | ✅ `full` | — | — | [link](2865) | `internal/engine/langchain_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/langchain.yaml`<br>`testdata/fixtures/typescript/langchain_chain.ts` | — |
+| Chain composition | ✅ `full` | `2026-05-28` | — | 2865 | `internal/engine/langchain_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/langchain.yaml`<br>`testdata/fixtures/typescript/langchain_chain.ts` | — |
+| Tool use detection | ✅ `full` | — | — | 2865 | `internal/engine/langchain_detect_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/langchain.yaml`<br>`testdata/fixtures/typescript/langchain_chain.ts` | — |
 
 ### Tracking
 

--- a/docs/coverage/detail/lang.jsts.framework.marblejs.md
+++ b/docs/coverage/detail/lang.jsts.framework.marblejs.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/marblejs_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/marblejs_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/marblejs.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/marblejs.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/marblejs.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/marblejs.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.nativescript.md
+++ b/docs/coverage/detail/lang.jsts.framework.nativescript.md
@@ -21,21 +21,21 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Deep link extraction | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
-| Navigation extraction | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
-| Screen detection | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
+| Deep link extraction | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
+| Navigation extraction | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
+| Screen detection | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
 
 ### Platform
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Platform branching | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
+| Platform branching | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Native module imports | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
+| Native module imports | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_nativescript/nav-service.ts` | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | 2932 | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-28` | — | 2932 | `internal/custom/javascript/nestjs.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/javascript_typescript/frameworks/nestjs.yaml` | — |
 
 ### Auth
 
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/nestjs_validation.ts` | — |
+| DTO extraction | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/nestjs_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Trace extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/nestjs.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Trace extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/nestjs.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/nestjs.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/nestjs.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -35,7 +35,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Route extraction | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/custom/javascript/nextjs.go`<br>`internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | — |
+| Route extraction | ✅ `full` | `2026-05-28` | — | 2932 | `internal/custom/javascript/nextjs.go`<br>`internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | — |
 | Router pattern | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | — |
 
 ### Build

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Component extraction | ✅ `full` | — | — | [link](2880) | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
+| Component extraction | ✅ `full` | — | — | 2880 | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
 | Hook recognition | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` | — |
-| Router pattern | ✅ `full` | — | — | [link](2880) | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
+| Router pattern | ✅ `full` | — | — | 2880 | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.polka.md
+++ b/docs/coverage/detail/lang.jsts.framework.polka.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/polka_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/polka_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/polka.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/polka.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/polka.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/polka.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.react-native.md
+++ b/docs/coverage/detail/lang.jsts.framework.react-native.md
@@ -21,7 +21,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Deep link extraction | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`testdata/fixtures/real-world/typescript/react_native_navigator.tsx` | — |
+| Deep link extraction | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`testdata/fixtures/real-world/typescript/react_native_navigator.tsx` | — |
 | Navigation extraction | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` | — |
 | Screen detection | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/react_native.yaml` | — |
 
@@ -29,13 +29,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Platform branching | ✅ `full` | `2026-05-28` | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/platform_variants.go`<br>`internal/extractors/javascript/testdata/mobile_react_native/AppNavigator.tsx` | — |
+| Platform branching | ✅ `full` | `2026-05-28` | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/platform_variants.go`<br>`internal/extractors/javascript/testdata/mobile_react_native/AppNavigator.tsx` | — |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Native module imports | ✅ `full` | — | — | [link](2860) | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_react_native/AppNavigator.tsx`<br>`testdata/fixtures/real-world/typescript/react_native_navigator.tsx` | — |
+| Native module imports | ✅ `full` | — | — | 2860 | `internal/extractors/javascript/mobile_navigation.go`<br>`internal/extractors/javascript/testdata/mobile_react_native/AppNavigator.tsx`<br>`testdata/fixtures/real-world/typescript/react_native_navigator.tsx` | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -58,7 +58,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_react/UserDashboard.tsx`<br>`internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/react_substrate_test.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_jsts.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.restify.md
+++ b/docs/coverage/detail/lang.jsts.framework.restify.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/restify_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/restify_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/restify.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/restify.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/restify.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/restify.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.sails.md
+++ b/docs/coverage/detail/lang.jsts.framework.sails.md
@@ -28,7 +28,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Request validation | ✅ `full` | — | — | [link](2904) | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/sails_validation.ts` | — |
+| Request validation | ✅ `full` | — | — | 2904 | `internal/extractors/javascript/issue2904_validation_linkage_test.go`<br>`internal/extractors/javascript/validation_linkage.go`<br>`testdata/fixtures/typescript/sails_validation.ts` | — |
 
 ### Middleware
 
@@ -50,19 +50,19 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ✅ `full` | — | — | [link](2905) | `internal/extractors/javascript/testdata/substrate_backend_observability/sails.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
+| Log extraction | ✅ `full` | — | — | 2905 | `internal/extractors/javascript/testdata/substrate_backend_observability/sails.ts`<br>`internal/patterns/observability_jsts_extractor.go` | — |
 
 ### Data
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DB effect | ✅ `full` | — | — | [link](2903) | `internal/extractors/javascript/testdata/substrate_backend_db/sails.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| DB effect | ✅ `full` | — | — | 2903 | `internal/extractors/javascript/testdata/substrate_backend_db/sails.ts`<br>`internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
 
 ### Substrate
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Confidence overlay | ✅ `full` | `2026-05-28` | — | [link](2932) | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | 2932 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
 | Import resolution quality | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Component extraction | ✅ `full` | — | — | [link](2880) | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/svelte.go` | — |
+| Component extraction | ✅ `full` | — | — | 2880 | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/svelte.go` | — |
 | Hook recognition | — `not_applicable` | — | — | — | — | — |
 
 ### Data Flow
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` | — |
-| Router pattern | ✅ `full` | — | — | [link](2880) | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/svelte.go` | — |
+| Router pattern | ✅ `full` | — | — | 2880 | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/svelte.go` | — |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.trpc.md
+++ b/docs/coverage/detail/lang.jsts.framework.trpc.md
@@ -16,19 +16,19 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Procedure extraction | ✅ `full` | `2026-05-28` | — | — | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/rules/javascript_typescript/frameworks/trpc.yaml` | — |
-| Schema extraction | ✅ `full` | `2026-05-28` | — | [link](2865) | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/http_endpoint_trpc_schema.go`<br>`internal/engine/http_endpoint_trpc_schema_test.go`<br>`testdata/fixtures/typescript/trpc_input_schema.ts` | — |
+| Schema extraction | ✅ `full` | `2026-05-28` | — | 2865 | `internal/engine/http_endpoint_trpc.go`<br>`internal/engine/http_endpoint_trpc_schema.go`<br>`internal/engine/http_endpoint_trpc_schema_test.go`<br>`testdata/fixtures/typescript/trpc_input_schema.ts` | — |
 
 ### Codegen
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Client codegen | ✅ `full` | — | — | [link](2865) | `internal/engine/rules/javascript_typescript/frameworks/trpc.yaml`<br>`internal/engine/trpc_client_codegen_test.go`<br>`testdata/fixtures/typescript/trpc_client_codegen.ts` | — |
+| Client codegen | ✅ `full` | — | — | 2865 | `internal/engine/rules/javascript_typescript/frameworks/trpc.yaml`<br>`internal/engine/trpc_client_codegen_test.go`<br>`testdata/fixtures/typescript/trpc_client_codegen.ts` | — |
 
 ### Transport
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transport binding | ✅ `full` | `2026-05-28` | — | [link](2906) | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_transport_binding.go`<br>`internal/engine/http_endpoint_transport_binding_test.go`<br>`testdata/fixtures/typescript/trpc_transport_http.ts`<br>`testdata/fixtures/typescript/trpc_transport_http_ws.ts`<br>`testdata/fixtures/typescript/trpc_transport_none.ts`<br>`testdata/fixtures/typescript/trpc_transport_ws.ts` | — |
+| Transport binding | ✅ `full` | `2026-05-28` | — | 2906 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/http_endpoint_transport_binding.go`<br>`internal/engine/http_endpoint_transport_binding_test.go`<br>`testdata/fixtures/typescript/trpc_transport_http.ts`<br>`testdata/fixtures/typescript/trpc_transport_http_ws.ts`<br>`testdata/fixtures/typescript/trpc_transport_none.ts`<br>`testdata/fixtures/typescript/trpc_transport_ws.ts` | — |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -42,16 +42,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -42,16 +42,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ❌ `missing` | — | — | — | — | — |
 | Handler attribution | ❌ `missing` | — | — | — | — | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/ktor.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | — | `internal/engine/spring_routes_kotlin.go` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Dead code detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/kotlin.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_kotlin.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Auth coverage | ✅ `full` | `2026-05-28` | — | [link](2816) | `internal/extractors/python/config_module.go`<br>`internal/extractors/python/django_drf_permissions.go`<br>`internal/mcp/auth_coverage.go` | — |
+| Auth coverage | ✅ `full` | `2026-05-28` | — | 2816 | `internal/extractors/python/config_module.go`<br>`internal/extractors/python/django_drf_permissions.go`<br>`internal/mcp/auth_coverage.go` | — |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ❌ `missing` | — | — | — | — | — |
 | Handler attribution | ❌ `missing` | — | — | — | — | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -42,16 +42,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
-| Route extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Route extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Request validation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DTO extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Request validation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
@@ -42,48 +42,48 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Tests linkage | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Type System
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Interface extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type alias extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Type extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Enum extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### DI
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI injection point | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| DI scope resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| DI binding extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI injection point | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction propagation | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Transaction rollback rules | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Transaction boundary extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Aspect extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Pointcut resolution | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Advice attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Metric extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
-| Trace extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Log extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Def use chain extraction | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-27` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Module cycle detection | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Pure function tagging | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | — | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | ❌ `missing` | — | — | [link](backfill:dictionary-completeness) | — | — |
+| Template pattern catalog | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/msg.bullmq.md
+++ b/docs/coverage/detail/msg.bullmq.md
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|--------------|-------|-------|-------|
 | Consumer extraction | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` | — |
 | Producer extraction | ✅ `full` | `2026-05-28` | — | — | `internal/engine/scheduled_jobs_edges.go` | — |
-| Topic attribution | ✅ `full` | `2026-05-28` | — | [link](2865) | `internal/engine/bullmq_edges.go`<br>`internal/engine/bullmq_edges_test.go`<br>`internal/links/topic_pass.go`<br>`internal/links/topic_pass_test.go`<br>`testdata/fixtures/typescript/bullmq_topic_attribution.ts` | — |
+| Topic attribution | ✅ `full` | `2026-05-28` | — | 2865 | `internal/engine/bullmq_edges.go`<br>`internal/engine/bullmq_edges_test.go`<br>`internal/links/topic_pass.go`<br>`internal/links/topic_pass_test.go`<br>`testdata/fixtures/typescript/bullmq_topic_attribution.ts` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.c-asm.md
+++ b/docs/coverage/detail/protocol.c-asm.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Cross repo linkage | ✅ `full` | `2026-05-28` | — | [link](2837) | `internal/extractors/cross/abibridge/extractor.go`<br>`internal/extractors/cross/abibridge/extractor_test.go` | — |
-| Method attribution | ✅ `full` | `2026-05-28` | — | [link](2837) | `internal/extractors/cross/abibridge/extractor.go`<br>`internal/extractors/cross/abibridge/testdata/crypt.s.fixture` | — |
-| Service extraction | ✅ `full` | `2026-05-28` | — | [link](2837) | `internal/extractors/cross/abibridge/extractor.go` | — |
+| Cross repo linkage | ✅ `full` | `2026-05-28` | — | 2837 | `internal/extractors/cross/abibridge/extractor.go`<br>`internal/extractors/cross/abibridge/extractor_test.go` | — |
+| Method attribution | ✅ `full` | `2026-05-28` | — | 2837 | `internal/extractors/cross/abibridge/extractor.go`<br>`internal/extractors/cross/abibridge/testdata/crypt.s.fixture` | — |
+| Service extraction | ✅ `full` | `2026-05-28` | — | 2837 | `internal/extractors/cross/abibridge/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/protocol.jcl-cobol.md
+++ b/docs/coverage/detail/protocol.jcl-cobol.md
@@ -11,9 +11,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Cross repo linkage | ✅ `full` | `2026-05-28` | — | [link](2843) | `internal/extractors/cobol/testdata/payroll.cbl`<br>`internal/extractors/jcl/extractor.go`<br>`internal/extractors/jcl/extractor_test.go` | — |
-| Method attribution | ✅ `full` | `2026-05-28` | — | [link](2843) | `internal/extractors/jcl/extractor.go`<br>`internal/extractors/jcl/testdata/payjob.jcl` | — |
-| Service extraction | ✅ `full` | `2026-05-28` | — | [link](2843) | `internal/extractors/jcl/extractor.go` | — |
+| Cross repo linkage | ✅ `full` | `2026-05-28` | — | 2843 | `internal/extractors/cobol/testdata/payroll.cbl`<br>`internal/extractors/jcl/extractor.go`<br>`internal/extractors/jcl/extractor_test.go` | — |
+| Method attribution | ✅ `full` | `2026-05-28` | — | 2843 | `internal/extractors/jcl/extractor.go`<br>`internal/extractors/jcl/testdata/payjob.jcl` | — |
+| Service extraction | ✅ `full` | `2026-05-28` | — | 2843 | `internal/extractors/jcl/extractor.go` | — |
 
 ## Provenance
 

--- a/tools/coverage/gen_test.go
+++ b/tools/coverage/gen_test.go
@@ -292,6 +292,101 @@ func TestGenHidesStrandedGroupColumns(t *testing.T) {
 	}
 }
 
+// TestRenderIssue verifies that renderIssue formats issue values correctly:
+// real URLs and #NNNN refs become markdown links, while non-URL tags
+// (e.g. backfill:dictionary-completeness) render as plain text.
+func TestRenderIssue(t *testing.T) {
+	cases := []struct {
+		issue string
+		want  string
+	}{
+		// empty → em-dash
+		{"", "—"},
+		// https URL → link
+		{"https://github.com/cajasmota/archigraph/issues/2953", "[link](https://github.com/cajasmota/archigraph/issues/2953)"},
+		// http URL → link
+		{"http://example.com/issues/1", "[link](http://example.com/issues/1)"},
+		// bare #NNNN → link
+		{"#2953", "[link](#2953)"},
+		// owner/repo#NNNN → link
+		{"owner/repo#42", "[link](owner/repo#42)"},
+		// backfill tag → plain text (the primary bug fix)
+		{"backfill:dictionary-completeness", "backfill:dictionary-completeness"},
+		// other non-URL tags → plain text
+		{"wontfix", "wontfix"},
+		{"n/a", "n/a"},
+	}
+	for _, tc := range cases {
+		got := renderIssue(tc.issue)
+		if got != tc.want {
+			t.Errorf("renderIssue(%q) = %q, want %q", tc.issue, got, tc.want)
+		}
+	}
+}
+
+// TestGenBackfillIssueRendersAsPlainText confirms end-to-end that a record
+// with issue:"backfill:dictionary-completeness" renders as plain text in the
+// generated detail page (not as a broken markdown link).
+func TestGenBackfillIssueRendersAsPlainText(t *testing.T) {
+	reg := &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			{
+				ID:       "lang.python.framework.starlette",
+				Category: "http_framework",
+				Language: "python",
+				Label:    "Starlette",
+				Capabilities: map[string]Capability{
+					"endpoint_synthesis": {Status: StatusMissing, Issue: "backfill:dictionary-completeness"},
+				},
+			},
+		},
+	}
+	root := t.TempDir()
+	if err := generate(reg, root); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "docs", "coverage", "detail", "lang.python.framework.starlette.md"))
+	if err != nil {
+		t.Fatalf("read detail: %v", err)
+	}
+	body := string(data)
+	// Must appear as plain text, not as a broken markdown link.
+	if strings.Contains(body, "[link](backfill:dictionary-completeness)") {
+		t.Errorf("backfill tag rendered as broken markdown link:\n%s", body)
+	}
+	if !strings.Contains(body, "backfill:dictionary-completeness") {
+		t.Errorf("backfill tag not present as plain text:\n%s", body)
+	}
+	// Real issue URLs must still render as links (regression guard).
+	reg2 := &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{
+			{
+				ID:       "lang.python.framework.flask",
+				Category: "http_framework",
+				Language: "python",
+				Label:    "Flask",
+				Capabilities: map[string]Capability{
+					"endpoint_synthesis": {Status: StatusPartial, Issue: "https://github.com/cajasmota/archigraph/issues/2953"},
+				},
+			},
+		},
+	}
+	root2 := t.TempDir()
+	if err := generate(reg2, root2); err != nil {
+		t.Fatalf("generate2: %v", err)
+	}
+	data2, err := os.ReadFile(filepath.Join(root2, "docs", "coverage", "detail", "lang.python.framework.flask.md"))
+	if err != nil {
+		t.Fatalf("read detail2: %v", err)
+	}
+	body2 := string(data2)
+	if !strings.Contains(body2, "[link](https://github.com/cajasmota/archigraph/issues/2953)") {
+		t.Errorf("real issue URL not rendered as link:\n%s", body2)
+	}
+}
+
 func TestGenSubcommandWiring(t *testing.T) {
 	reg, err := loadRegistry(fixturePath(t))
 	if err != nil {

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strings"
 	"text/template"
 )
 
@@ -464,6 +466,27 @@ func languageDisplay(slug string) string {
 	return slug
 }
 
+// issueRefRe matches bare GitHub issue refs: #NNNN or owner/repo#NNNN.
+var issueRefRe = regexp.MustCompile(`^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[0-9]+$`)
+
+// renderIssue formats a capability's issue field for markdown:
+//   - empty string → "—"
+//   - http(s) URL → "[link](<url>)"
+//   - #NNNN or owner/repo#NNNN → "[link](<ref>)"
+//   - anything else (e.g. "backfill:dictionary-completeness") → plain text
+func renderIssue(issue string) string {
+	if issue == "" {
+		return "—"
+	}
+	if strings.HasPrefix(issue, "https://") || strings.HasPrefix(issue, "http://") {
+		return "[link](" + issue + ")"
+	}
+	if issueRefRe.MatchString(issue) {
+		return "[link](" + issue + ")"
+	}
+	return issue
+}
+
 // templateFuncs are the helpers exposed to templates.
 var templateFuncs = template.FuncMap{
 	"glyph":            statusGlyph,
@@ -472,6 +495,7 @@ var templateFuncs = template.FuncMap{
 	"humanizeCapKey":   humanizeCapKey,
 	"subHeading":       subcategoryHeading,
 	"groupCell":        groupCell,
+	"renderIssue":      renderIssue,
 }
 
 // groupCell returns the digest string for groupName on a recordView or

--- a/tools/coverage/main_test.go
+++ b/tools/coverage/main_test.go
@@ -198,8 +198,8 @@ func TestStats(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stats: %v", err)
 	}
-	if !strings.Contains(out, "total records:    5") {
-		t.Errorf("expected 5 total records, got:\n%s", out)
+	if !strings.Contains(out, "total records:    6") {
+		t.Errorf("expected 6 total records, got:\n%s", out)
 	}
 }
 
@@ -208,8 +208,8 @@ func TestStatsJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stats json: %v", err)
 	}
-	if !strings.Contains(out, "\"total\": 5") {
-		t.Errorf("expected total=5 in JSON, got:\n%s", out)
+	if !strings.Contains(out, "\"total\": 6") {
+		t.Errorf("expected total=6 in JSON, got:\n%s", out)
 	}
 }
 

--- a/tools/coverage/templates/detail.md.tmpl
+++ b/tools/coverage/templates/detail.md.tmpl
@@ -16,14 +16,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 {{- range .CapList}}
-| {{humanizeCapKey .Key}} | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
+| {{humanizeCapKey .Key}} | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{renderIssue .Cap.Issue}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
 {{- end}}
 {{- end}}
 {{else}}
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 {{- range .CapList}}
-| {{humanizeCapKey .Key}} | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
+| {{humanizeCapKey .Key}} | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{renderIssue .Cap.Issue}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
 {{- end}}
 {{end}}
 {{if .FrameworkSpecific}}## Framework-specific
@@ -33,7 +33,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
 {{- range .CapList}}
-| {{humanizeCapKey .Key}} | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{if .Cap.Issue}}[link]({{.Cap.Issue}}){{else}}—{{end}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
+| {{humanizeCapKey .Key}} | {{glyph .Cap.Status}} `{{.Cap.Status}}` | {{if .Cap.VerifiedAt}}`{{.Cap.VerifiedAt}}`{{else}}—{{end}} | {{if .Cap.VerifiedSHA}}`{{.Cap.VerifiedSHA}}`{{else}}—{{end}} | {{renderIssue .Cap.Issue}} | {{if .Cap.Cites}}{{range $i, $p := .Cap.Cites}}{{if $i}}<br>{{end}}`{{$p}}`{{end}}{{else}}—{{end}} | {{if .Cap.Notes}}{{.Cap.Notes}}{{else}}—{{end}} |
 {{- end}}
 {{end}}
 {{end}}## Provenance

--- a/tools/coverage/testdata/fixture-out/by-category/http_framework.md
+++ b/tools/coverage/testdata/fixture-out/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 5 records · **JS/TS**: 2 · **python**: 3
+**Total**: 6 records · **JS/TS**: 2 · **python**: 4
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -22,3 +22,4 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | — | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | — | ✅ | — | — | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | — | ✅ | — | — | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | — | ❌ | ❌ | — | |

--- a/tools/coverage/testdata/fixture-out/by-language/python.md
+++ b/tools/coverage/testdata/fixture-out/by-language/python.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # python
 
-**Frameworks**: 3 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 4 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -12,3 +12,4 @@ Back to [summary](../summary.md).
 | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ⚠️ | ✅ | ✅ | — | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | — | ✅ | — | — | |
 | [Flask](../detail/lang.python.framework.flask.md) | — | ✅ | — | — | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | — | ❌ | ❌ | — | |

--- a/tools/coverage/testdata/fixture-out/detail/lang.python.framework.starlette.md
+++ b/tools/coverage/testdata/fixture-out/detail/lang.python.framework.starlette.md
@@ -1,23 +1,23 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# `pkg.npm` — package.json (npm/yarn/pnpm)
+# `lang.python.framework.starlette` — Starlette
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [JS/TS](../by-language/jsts.md)
-- **Category:** [package_manager](../by-category/package_manager.md)
+- **Language:** [python](../by-language/python.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
 - **Capability cells:** 2
 
 ## Capabilities
 
 | Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
 |------------|--------|-------------|--------------|-------|-------|-------|
-| Lockfile parsing | ✅ `full` | — | — | 2865 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/extractor_test.go` | — |
-| Manifest parsing | ✅ `full` | `2026-05-28` | — | — | `internal/extractors/cross/manifest/extractor.go` | — |
+| Endpoint synthesis | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
+| Handler attribution | ❌ `missing` | — | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 
 This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
-(or use `go run ./tools/coverage update pkg.npm ...`) then regenerate:
+(or use `go run ./tools/coverage update lang.python.framework.starlette ...`) then regenerate:
 
 ```
 go run ./tools/coverage validate

--- a/tools/coverage/testdata/fixture-out/summary.md
+++ b/tools/coverage/testdata/fixture-out/summary.md
@@ -1,13 +1,13 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 2 (2 active · 0 placeholder) · **Frameworks**: 5 · **ORMs**: 0 · **Tools**: 0 · **Other**: 0
+**Languages**: 2 (2 active · 0 placeholder) · **Frameworks**: 6 · **ORMs**: 0 · **Tools**: 0 · **Other**: 0
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [python](by-language/python.md) | 3 | 0 | 0 | 0 |
+| [python](by-language/python.md) | 4 | 0 | 0 | 0 |
 | [JS/TS](by-language/jsts.md) | 2 | 0 | 0 | 0 |
 
 ## Cross-cutting categories tracked but with no records
@@ -23,4 +23,4 @@
 | [Protocols](by-category/protocol.md) |
 | [Build Systems](by-category/build_system.md) |
 
-Total: 5 frameworks · 0 tools · 0 ORMs · 0 other
+Total: 6 frameworks · 0 tools · 0 ORMs · 0 other

--- a/tools/coverage/testdata/fixture.json
+++ b/tools/coverage/testdata/fixture.json
@@ -116,6 +116,22 @@
           "verified_at": "2026-05-27"
         }
       }
+    },
+    {
+      "id": "lang.python.framework.starlette",
+      "category": "http_framework",
+      "language": "python",
+      "label": "Starlette",
+      "capabilities": {
+        "endpoint_synthesis": {
+          "status": "missing",
+          "issue": "backfill:dictionary-completeness"
+        },
+        "handler_attribution": {
+          "status": "missing",
+          "issue": "backfill:dictionary-completeness"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `renderIssue(issue string) string` helper in `tools/coverage/generate.go` that distinguishes three kinds of issue values: http(s) URLs and `#NNNN`/`owner/repo#NNNN` refs render as `[link](...)`, while everything else (e.g. `backfill:dictionary-completeness`) renders as plain text
- Updates all three issue-rendering sites in `tools/coverage/templates/detail.md.tmpl` to call `{{renderIssue .Cap.Issue}}` instead of the inline conditional
- Regenerates 68 detail pages where backfill tags were being emitted as broken markdown links
- Adds `TestRenderIssue` unit test (8 cases) and `TestGenBackfillIssueRendersAsPlainText` end-to-end test
- Adds Starlette fixture record with `backfill:dictionary-completeness` issue tag; updates golden files and stats expectations accordingly

No registry/dictionary changes.

## Test plan

- [x] `go run ./tools/coverage validate` — 0 errors
- [x] `go run ./tools/coverage gen` twice — byte-stable
- [x] `go run ./tools/coverage fmt --check` — ok
- [x] `go test ./tools/coverage/` — all green
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Golden file `testdata/fixture-out/detail/lang.python.framework.starlette.md` shows `backfill:dictionary-completeness` as plain text
- [x] Golden file `testdata/fixture-out/detail/lang.python.framework.django-drf.md` still shows real URL as `[link](...)`

Closes #2953

🤖 Generated with [Claude Code](https://claude.com/claude-code)