### PR TITLE
coverage: record Django routing, tests, dto, auth, middleware capabilities

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -82,7 +82,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/8 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -14,7 +14,7 @@ Back to [summary](../summary.md).
 |---|---|---|---|---|---|---|---|
 | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Django](../detail/lang.python.framework.django.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/8 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -17,26 +17,26 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go`<br>`internal/engine/rules/python/frameworks/django.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/django_admin_routes.go`<br>`internal/engine/django_routes.go` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/django_routes.go`<br>`internal/engine/django_urlconf_nested.go` | — |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/django_drf_actions.go` | — |
+| Auth coverage | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/python/django.go`<br>`internal/mcp/auth_coverage.go` | login_required and permission_required decorators extracted by django.go; auth_coverage.go MCP tool analyses coverage graph-wide |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/django.go` | Django admin registrations (admin.site.register, @admin.register) and form patterns; full form field introspection not yet implemented |
 | Request validation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/django_imports_rewrite.go` | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/python/django.go` | Middleware class and process_request/process_response/process_view hooks extracted; MIDDLEWARE setting list analysis not yet implemented |
 
 ### Type System
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/pytest.go`<br>`internal/engine/tests_edges.go` | — |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -31935,21 +31935,26 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/django_routes.go","internal/engine/django_urlconf_nested.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/django_drf_actions.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/python/django.go","internal/mcp/auth_coverage.go"],
+            "notes": "login_required and permission_required decorators extracted by django.go; auth_coverage.go MCP tool analyses coverage graph-wide",
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/django.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Django admin registrations (admin.site.register, @admin.register) and form patterns; full form field introspection not yet implemented",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "missing",
@@ -31959,8 +31964,9 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/engine/django_imports_rewrite.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/python/django.go"],
+            "notes": "Middleware class and process_request/process_response/process_view hooks extracted; MIDDLEWARE setting list analysis not yet implemented",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -31983,8 +31989,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/pytest.go","internal/engine/tests_edges.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Observability": {


### PR DESCRIPTION
## Summary

Closes #2974

Records five Django coverage cells that were already implemented in production but not reflected in the registry:

| Capability | Before | After | Proof |
|---|---|---|---|
| `Routing/route_extraction` | `missing` | `full` | `django_routes.go` (DRF router composition), `django_urlconf_nested.go` (nested include composition); proven by `TestDetect_DjangoRouteComposition_Issue64` + `TestApplyDjangoNestedURLConf*` |
| `Testing/tests_linkage` | `missing` | `partial` | `pytest.go` (test function extraction) + `tests_edges.go` (multi-hop TESTS edges via HTTP client); partial because not all Django test patterns are covered |
| `Validation/dto_extraction` | `missing` | `partial` | `django.go` admin registrations (`admin.site.register`, `@admin.register`); partial because full form field introspection not yet implemented |
| `Auth/auth_coverage` | `partial` (wrong cite) | `partial` (correct cite) | Corrected from `django_drf_actions.go` → `django.go` (login_required/permission_required extraction) + `auth_coverage.go` (MCP tool) |
| `Middleware/middleware_coverage` | `partial` (wrong cite) | `partial` (correct cite) | Corrected from `django_imports_rewrite.go` → `django.go` (Middleware class + process_* hooks) |

## Approach

- Used `go run ./tools/coverage update` for all cells — no hand-edits to registry.json
- All `full` flips have existing proving fixtures; no new fixtures needed (issue confirmed existing tests cover these paths)
- `route_extraction → full` is honest: both `path()`/`re_path()` URL patterns, CBV classes, and nested include composition are fully extracted
- `tests_linkage → partial` is honest: multi-hop via HTTP client works but direct Django `TestCase` method-level linkage is incomplete
- `dto_extraction → partial` is honest: admin registration forms are tracked, but form field schema introspection is not yet done

## Verification

- `coverage validate`: 0 errors
- `coverage fmt --check`: ok, canonical
- `coverage gen`: byte-stable (557 records)
- `git diff registry.json`: only `lang.python.framework.django` cells modified
- `go test ./internal/extractors/python/ ./internal/engine/ ./tools/coverage/ ./internal/types/ ./internal/custom/python/`: all pass
- `go build ./...`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)