### PR TITLE
[coverage][foundation-w2] PR-E: orm_mapper subcategory + flat→grouped ORM migration + relationship reds

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -6,155 +6,158 @@
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
 
-| Language | Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | ❌ | ❌ | ❌ | |
-| [C/C++](../by-language/c-cpp.md) | [ODB](../detail/lang.c-cpp.orm.odb.md) | ❌ | ❌ | ❌ | |
-| [C/C++](../by-language/c-cpp.md) | [SOCI](../detail/lang.c-cpp.orm.soci.md) | ❌ | ❌ | ❌ | |
-| [C/C++](../by-language/c-cpp.md) | [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | ❌ | ❌ | ❌ | |
-| [C/C++](../by-language/c-cpp.md) | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | ❌ | ❌ | ❌ | |
-| [C/C++](../by-language/c-cpp.md) | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ❌ | ❌ | ❌ | |
-| [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ❌ | ❌ | ❌ | |
-| [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | — | — | ⚠️ | |
-| [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | — | — | ⚠️ | |
-| [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ | ⚠️ | ⚠️ | |
-| [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ | ✅ | ✅ | |
-| [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ | ⚠️ | ⚠️ | |
-| [C#](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ | ❌ | ❌ | |
-| [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | — | — | ⚠️ | |
-| [C#](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | — | — | ⚠️ | |
-| [C#](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | — | — | ⚠️ | |
-| [C#](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | — | — | ⚠️ | |
-| [C#](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ | ⚠️ | ⚠️ | |
-| [C#](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | — | — | ⚠️ | |
-| [C#](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | — | — | ⚠️ | |
-| [C#](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | — | — | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ | ✅ | ✅ | |
-| [elixir](../by-language/elixir.md) | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | — | — | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [MyXQL](../detail/lang.elixir.driver.myxql.md) | — | — | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [Postgrex](../detail/lang.elixir.driver.postgrex.md) | — | — | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [Redix](../detail/lang.elixir.driver.redix.md) | — | — | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | — | — | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | — | — | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ | ⚠️ | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | — | — | ⚠️ | |
-| [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ | ⚠️ | ⚠️ | |
-| [go](../by-language/go.md) | [GORM](../detail/lang.go.orm.gorm.md) | ❌ | ✅ | ✅ | |
-| [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | ❌ | ✅ | ✅ | |
-| [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | ❌ | ❌ | ❌ | |
-| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | ⚠️ | — | — | |
-| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | — | — | ⚠️ | |
-| [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ⚠️ | ⚠️ | ⚠️ | |
-| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ | ⚠️ | ⚠️ | |
-| [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | ❌ | ❌ | ❌ | |
-| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | — | ⚠️ | ⚠️ | |
-| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ | ❌ | ❌ | |
-| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ | ❌ | ❌ | |
-| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ | ✅ | ✅ | |
-| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ | ✅ | ⚠️ | |
-| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ | ⚠️ | ⚠️ | |
-| [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ | ⚠️ | ⚠️ | |
-| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ | ⚠️ | ⚠️ | |
-| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ | ⚠️ | ⚠️ | |
-| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ | ✅ | ✅ | |
-| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ | ⚠️ | ⚠️ | |
-| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ | ⚠️ | ⚠️ | |
-| [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ | ⚠️ | ⚠️ | |
-| [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ✅ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ✅ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | — | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ✅ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | ✅ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ✅ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ✅ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | — | — | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | — | — | ✅ | |
-| [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ | ✅ | ✅ | |
-| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ | ⚠️ | ⚠️ | |
-| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ | ⚠️ | ⚠️ | |
-| [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | — | ⚠️ | ⚠️ | |
-| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ | ⚠️ | ⚠️ | |
-| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ | ⚠️ | ⚠️ | |
-| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ | ⚠️ | ⚠️ | |
-| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | — | — | ⚠️ | |
-| [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ | ❌ | ❌ | |
-| [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ❌ | ✅ | ✅ | |
-| [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | ❌ | ✅ | ✅ | |
-| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | — | — | ⚠️ | |
-| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | — | — | ⚠️ | |
-| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | — | — | ⚠️ | |
-| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | ❌ | ⚠️ | ⚠️ | |
-| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ | ⚠️ | ⚠️ | |
-| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | — | — | ⚠️ | |
-| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | — | — | ⚠️ | |
-| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | — | — | ⚠️ | |
-| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | — | — | ⚠️ | |
-| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | — | — | ⚠️ | |
-| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ⚠️ | — | — | |
-| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | — | ⚠️ | ⚠️ | |
-| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ | ✅ | ✅ | |
-| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | — | ⚠️ | ⚠️ | |
-| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | — | — | ⚠️ | |
-| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ | ⚠️ | ⚠️ | |
-| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ | ⚠️ | ⚠️ | |
-| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ | ✅ | ✅ | |
-| [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ | ✅ | ✅ | |
-| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ | ✅ | ⚠️ | |
-| [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | — | — | ⚠️ | |
-| [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | — | — | ⚠️ | |
-| [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | — | — | ⚠️ | |
-| [python](../by-language/python.md) | [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | — | — | ⚠️ | |
-| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | — | — | ⚠️ | |
-| [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | — | — | ⚠️ | |
-| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | — | — | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | — | — | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ | ✅ | ✅ | |
-| [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ | ⚠️ | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | — | ⚠️ | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ | ⚠️ | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ | ⚠️ | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | — | — | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | — | — | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | — | — | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | — | — | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | — | — | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | — | — | ⚠️ | |
-| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ | ✅ | ✅ | |
-| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ | ❌ | ❌ | |
-| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | ❌ | ✅ | ✅ | |
-| [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [neo4rs](../detail/lang.rust.driver.neo4j.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | — | — | ⚠️ | |
-| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ | ⚠️ | ⚠️ | |
-| [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | — | — | ⚠️ | |
-| [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ | ⚠️ | ⚠️ | |
-| [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | — | ⚠️ | ⚠️ | |
-| [scala](../by-language/scala.md) | [Quill](../detail/lang.scala.orm.quill.md) | ❌ | ⚠️ | ⚠️ | |
-| [scala](../by-language/scala.md) | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ | ⚠️ | ⚠️ | |
-| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | — | ⚠️ | ⚠️ | |
-| [scala](../by-language/scala.md) | [Slick](../detail/lang.scala.orm.slick.md) | ❌ | ⚠️ | ⚠️ | |
+
+## ORM / Data Mapper
+
+| Language | Name | Other capabilities | Notes |
+|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | ❌ 0/8 | |
+| [C/C++](../by-language/c-cpp.md) | [ODB](../detail/lang.c-cpp.orm.odb.md) | ❌ 0/8 | |
+| [C/C++](../by-language/c-cpp.md) | [SOCI](../detail/lang.c-cpp.orm.soci.md) | ❌ 0/8 | |
+| [C/C++](../by-language/c-cpp.md) | [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | ❌ 0/8 | |
+| [C/C++](../by-language/c-cpp.md) | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | ❌ 0/8 | |
+| [C/C++](../by-language/c-cpp.md) | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ❌ 0/8 | |
+| [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ 2/8 | |
+| [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ 2/8 | |
+| [elixir](../by-language/elixir.md) | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [MyXQL](../detail/lang.elixir.driver.myxql.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [Postgrex](../detail/lang.elixir.driver.postgrex.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [Redix](../detail/lang.elixir.driver.redix.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [GORM](../detail/lang.go.orm.gorm.md) | ❌ 2/8 | |
+| [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | ❌ 2/8 | |
+| [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ 2/8 | |
+| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ 1/8 | |
+| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 2/8 | |
+| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ 0/8 | |
+| [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ❌ 3/8 | |
+| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/8 | |
+| [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ 3/8 | |
+| [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ❌ 2/8 | |
+| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 4/9 | |
+| [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | ❌ 3/8 | |
+| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ 3/8 | |
+| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 4/8 | |
+| [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | ❌ 1/8 | |
+| [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ 0/8 | |
+| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ 0/8 | |
+| [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | ❌ 0/8 | |
+| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ 0/8 | |
+| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ 0/8 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ❌ 2/8 | |
+| [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | ❌ 2/8 | |
+| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ❌ 6/8 | |
+| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ❌ 5/8 | |
+| [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ 2/8 | |
+| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 1/8 | |
+| [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | ❌ 0/8 | |
+| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ 2/8 | |
+| [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ 2/8 | |
+| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | ❌ 2/8 | |
+| [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [neo4rs](../detail/lang.rust.driver.neo4j.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | ❌ 0/8 | |
+| [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ 0/8 | |
+| [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | ❌ 0/8 | |
+| [scala](../by-language/scala.md) | [Quill](../detail/lang.scala.orm.quill.md) | ❌ 0/8 | |
+| [scala](../by-language/scala.md) | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ 0/8 | |
+| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | ❌ 0/8 | |
+| [scala](../by-language/scala.md) | [Slick](../detail/lang.scala.orm.slick.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -66,12 +66,15 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | ❌ | ❌ | ❌ | |
-| [ODB](../detail/lang.c-cpp.orm.odb.md) | ❌ | ❌ | ❌ | |
-| [SOCI](../detail/lang.c-cpp.orm.soci.md) | ❌ | ❌ | ❌ | |
-| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | ❌ | ❌ | ❌ | |
-| [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | ❌ | ❌ | ❌ | |
-| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ❌ | ❌ | ❌ | |
-| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ❌ | ❌ | ❌ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | ❌ 0/8 | |
+| [ODB](../detail/lang.c-cpp.orm.odb.md) | ❌ 0/8 | |
+| [SOCI](../detail/lang.c-cpp.orm.soci.md) | ❌ 0/8 | |
+| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | ❌ 0/8 | |
+| [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | ❌ 0/8 | |
+| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ❌ 0/8 | |
+| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -67,19 +67,22 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | — | — | ⚠️ | |
-| [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | — | — | ⚠️ | |
-| [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ | ⚠️ | ⚠️ | |
-| [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ | ✅ | ✅ | |
-| [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ | ⚠️ | ⚠️ | |
-| [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ | ❌ | ❌ | |
-| [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | — | — | ⚠️ | |
-| [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | — | — | ⚠️ | |
-| [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | — | — | ⚠️ | |
-| [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | — | — | ⚠️ | |
-| [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ | ⚠️ | ⚠️ | |
-| [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | — | — | ⚠️ | |
-| [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | — | — | ⚠️ | |
-| [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | — | — | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | ❌ 0/8 | |
+| [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | ❌ 0/8 | |
+| [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ 0/8 | |
+| [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ 2/8 | |
+| [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ 0/8 | |
+| [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ 0/8 | |
+| [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | ❌ 0/8 | |
+| [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | ❌ 0/8 | |
+| [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | ❌ 0/8 | |
+| [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | ❌ 0/8 | |
+| [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ 0/8 | |
+| [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | ❌ 0/8 | |
+| [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | ❌ 0/8 | |
+| [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -41,15 +41,18 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ | ✅ | ✅ | |
-| [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | — | — | ⚠️ | |
-| [MyXQL](../detail/lang.elixir.driver.myxql.md) | — | — | ⚠️ | |
-| [Postgrex](../detail/lang.elixir.driver.postgrex.md) | — | — | ⚠️ | |
-| [Redix](../detail/lang.elixir.driver.redix.md) | — | — | ⚠️ | |
-| [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | — | — | ⚠️ | |
-| [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | — | — | ⚠️ | |
-| [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ | ⚠️ | ⚠️ | |
-| [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | — | — | ⚠️ | |
-| [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | — | — | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ 2/8 | |
+| [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | ❌ 0/8 | |
+| [MyXQL](../detail/lang.elixir.driver.myxql.md) | ❌ 0/8 | |
+| [Postgrex](../detail/lang.elixir.driver.postgrex.md) | ❌ 0/8 | |
+| [Redix](../detail/lang.elixir.driver.redix.md) | ❌ 0/8 | |
+| [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | ❌ 0/8 | |
+| [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | ❌ 0/8 | |
+| [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ 0/8 | |
+| [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | ❌ 0/8 | |
+| [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -58,22 +58,25 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | — | — | ⚠️ | |
-| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ | ⚠️ | ⚠️ | |
-| [GORM](../detail/lang.go.orm.gorm.md) | ❌ | ✅ | ✅ | |
-| [ent (Facebook)](../detail/lang.go.orm.ent.md) | ❌ | ✅ | ✅ | |
-| [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | ❌ | ❌ | ❌ | |
-| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | — | — | ⚠️ | |
-| [go-redis](../detail/lang.go.driver.redis.md) | — | — | ⚠️ | |
-| [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | — | — | ⚠️ | |
-| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | — | — | ⚠️ | |
-| [golang-migrate](../detail/lang.go.orm.migrate.md) | ⚠️ | — | — | |
-| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | — | — | ⚠️ | |
-| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | — | — | ⚠️ | |
-| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | — | — | ⚠️ | |
-| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | — | — | ⚠️ | |
-| [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ⚠️ | ⚠️ | ⚠️ | |
-| [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ | ⚠️ | ⚠️ | |
-| [xo (codegen)](../detail/lang.go.orm.xo.md) | ❌ | ❌ | ❌ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | ❌ 0/8 | |
+| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ 0/8 | |
+| [GORM](../detail/lang.go.orm.gorm.md) | ❌ 2/8 | |
+| [ent (Facebook)](../detail/lang.go.orm.ent.md) | ❌ 2/8 | |
+| [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | ❌ 0/8 | |
+| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | ❌ 0/8 | |
+| [go-redis](../detail/lang.go.driver.redis.md) | ❌ 0/8 | |
+| [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | ❌ 0/8 | |
+| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | ❌ 0/8 | |
+| [golang-migrate](../detail/lang.go.orm.migrate.md) | ❌ 0/8 | |
+| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | ❌ 0/8 | |
+| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | ❌ 0/8 | |
+| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | ❌ 0/8 | |
+| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | ❌ 0/8 | |
+| [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ❌ 0/8 | |
+| [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ 0/8 | |
+| [xo (codegen)](../detail/lang.go.orm.xo.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -74,21 +74,25 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | — | ⚠️ | ⚠️ | |
-| [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ | ❌ | ❌ | |
-| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ | ❌ | ❌ | |
-| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ | ✅ | ✅ | |
-| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ | ✅ | ⚠️ | |
-| [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ | ⚠️ | ⚠️ | |
-| [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ | ⚠️ | ⚠️ | |
-| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ | ⚠️ | ⚠️ | |
-| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ | ⚠️ | ⚠️ | |
-| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ | ✅ | ✅ | |
-| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ | ⚠️ | ⚠️ | |
-| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ | ⚠️ | ⚠️ | |
-| [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ | ⚠️ | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | ❌ 0/8 | |
+| [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ 0/8 | |
+| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ 0/8 | |
+| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ 2/8 | |
+| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ 1/8 | |
+| [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 0/8 | |
+| [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 0/8 | |
+| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 0/8 | |
+| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 0/8 | |
+| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 2/8 | |
+| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 0/8 | |
+| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 0/8 | |
+| [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ 0/8 | |
+
 
 ## Other
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -108,26 +108,30 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | — | — | ✅ | |
-| [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | — | — | ✅ | |
-| [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ✅ | ✅ | ✅ | |
-| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ | — | ✅ | |
-| [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ✅ | ✅ | ✅ | |
-| [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | — | — | ✅ | |
-| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | — | ✅ | ✅ | |
-| [Objection.js](../detail/lang.jsts.orm.objection.md) | ✅ | ✅ | ✅ | |
-| [Prisma](../detail/lang.jsts.orm.prisma.md) | ✅ | ✅ | ✅ | |
-| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ✅ | ✅ | ✅ | |
-| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ✅ | ✅ | ✅ | |
-| [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | — | — | ✅ | |
-| [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | — | — | ✅ | |
-| [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | — | — | ✅ | |
-| [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | — | — | ✅ | |
-| [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | — | — | ✅ | |
-| [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | — | — | ✅ | |
-| [supabase-js](../detail/lang.jsts.driver.supabase.md) | — | — | ✅ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ❌ 1/8 | |
+| [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ❌ 1/8 | |
+| [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ❌ 3/8 | |
+| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/8 | |
+| [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ 3/8 | |
+| [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ❌ 1/8 | |
+| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ❌ 2/8 | |
+| [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 4/9 | |
+| [Prisma](../detail/lang.jsts.orm.prisma.md) | ❌ 3/8 | |
+| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ 3/8 | |
+| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 4/8 | |
+| [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ❌ 1/8 | |
+| [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ❌ 1/8 | |
+| [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ❌ 1/8 | |
+| [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | ❌ 1/8 | |
+| [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | ❌ 1/8 | |
+| [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ❌ 1/8 | |
+| [supabase-js](../detail/lang.jsts.driver.supabase.md) | ❌ 1/8 | |
+
 
 ## Other
 

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -40,12 +40,15 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ | ✅ | ✅ | |
-| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ | ⚠️ | ⚠️ | |
-| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ | ⚠️ | ⚠️ | |
-| [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | — | ⚠️ | ⚠️ | |
-| [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ | ⚠️ | ⚠️ | |
-| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ | ⚠️ | ⚠️ | |
-| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ | ⚠️ | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ 2/8 | |
+| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ 0/8 | |
+| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ 0/8 | |
+| [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | ❌ 0/8 | |
+| [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ 0/8 | |
+| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ 0/8 | |
+| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -39,19 +39,22 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | — | — | ⚠️ | |
-| [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ | ❌ | ❌ | |
-| [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ❌ | ✅ | ✅ | |
-| [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | ❌ | ✅ | ✅ | |
-| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | — | — | ⚠️ | |
-| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | — | — | ⚠️ | |
-| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | — | — | ⚠️ | |
-| [Propel](../detail/lang.php.orm.propel.md) | ❌ | ⚠️ | ⚠️ | |
-| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ | ⚠️ | ⚠️ | |
-| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | — | — | ⚠️ | |
-| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | — | — | ⚠️ | |
-| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | — | — | ⚠️ | |
-| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | — | — | ⚠️ | |
-| [phpredis / Predis](../detail/lang.php.driver.redis.md) | — | — | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | ❌ 0/8 | |
+| [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ 0/8 | |
+| [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ❌ 2/8 | |
+| [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | ❌ 2/8 | |
+| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | ❌ 0/8 | |
+| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | ❌ 0/8 | |
+| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | ❌ 0/8 | |
+| [Propel](../detail/lang.php.orm.propel.md) | ❌ 0/8 | |
+| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ 0/8 | |
+| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | ❌ 0/8 | |
+| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | ❌ 0/8 | |
+| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | ❌ 0/8 | |
+| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | ❌ 0/8 | |
+| [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -69,25 +69,29 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ⚠️ | — | — | |
-| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | — | ⚠️ | ⚠️ | |
-| [Django ORM](../detail/lang.python.orm.django.md) | ✅ | ✅ | ✅ | |
-| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | — | ⚠️ | ⚠️ | |
-| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | — | — | ⚠️ | |
-| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ | ⚠️ | ⚠️ | |
-| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ | ⚠️ | ⚠️ | |
-| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ | ✅ | ✅ | |
-| [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ | ✅ | ✅ | |
-| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ | ✅ | ⚠️ | |
-| [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | — | — | ⚠️ | |
-| [cassandra-driver](../detail/lang.python.driver.cassandra.md) | — | — | ⚠️ | |
-| [elasticsearch-py](../detail/lang.python.driver.elastic.md) | — | — | ⚠️ | |
-| [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | — | — | ⚠️ | |
-| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | — | — | ⚠️ | |
-| [redis-py](../detail/lang.python.driver.redis.md) | — | — | ⚠️ | |
-| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | — | — | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 0/8 | |
+| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 0/8 | |
+| [Django ORM](../detail/lang.python.orm.django.md) | ❌ 6/8 | |
+| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 0/8 | |
+| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 0/8 | |
+| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 0/8 | |
+| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 0/8 | |
+| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ❌ 5/8 | |
+| [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ 2/8 | |
+| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 1/8 | |
+| [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ❌ 0/8 | |
+| [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ❌ 0/8 | |
+| [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ❌ 0/8 | |
+| [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | ❌ 0/8 | |
+| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | ❌ 0/8 | |
+| [redis-py](../detail/lang.python.driver.redis.md) | ❌ 0/8 | |
+| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | ❌ 0/8 | |
+
 
 ## Other
 

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -35,21 +35,25 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | — | — | ⚠️ | |
-| [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ | ✅ | ✅ | |
-| [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ | ⚠️ | ⚠️ | |
-| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | — | ⚠️ | ⚠️ | |
-| [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ | ⚠️ | ⚠️ | |
-| [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ | ⚠️ | ⚠️ | |
-| [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | — | — | ⚠️ | |
-| [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | — | — | ⚠️ | |
-| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | — | — | ⚠️ | |
-| [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | — | — | ⚠️ | |
-| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | — | — | ⚠️ | |
-| [redis-rb](../detail/lang.ruby.driver.redis.md) | — | — | ⚠️ | |
-| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | — | — | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | ❌ 0/8 | |
+| [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ 2/8 | |
+| [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ 0/8 | |
+| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | ❌ 0/8 | |
+| [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ 0/8 | |
+| [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ 0/8 | |
+| [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | ❌ 0/8 | |
+| [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | ❌ 0/8 | |
+| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | ❌ 0/8 | |
+| [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | ❌ 0/8 | |
+| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | ❌ 0/8 | |
+| [redis-rb](../detail/lang.ruby.driver.redis.md) | ❌ 0/8 | |
+| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | ❌ 0/8 | |
+
 
 ## Other
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -44,19 +44,22 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ | ✅ | ✅ | |
-| [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ | ❌ | ❌ | |
-| [SeaORM](../detail/lang.rust.orm.seaorm.md) | ❌ | ✅ | ✅ | |
-| [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | — | — | ⚠️ | |
-| [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | — | — | ⚠️ | |
-| [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | — | — | ⚠️ | |
-| [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | — | — | ⚠️ | |
-| [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | — | — | ⚠️ | |
-| [neo4rs](../detail/lang.rust.driver.neo4j.md) | — | — | ⚠️ | |
-| [redis-rs](../detail/lang.rust.driver.redis.md) | — | — | ⚠️ | |
-| [rusqlite](../detail/lang.rust.orm.rusqlite.md) | — | — | ⚠️ | |
-| [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | — | — | ⚠️ | |
-| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ | ⚠️ | ⚠️ | |
-| [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | — | — | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ 2/8 | |
+| [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ 0/8 | |
+| [SeaORM](../detail/lang.rust.orm.seaorm.md) | ❌ 2/8 | |
+| [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | ❌ 0/8 | |
+| [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | ❌ 0/8 | |
+| [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | ❌ 0/8 | |
+| [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | ❌ 0/8 | |
+| [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | ❌ 0/8 | |
+| [neo4rs](../detail/lang.rust.driver.neo4j.md) | ❌ 0/8 | |
+| [redis-rs](../detail/lang.rust.driver.redis.md) | ❌ 0/8 | |
+| [rusqlite](../detail/lang.rust.orm.rusqlite.md) | ❌ 0/8 | |
+| [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | ❌ 0/8 | |
+| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ 0/8 | |
+| [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -39,11 +39,14 @@ Back to [summary](../summary.md).
 
 ## ORMs
 
-| Name | Migration parsing | Model extraction | Query attribution | Notes |
-|---|---|---|---|---|
-| [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ | ⚠️ | ⚠️ | |
-| [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | — | ⚠️ | ⚠️ | |
-| [Quill](../detail/lang.scala.orm.quill.md) | ❌ | ⚠️ | ⚠️ | |
-| [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ | ⚠️ | ⚠️ | |
-| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | — | ⚠️ | ⚠️ | |
-| [Slick](../detail/lang.scala.orm.slick.md) | ❌ | ⚠️ | ⚠️ | |
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ 0/8 | |
+| [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | ❌ 0/8 | |
+| [Quill](../detail/lang.scala.orm.quill.md) | ❌ 0/8 | |
+| [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ 0/8 | |
+| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | ❌ 0/8 | |
+| [Slick](../detail/lang.scala.orm.slick.md) | ❌ 0/8 | |

--- a/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.orm.odb.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.odb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.orm.soci.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.soci.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.orm.sqlpp11.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.sqlpp11.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C/C++](../by-language/c-cpp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.cassandra.md
+++ b/docs/coverage/detail/lang.csharp.driver.cassandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/cassandra_csharp.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/cassandra_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/dynamodb_csharp.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/dynamodb_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.elastic.md
+++ b/docs/coverage/detail/lang.csharp.driver.elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/nest_elasticsearch.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/nest_elasticsearch.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.mongodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.mongodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/mongodb_csharp.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/mongodb_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.mysql.md
+++ b/docs/coverage/detail/lang.csharp.driver.mysql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/mysql_csharp.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/mysql_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.neo4j.md
+++ b/docs/coverage/detail/lang.csharp.driver.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/neo4j.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.npgsql.md
+++ b/docs/coverage/detail/lang.csharp.driver.npgsql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/npgsql.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/npgsql.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.redis.md
+++ b/docs/coverage/detail/lang.csharp.driver.redis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/redis_stackexchange.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/redis_stackexchange.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.driver.sqlite.md
+++ b/docs/coverage/detail/lang.csharp.driver.sqlite.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/sqlite_csharp.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/sqlite_csharp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.dapper.md
+++ b/docs/coverage/detail/lang.csharp.orm.dapper.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/dapper.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/dapper.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/dapper.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/dapper.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.efcore.md
+++ b/docs/coverage/detail/lang.csharp.orm.efcore.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/csharp/frameworks/entity_framework_core.yaml`<br>`internal/engine/rules/csharp/orms/entity_framework_core.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/csharp/frameworks/entity_framework_core.yaml`<br>`internal/engine/rules/csharp/orms/entity_framework_core.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
+++ b/docs/coverage/detail/lang.csharp.orm.linq-to-sql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.linqtodb.md
+++ b/docs/coverage/detail/lang.csharp.orm.linqtodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.csharp.orm.nhibernate.md
+++ b/docs/coverage/detail/lang.csharp.orm.nhibernate.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [C#](../by-language/csharp.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/nhibernate.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.elastic.md
+++ b/docs/coverage/detail/lang.elixir.driver.elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.mongodb.md
+++ b/docs/coverage/detail/lang.elixir.driver.mongodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.myxql.md
+++ b/docs/coverage/detail/lang.elixir.driver.myxql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/myxql.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/myxql.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.neo4j.md
+++ b/docs/coverage/detail/lang.elixir.driver.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/orms/neo4j.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.postgrex.md
+++ b/docs/coverage/detail/lang.elixir.driver.postgrex.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/postgrex.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/postgrex.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.redix.md
+++ b/docs/coverage/detail/lang.elixir.driver.redix.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/redix.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/redix.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.driver.xandra.md
+++ b/docs/coverage/detail/lang.elixir.driver.xandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/xandra.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/xandra.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto-sqlite3.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.elixir.orm.ecto.md
+++ b/docs/coverage/detail/lang.elixir.orm.ecto.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ecto_standalone.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/ecto_standalone.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.cassandra.md
+++ b/docs/coverage/detail/lang.go.driver.cassandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/cassandra_go.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/cassandra_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.go.driver.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/dynamodb_go.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/dynamodb_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.elastic.md
+++ b/docs/coverage/detail/lang.go.driver.elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.mongodb.md
+++ b/docs/coverage/detail/lang.go.driver.mongodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/mongo_driver.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/mongo_driver.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.mysql.md
+++ b/docs/coverage/detail/lang.go.driver.mysql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/mysql_go.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/mysql_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.neo4j.md
+++ b/docs/coverage/detail/lang.go.driver.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/neo4j.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.redis.md
+++ b/docs/coverage/detail/lang.go.driver.redis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/go_redis.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/go_redis.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.sqlite.md
+++ b/docs/coverage/detail/lang.go.driver.sqlite.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlite_go.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlite_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.bun.md
+++ b/docs/coverage/detail/lang.go.orm.bun.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/bun.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/bun.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/bun.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/bun.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.ent.md
+++ b/docs/coverage/detail/lang.go.orm.ent.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/go/orms/ent.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/go/orms/ent.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.gen.md
+++ b/docs/coverage/detail/lang.go.orm.gen.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.gorm.md
+++ b/docs/coverage/detail/lang.go.orm.gorm.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/go/frameworks/gorm.yaml`<br>`internal/engine/rules/go/orms/gorm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/go/frameworks/gorm.yaml`<br>`internal/engine/rules/go/orms/gorm.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.migrate.md
+++ b/docs/coverage/detail/lang.go.orm.migrate.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | — `not_applicable` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/golang_migrate.yaml` | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | — `not_applicable` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.pgx.md
+++ b/docs/coverage/detail/lang.go.orm.pgx.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/pgx.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/pgx.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.sqlc.md
+++ b/docs/coverage/detail/lang.go.orm.sqlc.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlc.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlc.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlc.yaml` | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlc.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlc.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.sqlx.md
+++ b/docs/coverage/detail/lang.go.orm.sqlx.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlx.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlx.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlx.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlx.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.orm.xo.md
+++ b/docs/coverage/detail/lang.go.orm.xo.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [go](../by-language/go.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.dynamodb.md
+++ b/docs/coverage/detail/lang.java.orm.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/dynamodb_java.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.ebean.md
+++ b/docs/coverage/detail/lang.java.orm.ebean.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.eclipselink.md
+++ b/docs/coverage/detail/lang.java.orm.eclipselink.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.hibernate.md
+++ b/docs/coverage/detail/lang.java.orm.hibernate.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/hibernate_core.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/hibernate_core.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.jooq.md
+++ b/docs/coverage/detail/lang.java.orm.jooq.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/jooq.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/jooq.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/jooq.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/jooq.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.jpa.md
+++ b/docs/coverage/detail/lang.java.orm.jpa.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.mybatis.md
+++ b/docs/coverage/detail/lang.java.orm.mybatis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/mybatis.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/mybatis.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/mybatis.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/mybatis.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.neo4j.md
+++ b/docs/coverage/detail/lang.java.orm.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/neo4j.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/neo4j.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/neo4j.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/spring_data_jpa.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/spring_data_jpa.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [java](../by-language/java.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.cassandra.md
+++ b/docs/coverage/detail/lang.jsts.driver.cassandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.elastic.md
+++ b/docs/coverage/detail/lang.jsts.driver.elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.mongodb.md
+++ b/docs/coverage/detail/lang.jsts.driver.mongodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.mysql.md
+++ b/docs/coverage/detail/lang.jsts.driver.mysql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.neo4j.md
+++ b/docs/coverage/detail/lang.jsts.driver.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | Includes Cypher node-label attribution: session.run('MATCH (n:Label) ...') resolves the graph node label as the queried resource and maps MATCH/CREATE/MERGE/SET/DELETE clauses to canonical operations. |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | Includes Cypher node-label attribution: session.run('MATCH (n:Label) ...') resolves the graph node label as the queried resource and maps MATCH/CREATE/MERGE/SET/DELETE clauses to canonical operations. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.postgres.md
+++ b/docs/coverage/detail/lang.jsts.driver.postgres.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.redis.md
+++ b/docs/coverage/detail/lang.jsts.driver.redis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.sqlite.md
+++ b/docs/coverage/detail/lang.jsts.driver.sqlite.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.driver.supabase.md
+++ b/docs/coverage/detail/lang.jsts.driver.supabase.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go`<br>`internal/engine/orm_queries_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go`<br>`internal/engine/orm_queries_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.drizzle.md
+++ b/docs/coverage/detail/lang.jsts.orm.drizzle.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/drizzle.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/drizzle.go`<br>`internal/custom/javascript/extractors_coverage_test.go` | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/drizzle.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.knex.md
+++ b/docs/coverage/detail/lang.jsts.orm.knex.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | Knex is a SQL query builder, not an ORM — it has no model/entity layer to extract. Persistent model_extraction belongs to Objection.js, which layers Active-Record models on top of Knex (see lang.jsts.orm.objection). |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/knex.go` | — |
-| Model extraction | — `not_applicable` | — | — | — | Knex is a SQL query builder, not an ORM — it has no model/entity layer to extract. Persistent model_extraction belongs to Objection.js, which layers Active-Record models on top of Knex (see lang.jsts.orm.objection). |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
+++ b/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mikroorm.go`<br>`internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mikroorm.go` | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mikroorm.go`<br>`internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.mongoose.md
+++ b/docs/coverage/detail/lang.jsts.orm.mongoose.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/mongoose.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/mongoose.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.objection.md
+++ b/docs/coverage/detail/lang.jsts.orm.objection.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 4
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 9
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go`<br>`internal/engine/rules/javascript_typescript/orms/objection.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | — | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go`<br>`internal/engine/rules/javascript_typescript/orms/objection.yaml` | — |
-| Query attribution | ✅ `full` | — | — | `internal/engine/orm_queries_jsts_drivers.go`<br>`internal/engine/orm_queries_jsts_drivers_test.go` | — |
 
 ## Framework-specific
 

--- a/docs/coverage/detail/lang.jsts.orm.prisma.md
+++ b/docs/coverage/detail/lang.jsts.orm.prisma.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/prisma.yaml`<br>`internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml`<br>`internal/engine/rules/prisma/_manifest.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/prisma.go` | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/prisma.yaml`<br>`internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml`<br>`internal/engine/rules/prisma/_manifest.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.sequelize.md
+++ b/docs/coverage/detail/lang.jsts.orm.sequelize.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/sequelize.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/sequelize.go` | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/sequelize.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.jsts.orm.typeorm.md
+++ b/docs/coverage/detail/lang.jsts.orm.typeorm.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/typeorm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/javascript/typeorm.go` | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/typeorm.go` | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/typeorm.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_jsts.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.exposed.md
+++ b/docs/coverage/detail/lang.kotlin.orm.exposed.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/exposed.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/exposed.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/exposed.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/exposed.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.hibernate.md
+++ b/docs/coverage/detail/lang.kotlin.orm.hibernate.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.ktorm.md
+++ b/docs/coverage/detail/lang.kotlin.orm.ktorm.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.mongodb.md
+++ b/docs/coverage/detail/lang.kotlin.orm.mongodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.room.md
+++ b/docs/coverage/detail/lang.kotlin.orm.room.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/room_android.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/room_android.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/room_android.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/room_android.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.spring-data.md
+++ b/docs/coverage/detail/lang.kotlin.orm.spring-data.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
+++ b/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [kotlin](../by-language/kotlin.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.cassandra.md
+++ b/docs/coverage/detail/lang.php.driver.cassandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/cassandra_php.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/cassandra_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.php.driver.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/dynamodb_php.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/dynamodb_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.elastic.md
+++ b/docs/coverage/detail/lang.php.driver.elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/elasticsearch_php.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/elasticsearch_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.mongodb.md
+++ b/docs/coverage/detail/lang.php.driver.mongodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/mongodb_php.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/mongodb_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.mysql.md
+++ b/docs/coverage/detail/lang.php.driver.mysql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/mysql_php.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/mysql_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.neo4j.md
+++ b/docs/coverage/detail/lang.php.driver.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/neo4j.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.postgres.md
+++ b/docs/coverage/detail/lang.php.driver.postgres.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/postgresql_php.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/postgresql_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.redis.md
+++ b/docs/coverage/detail/lang.php.driver.redis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/redis_php.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/redis_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.driver.sqlite.md
+++ b/docs/coverage/detail/lang.php.driver.sqlite.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/sqlite_php.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/sqlite_php.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.cycleorm.md
+++ b/docs/coverage/detail/lang.php.orm.cycleorm.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.doctrine.md
+++ b/docs/coverage/detail/lang.php.orm.doctrine.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/php/orms/doctrine_orm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/php/orms/doctrine_orm.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.eloquent.md
+++ b/docs/coverage/detail/lang.php.orm.eloquent.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/php/orms/eloquent_laravel_orm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/php/orms/eloquent_laravel_orm.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_other.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.propel.md
+++ b/docs/coverage/detail/lang.php.orm.propel.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/propel.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/propel.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/propel.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/propel.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.redbeanphp.md
+++ b/docs/coverage/detail/lang.php.orm.redbeanphp.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [php](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/redbeanphp.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/redbeanphp.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/redbeanphp.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/redbeanphp.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.cassandra.md
+++ b/docs/coverage/detail/lang.python.driver.cassandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/cassandra_py.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/cassandra_py.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.python.driver.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/dynamodb_py.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/dynamodb_py.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.elastic.md
+++ b/docs/coverage/detail/lang.python.driver.elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/elasticsearch_py.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/elasticsearch_py.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.mysql.md
+++ b/docs/coverage/detail/lang.python.driver.mysql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mysql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mysql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.neo4j.md
+++ b/docs/coverage/detail/lang.python.driver.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/neo4j.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.postgres.md
+++ b/docs/coverage/detail/lang.python.driver.postgres.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/postgresql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/postgresql_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.redis.md
+++ b/docs/coverage/detail/lang.python.driver.redis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/redis_py.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/redis_py.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.driver.sqlite.md
+++ b/docs/coverage/detail/lang.python.driver.sqlite.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/sqlite_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/sqlite_py.yaml`<br>`internal/extractors/python/raw_sql_db_calls.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.alembic.md
+++ b/docs/coverage/detail/lang.python.orm.alembic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | — `not_applicable` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/alembic.yaml` | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | — `not_applicable` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.django.md
+++ b/docs/coverage/detail/lang.python.orm.django.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/django_orm.yaml`<br>`internal/extractors/python/django_relational.go` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/django_relational.go` | — |
+| Foreign key extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/django_relational.go` | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/django_relational.go` | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_python.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/python/django_migration.go` | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/django_orm.yaml`<br>`internal/extractors/python/django_relational.go` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_python.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.peewee.md
+++ b/docs/coverage/detail/lang.python.orm.peewee.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/peewee.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/peewee.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/peewee.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/peewee.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.pony.md
+++ b/docs/coverage/detail/lang.python.orm.pony.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/pony_orm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/pony_orm.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/pony_orm.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/pony_orm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.sqlalchemy.md
+++ b/docs/coverage/detail/lang.python.orm.sqlalchemy.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/python/orms/sqlalchemy.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/python/sqlalchemy.go` | — |
+| Foreign key extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/python/sqlalchemy.go` | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/python/sqlalchemy.go` | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_python.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/alembic.yaml` | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/python/orms/sqlalchemy.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_python.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.sqlmodel.md
+++ b/docs/coverage/detail/lang.python.orm.sqlmodel.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/sqlmodel.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_python.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/sqlmodel.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries_python.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.tortoise.md
+++ b/docs/coverage/detail/lang.python.orm.tortoise.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [python](../by-language/python.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/tortoise_orm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/orm_queries_python.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/tortoise_orm.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/orm_queries_python.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.cassandra.md
+++ b/docs/coverage/detail/lang.ruby.driver.cassandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/cassandra_ruby.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/cassandra_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.ruby.driver.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/dynamodb_ruby.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/dynamodb_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.elastic.md
+++ b/docs/coverage/detail/lang.ruby.driver.elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.mysql.md
+++ b/docs/coverage/detail/lang.ruby.driver.mysql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/mysql_ruby.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/mysql_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.neo4j.md
+++ b/docs/coverage/detail/lang.ruby.driver.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/neo4j.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.postgres.md
+++ b/docs/coverage/detail/lang.ruby.driver.postgres.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/pg_ruby.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/pg_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.redis.md
+++ b/docs/coverage/detail/lang.ruby.driver.redis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/redis_rb.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/redis_rb.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.driver.sqlite.md
+++ b/docs/coverage/detail/lang.ruby.driver.sqlite.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/sqlite_ruby.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/sqlite_ruby.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.activerecord.md
+++ b/docs/coverage/detail/lang.ruby.orm.activerecord.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/activerecord.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/activerecord.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.datamapper.md
+++ b/docs/coverage/detail/lang.ruby.orm.datamapper.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.mongoid.md
+++ b/docs/coverage/detail/lang.ruby.orm.mongoid.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/mongoid.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/mongoid.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/mongoid.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/mongoid.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.rom-rb.md
+++ b/docs/coverage/detail/lang.ruby.orm.rom-rb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml`<br>`internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml`<br>`internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.ruby.orm.sequel.md
+++ b/docs/coverage/detail/lang.ruby.orm.sequel.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [ruby](../by-language/ruby.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/sequel.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/sequel.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/sequel.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/sequel.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.cassandra.md
+++ b/docs/coverage/detail/lang.rust.driver.cassandra.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/cassandra_rust.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/cassandra_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.rust.driver.dynamodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/dynamodb_rust.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/dynamodb_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.elastic.md
+++ b/docs/coverage/detail/lang.rust.driver.elastic.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/elasticsearch_rs.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/elasticsearch_rs.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.mongodb.md
+++ b/docs/coverage/detail/lang.rust.driver.mongodb.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/mongodb_mongodb.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/mongodb_mongodb.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.mysql.md
+++ b/docs/coverage/detail/lang.rust.driver.mysql.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/mysql_rust.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/mysql_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.neo4j.md
+++ b/docs/coverage/detail/lang.rust.driver.neo4j.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/neo4j.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/neo4j.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.postgres.md
+++ b/docs/coverage/detail/lang.rust.driver.postgres.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/postgresql_rust.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/postgresql_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.redis.md
+++ b/docs/coverage/detail/lang.rust.driver.redis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/redis_redis_rs.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/redis_redis_rs.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.driver.sqlite.md
+++ b/docs/coverage/detail/lang.rust.driver.sqlite.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/sqlite_rust.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/sqlite_rust.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.diesel.md
+++ b/docs/coverage/detail/lang.rust.orm.diesel.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/diesel.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/diesel.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/diesel.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/diesel.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.rbatis.md
+++ b/docs/coverage/detail/lang.rust.orm.rbatis.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ❌ `missing` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ❌ `missing` | — | — | — | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ❌ `missing` | — | — | — | — |
-| Query attribution | ❌ `missing` | — | — | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.rusqlite.md
+++ b/docs/coverage/detail/lang.rust.orm.rusqlite.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/rusqlite.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/rusqlite.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.seaorm.md
+++ b/docs/coverage/detail/lang.rust.orm.seaorm.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/seaorm.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/seaorm.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/seaorm.yaml` | — |
-| Query attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/seaorm.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.sqlx.md
+++ b/docs/coverage/detail/lang.rust.orm.sqlx.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [rust](../by-language/rust.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/sqlx.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/sqlx.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/sqlx.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/sqlx.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.doobie.md
+++ b/docs/coverage/detail/lang.scala.orm.doobie.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/doobie.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/doobie.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/doobie.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/doobie.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.elastic4s.md
+++ b/docs/coverage/detail/lang.scala.orm.elastic4s.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/elastic4s.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/elastic4s.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/elastic4s.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/elastic4s.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.quill.md
+++ b/docs/coverage/detail/lang.scala.orm.quill.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/quill.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/quill.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/quill.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/quill.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.scalikejdbc.md
+++ b/docs/coverage/detail/lang.scala.orm.scalikejdbc.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scalikejdbc.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.scanamo.md
+++ b/docs/coverage/detail/lang.scala.orm.scanamo.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scanamo.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scanamo.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | — `not_applicable` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scanamo.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/scanamo.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.scala.orm.slick.md
+++ b/docs/coverage/detail/lang.scala.orm.slick.md
@@ -5,15 +5,39 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [scala](../by-language/scala.md)
 - **Category:** [orm](../by-category/orm.md)
-- **Capability cells:** 3
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
 
 ## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/slick.yaml` | — |
+| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/slick.yaml` | — |
+
+### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Migration parsing | ❌ `missing` | — | — | — | — |
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/slick.yaml` | — |
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/scala/orms/slick.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1716,68 +1716,184 @@
     {
       "id": "lang.c-cpp.driver.libpqxx",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "c-cpp",
       "label": "libpqxx (PostgreSQL)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.c-cpp.driver.mongocxx",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "c-cpp",
       "label": "mongocxx",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.c-cpp.driver.mysql-connector-cpp",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "c-cpp",
       "label": "MySQL Connector/C++",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.c-cpp.driver.redis-plus-plus",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "c-cpp",
       "label": "redis-plus-plus",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -3669,51 +3785,138 @@
     {
       "id": "lang.c-cpp.orm.odb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "c-cpp",
       "label": "ODB",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.c-cpp.orm.soci",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "c-cpp",
       "label": "SOCI",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.c-cpp.orm.sqlpp11",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "c-cpp",
       "label": "sqlpp11",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -3964,171 +4167,432 @@
     {
       "id": "lang.csharp.driver.cassandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "CassandraCSharpDriver",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.driver.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "AWSSDK.DynamoDBv2",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.driver.elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "NEST (Elasticsearch .NET)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.driver.mongodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "MongoDB.Driver (C#)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.driver.mysql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "MySQL.Data / MySqlConnector",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.driver.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "Neo4j.Driver (C#)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.driver.npgsql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "Npgsql (PostgreSQL)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.driver.redis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "StackExchange.Redis",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.driver.sqlite",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "Microsoft.Data.Sqlite",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
@@ -5777,253 +6241,630 @@
     {
       "id": "lang.csharp.orm.dapper",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "Dapper",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/dapper.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.orm.efcore",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "Entity Framework Core",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/csharp/frameworks/entity_framework_core.yaml","internal/engine/rules/csharp/orms/entity_framework_core.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/csharp/frameworks/entity_framework_core.yaml","internal/engine/rules/csharp/orms/entity_framework_core.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_other.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.orm.linq-to-sql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "LINQ to SQL",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/linqpad_linq_to_sql.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.orm.linqtodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "LinqToDB",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.csharp.orm.nhibernate",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "csharp",
       "label": "NHibernate",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/csharp/orms/nhibernate.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.driver.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "ExAws DynamoDB",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/ex_aws_dynamo.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.driver.elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "elasticsearch-elixir",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/elasticsearch_elixir.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.driver.mongodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "mongodb (Elixir driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/mongodb_elixir.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.driver.myxql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "MyXQL",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/myxql.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.driver.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "bolt_sips (Neo4j)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.driver.postgrex",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "Postgrex",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/postgrex.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.driver.redix",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "Redix",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/redix.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.driver.xandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "Xandra (Cassandra)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/xandra.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
@@ -7118,194 +7959,484 @@
     {
       "id": "lang.elixir.orm.ecto",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "Ecto",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_standalone.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_other.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.elixir.orm.ecto-sqlite3",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "elixir",
       "label": "ecto_sqlite3",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/elixir/frameworks/ecto_sqlite3.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.go.driver.cassandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "gocql (Cassandra)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.go.driver.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "AWS SDK DynamoDB (Go)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.go.driver.elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "go-elasticsearch",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.go.driver.mongodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "mongo-go-driver",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.go.driver.mysql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "go-sql-driver/mysql",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/mysql_go.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.go.driver.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "neo4j-go-driver",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.go.driver.redis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "go-redis",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.go.driver.sqlite",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "mattn/go-sqlite3",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
@@ -8430,179 +9561,440 @@
     {
       "id": "lang.go.orm.bun",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "Bun (uptrace)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/bun.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/bun.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/bun.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.go.orm.ent",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "ent (Facebook)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/go/orms/ent.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/go/orms/ent.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.go.orm.gen",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "gen (gentleman / GORM gen)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.go.orm.gorm",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "GORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/go/frameworks/gorm.yaml","internal/engine/rules/go/orms/gorm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/go/frameworks/gorm.yaml","internal/engine/rules/go/orms/gorm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.go.orm.migrate",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "golang-migrate",
       "capabilities": {
-        "migration_parsing": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "not_applicable"
+        "Queries": {
+          "query_attribution": {
+            "status": "not_applicable"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/golang_migrate.yaml"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.go.orm.pgx",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "pgx (PostgreSQL driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.go.orm.sqlc",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "sqlc (codegen)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/sqlc.yaml"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.go.orm.sqlx",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "sqlx",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.go.orm.xo",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "go",
       "label": "xo (codegen)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -11933,265 +13325,642 @@
     {
       "id": "lang.java.orm.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "AWS SDK DynamoDB (Java)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/dynamodb_java.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.ebean",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "Ebean ORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.eclipselink",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "EclipseLink",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.hibernate",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "Hibernate ORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/hibernate_core.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/hibernate_core.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.jooq",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "jOOQ",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/jooq.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.jpa",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "JPA / Jakarta Persistence API",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/orm_queries.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/orm_queries.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.mybatis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "MyBatis",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "Neo4j (Java driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.spring-data-cassandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "Spring Data Cassandra",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.spring-data-elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "Spring Data Elasticsearch",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.spring-data-jpa",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "Spring Data JPA",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/spring_data_jpa.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/java/orms/spring_data_jpa.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.spring-data-mongo",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "Spring Data MongoDB",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.java.orm.spring-data-redis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "java",
       "label": "Spring Data Redis",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -12263,191 +14032,481 @@
     {
       "id": "lang.jsts.driver.cassandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "cassandra-driver (JS)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "AWS SDK DynamoDB (JS)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "@elastic/elasticsearch",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.mongodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "MongoDB Node.js driver",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.mysql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "mysql / mysql2",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "neo4j-driver (JS)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "notes": "Includes Cypher node-label attribution: session.run('MATCH (n:Label) ...') resolves the graph node label as the queried resource and maps MATCH/CREATE/MERGE/SET/DELETE clauses to canonical operations.",
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "notes": "Includes Cypher node-label attribution: session.run('MATCH (n:Label) ...') resolves the graph node label as the queried resource and maps MATCH/CREATE/MERGE/SET/DELETE clauses to canonical operations.",
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.postgres",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "node-postgres / pg",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.redis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "ioredis / node-redis",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.sqlite",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "better-sqlite3 / sqlite3",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.driver.supabase",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "supabase-js",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go","internal/engine/orm_queries_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts.go","internal/engine/orm_queries_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
@@ -15826,111 +17885,256 @@
     {
       "id": "lang.jsts.orm.drizzle",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "Drizzle",
       "capabilities": {
-        "migration_parsing": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/drizzle.go","internal/custom/javascript/extractors_coverage_test.go"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/orms/drizzle.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/drizzle.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/drizzle.go","internal/custom/javascript/extractors_coverage_test.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.orm.knex",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "Knex (query builder)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/knex.go"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable",
+            "notes": "Knex is a SQL query builder, not an ORM — it has no model/entity layer to extract. Persistent model_extraction belongs to Objection.js, which layers Active-Record models on top of Knex (see lang.jsts.orm.objection)."
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable",
-          "notes": "Knex is a SQL query builder, not an ORM — it has no model/entity layer to extract. Persistent model_extraction belongs to Objection.js, which layers Active-Record models on top of Knex (see lang.jsts.orm.objection)."
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/knex.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.orm.mikro-orm",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "MikroORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mikroorm.go"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mikroorm.go","internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mikroorm.go","internal/engine/rules/javascript_typescript/orms/mikro_orm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mikroorm.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.orm.mongoose",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "Mongoose",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/mongoose.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.orm.objection",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "Objection.js",
       "capabilities": {
-        "migration_parsing": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go","internal/engine/rules/javascript_typescript/orms/objection.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go","internal/engine/rules/javascript_typescript/orms/objection.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"]
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts_drivers.go","internal/engine/orm_queries_jsts_drivers_test.go"]
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       },
       "framework_specific": {
@@ -15947,69 +18151,157 @@
     {
       "id": "lang.jsts.orm.prisma",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "Prisma",
       "capabilities": {
-        "migration_parsing": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/prisma.go"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/orms/prisma.yaml","internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml","internal/engine/rules/prisma/_manifest.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/prisma.yaml","internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml","internal/engine/rules/prisma/_manifest.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/prisma.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.orm.sequelize",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "Sequelize",
       "capabilities": {
-        "migration_parsing": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/sequelize.go"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/orms/sequelize.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/sequelize.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/sequelize.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.jsts.orm.typeorm",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "jsts",
       "label": "TypeORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "full",
-          "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/typeorm.go"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/javascript_typescript/orms/typeorm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/javascript_typescript/orms/typeorm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/typeorm.go"],
+            "verified_at": "2026-05-29"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_jsts.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_jsts.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/typeorm.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
@@ -18254,147 +20546,350 @@
     {
       "id": "lang.kotlin.orm.exposed",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "kotlin",
       "label": "Exposed (JetBrains)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/orms/exposed.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.orm.hibernate",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "kotlin",
       "label": "Hibernate (Kotlin)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/hibernate_kotlin.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.orm.ktorm",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "kotlin",
       "label": "Ktorm",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/ktorm.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.orm.mongodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "kotlin",
       "label": "MongoDB (Kotlin driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/mongodb_kotlin.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.orm.room",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "kotlin",
       "label": "Room (Android)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/room_android.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.orm.spring-data",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "kotlin",
       "label": "Spring Data (Kotlin)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/spring_data_kotlin.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.kotlin.orm.sqldelight",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "kotlin",
       "label": "SQLDelight",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/kotlin/orms/sqldelight.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -18457,171 +20952,432 @@
     {
       "id": "lang.php.driver.cassandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "datastax/php-driver (Cassandra)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/cassandra_php.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.php.driver.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "AWS SDK DynamoDB (PHP)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/dynamodb_php.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.php.driver.elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "elasticsearch-php",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/elasticsearch_php.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.php.driver.mongodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "mongodb (PHP driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/mongodb_php.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.php.driver.mysql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "PDO MySQL / mysqli",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/mysql_php.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.php.driver.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "neo4j-php-client",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.php.driver.postgres",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "PDO PostgreSQL",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/postgresql_php.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.php.driver.redis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "phpredis / Predis",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/redis_php.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.php.driver.sqlite",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "PDO SQLite",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/sqlite_php.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
@@ -20072,253 +22828,630 @@
     {
       "id": "lang.php.orm.cycleorm",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "CycleORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.php.orm.doctrine",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "Doctrine ORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/php/orms/doctrine_orm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/php/orms/doctrine_orm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_other.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.php.orm.eloquent",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "Eloquent (Laravel)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/php/orms/eloquent_laravel_orm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_other.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_other.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.php.orm.propel",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "Propel",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/propel.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/propel.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/propel.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.php.orm.redbeanphp",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "php",
       "label": "RedBeanPHP",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/php/orms/redbeanphp.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.python.driver.cassandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "cassandra-driver",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/cassandra_py.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.driver.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "boto3 DynamoDB",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/dynamodb_py.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.driver.elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "elasticsearch-py",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/elasticsearch_py.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.driver.mysql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "MySQL (PyMySQL / mysqlclient)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/mysql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.driver.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "neo4j (Python driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.driver.postgres",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "psycopg / asyncpg (PostgreSQL drivers)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/postgresql_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.driver.redis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "redis-py",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/redis_py.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.driver.sqlite",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "sqlite3 (stdlib)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/sqlite_py.yaml","internal/extractors/python/raw_sql_db_calls.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
@@ -21916,191 +25049,458 @@
     {
       "id": "lang.python.orm.alembic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "Alembic (migration tool)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "not_applicable"
+        "Queries": {
+          "query_attribution": {
+            "status": "not_applicable"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.python.orm.beanie",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "Beanie (async MongoDB ODM)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/beanie.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.orm.django",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "Django ORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "full",
-          "cites": ["internal/extractors/python/django_migration.go"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/python/orms/django_orm.yaml","internal/extractors/python/django_relational.go"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/python/orms/django_orm.yaml","internal/extractors/python/django_relational.go"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/python/django_relational.go"],
+            "verified_at": "2026-05-29"
+          },
+          "foreign_key_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/python/django_relational.go"],
+            "verified_at": "2026-05-29"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/python/django_relational.go"],
+            "verified_at": "2026-05-29"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_python.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "full",
+            "cites": ["internal/extractors/python/django_migration.go"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.python.orm.mongoengine",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "MongoEngine",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/mongoengine.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.python.orm.peewee",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "Peewee",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/peewee.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.python.orm.pony",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "Pony ORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/pony_orm.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.python.orm.sqlalchemy",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "SQLAlchemy",
       "capabilities": {
-        "migration_parsing": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
-          "verified_at": "2026-05-28"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/python/orms/sqlalchemy.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/orm_field_edges.go","internal/engine/rules/python/orms/sqlalchemy.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/python/sqlalchemy.go"],
+            "verified_at": "2026-05-29"
+          },
+          "foreign_key_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/python/sqlalchemy.go"],
+            "verified_at": "2026-05-29"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/python/sqlalchemy.go"],
+            "verified_at": "2026-05-29"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_python.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
+            "verified_at": "2026-05-28"
+          }
         }
       }
     },
     {
       "id": "lang.python.orm.sqlmodel",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "SQLModel",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/python/orms/sqlmodel.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/python/orms/sqlmodel.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries_python.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries_python.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.python.orm.tortoise",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "python",
       "label": "Tortoise ORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/python/orms/tortoise_orm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/python/orms/tortoise_orm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/orm_queries_python.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/orm_queries_python.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -22238,152 +25638,384 @@
     {
       "id": "lang.ruby.driver.cassandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "cassandra-driver (Ruby)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/cassandra_ruby.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.driver.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "AWS SDK DynamoDB (Ruby)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/dynamodb_ruby.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.driver.elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "elasticsearch-ruby",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/elasticsearch_ruby.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.driver.mysql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "mysql2 (Ruby driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/mysql_ruby.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.driver.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "neo4j-ruby-driver",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.driver.postgres",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "pg (Ruby driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/pg_ruby.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.driver.redis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "redis-rb",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/redis_rb.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.driver.sqlite",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "sqlite3 (Ruby driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/sqlite_ruby.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
@@ -23352,276 +26984,682 @@
     {
       "id": "lang.ruby.orm.activerecord",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "ActiveRecord",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/ruby/orms/activerecord.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/ruby/orms/activerecord.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/orm_queries.go"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/orm_queries.go"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.orm.datamapper",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "DataMapper / Hanami Model (legacy)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/datamapper_hanami_model_legacy.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.orm.mongoid",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "Mongoid",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/mongoid.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.orm.rom-rb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "ROM (Ruby Object Mapper)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml","internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/frameworks/rom_rb_ruby_object_mapper.yaml","internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/rom_rb_as_orm.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.ruby.orm.sequel",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "ruby",
       "label": "Sequel",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/ruby/orms/sequel.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.cassandra",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "cdrs / scylla-rust-driver",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/cassandra_rust.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.dynamodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "aws-sdk-dynamodb (Rust)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/dynamodb_rust.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.elastic",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "elasticsearch-rs",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/elasticsearch_rs.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.mongodb",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "mongodb (Rust driver)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/mongodb_mongodb.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.mysql",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "mysql / mysql_async",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/mysql_rust.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.neo4j",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "neo4rs",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/neo4j.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.postgres",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "tokio-postgres / postgres",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/postgresql_rust.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.redis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "redis-rs",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/redis_redis_rs.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.driver.sqlite",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "sqlite (Rust)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/sqlite_rust.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
@@ -24889,99 +28927,244 @@
     {
       "id": "lang.rust.orm.diesel",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "Diesel",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/rules/rust/orms/diesel.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.rust.orm.rbatis",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "Rbatis",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "missing"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "missing"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "missing"
+        "Queries": {
+          "query_attribution": {
+            "status": "missing"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.rust.orm.rusqlite",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "rusqlite",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "not_applicable"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "not_applicable"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/rusqlite.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/rusqlite.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.rust.orm.seaorm",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "SeaORM",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "full",
-          "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/rules/rust/orms/seaorm.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.rust.orm.sqlx",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "rust",
       "label": "sqlx (Rust)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/rust/orms/sqlx.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
@@ -26969,126 +31152,300 @@
     {
       "id": "lang.scala.orm.doobie",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "scala",
       "label": "Doobie",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/doobie.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.scala.orm.elastic4s",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "scala",
       "label": "Elastic4s",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/elastic4s.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.scala.orm.quill",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "scala",
       "label": "Quill",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/quill.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.scala.orm.scalikejdbc",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "scala",
       "label": "ScalikeJDBC",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/scalikejdbc.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },
     {
       "id": "lang.scala.orm.scanamo",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "scala",
       "label": "Scanamo (DynamoDB)",
       "capabilities": {
-        "migration_parsing": {
-          "status": "not_applicable"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/scanamo.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "not_applicable"
+          }
         }
       }
     },
     {
       "id": "lang.scala.orm.slick",
       "category": "orm",
+      "subcategory": "orm_mapper",
       "language": "scala",
       "label": "Slick",
       "capabilities": {
-        "migration_parsing": {
-          "status": "missing"
+        "Models": {
+          "model_extraction": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
+            "verified_at": "2026-05-28"
+          },
+          "schema_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "model_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
-          "verified_at": "2026-05-28"
+        "Relationships": {
+          "association_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
         },
-        "query_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
-          "verified_at": "2026-05-28"
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/engine/rules/scala/orms/slick.yaml"],
+            "verified_at": "2026-05-28"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing"
+          }
         }
       }
     },

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -53,6 +53,7 @@ categories:
     subcategory_order: [http_backend, jvm_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration, task_queue]
   orm:
     capabilities: [model_extraction, query_attribution, migration_parsing]
+    subcategory_order: [orm_mapper]
   message_broker:
     capabilities: [producer_extraction, consumer_extraction, topic_attribution]
   observability:
@@ -525,6 +526,28 @@ subcategories:
         keys: [tests_linkage]
       - name: Substrate
         keys: [constant_propagation, env_fallback_recognition, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
+
+  orm_mapper:
+    display: "ORM / Data Mapper"
+    parent_category: orm
+    capabilities:
+      - model_extraction
+      - schema_extraction
+      - relationship_extraction
+      - foreign_key_extraction
+      - association_extraction
+      - lazy_loading_recognition
+      - query_attribution
+      - migration_parsing
+    groups:
+      - name: Models
+        keys: [model_extraction, schema_extraction]
+      - name: Relationships
+        keys: [relationship_extraction, foreign_key_extraction, association_extraction, lazy_loading_recognition]
+      - name: Queries
+        keys: [query_attribution]
+      - name: Migrations
+        keys: [migration_parsing]
 
   validation_lib:
     display: "Validation"

--- a/tools/coverage/main.go
+++ b/tools/coverage/main.go
@@ -41,6 +41,8 @@ func run(argv []string, stdout, stderr io.Writer) error {
 		return cmdUpdate(rest, stdout)
 	case "backfill":
 		return cmdBackfill(rest, stdout)
+	case "regroup":
+		return cmdRegroup(rest, stdout)
 	case "remove":
 		return cmdRemove(rest, stdout)
 	case "gaps":
@@ -79,6 +81,7 @@ subcommands:
             --capability, --status (required); --cites, --verified-now, --issue, --notes, --clear-issue
             when status=full or not_applicable the issue field is auto-cleared unless --issue is given
   backfill  seed missing lane cells declared by the group taxonomy (--file, --issue, --language, --subcategory, --dry-run, --check)
+  regroup   migrate flat records whose subcategory declares a group taxonomy: move each flat key into its canonical group (--file, --subcategory, --dry-run, --check)
   remove    delete a record by id
   gaps      list missing/partial records (--language, --category, --json)
   stats     counters across the registry (--json)

--- a/tools/coverage/regroup.go
+++ b/tools/coverage/regroup.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// regroupMove is a single flat→grouped relocation the regroup pass would
+// perform: capability key Key on record RecordID moves from the flat
+// capabilities map into canonical group Group. Slices are sorted
+// deterministically before any output or write so dry-run reports and
+// registry writes are byte-stable across runs.
+type regroupMove struct {
+	RecordID string
+	Language string
+	Group    string
+	Key      string
+}
+
+// planRegroup computes the set of flat capability cells that should be
+// relocated into their canonical group. A record is in scope when:
+//
+//   - it carries a subcategory that is valid for its category, and
+//   - that subcategory declares a group taxonomy, and
+//   - the record still holds FLAT cells (len(Capabilities) > 0).
+//
+// Records already in the grouped shape are skipped (idempotency): a
+// second run finds no flat cells and plans nothing. The cell payload
+// (status/cites/verified_at/verified_sha/issue/notes) is preserved
+// verbatim by applyRegroup — planRegroup only records placement. A key
+// whose canonical owner is "" (not declared in any group) is parked in
+// the synthetic Uncategorized group so no data is lost.
+//
+// subFilter, when non-empty, scopes the plan to a single subcategory slug.
+func planRegroup(reg *Registry, subFilter string) []regroupMove {
+	var moves []regroupMove
+	for i := range reg.Records {
+		rec := &reg.Records[i]
+		if rec.Subcategory == "" || !validSubcategory(rec.Category, rec.Subcategory) {
+			continue
+		}
+		if len(groupsForSubcategory(rec.Subcategory)) == 0 {
+			continue
+		}
+		if subFilter != "" && rec.Subcategory != subFilter {
+			continue
+		}
+		if len(rec.Capabilities) == 0 {
+			// Already grouped (or empty): nothing flat to move.
+			continue
+		}
+		for key := range rec.Capabilities {
+			owner := groupForCapability(rec.Subcategory, key)
+			if owner == "" {
+				owner = uncategorizedGroup
+			}
+			moves = append(moves, regroupMove{
+				RecordID: rec.ID,
+				Language: rec.Language,
+				Group:    owner,
+				Key:      key,
+			})
+		}
+	}
+	sortRegroupMoves(moves)
+	return moves
+}
+
+// sortRegroupMoves orders moves by (RecordID, Group, Key) so dry-run
+// output and the resulting registry write are byte-stable across runs.
+func sortRegroupMoves(moves []regroupMove) {
+	sort.Slice(moves, func(i, j int) bool {
+		if moves[i].RecordID != moves[j].RecordID {
+			return moves[i].RecordID < moves[j].RecordID
+		}
+		if moves[i].Group != moves[j].Group {
+			return moves[i].Group < moves[j].Group
+		}
+		return moves[i].Key < moves[j].Key
+	})
+}
+
+// applyRegroup relocates each planned flat cell into its canonical group,
+// preserving the cell payload verbatim, then clears the now-empty flat
+// capabilities map so the record reads as grouped. Records that end up
+// with at least one moved cell have Capabilities set to nil so the
+// on-disk shape is unambiguously grouped (validate forbids carrying both
+// shapes). Returns the number of cells moved.
+func applyRegroup(reg *Registry, moves []regroupMove) int {
+	byID := map[string]*Record{}
+	for i := range reg.Records {
+		byID[reg.Records[i].ID] = &reg.Records[i]
+	}
+	touched := map[string]bool{}
+	moved := 0
+	for _, m := range moves {
+		rec := byID[m.RecordID]
+		if rec == nil {
+			continue
+		}
+		cell, ok := rec.Capabilities[m.Key]
+		if !ok {
+			continue
+		}
+		if rec.Groups == nil {
+			rec.Groups = map[string]map[string]Capability{}
+		}
+		if rec.Groups[m.Group] == nil {
+			rec.Groups[m.Group] = map[string]Capability{}
+		}
+		// No-clobber: never overwrite a cell that already exists in the
+		// target group (e.g. a re-run after a partial write).
+		if _, exists := rec.Groups[m.Group][m.Key]; !exists {
+			rec.Groups[m.Group][m.Key] = cell
+			moved++
+		}
+		delete(rec.Capabilities, m.Key)
+		touched[m.RecordID] = true
+	}
+	// Drop emptied flat maps so the record serialises as grouped.
+	for id := range touched {
+		rec := byID[id]
+		if len(rec.Capabilities) == 0 {
+			rec.Capabilities = nil
+		}
+	}
+	return moved
+}
+
+// cmdRegroup migrates records whose subcategory declares a group taxonomy
+// but whose cells are still flat, moving each flat capability key into its
+// canonical group (preserving status/cites/verified_at/issue/notes).
+// Idempotent and deterministic; writes via saveRegistry.
+func cmdRegroup(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("regroup", flag.ContinueOnError)
+	path := registryFlag(fs)
+	sub := fs.String("subcategory", "", "scope to a single subcategory slug")
+	dryRun := fs.Bool("dry-run", false, "print (record, group, key) moves + per-language counts; write nothing")
+	check := fs.Bool("check", false, "exit non-zero if any cell would be moved (CI guard); write nothing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	reg, err := loadRegistry(*path)
+	if err != nil {
+		return err
+	}
+	moves := planRegroup(reg, *sub)
+
+	if *dryRun || *check {
+		printRegroupReport(out, moves)
+	}
+	if *check {
+		if len(moves) > 0 {
+			return fmt.Errorf("regroup --check: %d cell(s) would be moved", len(moves))
+		}
+		return nil
+	}
+	if *dryRun {
+		return nil
+	}
+
+	moved := applyRegroup(reg, moves)
+	if moved == 0 {
+		fmt.Fprintln(out, "regroup: nothing to move (registry already grouped)")
+		return nil
+	}
+	if err := saveRegistry(*path, reg); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "regroup: moved %d cell(s)\n", moved)
+	return nil
+}
+
+// printRegroupReport writes the (record, group, key) moves in sorted
+// order followed by per-language counts and a grand total. Shared by
+// --dry-run and --check.
+func printRegroupReport(out io.Writer, moves []regroupMove) {
+	for _, m := range moves {
+		fmt.Fprintf(out, "%s\t%s\t%s\n", m.RecordID, m.Group, m.Key)
+	}
+	perLang := map[string]int{}
+	for _, m := range moves {
+		perLang[m.Language]++
+	}
+	langs := make([]string, 0, len(perLang))
+	for l := range perLang {
+		langs = append(langs, l)
+	}
+	sort.Strings(langs)
+	fmt.Fprintln(out, "per-language pending-move counts:")
+	for _, l := range langs {
+		fmt.Fprintf(out, "  %-14s %d\n", l, perLang[l])
+	}
+	fmt.Fprintf(out, "total: %d cell(s) would be moved\n", len(moves))
+}

--- a/tools/coverage/regroup_test.go
+++ b/tools/coverage/regroup_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFlatORMFixture writes a temp registry holding a single flat ORM
+// record tagged subcategory orm_mapper, carrying the three legacy flat
+// keys with payloads (status/cites/issue/verified_at) so the regroup
+// move can be asserted to preserve them.
+func writeFlatORMFixture(t *testing.T) string {
+	t.Helper()
+	reg := &Registry{
+		SchemaVersion: SchemaVersion,
+		Records: []Record{{
+			ID:          "lang.python.orm.sqlalchemy",
+			Category:    "orm",
+			Subcategory: "orm_mapper",
+			Language:    "python",
+			Label:       "SQLAlchemy",
+			Capabilities: map[string]Capability{
+				"model_extraction":  {Status: StatusFull, Cites: []string{"internal/custom/python/sqlalchemy.go"}, VerifiedAt: "2026-05-01"},
+				"query_attribution": {Status: StatusPartial, Issue: "https://example.com/i/q"},
+				"migration_parsing": {Status: StatusMissing},
+			},
+		}},
+	}
+	dst := filepath.Join(t.TempDir(), "orm.json")
+	if err := saveRegistry(dst, reg); err != nil {
+		t.Fatalf("save flat ORM fixture: %v", err)
+	}
+	return dst
+}
+
+// TestRegroupMovesFlatKeysIntoCanonicalGroups confirms regroup relocates
+// each flat key into its dictionary-declared group and preserves the full
+// cell payload (status/cites/verified_at/issue) verbatim. After the move
+// the record must read as grouped (no flat cells remain).
+func TestRegroupMovesFlatKeysIntoCanonicalGroups(t *testing.T) {
+	dst := writeFlatORMFixture(t)
+	if _, _, err := runCmd(t, "regroup", "--file", dst); err != nil {
+		t.Fatalf("regroup: %v", err)
+	}
+	reg, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	rec := findRecord(reg, "lang.python.orm.sqlalchemy")
+	if rec == nil {
+		t.Fatal("record missing after regroup")
+	}
+	if len(rec.Capabilities) != 0 {
+		t.Errorf("flat capabilities not cleared after regroup: %v", rec.Capabilities)
+	}
+	if !rec.IsGrouped() {
+		t.Fatal("record should be grouped after regroup")
+	}
+
+	// model_extraction → Models, preserving full + cites + verified_at.
+	model, ok := rec.Groups["Models"]["model_extraction"]
+	if !ok {
+		t.Fatal("model_extraction not placed under Models")
+	}
+	if model.Status != StatusFull {
+		t.Errorf("model_extraction status = %q, want full", model.Status)
+	}
+	if len(model.Cites) != 1 || model.Cites[0] != "internal/custom/python/sqlalchemy.go" {
+		t.Errorf("model_extraction cites not preserved: %v", model.Cites)
+	}
+	if model.VerifiedAt != "2026-05-01" {
+		t.Errorf("model_extraction verified_at not preserved: %q", model.VerifiedAt)
+	}
+
+	// query_attribution → Queries, preserving partial + issue.
+	q, ok := rec.Groups["Queries"]["query_attribution"]
+	if !ok {
+		t.Fatal("query_attribution not placed under Queries")
+	}
+	if q.Status != StatusPartial || q.Issue != "https://example.com/i/q" {
+		t.Errorf("query_attribution payload not preserved: %+v", q)
+	}
+
+	// migration_parsing → Migrations.
+	if m, ok := rec.Groups["Migrations"]["migration_parsing"]; !ok || m.Status != StatusMissing {
+		t.Errorf("migration_parsing not placed under Migrations as missing: %+v", m)
+	}
+}
+
+// TestRegroupIdempotent confirms a second regroup run produces no
+// byte-level change to the registry (nothing flat remains to move).
+func TestRegroupIdempotent(t *testing.T) {
+	dst := writeFlatORMFixture(t)
+	if _, _, err := runCmd(t, "regroup", "--file", dst); err != nil {
+		t.Fatalf("first regroup: %v", err)
+	}
+	after1, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+	out, _, err := runCmd(t, "regroup", "--file", dst)
+	if err != nil {
+		t.Fatalf("second regroup: %v", err)
+	}
+	if !strings.Contains(out, "nothing to move") {
+		t.Errorf("second run should be a no-op, got: %s", out)
+	}
+	after2, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+	if string(after1) != string(after2) {
+		t.Error("second regroup changed the registry; expected idempotent no-op")
+	}
+}
+
+// TestRegroupThenValidateZeroErrors confirms that after regroup the record
+// has no flat-shape-forbidden / shape errors (validate reports 0 errors
+// for it). Backfill-able missing relationship cells are advisory warnings,
+// not errors.
+func TestRegroupThenValidateZeroErrors(t *testing.T) {
+	dst := writeFlatORMFixture(t)
+	if _, _, err := runCmd(t, "regroup", "--file", dst); err != nil {
+		t.Fatalf("regroup: %v", err)
+	}
+	reg, err := loadRegistry(dst)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res := validateRegistry(reg, repoRoot(t))
+	var errs []string
+	for _, e := range res.Errors {
+		if strings.Contains(e, "lang.python.orm.sqlalchemy") {
+			errs = append(errs, e)
+		}
+	}
+	if len(errs) > 0 {
+		t.Errorf("validate reported errors for regrouped record:\n%s", strings.Join(errs, "\n"))
+	}
+}
+
+// TestRegroupDryRunWritesNothing confirms --dry-run prints the moves but
+// leaves the registry byte-identical.
+func TestRegroupDryRunWritesNothing(t *testing.T) {
+	dst := writeFlatORMFixture(t)
+	before, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+	out, _, err := runCmd(t, "regroup", "--file", dst, "--dry-run")
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	after, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("--dry-run wrote to the registry")
+	}
+	if !strings.Contains(out, "total:") {
+		t.Errorf("expected total line in dry-run output, got:\n%s", out)
+	}
+}
+
+// TestRegroupCheckReportsPending confirms --check exits non-zero when
+// cells would be moved and writes nothing.
+func TestRegroupCheckReportsPending(t *testing.T) {
+	dst := writeFlatORMFixture(t)
+	before, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+	out, _, err := runCmd(t, "regroup", "--file", dst, "--check")
+	if err == nil {
+		t.Fatal("expected non-zero exit from --check with pending moves")
+	}
+	if !strings.Contains(out, "per-language pending-move counts:") {
+		t.Errorf("expected per-language report, got:\n%s", out)
+	}
+	after, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("--check mutated the registry")
+	}
+}
+
+// TestRegroupSubcategoryFilter confirms --subcategory scopes the move to a
+// single subcategory: a non-matching filter is a no-op.
+func TestRegroupSubcategoryFilter(t *testing.T) {
+	dst := writeFlatORMFixture(t)
+	out, _, err := runCmd(t, "regroup", "--file", dst, "--subcategory", "validation_lib")
+	if err != nil {
+		t.Fatalf("regroup: %v", err)
+	}
+	if !strings.Contains(out, "nothing to move") {
+		t.Errorf("non-matching subcategory filter should be a no-op, got: %s", out)
+	}
+}

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -64,7 +64,10 @@ func TestValidSubcategory(t *testing.T) {
 		t.Errorf("bogus should not be valid")
 	}
 	if validSubcategory("orm", "ui_frontend") {
-		t.Errorf("orm has no subcategories — ui_frontend should not validate")
+		t.Errorf("ui_frontend belongs to http_framework, not orm — should not validate")
+	}
+	if !validSubcategory("orm", "orm_mapper") {
+		t.Errorf("orm_mapper should be valid for orm")
 	}
 }
 


### PR DESCRIPTION
## Foundation Wave 2, PR-E (the big ORM migration)

Introduces the `orm_mapper` subcategory and migrates all 150 `category: orm` records from the flat 3-key shape into the grouped taxonomy, surfacing the relationship capabilities we don't yet extract as honest reds.

### Dictionary (`capability-dictionary.yaml`)
- `orm` category: `subcategory_order: [orm_mapper]`
- New `orm_mapper` subcategory (display "ORM / Data Mapper", parent `orm`):
  - **Models**: `model_extraction`, `schema_extraction`
  - **Relationships**: `relationship_extraction`, `foreign_key_extraction`, `association_extraction`, `lazy_loading_recognition`
  - **Queries**: `query_attribution`
  - **Migrations**: `migration_parsing`

### Tooling — new `coverage regroup` subcommand
`regroup.go` + dispatch/usage in `main.go`. For records whose subcategory declares a group taxonomy but whose cells are still flat, MOVES each flat capability key into its canonical group (preserving `status`/`cites`/`verified_at`/`issue`/`notes` verbatim). Idempotent, deterministic, writes via `saveRegistry`. Flags: `--file`/`--subcategory`/`--dry-run`/`--check`. Covered by `regroup_test.go` (move-preserves-cells, idempotency, dry-run/check write-nothing, subcategory filter, post-regroup validate=0).

### Migration
1. `subcategory: orm_mapper` set on all **150** `orm` records.
2. `regroup --subcategory orm_mapper` → **moved 450** flat cells (150×3) into Models/Queries/Migrations.
3. `backfill --subcategory orm_mapper` → **seeded 750** honest `missing` cells (`schema_extraction` + the 4 Relationships keys).

### Relationship cells authored
`full` only where genuinely extracted **with a proving fixture**:
- **SQLAlchemy**: relationship + foreign_key + association (`saRelationshipRe`/`saForeignKeyRe`/`saAssocTableRe`; `TestSQLAlchemy_Relationship`)
- **Django ORM**: relationship + foreign_key + association (`django_relational.go` FK/O2O/M2M + on_delete + M2M-through; `django_relational_test.go`)
- **TypeORM**: relationship (`TestTypeORMRelation`)

Everything else left honest `missing`: `lazy_loading_recognition` everywhere (not recognized), JPA relationships (no JPA ORM-relationship extractor exists — `internal/extractors/java/` only emits AST CONTAINS/CALLS/IMPORTS edges), TypeORM FK/association, and `schema_extraction` (no separate proving fixture). No `full` without a proving fixture — most cells are the intended "show what we don't extract" reds.

### Acceptance
- `validate`: **0 errors** (warnings only)
- `gen`: byte-stable (verified twice)
- `fmt --check`: canonical
- `go test ./tools/coverage/` + `go build ./...` + `go vet`: green
- ORM detail pages render the new Models/Relationships/Queries/Migrations groups

Closes #2967

🤖 Generated with [Claude Code](https://claude.com/claude-code)