### PR TITLE
coverage(django-drf): flip route_extraction→full + record 4 new cells

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -83,7 +83,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/8 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/8 | |
 | [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -15,7 +15,7 @@ Back to [summary](../summary.md).
 | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/8 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/8 | |
 | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/django_drf_actions.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/django_drf_actions.go`<br>`internal/extractors/python/drf_serializer_fields.go` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/python_relational_bundle_test.go`<br>`internal/extractors/python/router_register.go` | — |
 
 ### Auth
 
@@ -29,14 +29,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/python/drf_serializer_fields.go`<br>`internal/extractors/python/drf_serializer_fields_test.go` | — |
+| Request validation | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/python/django_drf_permissions.go`<br>`internal/extractors/python/django_drf_permissions_test.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | — | `internal/engine/django_imports_rewrite.go` | Django middleware import rewriting provides partial coverage; DRF-specific middleware detection not yet implemented |
 
 ### Type System
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/extractors_test.go`<br>`internal/custom/python/pytest.go` | — |
 
 ### Observability
 
@@ -74,7 +74,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | — |
-| Def use chain extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_python.go` | — |
+| Def use chain extraction | ⚠️ `partial` | `2026-05-29` | — | `internal/substrate/def_use_python.go`<br>`internal/substrate/def_use_test.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | — |
@@ -87,9 +87,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | Sanitizer recognition | ⚠️ `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | — |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
-| Taint sink detection | ⚠️ `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | — |
-| Taint source detection | ⚠️ `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | — |
-| Template pattern catalog | ⚠️ `partial` | `2026-05-28` | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_python.go` | — |
+| Taint sink detection | ⚠️ `partial` | `2026-05-29` | — | `internal/substrate/taint_sites_python.go`<br>`internal/substrate/taint_sites_test.go` | — |
+| Taint source detection | ⚠️ `partial` | `2026-05-29` | — | `internal/substrate/taint_sites_python.go`<br>`internal/substrate/taint_sites_test.go` | — |
+| Template pattern catalog | ⚠️ `partial` | `2026-05-29` | — | `internal/substrate/template_pattern_python.go`<br>`internal/substrate/template_pattern_test.go` | — |
 | Vulnerability finding | ⚠️ `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | — |
 
 ## Framework-specific

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -32124,8 +32124,9 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/python/python_relational_bundle_test.go","internal/extractors/python/router_register.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
@@ -32138,17 +32139,24 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/drf_serializer_fields.go","internal/extractors/python/drf_serializer_fields_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/django_drf_permissions.go","internal/extractors/python/django_drf_permissions_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/engine/django_imports_rewrite.go"],
+            "notes": "Django middleware import rewriting provides partial coverage; DRF-specific middleware detection not yet implemented",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -32171,8 +32179,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/extractors_test.go","internal/custom/python/pytest.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Observability": {
@@ -32211,8 +32221,8 @@
           },
           "def_use_chain_extraction": {
             "status": "partial",
-            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use.go","internal/substrate/def_use_python.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/substrate/def_use_python.go","internal/substrate/def_use_test.go"],
+            "verified_at": "2026-05-29"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -32276,18 +32286,18 @@
           },
           "taint_sink_detection": {
             "status": "partial",
-            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/substrate/taint_sites_python.go","internal/substrate/taint_sites_test.go"],
+            "verified_at": "2026-05-29"
           },
           "taint_source_detection": {
             "status": "partial",
-            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/substrate/taint_sites_python.go","internal/substrate/taint_sites_test.go"],
+            "verified_at": "2026-05-29"
           },
           "template_pattern_catalog": {
             "status": "partial",
-            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern.go","internal/substrate/template_pattern_python.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/substrate/template_pattern_python.go","internal/substrate/template_pattern_test.go"],
+            "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
             "status": "partial",


### PR DESCRIPTION
## Summary

Closes #2975

Records and promotes DRF capability cells in `lang.python.framework.django-drf`:

- **Routing/route_extraction** → `full` — `router_register.go` emits REFERENCES edges from `urls.py` to registered ViewSet classes with `url_prefix`/`basename` properties; proven by `TestIssue2010_RouterRegisterEmitsEdge` in `python_relational_bundle_test.go`
- **Validation/dto_extraction** → `partial` — `drf_serializer_fields.go` emits REFERENCES from serializer fields to related models/serializers; 7 tests covering PrimaryKeyRelatedField, nested serializers, source-path fields, scalar fields
- **Validation/request_validation** → `partial` — `django_drf_permissions.go` stamps `permission_classes`, `has_permission_classes`, `has_get_permissions` onto ViewSet/APIView class entities
- **Testing/tests_linkage** → `partial` — `custom/python/pytest.go` extracts pytest test functions, classes, fixtures, parametrize marks; 5 tests in `extractors_test.go`
- **Middleware/middleware_coverage** → `partial` — `django_imports_rewrite.go` rewrites Django MW import suffixes; DRF-specific middleware detection not yet implemented (honest gap noted)
- **Substrate partials confirmed** — taint_source_detection, taint_sink_detection, def_use_chain_extraction, template_pattern_catalog re-verified with test cites and `verified_at: 2026-05-29`

## Test plan

- [x] `go run ./tools/coverage validate` → 0 errors (557 records, warnings only on unrelated records)
- [x] `go test ./internal/custom/python/ ./internal/engine/ ./tools/coverage/ ./internal/types/` → all pass
- [x] `go build ./...` → clean
- [x] `go run ./tools/coverage gen` → 557 records regenerated (byte-stable)
- [x] Only `docs/coverage/registry.json` and generated docs changed; no Go source files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)