### PR TITLE
coverage(java/langchain4j): chain_composition + tool_use_detection + prompt_template_extraction missing→partial

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -230,7 +230,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Other capabilities | Notes |
 |---|---|---|---|
-| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/3 | |
+| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ⚠️ 0/3 | |
 | [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ✅ 3/3 | |
 | [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/3 | |
 

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -54,7 +54,7 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ❌ 0/3 | |
+| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ⚠️ 0/3 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.java.framework.langchain4j.md
+++ b/docs/coverage/detail/lang.java.framework.langchain4j.md
@@ -15,14 +15,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Prompt template extraction | ❌ `missing` | — | — | — | — |
+| Prompt template extraction | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/java/langchain4j.go` | @SystemMessage/@UserMessage annotation extraction: lc4jSystemMessageRE and lc4jUserMessageRE capture annotation-level prompt template strings. Runtime template variable resolution not captured. |
 
 ### Composition
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Chain composition | ❌ `missing` | — | — | — | — |
-| Tool use detection | ❌ `missing` | — | — | — | — |
+| Chain composition | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/java/langchain4j.go` | @AiService interface extraction plus RAG/ChatMemory component detection: structural composition captured (AiService, EmbeddingStoreContentRetriever, EmbeddingStoreIngestor, ChatMemory fields). Runtime chain wiring not traced. |
+| Tool use detection | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/java/langchain4j.go` | @Tool annotation extraction: lc4jToolMethodRE extracts @Tool-annotated methods, emitting SCOPE.Operation entities with tool_method property. Dynamic tool registration not captured. |
 
 ### Tracking
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15757,15 +15757,24 @@
       "capabilities": {
         "Prompts": {
           "prompt_template_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/langchain4j.go"],
+            "notes": "@SystemMessage/@UserMessage annotation extraction: lc4jSystemMessageRE and lc4jUserMessageRE capture annotation-level prompt template strings. Runtime template variable resolution not captured.",
+            "verified_at": "2026-05-29"
           }
         },
         "Composition": {
           "chain_composition": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/langchain4j.go"],
+            "notes": "@AiService interface extraction plus RAG/ChatMemory component detection: structural composition captured (AiService, EmbeddingStoreContentRetriever, EmbeddingStoreIngestor, ChatMemory fields). Runtime chain wiring not traced.",
+            "verified_at": "2026-05-29"
           },
           "tool_use_detection": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/langchain4j.go"],
+            "notes": "@Tool annotation extraction: lc4jToolMethodRE extracts @Tool-annotated methods, emitting SCOPE.Operation entities with tool_method property. Dynamic tool registration not captured.",
+            "verified_at": "2026-05-29"
           }
         }
       }

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -560,6 +560,114 @@ func TestLangChain4J_WrongFramework(t *testing.T) {
 	}
 }
 
+// TestLangChain4J_AIServiceFixture proves chain_composition + tool_use_detection + prompt_template_extraction
+// using the fixture at testdata/fixtures/sources/java/langchain4j/AIServiceFixture.java (issue #2998).
+func TestLangChain4J_AIServiceFixture(t *testing.T) {
+	source := `
+@AiService
+interface CustomerSupportAgent {
+    @SystemMessage("You are a helpful customer support agent for {companyName}.")
+    @UserMessage("Customer query: {query}")
+    String answer(String companyName, String query);
+}
+
+public class BookingTools {
+    @Tool("Get available flights for a date")
+    public List<Flight> getFlights(String date) { return List.of(); }
+
+    @Tool
+    public BookingResult bookFlight(String flightId) { return new BookingResult(flightId); }
+}
+
+public class SupportBot {
+    private ChatLanguageModel model;
+    private EmbeddingStoreContentRetriever retriever;
+    private MessageWindowChatMemory memory;
+}
+`
+	r := ExtractLangChain4J(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "langchain4j",
+		FilePath:  "AIServiceFixture.java",
+	})
+
+	// chain_composition: @AiService entity
+	hasService := false
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Service" && e.Name == "CustomerSupportAgent" {
+			hasService = true
+		}
+	}
+	if !hasService {
+		t.Error("chain_composition: expected SCOPE.Service entity for CustomerSupportAgent (@AiService)")
+	}
+
+	// chain_composition: RAG component
+	hasRAG := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_LANGCHAIN4J_RAG" {
+			hasRAG = true
+		}
+	}
+	if !hasRAG {
+		t.Error("chain_composition: expected SCOPE.Pattern entity for EmbeddingStoreContentRetriever (RAG component)")
+	}
+
+	// chain_composition: ChatMemory component
+	hasMemory := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_LANGCHAIN4J_MEMORY" {
+			hasMemory = true
+		}
+	}
+	if !hasMemory {
+		t.Error("chain_composition: expected SCOPE.Component entity for MessageWindowChatMemory")
+	}
+
+	// tool_use_detection: @Tool methods
+	toolMethods := map[string]bool{}
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_LANGCHAIN4J_TOOL" {
+			if m, ok := e.Properties["tool_method"]; ok {
+				toolMethods[m.(string)] = true
+			}
+		}
+	}
+	if !toolMethods["getFlights"] {
+		t.Error("tool_use_detection: expected SCOPE.Operation entity for @Tool method getFlights")
+	}
+	if !toolMethods["bookFlight"] {
+		t.Error("tool_use_detection: expected SCOPE.Operation entity for @Tool method bookFlight")
+	}
+
+	// prompt_template_extraction: @SystemMessage
+	hasSystem := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_LANGCHAIN4J_PROMPT" {
+			if pt, ok := e.Properties["prompt_type"]; ok && pt == "system_message" {
+				hasSystem = true
+			}
+		}
+	}
+	if !hasSystem {
+		t.Error("prompt_template_extraction: expected SCOPE.Pattern entity for @SystemMessage on answer()")
+	}
+
+	// prompt_template_extraction: @UserMessage
+	hasUser := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_LANGCHAIN4J_PROMPT" {
+			if pt, ok := e.Properties["prompt_type"]; ok && pt == "user_message" {
+				hasUser = true
+			}
+		}
+	}
+	if !hasUser {
+		t.Error("prompt_template_extraction: expected SCOPE.Pattern entity for @UserMessage on answer()")
+	}
+}
+
 // ============================================================================
 // Micronaut tests
 // ============================================================================

--- a/testdata/fixtures/sources/java/langchain4j/AIServiceFixture.java
+++ b/testdata/fixtures/sources/java/langchain4j/AIServiceFixture.java
@@ -1,0 +1,51 @@
+package io.example.langchain4j;
+
+import dev.langchain4j.service.AiService;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.agent.tool.Tool;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever;
+import java.util.List;
+
+/**
+ * Fixture for LangChain4J extraction tests.
+ * Proves: chain_composition, tool_use_detection, prompt_template_extraction.
+ *
+ * Expected extractions:
+ *   - SCOPE.Service for CustomerSupportAgent (ai_service)
+ *   - SCOPE.Pattern entities for @SystemMessage and @UserMessage templates
+ *   - SCOPE.Operation entities for @Tool-annotated methods (getFlights, bookFlight)
+ *   - SCOPE.Component for ChatLanguageModel field
+ *   - SCOPE.Pattern for EmbeddingStoreContentRetriever (RAG component)
+ *   - SCOPE.Component for ChatMemory field
+ */
+
+@AiService
+interface CustomerSupportAgent {
+
+    @SystemMessage("You are a helpful customer support agent for {companyName}.")
+    @UserMessage("Customer query: {query}")
+    String answer(String companyName, String query);
+}
+
+public class BookingTools {
+
+    @Tool("Get available flights for a date")
+    public List<Flight> getFlights(String date) {
+        return List.of();
+    }
+
+    @Tool
+    public BookingResult bookFlight(String flightId) {
+        return new BookingResult(flightId);
+    }
+}
+
+public class SupportBot {
+    private ChatLanguageModel model;
+    private EmbeddingStoreContentRetriever retriever;
+    private MessageWindowChatMemory memory;
+}


### PR DESCRIPTION
## Summary

Flips three missing cells on `lang.java.framework.langchain4j` to **partial** — all are A-wins because the extractor already delivers the underlying extraction. Part of epic #2847.

| Capability | Group | Before → After | Proof |
|---|---|---|---|
| `chain_composition` | Composition | missing → partial | `@AiService` + RAG/ChatMemory component detection |
| `tool_use_detection` | Composition | missing → partial | `@Tool` method extraction via `lc4jToolMethodRE` |
| `prompt_template_extraction` | Prompts | missing → partial | `@SystemMessage`/`@UserMessage` annotation capture |

## Changes

- **`docs/coverage/registry.json`**: flip all three cells to `partial`, cite `internal/custom/java/langchain4j.go`, add scope notes, `verified_at: 2026-05-29`
- **`internal/custom/java/extractors_test.go`**: add `TestLangChain4J_AIServiceFixture` — single test proving all three capabilities using the issue's proving fixture
- **`testdata/fixtures/sources/java/langchain4j/AIServiceFixture.java`**: proving fixture with `@AiService`, `@SystemMessage`, `@UserMessage`, `@Tool×2`, `ChatLanguageModel`, `EmbeddingStoreContentRetriever`, `MessageWindowChatMemory`
- **`docs/coverage/{by-category,by-language,detail}/`**: regenerated via `go run ./tools/coverage gen`

## Validation

- `go run ./tools/coverage validate` → **0 errors** (4985 advisory warnings, expected)
- `go test ./internal/custom/java/ ./tools/coverage/ ./internal/types/` → all pass
- `go build ./...` → clean
- Rebased onto `origin/main` — mergeable

## Scope notes (why partial, not full)

- **`chain_composition`**: structural composition captured; runtime chain wiring (e.g. AiServices.builder() dynamic assembly) not traced
- **`tool_use_detection`**: `@Tool` annotation extraction works; dynamic tool registration (programmatic `ToolProvider`) not captured
- **`prompt_template_extraction`**: annotation-level prompt strings captured; runtime template variable resolution not resolved

Closes #2998

🤖 Generated with [Claude Code](https://claude.com/claude-code)