### PR TITLE
coverage(quarkus): flip CDI DI cells missing→partial (closes #2994)

### DIFF
--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/quarkus.go` | — |
+| DI injection point | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/quarkus.go` | — |
+| DI scope resolution | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/quarkus.go` | — |
 
 ### Transactions
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -16434,16 +16434,22 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Transactions": {

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -872,6 +872,138 @@ public class OrderService {}
 	}
 }
 
+// TestQuarkus_CDIScopes proves di_binding_extraction: extractor emits SCOPE.Service
+// with cdi_scope property for all supported CDI scope annotations.
+func TestQuarkus_CDIScopes(t *testing.T) {
+	cases := []struct {
+		annotation string
+		wantScope  string
+	}{
+		{"@ApplicationScoped", "ApplicationScoped"},
+		{"@RequestScoped", "RequestScoped"},
+		{"@Singleton", "Singleton"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.annotation, func(t *testing.T) {
+			source := tc.annotation + "\npublic class MyBean {}"
+			r := ExtractQuarkus(PatternContext{
+				Source: source, Language: "java", Framework: "quarkus",
+				FilePath: "MyBean.java",
+			})
+			found := false
+			for _, e := range r.Entities {
+				if e.Kind == "SCOPE.Service" && e.Properties["cdi_scope"] == tc.wantScope {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("di_binding_extraction: expected SCOPE.Service with cdi_scope=%s for %s", tc.wantScope, tc.annotation)
+			}
+		})
+	}
+}
+
+// TestQuarkus_CDIInjectField proves di_injection_point: @Inject field injection
+// emits a DEPENDS_ON relationship with injection_kind=cdi_inject.
+func TestQuarkus_CDIInjectField(t *testing.T) {
+	source := `
+@RequestScoped
+public class OrderController {
+    @Inject
+    private OrderService orderService;
+}
+`
+	r := ExtractQuarkus(PatternContext{
+		Source: source, Language: "java", Framework: "quarkus",
+		FilePath: "OrderController.java",
+	})
+	hasRel := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "DEPENDS_ON" && rel.Properties["injection_kind"] == "cdi_inject" {
+			hasRel = true
+		}
+	}
+	if !hasRel {
+		t.Error("di_injection_point: expected DEPENDS_ON with injection_kind=cdi_inject for @Inject field")
+	}
+}
+
+// TestQuarkus_CDIInjectConstructor proves di_injection_point: @Inject constructor
+// injection emits a DEPENDS_ON relationship with injection_kind=cdi_constructor.
+func TestQuarkus_CDIInjectConstructor(t *testing.T) {
+	source := `
+@ApplicationScoped
+public class OrderService {
+    private final OrderRepository repository;
+
+    @Inject
+    public OrderService(OrderRepository repository) {
+        this.repository = repository;
+    }
+}
+`
+	r := ExtractQuarkus(PatternContext{
+		Source: source, Language: "java", Framework: "quarkus",
+		FilePath: "OrderService.java",
+	})
+	hasRel := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "DEPENDS_ON" && rel.Properties["injection_kind"] == "cdi_constructor" {
+			hasRel = true
+		}
+	}
+	if !hasRel {
+		t.Error("di_injection_point: expected DEPENDS_ON with injection_kind=cdi_constructor for @Inject constructor")
+	}
+}
+
+// TestQuarkus_CDIScopeResolution proves di_scope_resolution: the resolved CDI
+// scope name is captured in the cdi_scope property on the SCOPE.Service entity.
+func TestQuarkus_CDIScopeResolution(t *testing.T) {
+	source := `
+@ApplicationScoped
+public class OrderService {}
+
+@RequestScoped
+public class OrderController {
+    @Inject
+    OrderService orderService;
+}
+`
+	r := ExtractQuarkus(PatternContext{
+		Source: source, Language: "java", Framework: "quarkus",
+		FilePath: "CDIBeansFixture.java",
+	})
+
+	scopeMap := make(map[string]string) // className -> cdi_scope
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Service" {
+			if scope, ok := e.Properties["cdi_scope"].(string); ok {
+				scopeMap[e.Name] = scope
+			}
+		}
+	}
+
+	if scopeMap["OrderService"] != "ApplicationScoped" {
+		t.Errorf("di_scope_resolution: OrderService cdi_scope=%q, want ApplicationScoped", scopeMap["OrderService"])
+	}
+	if scopeMap["OrderController"] != "RequestScoped" {
+		t.Errorf("di_scope_resolution: OrderController cdi_scope=%q, want RequestScoped", scopeMap["OrderController"])
+	}
+
+	// Also confirm the injection point is present
+	hasInject := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "DEPENDS_ON" && rel.Properties["injection_kind"] == "cdi_inject" {
+			hasInject = true
+		}
+	}
+	if !hasInject {
+		t.Error("di_injection_point: expected DEPENDS_ON cdi_inject from OrderController->OrderService")
+	}
+}
+
 // ============================================================================
 // Android tests
 // ============================================================================

--- a/testdata/fixtures/sources/java/quarkus/CDIBeansFixture.java
+++ b/testdata/fixtures/sources/java/quarkus/CDIBeansFixture.java
@@ -1,0 +1,34 @@
+package io.example.quarkus;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Fixture for Quarkus CDI DI extraction tests.
+ * Proves: di_binding_extraction, di_injection_point, di_scope_resolution.
+ *
+ * Expected extractions:
+ *   - SCOPE.Service for OrderService with cdi_scope=ApplicationScoped
+ *   - SCOPE.Service for OrderController with cdi_scope=RequestScoped
+ *   - DEPENDS_ON from OrderController -> OrderService  (injection_kind=cdi_inject)
+ *   - DEPENDS_ON from OrderService -> OrderRepository  (injection_kind=cdi_constructor)
+ */
+
+@ApplicationScoped
+public class OrderService {
+
+    private final OrderRepository repository;
+
+    @Inject
+    public OrderService(OrderRepository repository) {
+        this.repository = repository;
+    }
+}
+
+@RequestScoped
+public class OrderController {
+
+    @Inject
+    private OrderService orderService;
+}


### PR DESCRIPTION
## Summary

`internal/custom/java/quarkus.go` already extracts Quarkus CDI scoped beans and `@Inject` injection points — the coverage registry was never updated to reflect this. This is a pure recording win (classification: A).

**Cells flipped** (`lang.java.framework.quarkus`):

| Lane | Capability | Before | After |
|------|-----------|--------|-------|
| DI | `di_binding_extraction` | missing | partial |
| DI | `di_injection_point` | missing | partial |
| DI | `di_scope_resolution` | missing | partial |

**Evidence** — existing extractor code in `internal/custom/java/quarkus.go`:
- Lines 32–40: `qkCDIScopedRE`, `qkInjectFieldRE`, `qkInjectCtorRE` regex definitions
- Lines 179–191: CDI scoped bean extraction → `SCOPE.Service` with `cdi_scope` property
- Lines 193–211: `@Inject` field injection → `DEPENDS_ON` with `injection_kind=cdi_inject`
- Lines 213–231: `@Inject` constructor injection → `DEPENDS_ON` with `injection_kind=cdi_constructor`

## Proving fixture + tests

Added `testdata/fixtures/sources/java/quarkus/CDIBeansFixture.java` (the canonical fixture from the issue).

New tests in `internal/custom/java/extractors_test.go`:
- `TestQuarkus_CDIScopes` — di_binding_extraction: `@ApplicationScoped`, `@RequestScoped`, `@Singleton`
- `TestQuarkus_CDIInjectField` — di_injection_point: field injection
- `TestQuarkus_CDIInjectConstructor` — di_injection_point: constructor injection
- `TestQuarkus_CDIScopeResolution` — di_scope_resolution: `cdi_scope` property on emitted entity

## Test plan

- [x] `go test ./internal/custom/java/ ./tools/coverage/ ./internal/types/` — all pass
- [x] `go run ./tools/coverage validate` — 0 errors
- [x] `go run ./tools/coverage gen` — docs regenerated, byte-stable
- [x] `go build ./...` — clean
- [x] `gofmt -l` — no changes

Closes #2994

🤖 Generated with [Claude Code](https://claude.com/claude-code)