### PR TITLE
coverage: Flask recording — route_extraction→full, auth/middleware/dto/validation/tests→partial

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -86,7 +86,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/8 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -18,7 +18,7 @@ Back to [summary](../summary.md).
 | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/8 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Flask](../detail/lang.python.framework.flask.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Litestar](../detail/lang.python.framework.litestar.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Pyramid](../detail/lang.python.framework.pyramid.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -17,26 +17,26 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/flask.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/flask.yaml` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go` | — |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | ❌ `missing` | — | — | — | — |
+| Auth coverage | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/python/flask.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/flask_reqresp.go` | — |
+| Request validation | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/flask.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/python/flask.go` | — |
 
 ### Type System
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/pytest.go` | — |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -32831,28 +32831,37 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/flask.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/flask_reqresp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/flask.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/flask.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -32875,8 +32884,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/pytest.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Observability": {

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -796,6 +796,54 @@ records:
             - file: internal/engine/rules/python/frameworks/flask.yaml
           issues_implemented: ["2681"]
           verified_at: "2026-05-28"
+        route_extraction:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeFlask, parseFlaskMethods]
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_test.go
+          issues_implemented: ["2977"]
+          verified_at: "2026-05-29"
+      Auth:
+        auth_coverage:
+          status: partial
+          symbols:
+            - file: internal/custom/python/flask.go
+              functions: [Extract]
+          issues_implemented: ["2977"]
+          verified_at: "2026-05-29"
+      Middleware:
+        middleware_coverage:
+          status: partial
+          symbols:
+            - file: internal/custom/python/flask.go
+              functions: [Extract]
+          issues_implemented: ["2977"]
+          verified_at: "2026-05-29"
+      Validation:
+        dto_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/python/flask_reqresp.go
+              functions: [Extract]
+          issues_implemented: ["2977"]
+          verified_at: "2026-05-29"
+        request_validation:
+          status: partial
+          symbols:
+            - file: internal/custom/python/flask.go
+              functions: [Extract]
+          issues_implemented: ["2977"]
+          verified_at: "2026-05-29"
+      Testing:
+        tests_linkage:
+          status: partial
+          symbols:
+            - file: internal/custom/python/pytest.go
+              functions: [Extract]
+          issues_implemented: ["2977"]
+          verified_at: "2026-05-29"
 
   lang.python.framework.fastapi:
     capabilities:


### PR DESCRIPTION
## Summary

- `Routing/route_extraction` → **full** — cites `internal/engine/http_endpoint_synthesis.go:synthesizeFlask()` (already exercised by `TestSynth_Flask` and the end-to-end test in `http_endpoint_synthesis_test.go`)
- `Auth/auth_coverage` → **partial** — `FlaskExtractor` captures `@login_required` hooks (`flLoginRequiredRe`, line 38 of `flask.go`)
- `Middleware/middleware_coverage` → **partial** — `FlaskExtractor` captures `before_request`/`after_request`/`errorhandler` decorators
- `Validation/dto_extraction` → **partial** — `FlaskReqRespExtractor` parses `marshmallow schema.load()` calls and return-type annotations
- `Validation/request_validation` → **partial** — `FlaskExtractor` records Blueprint registration and route path-converter params
- `Testing/tests_linkage` → **partial** — language-wide pytest coverage via `PytestExtractor`

Still **missing** (honest gaps, left red per issue): `Type System/*`, `Observability/*`.

## Proof

All six cited files exist and extractors are registered.  
Tests pass: `go test ./internal/custom/python/ ./internal/engine/ ./tools/coverage/ ./internal/types/` ✓  
`go build ./...` ✓  
`coverage validate` → 0 errors ✓  
`coverage fmt --check` → canonical ✓  
`coverage gen` → byte-stable (557 records) ✓  
Registry diff minimal: only `lang.python.framework.flask` record touched.

## Test plan

- [ ] `go test ./internal/custom/python/ ./internal/engine/ ./tools/coverage/ ./internal/types/` — all pass
- [ ] `go run ./tools/coverage validate` — 0 errors
- [ ] `go run ./tools/coverage fmt --check` — ok canonical
- [ ] `go run ./tools/coverage get lang.python.framework.flask` — confirm 6 cells flipped

Closes #2977

🤖 Generated with [Claude Code](https://claude.com/claude-code)