### PR TITLE
coverage(java/orm): CREATE lang.java.orm.panache record + model/query/relationship cells

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 150 records · **C/C++**: 7 · **C#**: 14 · **elixir**: 10 · **go**: 17 · **java**: 13 · **JS/TS**: 18 · **kotlin**: 7 · **php**: 14 · **python**: 17 · **ruby**: 13 · **rust**: 14 · **scala**: 6
+**Total**: 151 records · **C/C++**: 7 · **C#**: 14 · **elixir**: 10 · **go**: 17 · **java**: 14 · **JS/TS**: 18 · **kotlin**: 7 · **php**: 14 · **python**: 17 · **ruby**: 13 · **rust**: 14 · **scala**: 6
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -66,6 +66,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ 1/8 | |
 | [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 0/8 | |
 | [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | ❌ 1/8 | |
 | [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 0/8 | |
 | [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 0/8 | |
 | [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 2/8 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # java
 
-**Frameworks**: 19 · **Tools**: 10 · **ORMs**: 13 · **Other**: 3
+**Frameworks**: 19 · **Tools**: 10 · **ORMs**: 14 · **Other**: 3
 
 Back to [summary](../summary.md).
 
@@ -86,6 +86,7 @@ Back to [summary](../summary.md).
 | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ 1/8 | |
 | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 0/8 | |
 | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 0/8 | |
+| [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | ❌ 1/8 | |
 | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 0/8 | |
 | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 0/8 | |
 | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 2/8 | |

--- a/docs/coverage/detail/lang.java.orm.panache.md
+++ b/docs/coverage/detail/lang.java.orm.panache.md
@@ -1,0 +1,50 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.java.orm.panache` — Quarkus Panache (SQL + Reactive + MongoDB)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [java](../by-language/java.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 8
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | — |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Panache entities use standard JPA @Entity/@Table/@Column annotations parsed by the Hibernate extractor; panache.go synthesizes entity records but does not independently parse field schemas |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Panache entity classes use JPA @OneToMany/@ManyToOne/@OneToOne/@ManyToMany annotations parsed by the Hibernate extractor; panache.go synthesizes operation entities for CRUD but does not itself parse association annotations |
+| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Relationships inferred via JPA annotation parsing in hibernate.go; panache.go synthesizes repository binding edges but no direct FK/join column resolution |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Synthesizes full static-method and DSL-builder operation entities (findById, count, list, page, stream, etc.) and named query entities; does not parse inline JPQL/HQL string content |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.java.orm.panache ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -18082,6 +18082,68 @@
       }
     },
     {
+      "id": "lang.java.orm.panache",
+      "category": "orm",
+      "subcategory": "orm_mapper",
+      "language": "java",
+      "label": "Quarkus Panache (SQL + Reactive + MongoDB)",
+      "capabilities": {
+        "Models": {
+          "model_extraction": {
+            "status": "full",
+            "cites": ["internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "verified_at": "2026-05-29"
+          },
+          "schema_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/java/hibernate.go","internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Panache entities use standard JPA @Entity/@Table/@Column annotations parsed by the Hibernate extractor; panache.go synthesizes entity records but does not independently parse field schemas",
+            "verified_at": "2026-05-29"
+          }
+        },
+        "Relationships": {
+          "association_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/java/hibernate.go","internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Panache entity classes use JPA @OneToMany/@ManyToOne/@OneToOne/@ManyToMany annotations parsed by the Hibernate extractor; panache.go synthesizes operation entities for CRUD but does not itself parse association annotations",
+            "verified_at": "2026-05-29"
+          },
+          "foreign_key_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "lazy_loading_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "relationship_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/java/hibernate.go","internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Relationships inferred via JPA annotation parsing in hibernate.go; panache.go synthesizes repository binding edges but no direct FK/join column resolution",
+            "verified_at": "2026-05-29"
+          }
+        },
+        "Queries": {
+          "query_attribution": {
+            "status": "partial",
+            "cites": ["internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Synthesizes full static-method and DSL-builder operation entities (findById, count, list, page, stream, etc.) and named query entities; does not parse inline JPQL/HQL string content",
+            "verified_at": "2026-05-29"
+          }
+        },
+        "Migrations": {
+          "migration_parsing": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.java.orm.spring-data-cassandra",
       "category": "orm",
       "subcategory": "orm_mapper",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 183 · **ORMs**: 150 · **Tools**: 110 · **Other**: 114
+**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 183 · **ORMs**: 151 · **Tools**: 110 · **Other**: 114
 
 ## Coverage by language
 
@@ -9,7 +9,7 @@
 |---|---:|---:|---:|---:|
 | [JS/TS](by-language/jsts.md) | 30 | 21 | 18 | 2 |
 | [python](by-language/python.md) | 21 | 15 | 17 | 6 |
-| [java](by-language/java.md) | 19 | 10 | 13 | 3 |
+| [java](by-language/java.md) | 19 | 10 | 14 | 3 |
 | [C/C++](by-language/c-cpp.md) | 17 | 16 | 7 | 0 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
@@ -66,4 +66,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 183 frameworks · 110 tools · 150 ORMs · 114 other
+Total: 183 frameworks · 110 tools · 151 ORMs · 114 other


### PR DESCRIPTION
## Summary

Creates the `lang.java.orm.panache` coverage registry record for the Quarkus Panache ORM synthesizer (`internal/extractors/java/panache.go`, 924 lines). Part of epic #2847.

**Cells authored** (verified against `panache.go` + `panache_test.go`):

| Group | Capability | Status | Extractor cite |
|-------|-----------|--------|---------------|
| Models | `model_extraction` | **full** | `internal/extractors/java/panache.go` — `synthesizePanacheEntities` emits Operation entities for all PanacheEntity/PanacheEntityBase + PanacheRepository variants (SQL, Reactive, MongoDB) |
| Models | `schema_extraction` | **partial** | Panache entities use standard JPA `@Entity`/`@Table`/`@Column` parsed by shared `internal/custom/java/hibernate.go`; panache.go itself does not parse field schemas |
| Queries | `query_attribution` | **partial** | Full static-method surface (findById, count, list, stream, delete, persist, update, project) + DSL-builder chain (PanacheQuery.list/page/stream/count) + `@NamedQuery` synthesis; inline JPQL string content not parsed |
| Relationships | `association_extraction` | **partial** | JPA `@OneToMany`/`@ManyToOne`/`@OneToOne`/`@ManyToMany` parsed via shared Hibernate extractor |
| Relationships | `relationship_extraction` | **partial** | Same as association_extraction |
| Relationships | `foreign_key_extraction` | **missing** | `@JoinColumn` / FK resolution not implemented |
| Relationships | `lazy_loading_recognition` | **missing** | Fetch-type detection not implemented |
| Migrations | `migration_parsing` | **missing** | Panache has no migration layer |

## Test plan

- [x] `go run ./tools/coverage validate` → 0 errors (4758 warnings, all pre-existing advisory)
- [x] `go run ./tools/coverage fmt --check` → `ok: docs/coverage/registry.json is canonical`
- [x] `go run ./tools/coverage gen` → generated 558 records, byte-stable
- [x] `go build ./...` → clean
- [x] `go test ./internal/extractors/java/ ./tools/coverage/ ./internal/types/` → all pass
- [x] Rebased onto latest `origin/main` (commit a36a58e + 1 new coverage commit from #3019)

Closes #3000
Epic: #2847

🤖 Generated with [Claude Code](https://claude.com/claude-code)