### PR TITLE
coverage: flip completeness gate to ERROR + CI backfill --check guard

### DIFF
--- a/.github/workflows/coverage-docs.yml
+++ b/.github/workflows/coverage-docs.yml
@@ -19,6 +19,8 @@ jobs:
           go-version: '1.22'
       - name: Validate schema + cites
         run: go run ./tools/coverage validate
+      - name: Guard against incomplete grouped records (#2971)
+        run: go run ./tools/coverage backfill --check
       - name: Verify registry.json is canonical (guards against recompaction, #2907)
         run: |
           if ! go run ./tools/coverage fmt --check; then

--- a/tools/coverage/backfill_test.go
+++ b/tools/coverage/backfill_test.go
@@ -135,20 +135,21 @@ func TestBackfillDryRunWritesNothing(t *testing.T) {
 	}
 }
 
-// TestCompletenessWarningsZeroAfterBackfill confirms that once backfill
-// has seeded every declared lane cell, validateRegistry emits zero
-// grouped-completeness warnings.
-func TestCompletenessWarningsZeroAfterBackfill(t *testing.T) {
+// TestCompletenessErrorsZeroAfterBackfill confirms that once backfill has
+// seeded every declared lane cell, validateRegistry emits zero grouped-
+// completeness errors. (The gate was flipped to error in #2971; the
+// function was previously named TestCompletenessWarningsZeroAfterBackfill.)
+func TestCompletenessErrorsZeroAfterBackfill(t *testing.T) {
 	dst := copyFixture(t)
 
 	// Before: the fixture's grouped nestjs record is incomplete, so at
-	// least one completeness warning must be present.
+	// least one completeness error must be present.
 	before, err := loadRegistry(dst)
 	if err != nil {
 		t.Fatalf("load before: %v", err)
 	}
-	if n := countCompletenessWarnings(validateRegistry(before, repoRoot(t))); n == 0 {
-		t.Fatal("fixture precondition: expected completeness warnings before backfill")
+	if n := countCompletenessErrors(validateRegistry(before, repoRoot(t))); n == 0 {
+		t.Fatal("fixture precondition: expected completeness errors before backfill")
 	}
 
 	if _, _, err := runCmd(t, "backfill", "--file", dst); err != nil {
@@ -158,17 +159,18 @@ func TestCompletenessWarningsZeroAfterBackfill(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load after: %v", err)
 	}
-	if n := countCompletenessWarnings(validateRegistry(after, repoRoot(t))); n != 0 {
-		t.Errorf("expected 0 completeness warnings after backfill, got %d", n)
+	if n := countCompletenessErrors(validateRegistry(after, repoRoot(t))); n != 0 {
+		t.Errorf("expected 0 completeness errors after backfill, got %d", n)
 	}
 }
 
-// countCompletenessWarnings counts warnings emitted by
+// countCompletenessErrors counts errors emitted by
 // validateGroupedCompleteness (identified by their stable message stem).
-func countCompletenessWarnings(res *ValidationResult) int {
+// Before #2971 these were warnings; the gate is now true so they are errors.
+func countCompletenessErrors(res *ValidationResult) int {
 	n := 0
-	for _, w := range res.Warnings {
-		if strings.Contains(w, "declared by subcategory") {
+	for _, e := range res.Errors {
+		if strings.Contains(e, "declared by subcategory") {
 			n++
 		}
 	}

--- a/tools/coverage/main_test.go
+++ b/tools/coverage/main_test.go
@@ -214,7 +214,15 @@ func TestStatsJSON(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	_, errout, err := runCmd(t, "validate", "--file", fixturePath(t), "--repo-root", repoRoot(t), "--skip-map")
+	// The checked-in fixture is intentionally incomplete (backfill tests need
+	// absent lane cells). Backfill a temp copy first so completeness errors
+	// don't interfere with this schema/cite smoke-test. (#2971: gate is now
+	// true, so an incomplete fixture would exit non-zero.)
+	tmp := copyFixture(t)
+	if _, _, err := runCmd(t, "backfill", "--file", tmp); err != nil {
+		t.Fatalf("backfill before validate: %v", err)
+	}
+	_, errout, err := runCmd(t, "validate", "--file", tmp, "--repo-root", repoRoot(t), "--skip-map")
 	if err != nil {
 		t.Fatalf("validate: %v\nstderr:\n%s", err, errout)
 	}

--- a/tools/coverage/regroup_test.go
+++ b/tools/coverage/regroup_test.go
@@ -116,14 +116,19 @@ func TestRegroupIdempotent(t *testing.T) {
 	}
 }
 
-// TestRegroupThenValidateZeroErrors confirms that after regroup the record
-// has no flat-shape-forbidden / shape errors (validate reports 0 errors
-// for it). Backfill-able missing relationship cells are advisory warnings,
-// not errors.
+// TestRegroupThenValidateZeroErrors confirms that after regroup + backfill
+// the record has no errors (validate reports 0 errors for it). Prior to
+// #2971 backfill-able missing cells were advisory warnings; they are now
+// hard errors, so the test runs backfill after regroup to seed them.
 func TestRegroupThenValidateZeroErrors(t *testing.T) {
 	dst := writeFlatORMFixture(t)
 	if _, _, err := runCmd(t, "regroup", "--file", dst); err != nil {
 		t.Fatalf("regroup: %v", err)
+	}
+	// Seed any lane cells that regroup left unset so the completeness gate
+	// (now an error since #2971) doesn't trip on the regrouped record.
+	if _, _, err := runCmd(t, "backfill", "--file", dst); err != nil {
+		t.Fatalf("backfill after regroup: %v", err)
 	}
 	reg, err := loadRegistry(dst)
 	if err != nil {
@@ -137,7 +142,7 @@ func TestRegroupThenValidateZeroErrors(t *testing.T) {
 		}
 	}
 	if len(errs) > 0 {
-		t.Errorf("validate reported errors for regrouped record:\n%s", strings.Join(errs, "\n"))
+		t.Errorf("validate reported errors for regrouped+backfilled record:\n%s", strings.Join(errs, "\n"))
 	}
 }
 

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -259,22 +259,28 @@ func TestValidateRegistrySubcategory(t *testing.T) {
 		},
 	}
 	res := validateRegistry(reg, ".")
-	// React record should be clean (no errors involving it).
-	hasError := func(needle string) bool {
+	// React record should be clean — no structural errors. Since the gate is
+	// now true (#2971), the minimal in-memory record will have completeness
+	// errors for undeclared lane cells; those are expected and excluded here
+	// (this test is scoped to subcategory/key validation, not completeness).
+	hasStructuralError := func(needle string) bool {
 		for _, e := range res.Errors {
+			if containsStr(e, "declared by subcategory") {
+				continue // completeness error — not this test's concern
+			}
 			if containsStr(e, needle) {
 				return true
 			}
 		}
 		return false
 	}
-	if hasError("lang.jsts.framework.react") {
-		t.Errorf("react record should validate; got errors: %v", res.Errors)
+	if hasStructuralError("lang.jsts.framework.react") {
+		t.Errorf("react record should have no structural errors; got errors: %v", res.Errors)
 	}
-	if !hasError("no_such_subcategory") {
+	if !hasStructuralError("no_such_subcategory") {
 		t.Errorf("expected unknown-subcategory error; got: %v", res.Errors)
 	}
-	if !hasError("ipc_extraction") {
+	if !hasStructuralError("ipc_extraction") {
 		t.Errorf("expected cross-subcategory key rejection; got: %v", res.Errors)
 	}
 }
@@ -465,24 +471,31 @@ func TestValidateGroupedRecord(t *testing.T) {
 		},
 	}
 	res := validateRegistry(reg, ".")
-	hasError := func(needle string) bool {
+	// Since the completeness gate is now true (#2971), the minimal in-memory
+	// records will carry completeness errors for undeclared lane cells.
+	// Exclude those from structural-rule checks — this test is scoped to
+	// group-name validation, capability placement, and dup-key detection.
+	hasStructuralError := func(needle string) bool {
 		for _, e := range res.Errors {
+			if containsStr(e, "declared by subcategory") {
+				continue // completeness error — not this test's concern
+			}
 			if containsStr(e, needle) {
 				return true
 			}
 		}
 		return false
 	}
-	if hasError("lang.jsts.framework.react") {
-		t.Errorf("react should validate; got: %v", res.Errors)
+	if hasStructuralError("lang.jsts.framework.react") {
+		t.Errorf("react should have no structural errors; got: %v", res.Errors)
 	}
-	if !hasError(`unknown group "Strcture"`) {
+	if !hasStructuralError(`unknown group "Strcture"`) {
 		t.Errorf("expected unknown group error; got: %v", res.Errors)
 	}
-	if !hasError("does not belong to group") {
+	if !hasStructuralError("does not belong to group") {
 		t.Errorf("expected capability-belongs-to-group error; got: %v", res.Errors)
 	}
-	if !hasError("already declared under group") {
+	if !hasStructuralError("already declared under group") {
 		t.Errorf("expected duplicate-key error; got: %v", res.Errors)
 	}
 }

--- a/tools/coverage/validate.go
+++ b/tools/coverage/validate.go
@@ -23,12 +23,11 @@ const staleDays = 90
 // completenessGateIsError controls the severity of the grouped-
 // completeness check (validateGroupedCompleteness): a lane key declared
 // by a record's subcategory group taxonomy but absent from the record's
-// cells. While false (this PR, #2942) these surface as WARNINGS, which
-// never fail CI — the `backfill` subcommand exists to seed those cells so
-// they become explicit `missing` placeholders. A later PR flips this to
-// true once the registry is backfilled, turning dictionary completeness
-// into a hard gate.
-const completenessGateIsError = false
+// cells. Now true (#2971, Foundation Wave 2 final step): the registry was
+// fully backfilled in #2970, so any missing lane cell is a hard ERROR that
+// fails CI. Use `go run ./tools/coverage backfill` to seed new cells before
+// adding a record to a grouped subcategory.
+const completenessGateIsError = true
 
 // ValidationResult collects errors (block) and warnings (advisory).
 type ValidationResult struct {


### PR DESCRIPTION
## Summary

Foundation Wave 2, **final step** (PR-G). Closes #2971.

- **`tools/coverage/validate.go`**: flip `completenessGateIsError` `false` → `true`. Any grouped record missing a lane cell declared by its subcategory taxonomy is now a hard ERROR (not a warning). The registry was fully backfilled in #2970 so `validate` still exits 0 on the current registry.
- **`.github/workflows/coverage-docs.yml`**: add `go run ./tools/coverage backfill --check` step as a belt-and-suspenders CI guard alongside the now-erroring validate.
- **Tests updated** (tooling/CI only — no registry or docs data changed):
  - `TestCompletenessWarningsZeroAfterBackfill` → `TestCompletenessErrorsZeroAfterBackfill`: checks `res.Errors` instead of `res.Warnings`.
  - `TestValidateGroupedRecord` / `TestValidateRegistrySubcategory`: structural-rule tests use minimal in-memory records; filter completeness errors from the "react should validate" assertions (these tests are scoped to group-name/placement/dup-key rules, not completeness).
  - `TestValidate`: backfill a temp copy before validating (the checked-in fixture is intentionally incomplete so backfill tests have cells to seed).
  - `TestRegroupThenValidateZeroErrors`: run `backfill` after `regroup` before validating (proper regroup → backfill → validate workflow).

## Scratch-test result (gate works)

Temporarily deleted `model_extraction` from group `Models` in `lang.c-cpp.driver.libpqxx` in a `/tmp` copy:

```
error: records[99] (lang.c-cpp.driver.libpqxx): lane key "model_extraction" (group "Models") declared by subcategory "orm_mapper" taxonomy but absent from record
error: validation failed: 1 error(s)
exit status 1
```

Exit code 1. Scratch copy discarded. Current complete registry exits 0.

## Acceptance checklist

- [x] `go run ./tools/coverage validate` exits **0** on the current complete registry
- [x] `go test ./tools/coverage/` green
- [x] `go build ./...` green
- [x] `go vet ./...` clean
- [x] `gen` byte-stable — no docs/registry data changes
- [x] Gate verified: missing lane cell → ERROR + exit 1 on scratch copy
- [x] No stray `coverage` binary

Closes #2971