### PR TITLE
coverage(python-orm): Django+SQLAlchemy lazy_loading+schema_extraction missing→partial

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -113,12 +113,12 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 0/8 | |
 | [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 0/8 | |
 | [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ❌ 6/8 | |
+| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ⚠️ 6/8 | |
 | [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 0/8 | |
 | [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 0/8 | |
 | [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 0/8 | |
 | [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ❌ 5/8 | |
+| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ 5/8 | |
 | [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ 2/8 | |
 | [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 1/8 | |
 | [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -76,12 +76,12 @@ Back to [summary](../summary.md).
 |---|---|---|
 | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 0/8 | |
 | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 0/8 | |
-| [Django ORM](../detail/lang.python.orm.django.md) | ❌ 6/8 | |
+| [Django ORM](../detail/lang.python.orm.django.md) | ⚠️ 6/8 | |
 | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 0/8 | |
 | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 0/8 | |
 | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 0/8 | |
 | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 0/8 | |
-| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ❌ 5/8 | |
+| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ 5/8 | |
 | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ 2/8 | |
 | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 1/8 | |
 | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ❌ 0/8 | |

--- a/docs/coverage/detail/lang.python.orm.django.md
+++ b/docs/coverage/detail/lang.python.orm.django.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/django_orm.yaml`<br>`internal/extractors/python/django_relational.go` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/python/django_relational.go` | field_type and all keyword arguments (max_length, null, blank, on_delete, related_name, etc.) are stamped on each SCOPE.Schema/field entity by stampDjangoFieldProperties(); structured JSON Schema or OpenAPI emission not yet implemented |
 
 ### Relationships
 
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/django_relational.go` | — |
 | Foreign key extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/django_relational.go` | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/engine/orm_queries_python.go` | select_related() and prefetch_related() detected as is_join=true by pythonIsJoinDjango(); full recognition of all lazy strategies not yet implemented |
 | Relationship extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/django_relational.go` | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.python.orm.sqlalchemy.md
+++ b/docs/coverage/detail/lang.python.orm.sqlalchemy.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/orm_field_edges.go`<br>`internal/engine/rules/python/orms/sqlalchemy.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/sqlalchemy.go`<br>`internal/engine/orm_field_edges.go` | __tablename__, Mapped[] columns, relationship attributes, and ForeignKey targets are extracted as SCOPE.Schema entities; structured JSON Schema or OpenAPI emission not yet implemented |
 
 ### Relationships
 
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/python/sqlalchemy.go` | — |
 | Foreign key extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/python/sqlalchemy.go` | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/sqlalchemy.go` | lazy= kwarg in relationship() calls is detected and recorded as lazy_strategy on the SCOPE.Schema entity; lazy_select_in, write_only, and dynamic_write_only strategies not yet distinguished |
 | Relationship extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/python/sqlalchemy.go` | — |
 
 ### Queries

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -34941,8 +34941,11 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/django_relational.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "field_type and all keyword arguments (max_length, null, blank, on_delete, related_name, etc.) are stamped on each SCOPE.Schema/field entity by stampDjangoFieldProperties(); structured JSON Schema or OpenAPI emission not yet implemented",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
@@ -34957,8 +34960,11 @@
             "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/engine/orm_queries_python.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "select_related() and prefetch_related() detected as is_join=true by pythonIsJoinDjango(); full recognition of all lazy strategies not yet implemented",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "full",
@@ -35146,8 +35152,11 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/sqlalchemy.go","internal/engine/orm_field_edges.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "__tablename__, Mapped[] columns, relationship attributes, and ForeignKey targets are extracted as SCOPE.Schema entities; structured JSON Schema or OpenAPI emission not yet implemented",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
@@ -35162,8 +35171,11 @@
             "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/sqlalchemy.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "lazy= kwarg in relationship() calls is detected and recorded as lazy_strategy on the SCOPE.Schema entity; lazy_select_in, write_only, and dynamic_write_only strategies not yet distinguished",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "full",

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -1476,6 +1476,43 @@ func TestSQLAlchemy_Relationship(t *testing.T) {
 	}
 }
 
+// TestSQLAlchemy_LazyLoadingRecognition verifies that a relationship() with a
+// lazy= kwarg is detected and the strategy is recorded on the entity.
+// Issue #2986 — lazy_loading_recognition partial for SQLAlchemy.
+func TestSQLAlchemy_LazyLoadingRecognition(t *testing.T) {
+	src := `class User(Base):
+    __tablename__ = "users"
+    posts = relationship("Post", back_populates="author", lazy="dynamic")
+    orders = relationship("Order", lazy='select')
+`
+	ents := extract(t, "python_sqlalchemy", src)
+	var dynamicEnt, selectEnt *extractResult
+	for i := range ents {
+		e := &ents[i]
+		if e.Props["pattern_type"] != "relationship" {
+			continue
+		}
+		switch e.Props["target_model"] {
+		case "Post":
+			dynamicEnt = e
+		case "Order":
+			selectEnt = e
+		}
+	}
+	if dynamicEnt == nil {
+		t.Fatal("expected relationship entity for Post")
+	}
+	if dynamicEnt.Props["lazy_strategy"] != "dynamic" {
+		t.Errorf("expected lazy_strategy=dynamic, got %q", dynamicEnt.Props["lazy_strategy"])
+	}
+	if selectEnt == nil {
+		t.Fatal("expected relationship entity for Order")
+	}
+	if selectEnt.Props["lazy_strategy"] != "select" {
+		t.Errorf("expected lazy_strategy=select, got %q", selectEnt.Props["lazy_strategy"])
+	}
+}
+
 func TestSQLAlchemy_Engine(t *testing.T) {
 	src := `engine = create_engine("postgresql://user:pass@localhost/db")
 `

--- a/internal/custom/python/sqlalchemy.go
+++ b/internal/custom/python/sqlalchemy.go
@@ -29,6 +29,11 @@ var (
 	saMappedAnnotationRe = regexp.MustCompile(`:\s*Mapped\s*\[`)
 	saRelationshipRe     = regexp.MustCompile(
 		`(?m)^\s+(\w+)\s*(?::\s*Mapped\[[^\]]*\])?\s*=\s*relationship\s*\(\s*["']([A-Za-z_][A-Za-z0-9_]*)["']([^)]*)\)`)
+	// saLazyKwargRe matches a lazy= keyword argument in a relationship() call.
+	// Captures the lazy strategy value: "dynamic", "select", "joined",
+	// "subquery", "raise", "raise_on_sql", True, False, or "write_only".
+	// Issue #2986 — lazy_loading_recognition partial for SQLAlchemy.
+	saLazyKwargRe       = regexp.MustCompile(`\blazy\s*=\s*["']?([A-Za-z_][A-Za-z0-9_]*)["']?`)
 	saForeignKeyRe      = regexp.MustCompile(`ForeignKey\s*\(\s*["']([^"']+)["']`)
 	saAssocTableRe      = regexp.MustCompile(`(?m)^(\w+)\s*=\s*Table\s*\(\s*["']([^"']+)["']`)
 	saCreateEngineRe    = regexp.MustCompile(`(?m)(\w+)\s*=\s*create_(?:async_)?engine\s*\(\s*["']([^"']*)["']`)
@@ -119,8 +124,22 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 			relAttr := body[rIdx[2]:rIdx[3]]
 			targetModel := body[rIdx[4]:rIdx[5]]
 			relLine := line + strings.Count(body[:rIdx[0]], "\n")
-			out = append(out, entity(className+"."+relAttr, "SCOPE.Schema", "", file.Path, relLine,
-				map[string]string{"framework": "sqlalchemy", "pattern_type": "relationship", "target_model": targetModel, "parent_class": className}))
+			relProps := map[string]string{
+				"framework":    "sqlalchemy",
+				"pattern_type": "relationship",
+				"target_model": targetModel,
+				"parent_class": className,
+			}
+			// Issue #2986 — detect lazy= kwarg in the relationship args blob.
+			// Captures strategies like "dynamic", "select", "joined", "subquery",
+			// "raise", "raise_on_sql", "write_only", True, False.
+			if rIdx[7] >= 0 {
+				argsBlob := body[rIdx[6]:rIdx[7]]
+				if lm := saLazyKwargRe.FindStringSubmatch(argsBlob); lm != nil {
+					relProps["lazy_strategy"] = lm[1]
+				}
+			}
+			out = append(out, entity(className+"."+relAttr, "SCOPE.Schema", "", file.Path, relLine, relProps))
 		}
 
 		// ForeignKey references in the class body

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -2803,3 +2803,59 @@ records:
           - file: internal/extractors/cross/abibridge/extractor_test.go
         issues_implemented: ["2837"]
         verified_at: "2026-05-28"
+
+  lang.python.orm.django:
+    capabilities:
+      Relationships:
+        lazy_loading_recognition:
+          # select_related() and prefetch_related() are detected as is_join=true
+          # by pythonIsJoinDjango(); issue #2986.
+          status: partial
+          symbols:
+            - file: internal/engine/orm_queries_python.go
+              functions: [pythonIsJoinDjango, scanPythonORM]
+          tests:
+            - file: internal/engine/orm_queries_test.go
+          issues_implemented: ["2986"]
+          verified_at: "2026-05-29"
+      Models:
+        schema_extraction:
+          # field_type + all kwargs stamped on each SCOPE.Schema/field entity;
+          # issue #2986.
+          status: partial
+          symbols:
+            - file: internal/extractors/python/django_relational.go
+              functions: [stampDjangoFieldProperties, enrichDjangoModelFieldsAndManagers]
+          tests:
+            - file: internal/extractors/python/django_relational_test.go
+          issues_implemented: ["2986"]
+          verified_at: "2026-05-29"
+
+  lang.python.orm.sqlalchemy:
+    capabilities:
+      Relationships:
+        lazy_loading_recognition:
+          # lazy= kwarg in relationship() recorded as lazy_strategy property;
+          # issue #2986.
+          status: partial
+          symbols:
+            - file: internal/custom/python/sqlalchemy.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/python/extractors_test.go
+          issues_implemented: ["2986"]
+          verified_at: "2026-05-29"
+      Models:
+        schema_extraction:
+          # __tablename__, Mapped[] annotations, relationship attrs, ForeignKey
+          # targets extracted as SCOPE.Schema entities; issue #2986.
+          status: partial
+          symbols:
+            - file: internal/engine/field_index.go
+              functions: [BuildFieldIndex]
+            - file: internal/custom/python/sqlalchemy.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/python/extractors_test.go
+          issues_implemented: ["2986"]
+          verified_at: "2026-05-29"


### PR DESCRIPTION
## Summary

Flips 4 coverage cells from `missing` → `partial` for `lang.python.orm.django` and `lang.python.orm.sqlalchemy`, implementing all acceptance criteria from issue #2986.

- **Django ORM `lazy_loading_recognition` → partial**: `select_related()` / `prefetch_related()` detected as `is_join=true` by `pythonIsJoinDjango()` in `internal/engine/orm_queries_python.go` — proven by existing `TestDjangoORM_SelectRelated` fixture.
- **Django ORM `schema_extraction` → partial**: `field_type` + all kwargs (`max_length`, `null`, `blank`, `on_delete`, …) stamped on each `SCOPE.Schema/field` entity by `stampDjangoFieldProperties()` in `internal/extractors/python/django_relational.go`.
- **SQLAlchemy `lazy_loading_recognition` → partial**: Added `saLazyKwargRe` regex to detect `lazy=` kwarg in `relationship()` calls; strategy recorded as `lazy_strategy` property on the `SCOPE.Schema` entity. New test: `TestSQLAlchemy_LazyLoadingRecognition`.
- **SQLAlchemy `schema_extraction` → partial**: `__tablename__`, `Mapped[]` annotations, relationship attrs, and `ForeignKey` targets already extracted — citing `internal/engine/field_index.go` + `internal/custom/python/sqlalchemy.go`.

## Files changed

| File | Change |
|---|---|
| `internal/custom/python/sqlalchemy.go` | Add `saLazyKwargRe`; stamp `lazy_strategy` on relationship entities |
| `internal/custom/python/extractors_test.go` | Add `TestSQLAlchemy_LazyLoadingRecognition` |
| `docs/coverage/registry.json` | 4 cells updated missing→partial with cites + verified_at |
| `tools/coverage/capability-map.yaml` | 2 new records, 4 capability entries with symbol+test mappings |
| `docs/coverage/{by-category,by-language,detail}` | Regenerated (byte-stable) |

## Test plan

- [x] `go test ./internal/custom/python/ ./internal/extractors/python/ ./tools/coverage/` — all pass
- [x] `go build ./...` — clean
- [x] `go run ./tools/coverage validate` — 0 errors
- [x] `go run ./tools/coverage gen` twice — byte-identical output
- [x] No stray binaries or untracked files

Closes #2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)