### PR TITLE
[Java coverage] type_alias_extraction → not_applicable (#2997)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -122,19 +122,19 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ 2/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ❌ 2/3 | ✅ 1/1 | ❌ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ❌ 2/3 | ✅ 1/1 | ✅ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -12,19 +12,19 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ 2/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ❌ 2/3 | ✅ 1/1 | ❌ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Helidon](../detail/lang.java.framework.helidon.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ❌ 2/3 | ✅ 1/1 | ✅ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 | Interface extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type alias syntax |
 | Type extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/java/java.go` | — |
 
 ### DI

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14015,8 +14015,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -14543,8 +14543,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -14907,8 +14907,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -15129,8 +15129,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -15351,8 +15351,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -15575,8 +15575,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -15821,8 +15821,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -16049,8 +16049,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -16423,8 +16423,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -16649,8 +16649,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -16905,8 +16905,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -17127,8 +17127,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",
@@ -17495,8 +17495,8 @@
             "verified_at": "2026-05-28"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Java has no type alias syntax"
           },
           "type_extraction": {
             "status": "full",


### PR DESCRIPTION
## Summary

Honesty fix: Java has no type alias syntax. All `type_alias_extraction` cells across 13 Java framework records have been updated from `missing` to `not_applicable` and the `backfill:dictionary-completeness` tracking issue has been removed.

## Changes

- Updated type_alias_extraction status for all 13 Java framework records to `not_applicable`
- Regenerated coverage documentation
- Registry validation: 0 errors
- All tests passing

## Records Updated

- lang.java.framework.spring-boot
- lang.java.framework.spring-webflux
- lang.java.framework.quarkus
- lang.java.framework.micronaut
- lang.java.framework.microprofile
- lang.java.framework.jakarta-ee
- lang.java.framework.jaxrs
- lang.java.framework.helidon
- lang.java.framework.dropwizard
- lang.java.framework.javalin
- lang.java.framework.vertx
- lang.java.framework.struts
- lang.java.framework.akka-http

Closes #2997