### PR TITLE
coverage(spring-boot/webflux): flip route_extraction+dto_extraction+request_validation missing→partial

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -132,7 +132,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ❌ 2/3 | ✅ 1/1 | ✅ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 2/3 | ✅ 1/1 | ✅ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -22,7 +22,7 @@ Back to [summary](../summary.md).
 | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ❌ 2/3 | ✅ 1/1 | ✅ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 2/3 | ✅ 1/1 | ✅ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/java/frameworks/spring_boot.yaml`<br>`internal/engine/rules/java/frameworks/spring_mvc.yaml`<br>`internal/engine/spring_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_routes.go`<br>`internal/engine/spring_routes.go` | Annotation-driven route composition scanned (@RequestMapping/@GetMapping/etc.); path-variable expression resolution not implemented |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_request_response.go` | SCOPE.Schema(kind=dto) entities emitted for @RequestBody parameter types and ResponseEntity<T>/Mono<T>/Flux<T> return types; generic collections (List/Map/Set) skipped via srrSkipTypes |
+| Request validation | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_params.go` | Bean Validation annotations (@NotNull, @NotBlank, @NotEmpty, @Valid, @Min, @Max, @Size, @Pattern, @Email) captured per handler parameter; required flag set; no field-level constraint recursion |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_request_response.go` | SCOPE.Schema(kind=dto) entities emitted for @RequestBody types and Mono<T>/Flux<T> return types; generic collections (List/Map/Set) skipped via srrSkipTypes |
+| Request validation | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/java_annotation_params.go` | Bean Validation annotations (@Valid, @NotNull, @NotBlank, @NotEmpty) captured per handler parameter; required flag set; same extractor as spring-boot; no field-level recursion |
 
 ### Middleware
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -16603,8 +16603,11 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/engine/java_annotation_routes.go","internal/engine/spring_routes.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Annotation-driven route composition scanned (@RequestMapping/@GetMapping/etc.); path-variable expression resolution not implemented",
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
@@ -16616,12 +16619,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_request_response.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "SCOPE.Schema(kind=dto) entities emitted for @RequestBody parameter types and ResponseEntity\u003cT\u003e/Mono\u003cT\u003e/Flux\u003cT\u003e return types; generic collections (List/Map/Set) skipped via srrSkipTypes",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/engine/java_annotation_params.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Bean Validation annotations (@NotNull, @NotBlank, @NotEmpty, @Valid, @Min, @Max, @Size, @Pattern, @Email) captured per handler parameter; required flag set; no field-level constraint recursion",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -16874,12 +16883,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_request_response.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "SCOPE.Schema(kind=dto) entities emitted for @RequestBody types and Mono\u003cT\u003e/Flux\u003cT\u003e return types; generic collections (List/Map/Set) skipped via srrSkipTypes",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/engine/java_annotation_params.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Bean Validation annotations (@Valid, @NotNull, @NotBlank, @NotEmpty) captured per handler parameter; required flag set; same extractor as spring-boot; no field-level recursion",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -1198,6 +1198,277 @@ func TestQuartzJava_NonJavaLanguageSkipped(t *testing.T) {
 }
 
 // ============================================================================
+// Issue #2988 — Spring Boot / WebFlux proving tests
+// Cells: route_extraction, dto_extraction, request_validation
+// ============================================================================
+
+// TestSpringBoot_RouteExtraction_Issue2988 proves that ExtractSpringBoot
+// emits endpoint entities whose properties carry the composed HTTP route
+// path and method — confirming route_extraction is delivered by the
+// spring_boot custom extractor + the engine-level spring_routes.go pass.
+// The registry target is `partial` (annotations scanned; path-variable
+// resolution may be incomplete). Cite: internal/engine/spring_routes.go,
+// internal/engine/java_annotation_routes.go.
+func TestSpringBoot_RouteExtraction_Issue2988(t *testing.T) {
+	source := `
+package com.example;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OrderController {
+    @GetMapping("/orders")
+    public List<OrderDto> getOrders() { return null; }
+
+    @PostMapping("/orders")
+    public OrderDto createOrder(@RequestBody CreateOrderRequest req) { return null; }
+
+    @GetMapping("/orders/{id}")
+    public OrderDto getOrder(@PathVariable Long id) { return null; }
+}
+`
+	r := ExtractSpringBoot(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_boot",
+		FilePath:  "OrderController.java",
+	})
+
+	// Must emit at least 3 endpoint entities for the 3 handler methods.
+	var endpointNames []string
+	for _, e := range r.Entities {
+		if e.Subtype == "endpoint" {
+			endpointNames = append(endpointNames, e.Name)
+		}
+	}
+	if len(endpointNames) < 3 {
+		t.Errorf("[#2988 route_extraction] expected >= 3 endpoint entities, got %d: %v", len(endpointNames), endpointNames)
+	}
+
+	// Validate HTTP verbs are captured on the operation entities.
+	verbsSeen := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Subtype == "endpoint" {
+			if raw, ok := e.Properties["http_method"]; ok {
+				if v, ok2 := raw.(string); ok2 && v != "" {
+					verbsSeen[v] = true
+				}
+			}
+		}
+	}
+	for _, want := range []string{"GET", "POST"} {
+		if !verbsSeen[want] {
+			t.Errorf("[#2988 route_extraction] HTTP method %q not found among endpoint entities", want)
+		}
+	}
+}
+
+// TestSpringBoot_DtoExtraction_Issue2988 proves that ExtractSpringRequestResponse
+// emits SCOPE.Schema(kind=dto) entities for @RequestBody parameter types and
+// return types, and wires ACCEPTS_INPUT / RETURNS relationships.
+// Registry target: partial. Cite: internal/custom/java/spring_request_response.go.
+func TestSpringBoot_DtoExtraction_Issue2988(t *testing.T) {
+	source := `
+package com.example;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OrderController {
+    @GetMapping("/orders")
+    public List<OrderDto> getOrders() { return null; }
+
+    @PostMapping("/orders")
+    public OrderDto createOrder(@RequestBody CreateOrderRequest req) { return null; }
+}
+`
+	r := ExtractSpringRequestResponse(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_boot",
+		FilePath:  "OrderController.java",
+	})
+
+	// Expect SCOPE.Schema entities for CreateOrderRequest and OrderDto.
+	dtoNames := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Schema" {
+			dtoNames[e.Name] = true
+			if e.Properties["kind"] != "dto" {
+				t.Errorf("[#2988 dto_extraction] entity %q has kind=%q, want dto",
+					e.Name, e.Properties["kind"])
+			}
+		}
+	}
+	for _, want := range []string{"CreateOrderRequest", "OrderDto"} {
+		if !dtoNames[want] {
+			t.Errorf("[#2988 dto_extraction] expected SCOPE.Schema entity for %q, got entities: %v", want, dtoNames)
+		}
+	}
+
+	// Expect ACCEPTS_INPUT and RETURNS relationships.
+	relTypes := make(map[string]bool)
+	for _, rel := range r.Relationships {
+		relTypes[rel.RelationshipType] = true
+	}
+	for _, want := range []string{"ACCEPTS_INPUT", "RETURNS"} {
+		if !relTypes[want] {
+			t.Errorf("[#2988 dto_extraction] expected %q relationship, got: %v", want, relTypes)
+		}
+	}
+}
+
+// TestSpringWebFlux_DtoExtraction_Issue2988 proves that ExtractSpringRequestResponse
+// also handles spring_webflux framework (springReqRespFrameworks includes it),
+// emitting dto entities for Mono<T>/Flux<T> return types and @RequestBody params.
+// Registry target: partial. Cite: internal/custom/java/spring_request_response.go.
+func TestSpringWebFlux_DtoExtraction_Issue2988(t *testing.T) {
+	source := `
+package com.example;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ProductController {
+    @GetMapping("/products")
+    public Flux<ProductDto> listProducts() { return null; }
+
+    @PostMapping("/products")
+    public Mono<ProductDto> createProduct(@RequestBody CreateProductRequest req) { return null; }
+}
+`
+	r := ExtractSpringRequestResponse(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_webflux",
+		FilePath:  "ProductController.java",
+	})
+
+	dtoNames := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Schema" {
+			dtoNames[e.Name] = true
+		}
+	}
+	// Mono<T>/Flux<T> are unwrapped; CreateProductRequest is explicit via @RequestBody.
+	for _, want := range []string{"CreateProductRequest", "ProductDto"} {
+		if !dtoNames[want] {
+			t.Errorf("[#2988 webflux dto_extraction] expected SCOPE.Schema for %q, got: %v", want, dtoNames)
+		}
+	}
+
+	relTypes := make(map[string]bool)
+	for _, rel := range r.Relationships {
+		relTypes[rel.RelationshipType] = true
+	}
+	if !relTypes["ACCEPTS_INPUT"] {
+		t.Errorf("[#2988 webflux dto_extraction] expected ACCEPTS_INPUT relationship")
+	}
+	if !relTypes["RETURNS"] {
+		t.Errorf("[#2988 webflux dto_extraction] expected RETURNS relationship")
+	}
+}
+
+// TestSpringBoot_RequestValidation_Issue2988 proves that Bean Validation
+// annotations (@Valid, @NotNull) on Spring handler parameters drive the
+// required flag on the endpoint.  This test exercises the custom extractor
+// layer: a controller source containing @Valid @RequestBody must produce an
+// ACCEPTS_INPUT relationship — confirming the plumbing is wired.
+// The parameter-level @Required flag is asserted in the engine-level test
+// TestSpringBoot_RequestValidation_Engine_Issue2988 (java_annotation_params_test.go).
+// Registry target: partial. Cite: internal/engine/java_annotation_params.go.
+func TestSpringBoot_RequestValidation_Issue2988(t *testing.T) {
+	source := `
+package com.example;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OrderController {
+    @PostMapping("/orders")
+    public OrderDto createOrder(@Valid @RequestBody @NotNull CreateOrderRequest req) { return null; }
+}
+`
+	r := ExtractSpringRequestResponse(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_boot",
+		FilePath:  "OrderController.java",
+	})
+
+	// ACCEPTS_INPUT relationship must be emitted — proving request body
+	// was recognised even when combined with validation annotations.
+	hasAcceptsInput := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "ACCEPTS_INPUT" {
+			hasAcceptsInput = true
+			break
+		}
+	}
+	if !hasAcceptsInput {
+		t.Errorf("[#2988 request_validation] expected ACCEPTS_INPUT relationship for @Valid @RequestBody param")
+	}
+
+	// The DTO entity must exist.
+	hasDtoEntity := false
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Schema" && e.Name == "CreateOrderRequest" {
+			hasDtoEntity = true
+			break
+		}
+	}
+	if !hasDtoEntity {
+		t.Errorf("[#2988 request_validation] expected SCOPE.Schema entity for CreateOrderRequest")
+	}
+}
+
+// TestSpringWebFlux_RequestValidation_Issue2988 proves Bean Validation
+// annotation handling for spring_webflux — the springReqRespFrameworks map
+// in spring_request_response.go includes spring_webflux, so @Valid @RequestBody
+// on a reactive controller must also yield ACCEPTS_INPUT + a DTO entity.
+// Registry target: partial. Cite: internal/engine/java_annotation_params.go,
+// internal/custom/java/spring_request_response.go.
+func TestSpringWebFlux_RequestValidation_Issue2988(t *testing.T) {
+	source := `
+package com.example;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ProductController {
+    @PostMapping("/products")
+    public Mono<ProductDto> createProduct(@Valid @RequestBody CreateProductRequest req) { return null; }
+}
+`
+	r := ExtractSpringRequestResponse(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_webflux",
+		FilePath:  "ProductController.java",
+	})
+
+	hasAcceptsInput := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "ACCEPTS_INPUT" {
+			hasAcceptsInput = true
+			break
+		}
+	}
+	if !hasAcceptsInput {
+		t.Errorf("[#2988 webflux request_validation] expected ACCEPTS_INPUT for @Valid @RequestBody")
+	}
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/internal/engine/java_annotation_params_test.go
+++ b/internal/engine/java_annotation_params_test.go
@@ -258,3 +258,89 @@ func TestEncodeJavaParameters_EmptyReturnsEmpty(t *testing.T) {
 		t.Errorf("empty input should encode to \"\", got %q", got)
 	}
 }
+
+// ============================================================================
+// Issue #2988 — request_validation proving tests for spring-boot / spring-webflux
+// ============================================================================
+
+// TestSpringBoot_RequestValidation_Engine_Issue2988 proves that Bean Validation
+// annotations (@Valid, @NotNull, @NotBlank, @NotEmpty) on Spring MVC handler
+// parameters are recognised and set required=true on the emitted JavaParam
+// records.  This is the authoritative engine-layer proof for the
+// lang.java.framework.spring-boot / request_validation cell.
+// Registry target: partial (parameter-level only; no field-level recursion).
+// Cite: internal/engine/java_annotation_params.go (lines 120-129).
+func TestSpringBoot_RequestValidation_Engine_Issue2988(t *testing.T) {
+	// Canonical Spring Boot pattern: @Valid @RequestBody @NotNull on a POST handler.
+	frag := `@Valid @RequestBody @NotNull CreateOrderRequest req, @RequestParam String currency)`
+	params := extractJavaParameters(frag, []string{"POST"})
+
+	if len(params) < 2 {
+		t.Fatalf("[#2988 spring-boot request_validation] expected >=2 params, got %d: %+v", len(params), params)
+	}
+
+	body := findParamByIn(params, "body")
+	if body == nil {
+		t.Fatalf("[#2988 spring-boot request_validation] body param missing; params=%+v", params)
+	}
+	if !body.Required {
+		t.Errorf("[#2988 spring-boot request_validation] @Valid @NotNull body must be required=true")
+	}
+	if body.Type != "CreateOrderRequest" {
+		t.Errorf("[#2988 spring-boot request_validation] body type=%q, want CreateOrderRequest", body.Type)
+	}
+
+	// @Valid and @NotNull must appear in the Annotations list.
+	annoSet := make(map[string]bool)
+	for _, a := range body.Annotations {
+		annoSet[a] = true
+	}
+	for _, want := range []string{"@Valid", "@NotNull"} {
+		if !annoSet[want] {
+			t.Errorf("[#2988 spring-boot request_validation] annotation %q missing from body param; got %v",
+				want, body.Annotations)
+		}
+	}
+
+	// @NotBlank on a query param must also set required=true.
+	fragNB := `@NotBlank @RequestParam String currency)`
+	paramsNB := extractJavaParameters(fragNB, []string{"GET"})
+	if len(paramsNB) < 1 {
+		t.Fatalf("[#2988 spring-boot request_validation] expected 1 param for @NotBlank case")
+	}
+	if !paramsNB[0].Required {
+		t.Errorf("[#2988 spring-boot request_validation] @NotBlank @RequestParam must be required=true")
+	}
+}
+
+// TestSpringWebFlux_RequestValidation_Engine_Issue2988 proves that the same
+// validation-annotation capture logic applies to Spring WebFlux handler
+// parameters — the extractJavaParameters function is framework-agnostic (no
+// framework context arg); the test mirrors what a WebFlux reactive controller
+// handler would produce after line-buffer parsing.
+// Registry target: partial. Cite: internal/engine/java_annotation_params.go.
+func TestSpringWebFlux_RequestValidation_Engine_Issue2988(t *testing.T) {
+	// WebFlux uses the same @RequestBody / @Valid annotations as Spring MVC.
+	frag := `@Valid @RequestBody CreateProductRequest req, @RequestParam(required = false) String tag)`
+	params := extractJavaParameters(frag, []string{"POST"})
+
+	if len(params) < 2 {
+		t.Fatalf("[#2988 webflux request_validation] expected >=2 params, got %d: %+v", len(params), params)
+	}
+
+	body := findParamByIn(params, "body")
+	if body == nil {
+		t.Fatalf("[#2988 webflux request_validation] body param missing; params=%+v", params)
+	}
+	if !body.Required {
+		t.Errorf("[#2988 webflux request_validation] @Valid body must be required=true")
+	}
+
+	query := findParamByIn(params, "query")
+	if query == nil {
+		t.Fatalf("[#2988 webflux request_validation] query param missing")
+	}
+	if query.Required {
+		t.Errorf("[#2988 webflux request_validation] required=false @RequestParam should NOT be required")
+	}
+}

--- a/internal/engine/java_annotation_routes_test.go
+++ b/internal/engine/java_annotation_routes_test.go
@@ -558,3 +558,99 @@ public class CatalogResource {
 		t.Fatalf("[#683] deep annotation stack: ids = %v\nwant %v", ids, want)
 	}
 }
+
+// ============================================================================
+// Issue #2988 — route_extraction proving tests for spring-boot / spring-webflux
+// ============================================================================
+
+// TestSpringBoot_RouteExtraction_Engine_Issue2988 proves that
+// ApplyJavaAnnotationRoutes (which underpins the spring-boot route_extraction
+// capability) emits composed http:VERB:/path endpoint records for a
+// representative Spring MVC @RestController with class-level
+// @RequestMapping prefix + method-level verb mappings.
+// Registry target: partial (annotations scanned; path-variable resolution
+// may be incomplete). Cite: internal/engine/java_annotation_routes.go,
+// internal/engine/spring_routes.go.
+func TestSpringBoot_RouteExtraction_Engine_Issue2988(t *testing.T) {
+	src := `package com.example;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+public class OrderController {
+    @GetMapping("/orders")
+    public List<OrderDto> getOrders() { return null; }
+
+    @PostMapping("/orders")
+    public OrderDto createOrder(@RequestBody CreateOrderRequest req) { return null; }
+
+    @GetMapping("/orders/{id}")
+    public OrderDto getOrder(@PathVariable Long id) { return null; }
+
+    @DeleteMapping("/orders/{id}")
+    public void deleteOrder(@PathVariable Long id) {}
+}
+`
+	got := collect(t, map[string]string{"OrderController.java": src})
+	ids := endpointIDs(got)
+
+	wantIDs := []string{
+		"http:GET:/api/v1/orders",
+		"http:POST:/api/v1/orders",
+		"http:GET:/api/v1/orders/{id}",
+		"http:DELETE:/api/v1/orders/{id}",
+	}
+	sort.Strings(wantIDs)
+	sort.Strings(ids)
+	if strings.Join(ids, "|") != strings.Join(wantIDs, "|") {
+		t.Fatalf("[#2988 spring-boot route_extraction] ids=%v\nwant=%v", ids, wantIDs)
+	}
+
+	// Verify source_handler is correctly attributed.
+	for _, r := range got {
+		if !strings.HasPrefix(r.Props["source_handler"], "SCOPE.Operation:OrderController.") {
+			t.Errorf("[#2988 spring-boot route_extraction] bad source_handler %q on %s",
+				r.Props["source_handler"], r.ID)
+		}
+	}
+}
+
+// TestSpringWebFlux_RouteExtraction_Engine_Issue2988 proves route_extraction
+// for Spring WebFlux — WebFlux uses the same @RestController + @RequestMapping
+// / @GetMapping / @PostMapping annotations as Spring MVC, so
+// ApplyJavaAnnotationRoutes handles it identically.
+// Registry target: partial. Cite: internal/engine/java_annotation_routes.go.
+func TestSpringWebFlux_RouteExtraction_Engine_Issue2988(t *testing.T) {
+	src := `package com.example;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1")
+public class ProductController {
+    @GetMapping("/products")
+    public Flux<ProductDto> listProducts() { return null; }
+
+    @PostMapping("/products")
+    public Mono<ProductDto> createProduct(@RequestBody CreateProductRequest req) { return null; }
+
+    @PutMapping("/products/{id}")
+    public Mono<ProductDto> updateProduct(@PathVariable Long id, @RequestBody UpdateProductRequest req) { return null; }
+}
+`
+	got := collect(t, map[string]string{"ProductController.java": src})
+	ids := endpointIDs(got)
+
+	wantIDs := []string{
+		"http:GET:/api/v1/products",
+		"http:POST:/api/v1/products",
+		"http:PUT:/api/v1/products/{id}",
+	}
+	sort.Strings(wantIDs)
+	sort.Strings(ids)
+	if strings.Join(ids, "|") != strings.Join(wantIDs, "|") {
+		t.Fatalf("[#2988 webflux route_extraction] ids=%v\nwant=%v", ids, wantIDs)
+	}
+}


### PR DESCRIPTION
## Summary

Recording wins (class A) for `lang.java.framework.spring-boot` and `lang.java.framework.spring-webflux` — the extractors already delivered these capabilities; the registry just needed to be updated.

- **`lang.java.framework.spring-boot / route_extraction`**: missing → partial. `@RequestMapping`/`@GetMapping`/etc. annotations scanned and composed into `Route` entities by `spring_routes.go` + `java_annotation_routes.go`. Path-variable expression resolution not implemented (hence partial).
- **`lang.java.framework.spring-boot / dto_extraction`**: missing → partial. `SCOPE.Schema(kind=dto)` entities emitted for `@RequestBody` parameter types and `ResponseEntity<T>` return types by `spring_request_response.go`. Generic collections (List/Map/Set) skipped via `srrSkipTypes`.
- **`lang.java.framework.spring-boot / request_validation`**: missing → partial. Bean Validation annotations (`@NotNull`, `@NotBlank`, `@NotEmpty`, `@Valid`, `@Min`/`@Max`/`@Size`/`@Pattern`/`@Email`) captured per handler parameter; `required` flag set. No field-level constraint recursion.
- **`lang.java.framework.spring-webflux / dto_extraction`**: missing → partial. Same extractor (`spring_request_response.go`) handles `spring_webflux` via `springReqRespFrameworks` map; `Mono<T>`/`Flux<T>` return types unwrapped.
- **`lang.java.framework.spring-webflux / request_validation`**: missing → partial. Same `java_annotation_params.go` extractor; framework-agnostic parameter annotation capture.

## Cells flipped: 5

| Record | Capability | Before | After |
|--------|-----------|--------|-------|
| `lang.java.framework.spring-boot` | `route_extraction` | missing | partial |
| `lang.java.framework.spring-boot` | `dto_extraction` | missing | partial |
| `lang.java.framework.spring-boot` | `request_validation` | missing | partial |
| `lang.java.framework.spring-webflux` | `dto_extraction` | missing | partial |
| `lang.java.framework.spring-webflux` | `request_validation` | missing | partial |

## Proving tests added: 7 new tests

**`internal/custom/java/extractors_test.go`** (5 tests):
- `TestSpringBoot_RouteExtraction_Issue2988`
- `TestSpringBoot_DtoExtraction_Issue2988`
- `TestSpringWebFlux_DtoExtraction_Issue2988`
- `TestSpringBoot_RequestValidation_Issue2988`
- `TestSpringWebFlux_RequestValidation_Issue2988`

**`internal/engine/java_annotation_params_test.go`** (2 tests):
- `TestSpringBoot_RequestValidation_Engine_Issue2988`
- `TestSpringWebFlux_RequestValidation_Engine_Issue2988`

**`internal/engine/java_annotation_routes_test.go`** (2 tests):
- `TestSpringBoot_RouteExtraction_Engine_Issue2988`
- `TestSpringWebFlux_RouteExtraction_Engine_Issue2988`

## Validation

- `coverage validate` → 0 errors
- `go fmt --check` → clean
- `go run ./tools/coverage gen` → byte-stable (idempotent)
- `go test ./internal/custom/java/ ./internal/engine/ ./tools/coverage/ ./internal/types/` → all green
- `go build ./...` → green
- No extractor code changes — registry + proving tests only

Closes #2988