### PR TITLE
coverage: route update/backfill by subcategory taxonomy, not IsGrouped() state

### DIFF
--- a/tools/coverage/backfill.go
+++ b/tools/coverage/backfill.go
@@ -43,20 +43,22 @@ func planBackfill(reg *Registry, langFilter, subFilter string) []seedPlan {
 	var plans []seedPlan
 	for i := range reg.Records {
 		rec := &reg.Records[i]
-		if !rec.IsGrouped() {
+		// Gate on whether the record's SUBCATEGORY declares a group
+		// taxonomy, not on the record's current IsGrouped() state. A
+		// freshly `add`-ed record has an empty flat capabilities map
+		// and IsGrouped()==false, but if its subcategory has a group
+		// taxonomy it still needs backfilling into that taxonomy.
+		if rec.Subcategory == "" || !validSubcategory(rec.Category, rec.Subcategory) {
 			continue
 		}
-		if rec.Subcategory == "" || !validSubcategory(rec.Category, rec.Subcategory) {
+		groups := groupsForSubcategory(rec.Subcategory)
+		if len(groups) == 0 {
 			continue
 		}
 		if langFilter != "" && rec.Language != langFilter {
 			continue
 		}
 		if subFilter != "" && rec.Subcategory != subFilter {
-			continue
-		}
-		groups := groupsForSubcategory(rec.Subcategory)
-		if len(groups) == 0 {
 			continue
 		}
 		existing := rec.AllCapabilities()

--- a/tools/coverage/backfill_test.go
+++ b/tools/coverage/backfill_test.go
@@ -174,3 +174,109 @@ func countCompletenessWarnings(res *ValidationResult) int {
 	}
 	return n
 }
+
+// TestGroupedAuthoringFullCycle verifies the end-to-end authoring flow for
+// a freshly `add`-ed record in a grouped subcategory (http_backend), whose
+// capabilities field starts empty. Before this fix, `update` wrote flat
+// cells and `backfill` skipped the record — both gates were IsGrouped()
+// which is false until Groups is non-empty. Now both route by the
+// subcategory's dictionary taxonomy instead.
+//
+//  1. `add` creates the record with an empty capabilities map.
+//  2. `update` places the first cell into its canonical group (Routing).
+//  3. `backfill` seeds every other declared lane cell.
+//  4. `validate` reports 0 errors on the resulting record.
+func TestGroupedAuthoringFullCycle(t *testing.T) {
+	dst := copyFixture(t)
+	const newID = "lang.jsts.framework.koa-grouped"
+
+	// 1. add — creates record with Capabilities:{} and no Groups.
+	if _, _, err := runCmd(t, "add", "--file", dst,
+		"--id", newID,
+		"--category", "http_framework",
+		"--subcategory", "http_backend",
+		"--language", "jsts",
+		"--label", "Koa (grouped test)"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// Confirm the record is freshly flat (IsGrouped == false).
+	before, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load after add: %v", err)
+	}
+	fresh := findRecord(before, newID)
+	if fresh == nil {
+		t.Fatal("record not found after add")
+	}
+	if fresh.IsGrouped() {
+		t.Fatal("precondition: freshly-added record should not be grouped yet")
+	}
+
+	// 2. update — must auto-place into the canonical group (Routing)
+	// rather than writing a flat cell. Before the fix this wrote flat.
+	if _, _, err := runCmd(t, "update", "--file", dst,
+		"--capability", "endpoint_synthesis",
+		"--status", "full",
+		"--cites", "internal/engine/http_endpoint_synthesis.go",
+		newID); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	afterUpdate, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load after update: %v", err)
+	}
+	updated := findRecord(afterUpdate, newID)
+	if updated == nil {
+		t.Fatal("record missing after update")
+	}
+	if !updated.IsGrouped() {
+		t.Fatal("update should have produced a grouped record for a grouped subcategory")
+	}
+	if _, ok := updated.Groups["Routing"]["endpoint_synthesis"]; !ok {
+		t.Fatal("update should have placed endpoint_synthesis under Routing")
+	}
+	if len(updated.Capabilities) > 0 {
+		t.Fatalf("update must not write flat cells for a grouped subcategory; flat caps: %v", updated.Capabilities)
+	}
+
+	// 3. backfill — must seed the remaining declared lane cells that
+	// `update` hasn't filled yet. Before the fix, backfill skipped
+	// this record because IsGrouped() was false before step 2 set
+	// the first group cell.
+	if _, _, err := runCmd(t, "backfill", "--file", dst); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	afterBackfill, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load after backfill: %v", err)
+	}
+	backfilled := findRecord(afterBackfill, newID)
+	if backfilled == nil {
+		t.Fatal("record missing after backfill")
+	}
+	// Every lane key in the http_backend taxonomy must now exist on the
+	// record (either set by update or seeded by backfill).
+	groups := groupsForSubcategory("http_backend")
+	for _, g := range groups {
+		for _, key := range g.Keys {
+			all := backfilled.AllCapabilities()
+			if _, ok := all[key]; !ok {
+				t.Errorf("expected lane key %q (group %q) after backfill, but it is absent", key, g.Name)
+			}
+		}
+	}
+
+	// 4. validate — must report 0 errors on the resulting record.
+	res := validateRegistry(afterBackfill, repoRoot(t))
+	var newRecErrs []string
+	for _, e := range res.Errors {
+		if strings.Contains(e, newID) {
+			newRecErrs = append(newRecErrs, e)
+		}
+	}
+	if len(newRecErrs) > 0 {
+		t.Errorf("validateRegistry reported errors for %s after full authoring cycle:\n%s",
+			newID, strings.Join(newRecErrs, "\n"))
+	}
+}

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -240,11 +240,19 @@ func cmdUpdate(args []string, out io.Writer) error {
 	} else if !validCapabilityKey(rec.Category, *cap) {
 		return fmt.Errorf("update: capability %q not valid for category %q", *cap, rec.Category)
 	}
-	// Route the write to the right shape. Grouped records auto-place
-	// the cell into its canonical group (per subcategoryGroups); keys
-	// outside the taxonomy fall into the synthetic Uncategorized
-	// group so we never lose data.
-	if rec.IsGrouped() {
+	// Route the write to the right shape. The routing decision is made
+	// by whether the record's SUBCATEGORY declares a group taxonomy
+	// (dictionary lookup), NOT by the record's current IsGrouped() state.
+	// A freshly `add`-ed record has an empty flat capabilities map and
+	// IsGrouped()==false, but if its subcategory has a group taxonomy
+	// the cell must be placed into the canonical group so the record
+	// is valid after the first `update`. Records with no subcategory or
+	// a subcategory without a taxonomy fall through to the flat path.
+	subcatHasGroups := rec.Subcategory != "" && len(groupsForSubcategory(rec.Subcategory)) > 0
+	if subcatHasGroups {
+		if rec.Groups == nil {
+			rec.Groups = map[string]map[string]Capability{}
+		}
 		group := groupForCapability(rec.Subcategory, *cap)
 		if group == "" {
 			group = uncategorizedGroup


### PR DESCRIPTION
## Summary

- **Root cause**: `cmdUpdate` and `planBackfill` gated grouped-record routing on `Record.IsGrouped()` (true only when `Groups` is non-empty). A freshly `add`-ed record starts with an empty flat `Capabilities` map, so `IsGrouped()==false`. This caused `update` to write flat cells (triggering the "flat shape forbidden" validate error) and `backfill` to skip the record entirely.
- **Fix**: Both sites now route by whether the record's **subcategory** declares a group taxonomy (`len(groupsForSubcategory(rec.Subcategory)) > 0`), not by the record's current shape state. Genuinely-flat subcategories (no declared taxonomy) are unaffected.
- **Test**: `TestGroupedAuthoringFullCycle` — add a record in `http_backend` (grouped subcategory), `update` one cell, `backfill` the rest, assert valid grouped shape + 0 `validateRegistry` errors.

## Scope

- `tools/coverage/main.go` — `cmdUpdate` routing
- `tools/coverage/backfill.go` — `planBackfill` routing  
- `tools/coverage/backfill_test.go` — new full-cycle test

No registry, docs/coverage/, or capability-dictionary.yaml changes.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./tools/coverage/` — all tests pass (120+), including `TestGroupedAuthoringFullCycle`
- [x] `go vet ./...` clean
- [x] `git diff HEAD -- docs/coverage/` — no docs/registry diff

Closes #2961

🤖 Generated with [Claude Code](https://claude.com/claude-code)