### PR TITLE
[Python coverage] Honesty fix: downgrade endpoint_synthesis/handler_attribution full→missing

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -80,7 +80,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/8 | |
@@ -88,15 +88,15 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -12,7 +12,7 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Django](../detail/lang.python.framework.django.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/8 | |
@@ -20,15 +20,15 @@ Back to [summary](../summary.md).
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Flask](../detail/lang.python.framework.flask.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Pyramid](../detail/lang.python.framework.pyramid.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Starlette](../detail/lang.python.framework.starlette.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Tornado](../detail/lang.python.framework.tornado.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
+| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2979 | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
+| Handler attribution | ❌ `missing` | `2026-05-28` | 2979 | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
 | Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
+| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2979 | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
+| Handler attribution | ❌ `missing` | `2026-05-28` | 2979 | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
 | Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
+| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
+| Handler attribution | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
 | Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
+| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
+| Handler attribution | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
 | Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
+| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
+| Handler attribution | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
 | Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -31248,13 +31248,15 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
+            "issue": "2979",
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
+            "issue": "2979",
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
@@ -31425,13 +31427,15 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
+            "issue": "2979",
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
+            "issue": "2979",
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
@@ -33172,13 +33176,15 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
+            "issue": "2980",
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
+            "issue": "2980",
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
@@ -33699,13 +33705,15 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
+            "issue": "2980",
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
+            "issue": "2980",
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
@@ -34011,13 +34019,15 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
+            "issue": "2980",
             "verified_at": "2026-05-28"
           },
           "handler_attribution": {
-            "status": "full",
+            "status": "missing",
             "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
+            "issue": "2980",
             "verified_at": "2026-05-28"
           },
           "route_extraction": {


### PR DESCRIPTION
## Summary

Closes #2978. Honesty fix — downgrades `Routing/endpoint_synthesis` and `Routing/handler_attribution` from `full` → `missing` on five Python frameworks that cite only YAML detection manifests with no actual synthesis implementations.

## Frameworks downgraded

**Issue #2979 (aiohttp + bottle):**
- `lang.python.framework.aiohttp` — endpoint_synthesis, handler_attribution
- `lang.python.framework.bottle` — endpoint_synthesis, handler_attribution

**Issue #2980 (sanic + litestar + robyn):**
- `lang.python.framework.litestar` — endpoint_synthesis, handler_attribution
- `lang.python.framework.sanic` — endpoint_synthesis, handler_attribution
- `lang.python.framework.robyn` — endpoint_synthesis, handler_attribution

## Verification

- Registry validate: **0 errors**, 4715 warnings (expected)
- Coverage gen: 557 record(s) generated
- Coverage fmt: canonical
- Tests: `go test ./tools/coverage/...` green
- Build: `go build ./...` green
- Git diff: Only 10 cells changed (5 frameworks × 2 capabilities)

## Test plan

- [x] Verify each framework's synthesis capability is `missing` with correct issue reference
- [x] Confirm registry validates with 0 errors
- [x] Ensure code builds and tests pass

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>