### PR TITLE
taxonomy: remove hook_recognition from shared ui_frontend; re-home to React/Vue framework_specific

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -157,15 +157,15 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
-| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 17/18 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/8 | |
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | ✅ 18/18 | ⚠️ 20/23 | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 16/18 | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 16/17 | |
 | [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 18/20 | |
 
 

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -32,7 +32,7 @@ Back to [summary](../summary.md).
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/8 | |
 
 
 ### Desktop

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -24,9 +24,9 @@ Back to [summary](../summary.md).
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/9 | |
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/8 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/8 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 5/14 | ❌ 0/8 | |
 
 
 ### Mobile

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -31,8 +31,8 @@ Back to [summary](../summary.md).
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
-| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/9 | |
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/8 | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 2/3 | ❌ 0/8 | |
 
 
 ### Meta Framework

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -30,9 +30,9 @@ Back to [summary](../summary.md).
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 17/18 | |
+| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 17/17 | |
 | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | ✅ 18/18 | ⚠️ 20/23 | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 16/18 | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 16/17 | |
 | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | ✅ 7/7 | ⚠️ 18/20 | |
 
 

--- a/docs/coverage/detail/lang.c-cpp.framework.qt.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.qt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 27
+- **Capability cells:** 26
 
 ## Capabilities
 
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ❌ `missing` | — | — | — | — |
 | Context extraction | ❌ `missing` | — | — | — | — |
-| Hook recognition | ❌ `missing` | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 27
+- **Capability cells:** 26
 
 ## Capabilities
 
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ❌ `missing` | — | — | — | — |
 | Context extraction | ❌ `missing` | — | — | — | — |
-| Hook recognition | ❌ `missing` | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 27
+- **Capability cells:** 26
 
 ## Capabilities
 
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ❌ `missing` | — | — | — | — |
 | Context extraction | ❌ `missing` | — | — | — | — |
-| Hook recognition | ❌ `missing` | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 27
+- **Capability cells:** 26
 
 ## Capabilities
 
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ❌ `missing` | — | — | — | — |
 | Context extraction | ❌ `missing` | — | — | — | — |
-| Hook recognition | ❌ `missing` | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 16
+- **Capability cells:** 15
 
 ## Capabilities
 
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ❌ `missing` | — | — | — | — |
 | Context extraction | ❌ `missing` | — | — | — | — |
-| Hook recognition | ❌ `missing` | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.java.framework.vaadin.md
+++ b/docs/coverage/detail/lang.java.framework.vaadin.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [java](../by-language/java.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 16
+- **Capability cells:** 15
 
 ## Capabilities
 
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ❌ `missing` | — | — | — | — |
 | Context extraction | ❌ `missing` | — | — | — | — |
-| Hook recognition | ❌ `missing` | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.angular.md
+++ b/docs/coverage/detail/lang.jsts.framework.angular.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 25
+- **Capability cells:** 24
 
 ## Capabilities
 
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | — |
 | Context extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2751) | `internal/extractors/javascript/angular.go`<br>`internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2854_angular_test.go` | — |
-| Hook recognition | — `not_applicable` | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.react.md
+++ b/docs/coverage/detail/lang.jsts.framework.react.md
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/extractors/javascript/react.go` | — |
 | Context extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/javascript/extractor.go` | — |
-| Hook recognition | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2854_react_test.go`<br>`internal/extractors/javascript/react.go` | — |
 
 ### Data Flow
 
@@ -97,6 +96,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Context HOC | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | — | Covered by generic Structure/context_extraction (createContext, #611) and Structure/hoc_wrapper_recognition (forwardRef/memo/lazy/connect/withX, extractor.go). Not duplicated here to avoid double-counting. |
 | HOC wrapper recognition | ✅ `full` | `2026-05-28` | — | `internal/extractors/javascript/extractor.go` | — |
+| Hook recognition | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2735) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2854_react_test.go`<br>`internal/extractors/javascript/react.go` | — |
 | Hooks | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/2875) | — | Covered by generic Structure/hook_recognition (react.go USES_HOOK + custom-hook subtype). Not duplicated here to avoid double-counting. |
 | JSX template | ✅ `full` | `2026-05-28` | — | `internal/extractors/javascript/extractor.go` | — |
 | Lazy code splitting | ⚠️ `partial` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2875) | `internal/extractors/javascript/extractor.go`<br>`internal/extractors/javascript/issue2875_react_internals_test.go`<br>`internal/extractors/javascript/react_internals.go`<br>`internal/extractors/javascript/testdata/react_internals/AppShell.tsx` | React.lazy(() => import('mod')) is decorated react_lazy + lazy_module (the code-split target). Partial: the dynamic-import specifier is recovered only when it is a string literal; computed/template specifiers are not resolved. |

--- a/docs/coverage/detail/lang.jsts.framework.svelte.md
+++ b/docs/coverage/detail/lang.jsts.framework.svelte.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** UI Frontend
-- **Capability cells:** 29
+- **Capability cells:** 28
 
 ## Capabilities
 
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/svelte/extractor.go`<br>`internal/extractors/svelte/issue2854_test.go` | — |
 | Context extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2751) | `internal/extractors/svelte/extractor.go`<br>`internal/extractors/svelte/issue2854_test.go` | — |
-| Hook recognition | — `not_applicable` | — | — | — | — |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.jsts.framework.vue.md
+++ b/docs/coverage/detail/lang.jsts.framework.vue.md
@@ -17,7 +17,6 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Component extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2854_test.go` | — |
 | Context extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2751) | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2854_test.go` | — |
-| Hook recognition | ✅ `full` | `2026-05-28` | — | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2854_test.go` | — |
 
 ### Data Flow
 
@@ -74,6 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Composition API | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/javascript/testdata/vue_internals/Comp.vue`<br>`internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go` | — |
 | Directive recognition | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/javascript/testdata/vue_internals/Comp.vue`<br>`internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go` | — |
+| Hook recognition | ✅ `full` | `2026-05-28` | — | `internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2854_test.go` | — |
 | Options API | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/javascript/testdata/vue_internals/OptionsComp.vue`<br>`internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go` | — |
 | Pinia store | ✅ `full` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2890) | `internal/extractors/javascript/testdata/vue_internals/CounterStore.vue`<br>`internal/extractors/vue/issue2890_pinia_test.go`<br>`internal/extractors/vue/pinia_store.go` | — |
 | Props emits macros | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2876) | `internal/extractors/javascript/testdata/vue_internals/Comp.vue`<br>`internal/extractors/vue/extractor.go`<br>`internal/extractors/vue/issue2876_internals_test.go` | — |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -3198,9 +3198,6 @@
           },
           "context_extraction": {
             "status": "missing"
-          },
-          "hook_recognition": {
-            "status": "missing"
           }
         },
         "Data Flow": {
@@ -4392,9 +4389,6 @@
           },
           "context_extraction": {
             "status": "missing"
-          },
-          "hook_recognition": {
-            "status": "missing"
           }
         },
         "Data Flow": {
@@ -4524,9 +4518,6 @@
           },
           "context_extraction": {
             "status": "missing"
-          },
-          "hook_recognition": {
-            "status": "missing"
           }
         },
         "Data Flow": {
@@ -4655,9 +4646,6 @@
             "status": "missing"
           },
           "context_extraction": {
-            "status": "missing"
-          },
-          "hook_recognition": {
             "status": "missing"
           }
         },
@@ -9233,9 +9221,6 @@
           },
           "context_extraction": {
             "status": "missing"
-          },
-          "hook_recognition": {
-            "status": "missing"
           }
         },
         "Data Flow": {
@@ -11662,9 +11647,6 @@
           },
           "context_extraction": {
             "status": "missing"
-          },
-          "hook_recognition": {
-            "status": "missing"
           }
         },
         "Data Flow": {
@@ -12537,9 +12519,6 @@
             "cites": ["internal/extractors/javascript/angular.go","internal/extractors/javascript/extractor.go","internal/extractors/javascript/issue2854_angular_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2751",
             "verified_at": "2026-05-28"
-          },
-          "hook_recognition": {
-            "status": "not_applicable"
           }
         },
         "Data Flow": {
@@ -14492,12 +14471,6 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go"],
             "verified_at": "2026-05-28"
-          },
-          "hook_recognition": {
-            "status": "full",
-            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/issue2854_react_test.go","internal/extractors/javascript/react.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
-            "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
@@ -14720,6 +14693,12 @@
           "hoc_wrapper_recognition": {
             "status": "full",
             "cites": ["internal/extractors/javascript/extractor.go"],
+            "verified_at": "2026-05-28"
+          },
+          "hook_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/javascript/extractor.go","internal/extractors/javascript/issue2854_react_test.go","internal/extractors/javascript/react.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2735",
             "verified_at": "2026-05-28"
           },
           "hooks": {
@@ -15270,9 +15249,6 @@
             "cites": ["internal/extractors/svelte/extractor.go","internal/extractors/svelte/issue2854_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2751",
             "verified_at": "2026-05-28"
-          },
-          "hook_recognition": {
-            "status": "not_applicable"
           }
         },
         "Data Flow": {
@@ -15620,11 +15596,6 @@
             "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2854_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2751",
             "verified_at": "2026-05-28"
-          },
-          "hook_recognition": {
-            "status": "full",
-            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2854_test.go"],
-            "verified_at": "2026-05-28"
           }
         },
         "Data Flow": {
@@ -15742,6 +15713,11 @@
             "status": "full",
             "cites": ["internal/extractors/javascript/testdata/vue_internals/Comp.vue","internal/extractors/vue/extractor.go","internal/extractors/vue/issue2876_internals_test.go"],
             "issue": "https://github.com/cajasmota/archigraph/issues/2876",
+            "verified_at": "2026-05-28"
+          },
+          "hook_recognition": {
+            "status": "full",
+            "cites": ["internal/extractors/vue/extractor.go","internal/extractors/vue/issue2854_test.go"],
             "verified_at": "2026-05-28"
           },
           "options_api": {

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -223,7 +223,6 @@ subcategories:
     capabilities:
       - component_extraction
       - prop_extraction
-      - hook_recognition
       - state_management
       - data_fetching
       - router_pattern
@@ -257,7 +256,7 @@ subcategories:
       - template_pattern_catalog
     groups:
       - name: Structure
-        keys: [component_extraction, hook_recognition, context_extraction]
+        keys: [component_extraction, context_extraction]
       - name: Data Flow
         keys: [prop_extraction, state_management, data_fetching, branch_conditions]
       - name: Navigation

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -250,13 +250,6 @@ records:
               functions: [extractJSXRendersRelationships]
           issues_implemented: ["2735"]
           verified_at: "2026-05-28"
-        hook_recognition:
-          status: partial
-          symbols:
-            - file: internal/extractors/javascript/destructure_bindings.go
-              functions: [isZustandHookName, isReactQueryHook]
-          issues_implemented: ["2735"]
-          verified_at: "2026-05-28"
         context_extraction:
           status: full
           symbols:

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -111,7 +111,8 @@ func TestSubcategoryRenderKeysExcludesCategoryUnion(t *testing.T) {
 		"fs_effect",
 		// #2938 jsx_template + hoc_wrapper_recognition removed from the shared
 		// ui_frontend Structure group; re-homed to React framework_specific.
-		"hook_recognition",
+		// #2948 hook_recognition also removed from ui_frontend; re-homed to
+		// React/Vue framework_specific (composables are Vue-specific; hooks are React).
 		"http_effect",
 		"import_resolution_quality",
 		"interface_extraction",
@@ -170,7 +171,7 @@ func TestSubcategoryCapabilityKeysSorted(t *testing.T) {
 		"fs_effect",
 		"handler_attribution",
 		// #2938 jsx_template + hoc_wrapper_recognition removed from ui_frontend.
-		"hook_recognition",
+		// #2948 hook_recognition also removed; re-homed to React/Vue framework_specific.
 		"http_effect",
 		"import_resolution_quality",
 		"interface_extraction",


### PR DESCRIPTION
## Summary

- **Dictionary**: removed `hook_recognition` from the `ui_frontend` Structure group capabilities list and group keys. Structure now has `[component_extraction, context_extraction]` — mirrors the #2938 treatment of `jsx_template`/`hoc_wrapper_recognition`.
- **React** (`lang.jsts.framework.react`): re-homed `hook_recognition` (full) from `Structure` → `framework_specific["React Internals"]`. Cites/verified_at/issue preserved. Meaning: React hooks USES_HOOK emission + custom-hook subtype detection (`extractor.go`, `react.go`).
- **Vue** (`lang.jsts.framework.vue`): re-homed `hook_recognition` (full) from `Structure` → `framework_specific["Vue Internals"]`. Cites/verified_at preserved. Meaning: Vue composables (`use*` functions detected in SFC `<script setup>`, `extractor.go`).
- **Deleted** `hook_recognition` cells from all other ui_frontend records: `angular` (not_applicable), `svelte` (not_applicable), `qt`/`blazor`/`blazor-server`/`blazor-wasm`/`gwt`/`vaadin` (all missing).
- `capability-map.yaml`: removed the `react` Structure/`hook_recognition` mapping (framework_specific cells carry their own cites).
- `subcategory_test.go`: updated both expected key-set assertions; added #2948 comment.

## Verification

- `coverage validate` → 0 errors
- `coverage fmt --check` → canonical
- `coverage gen` → byte-stable (run twice, no diff)
- `go test ./tools/coverage/` → ok
- `go build ./...` → clean
- Angular/Svelte detail pages: no hook_recognition row
- React detail page: hook_recognition under "React Internals" (framework_specific)
- Vue detail page: hook_recognition under "Vue Internals" (framework_specific)
- No extractor code changes

## Test plan

- [ ] CI coverage-docs gate passes (regenerated docs committed together)
- [ ] `coverage validate` 0 errors
- [ ] `go test ./tools/coverage/` passes
- [ ] Angular/Svelte detail pages no longer show hook_recognition
- [ ] React/Vue keep hook_recognition under framework_specific

Closes #2948

🤖 Generated with [Claude Code](https://claude.com/claude-code)