### PR TITLE
coverage(java/jpa): flip association/relationship/schema_extraction to partial for hibernate, jpa, spring-data-jpa

### DIFF
--- a/docs/coverage/detail/lang.java.orm.hibernate.md
+++ b/docs/coverage/detail/lang.java.orm.hibernate.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/hibernate_core.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.java.orm.jpa.md
+++ b/docs/coverage/detail/lang.java.orm.jpa.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/java/orms/jpa_jakarta_persistence_api.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/java/orms/spring_data_jpa.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/hibernate.go` | — |
 
 ### Queries
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -17827,14 +17827,18 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
             "status": "missing",
@@ -17845,8 +17849,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Queries": {
@@ -17927,14 +17933,18 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
             "status": "missing",
@@ -17945,8 +17955,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Queries": {
@@ -18177,14 +18189,18 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
             "status": "missing",
@@ -18195,8 +18211,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-29"
           }
         },
         "Queries": {

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -359,6 +359,47 @@ public class MoneyConverter implements AttributeConverter<Money, BigDecimal> {}
 	}
 }
 
+func TestHibernate_AssociationSpringDataJPA(t *testing.T) {
+	source := `
+@Entity
+public class Product {
+    @OneToMany
+    private List<OrderItem> items;
+}
+`
+	r := ExtractHibernate(PatternContext{Source: source, Language: "java", Framework: "spring_data_jpa", FilePath: "Product.java"})
+	if len(r.Relationships) == 0 {
+		t.Error("expected DEPENDS_ON relationship for spring_data_jpa association")
+	}
+	found := false
+	for _, rel := range r.Relationships {
+		if rel.Properties["association_kind"] == "OneToMany" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected association_kind=OneToMany in spring_data_jpa relationship")
+	}
+}
+
+func TestHibernate_SchemaExtraction(t *testing.T) {
+	source := `
+@Entity
+@Table(name="products")
+public class Product {
+    @Id
+    private Long id;
+}
+`
+	r := ExtractHibernate(PatternContext{Source: source, Language: "java", Framework: "jpa", FilePath: "Product.java"})
+	if len(r.Entities) == 0 {
+		t.Fatal("expected entity for jpa schema extraction")
+	}
+	if r.Entities[0].Properties["table_name"] != "products" {
+		t.Errorf("expected table_name=products, got %v", r.Entities[0].Properties["table_name"])
+	}
+}
+
 func TestHibernate_WrongFramework(t *testing.T) {
 	source := `@Entity public class X {}`
 	r := ExtractHibernate(PatternContext{Source: source, Language: "java", Framework: "django", FilePath: "X.java"})


### PR DESCRIPTION
## Summary

- Flips `association_extraction`, `relationship_extraction`, and `schema_extraction` from `missing` → `partial` for three ORM records: `lang.java.orm.hibernate`, `lang.java.orm.jpa`, `lang.java.orm.spring-data-jpa`
- Adds `TestHibernate_AssociationSpringDataJPA` test to prove spring_data_jpa framework tag works identically
- Adds `TestHibernate_SchemaExtraction` test to explicitly prove jpa schema extraction via `@Table(name=...)`

## Evidence

`hibAssociationRE` in `internal/custom/java/hibernate.go` (lines 18-23) extracts `@OneToMany`/`@ManyToOne`/`@OneToOne`/`@ManyToMany` and emits `DEPENDS_ON` relationships with `association_kind` + `field_type` properties. This serves all three frameworks via `hibernateFrameworks` map.

`hibTableNameRE` (line 16-17) extracts `@Table(name="...")` and sets `table_name` on entity properties — partial schema extraction.

Existing test `TestHibernate_Association` (line 331) already proves hibernate association extraction. New tests cover spring_data_jpa and jpa schema explicitly.

## Honest gaps left as missing (B-build)

- `foreign_key_extraction`: `@JoinColumn(name="...")` is NOT parsed — needs a separate `hibJoinColumnRE`
- `lazy_loading_recognition`: `fetch=FetchType.LAZY` is NOT captured from annotation attributes

## Test plan

- [x] `go test ./internal/custom/java/ ./tools/coverage/ ./internal/types/` — all pass
- [x] `go build ./...` — green
- [x] `go run ./tools/coverage validate` — 0 errors
- [x] `go run ./tools/coverage gen` — byte-stable, 557 records

Closes #2999

🤖 Generated with [Claude Code](https://claude.com/claude-code)