### PR TITLE
coverage(celery): flip 7 substrate+testing cells partial, tag B-build gaps

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -239,6 +239,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ❌ 0/1 | ❌ 5/21 | ❌ 4/6 | |
+| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ⚠️ 0/1 | ❌ 5/21 | ❌ 4/6 | |
 | [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
 | [python](../by-language/python.md) | [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -42,7 +42,7 @@ Back to [summary](../summary.md).
 
 | Name | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|
-| [Celery (task queue)](../detail/lang.python.framework.celery.md) | ❌ 0/1 | ❌ 5/21 | ❌ 4/6 | |
+| [Celery (task queue)](../detail/lang.python.framework.celery.md) | ⚠️ 0/1 | ❌ 5/21 | ❌ 4/6 | |
 | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
 | [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |
 

--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -28,8 +28,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Broker binding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Result backend binding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Broker binding | ❌ `missing` | — | #2982-B-build | — | No broker-URL extraction implemented yet; requires parsing CELERY_BROKER_URL / broker= constructor arg |
+| Result backend binding | ❌ `missing` | — | #2982-B-build | — | No result-backend extraction implemented yet; requires parsing CELERY_RESULT_BACKEND / backend= constructor arg |
 
 ### Reliability
 
@@ -41,7 +41,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/pytest.go` | pytest.go extracts test functions and fixtures; coverage is partial because Celery-task test helpers are not directly linked |
 
 ### Substrate
 
@@ -49,9 +49,9 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Confidence overlay | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| DB effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | language-wide Python effect sniffer detects Django ORM / SQLAlchemy db writes and reads; partial because Celery-specific task context is not disambiguated |
 | Dead code detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/def_use_python.go` | language-wide Python def-use sniffer captures variable defs/uses; partial for Celery task argument flows |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | HTTP effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
@@ -59,14 +59,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Module cycle detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Mutation effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Pure function tagging | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/entry_points_python.go` | language-wide Python entry-point sniffer detects module-level test/main/lifecycle entry points; partial for Celery worker entry wiring |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | Sanitizer recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
-| Taint sink detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Taint source detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | language-wide Python effect sniffer recognises SQL/command-injection sink shapes; partial for Celery task context |
+| Taint source detection | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/taint_sites_python.go` | language-wide Python taint sniffer recognises request/env sources; partial for Celery task context |
+| Template pattern catalog | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/template_pattern_python.go` | language-wide Python template-pattern sniffer covers i18n/log/SQL patterns; partial for Celery-specific message formatting |
 | Vulnerability finding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -31628,11 +31628,13 @@
         "Broker": {
           "broker_binding": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "#2982-B-build",
+            "notes": "No broker-URL extraction implemented yet; requires parsing CELERY_BROKER_URL / broker= constructor arg"
           },
           "result_backend_binding": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "#2982-B-build",
+            "notes": "No result-backend extraction implemented yet; requires parsing CELERY_RESULT_BACKEND / backend= constructor arg"
           }
         },
         "Reliability": {
@@ -31645,8 +31647,11 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/pytest.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "pytest.go extracts test functions and fixtures; coverage is partial because Celery-task test helpers are not directly linked",
+            "verified_at": "2026-05-29"
           }
         },
         "Substrate": {
@@ -31660,16 +31665,22 @@
             "verified_at": "2026-05-28"
           },
           "db_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_python.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "language-wide Python effect sniffer detects Django ORM / SQLAlchemy db writes and reads; partial because Celery-specific task context is not disambiguated",
+            "verified_at": "2026-05-29"
           },
           "dead_code_detection": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/def_use_python.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "language-wide Python def-use sniffer captures variable defs/uses; partial for Celery task argument flows",
+            "verified_at": "2026-05-29"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -31702,8 +31713,11 @@
             "issue": "backfill:dictionary-completeness"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/entry_points_python.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "language-wide Python entry-point sniffer detects module-level test/main/lifecycle entry points; partial for Celery worker entry wiring",
+            "verified_at": "2026-05-29"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -31725,16 +31739,25 @@
             "verified_at": "2026-05-27"
           },
           "taint_sink_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_python.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "language-wide Python effect sniffer recognises SQL/command-injection sink shapes; partial for Celery task context",
+            "verified_at": "2026-05-29"
           },
           "taint_source_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/taint_sites_python.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "language-wide Python taint sniffer recognises request/env sources; partial for Celery task context",
+            "verified_at": "2026-05-29"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_python.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "language-wide Python template-pattern sniffer covers i18n/log/SQL patterns; partial for Celery-specific message formatting",
+            "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
             "status": "missing",

--- a/internal/substrate/effects_test.go
+++ b/internal/substrate/effects_test.go
@@ -658,6 +658,39 @@ public:
 	mustHave(t, byEffect, EffectMutation, "set_count")
 }
 
+// TestSniffEffectsPython_CeleryTaskBody is the proving fixture for
+// #2982 (Celery substrate A-win cells). It verifies that the language-wide
+// Python effect sniffer detects db_write, db_read, http_out, and env_read
+// inside a @shared_task function body — confirming that the substrate
+// db_effect, taint_source_detection, and taint_sink_detection cells are
+// legitimately partial for lang.python.framework.celery.
+func TestSniffEffectsPython_CeleryTaskBody(t *testing.T) {
+	const src = `
+from celery import shared_task
+import os, boto3, psycopg2
+
+@shared_task(bind=True, max_retries=3)
+def process_invoice(self, invoice_id):
+    conn = psycopg2.connect(os.getenv("DATABASE_URL"))
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM invoices WHERE id = %s", (invoice_id,))
+    row = cur.fetchone()
+    s3 = boto3.client("s3", region_name=os.environ.get("AWS_REGION"))
+    s3.upload_file("/tmp/invoice.pdf", "bucket", "key")
+    cur.execute("UPDATE invoices SET processed = true WHERE id = %s", (invoice_id,))
+    conn.commit()
+`
+	got := sniffEffectsPython(src)
+	if len(got) == 0 {
+		t.Fatal("#2982 proof: expected effect matches inside @shared_task body; got none")
+	}
+	by := groupByEffect(got)
+	mustHave(t, by, EffectDBRead, "process_invoice")
+	mustHave(t, by, EffectDBWrite, "process_invoice")
+	mustHave(t, by, EffectHTTPOut, "process_invoice")
+	mustHave(t, by, EffectEnvRead, "process_invoice")
+}
+
 func groupByEffect(ms []EffectMatch) map[Effect]map[string]bool {
 	out := map[Effect]map[string]bool{}
 	for _, m := range ms {


### PR DESCRIPTION
## Summary

- Flips 7 `missing` → `partial` for `lang.python.framework.celery` using language-wide Python substrate sniffers (A-win cells per issue #2982)
- Tags `broker_binding` and `result_backend_binding` as `missing` with `#2982-B-build` issue note (no extractor exists yet)
- Adds proving fixture `TestSniffEffectsPython_CeleryTaskBody` in `internal/substrate/effects_test.go`
- Regenerates `docs/coverage/` pages

## Cells flipped (missing → partial)

| Cell | Cite |
|---|---|
| `Testing/tests_linkage` | `internal/custom/python/pytest.go` |
| `Substrate/db_effect` | `internal/substrate/effect_sinks_python.go` |
| `Substrate/taint_source_detection` | `internal/substrate/taint_sites_python.go` |
| `Substrate/taint_sink_detection` | `internal/substrate/effect_sinks_python.go` |
| `Substrate/template_pattern_catalog` | `internal/substrate/template_pattern_python.go` |
| `Substrate/def_use_chain_extraction` | `internal/substrate/def_use_python.go` |
| `Substrate/reachability_analysis` | `internal/substrate/entry_points_python.go` |

## B-build gaps (remain missing)

- `Broker/broker_binding` — no `CELERY_BROKER_URL` / `broker=` arg extractor yet
- `Broker/result_backend_binding` — no `CELERY_RESULT_BACKEND` / `backend=` arg extractor yet

## Test plan

- [x] `go run ./tools/coverage validate` exits 0 (only warnings, no errors)
- [x] `TestSniffEffectsPython_CeleryTaskBody` passes — proves substrate sniffers detect db_read/write, http_out, env_read inside `@shared_task` body
- [x] `go test ./internal/custom/python/ ./internal/substrate/ ./internal/links/ ./tools/coverage/` all green
- [x] `go build ./...` clean
- [x] Registry diff is minimal: only `lang.python.framework.celery` changed

Closes #2982

🤖 Generated with [Claude Code](https://claude.com/claude-code)