### PR TITLE
coverage(java): Spring Boot tests_linkage + WebFlux DI/tests missing→partial (#2991)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -132,8 +132,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 2/3 | ✅ 1/1 | ✅ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 2/3 | ✅ 1/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/18 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -22,8 +22,8 @@ Back to [summary](../summary.md).
 | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 2/3 | ✅ 1/1 | ✅ 3/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/18 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 2/3 | ✅ 1/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/18 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
 
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | `2026-05-29` | [link](#2991) | `internal/custom/java/junit5.go` | Spring Boot test classes use JUnit 5 (@SpringBootTest/@WebMvcTest); @Test/@ParameterizedTest/@RepeatedTest methods extracted as SCOPE.Operation entities with test_annotation property and OWNS edges from test class. TESTS multi-hop via HTTP layer requires separate work. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | `2026-05-29` | [link](#2991) | `internal/custom/java/junit5.go` | Spring WebFlux test classes use JUnit 5 (@WebFluxTest); @Test/@ParameterizedTest/@RepeatedTest methods extracted as SCOPE.Operation entities with test_annotation property and OWNS edges. TESTS multi-hop via reactive router not yet implemented. |
 
 ### Type System
 
@@ -57,8 +57,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | ⚠️ `partial` | `2026-05-29` | [link](#2991) | `internal/custom/java/spring_boot.go` | spring_webflux shares same DI model as spring_boot; @Autowired field/setter/constructor injection and @Bean method extraction handled by ExtractSpringBoot. No @Qualifier resolution. |
+| DI injection point | ⚠️ `partial` | `2026-05-29` | [link](#2991) | `internal/custom/java/spring_boot.go` | spring_webflux uses same @Autowired/@Bean extractor as spring_boot; field, setter, and constructor injection detected. No @Qualifier or @Primary resolution. |
 | DI scope resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Transactions

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -16685,8 +16685,11 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/junit5.go"],
+            "issue": "#2991",
+            "notes": "Spring Boot test classes use JUnit 5 (@SpringBootTest/@WebMvcTest); @Test/@ParameterizedTest/@RepeatedTest methods extracted as SCOPE.Operation entities with test_annotation property and OWNS edges from test class. TESTS multi-hop via HTTP layer requires separate work.",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -16947,8 +16950,11 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/junit5.go"],
+            "issue": "#2991",
+            "notes": "Spring WebFlux test classes use JUnit 5 (@WebFluxTest); @Test/@ParameterizedTest/@RepeatedTest methods extracted as SCOPE.Operation entities with test_annotation property and OWNS edges. TESTS multi-hop via reactive router not yet implemented.",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -16974,12 +16980,18 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_boot.go"],
+            "issue": "#2991",
+            "notes": "spring_webflux shares same DI model as spring_boot; @Autowired field/setter/constructor injection and @Bean method extraction handled by ExtractSpringBoot. No @Qualifier resolution.",
+            "verified_at": "2026-05-29"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_boot.go"],
+            "issue": "#2991",
+            "notes": "spring_webflux uses same @Autowired/@Bean extractor as spring_boot; field, setter, and constructor injection detected. No @Qualifier or @Primary resolution.",
+            "verified_at": "2026-05-29"
           },
           "di_scope_resolution": {
             "status": "missing",

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -2090,6 +2090,178 @@ class ProductResourceTest {
 }
 
 // ============================================================================
+// Spring Boot tests_linkage (#2991)
+// ============================================================================
+
+// TestSpringBoot_TestsLinkage_Issue2991 proves that ExtractJUnit5 runs for
+// the "spring_boot" framework (tests_linkage cell).
+// Registry target: lang.java.framework.spring-boot tests_linkage=partial.
+// Cite: internal/custom/java/junit5.go.
+func TestSpringBoot_TestsLinkage_Issue2991(t *testing.T) {
+	source := `
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceTest {
+    @Test
+    void createUser_shouldReturnDto() {
+        assertEquals(1, 1);
+    }
+
+    @Test
+    void deleteUser_shouldRemoveRecord() {
+        assertTrue(true);
+    }
+}
+`
+	r := ExtractJUnit5(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_boot",
+		FilePath:  "UserServiceTest.java",
+	})
+
+	hasTestMethod := false
+	for _, e := range r.Entities {
+		if e.Properties["test_annotation"] == "Test" {
+			hasTestMethod = true
+			break
+		}
+	}
+	if !hasTestMethod {
+		t.Errorf("[#2991 spring-boot tests_linkage] expected @Test entity from JUnit5 extractor for spring_boot framework")
+	}
+
+	// Verify OWNS edge from class → test method
+	hasOwns := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "OWNS" {
+			hasOwns = true
+			break
+		}
+	}
+	if !hasOwns {
+		t.Errorf("[#2991 spring-boot tests_linkage] expected OWNS relationship from test class to test method")
+	}
+}
+
+// ============================================================================
+// Spring WebFlux DI + tests_linkage (#2991)
+// ============================================================================
+
+// TestSpringWebFlux_DIBinding_Issue2991 proves that ExtractSpringBoot emits
+// DI DEPENDS_ON edges for spring_webflux (di_binding_extraction cell).
+// Registry target: lang.java.framework.spring-webflux di_binding_extraction=partial.
+// Cite: internal/custom/java/spring_boot.go.
+func TestSpringWebFlux_DIBinding_Issue2991(t *testing.T) {
+	source := `
+package com.example.webflux;
+
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Service
+public class OrderHandler {
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private RouterConfig routerConfig;
+}
+
+@Configuration
+public class RouterConfig {
+    @Bean
+    public RouterFunction<ServerResponse> routes(OrderHandler handler) {
+        return RouterFunctions.route()
+            .GET("/orders", handler::listOrders)
+            .build();
+    }
+}
+`
+	r := ExtractSpringBoot(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_webflux",
+		FilePath:  "OrderHandler.java",
+	})
+
+	// di_binding_extraction: @Bean method (name stored as "OwnerClass.methodName")
+	hasBean := false
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "function" && e.Provenance == "INFERRED_FROM_SPRING_BOOT_BEAN" {
+			hasBean = true
+			break
+		}
+	}
+	if !hasBean {
+		t.Errorf("[#2991 spring-webflux di_binding_extraction] expected @Bean entity from spring_webflux extractor")
+	}
+
+	// di_injection_point: @Autowired field injection emits DEPENDS_ON
+	hasDep := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "DEPENDS_ON" && rel.Properties["injection_kind"] == "field" {
+			hasDep = true
+			break
+		}
+	}
+	if !hasDep {
+		t.Errorf("[#2991 spring-webflux di_injection_point] expected DEPENDS_ON(injection_kind=field) from spring_webflux extractor")
+	}
+}
+
+// TestSpringWebFlux_TestsLinkage_Issue2991 proves that ExtractJUnit5 runs for
+// the "spring_webflux" framework (tests_linkage cell).
+// Registry target: lang.java.framework.spring-webflux tests_linkage=partial.
+// Cite: internal/custom/java/junit5.go.
+func TestSpringWebFlux_TestsLinkage_Issue2991(t *testing.T) {
+	source := `
+package com.example.webflux;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import static org.junit.jupiter.api.Assertions.*;
+
+@WebFluxTest
+class OrderHandlerTest {
+    @Test
+    void listOrders_returnsOk() {
+        assertTrue(true);
+    }
+
+    @Test
+    void createOrder_returnsCreated() {
+        assertTrue(true);
+    }
+}
+`
+	r := ExtractJUnit5(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_webflux",
+		FilePath:  "OrderHandlerTest.java",
+	})
+
+	hasTestMethod := false
+	for _, e := range r.Entities {
+		if e.Properties["test_annotation"] == "Test" {
+			hasTestMethod = true
+			break
+		}
+	}
+	if !hasTestMethod {
+		t.Errorf("[#2991 spring-webflux tests_linkage] expected @Test entity from JUnit5 extractor for spring_webflux framework")
+	}
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/internal/custom/java/junit5.go
+++ b/internal/custom/java/junit5.go
@@ -19,6 +19,10 @@ var junit5Frameworks = map[string]bool{
 	"jakarta_ee": true, "jakarta-ee": true, "jakartaee": true,
 	"microprofile": true, "eclipse-microprofile": true,
 	"open_liberty": true, "payara": true, "helidon": true,
+	// Spring Boot and Spring WebFlux projects use JUnit 5 (via @SpringBootTest /
+	// @WebFluxTest) for tests_linkage (#2991).
+	"spring_boot": true, "spring-boot": true, "springboot": true,
+	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
 }
 
 var (

--- a/internal/custom/java/spring_boot.go
+++ b/internal/custom/java/spring_boot.go
@@ -7,6 +7,10 @@ import "regexp"
 
 var springBootFrameworks = map[string]bool{
 	"spring_boot": true, "spring-boot": true, "springboot": true,
+	// Spring WebFlux shares the same DI model (@Autowired, @Bean, @Component) as
+	// Spring Boot — the same extractor handles di_binding_extraction and
+	// di_injection_point for both frameworks (#2991).
+	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
 }
 
 var (


### PR DESCRIPTION
## Summary

Closes #2991

Flips 4 capability cells from `missing` → `partial`:

| Record | Lane | Capability | Before → After |
|--------|------|-----------|----------------|
| `lang.java.framework.spring-boot` | Testing | `tests_linkage` | missing → **partial** |
| `lang.java.framework.spring-webflux` | DI | `di_binding_extraction` | missing → **partial** |
| `lang.java.framework.spring-webflux` | DI | `di_injection_point` | missing → **partial** |
| `lang.java.framework.spring-webflux` | Testing | `tests_linkage` | missing → **partial** |

Skipped cells (already done or intentionally left):
- `type_alias_extraction` → already `not_applicable` on both records (done by #2997)
- `di_scope_resolution` (spring-boot) → left-red as specified; genuine missing, no extractor

## What changed

**`internal/custom/java/junit5.go`** — added `spring_boot`/`spring-boot`/`springboot` and `spring_webflux`/`spring-webflux`/`springwebflux` to `junit5Frameworks`. This activates `ExtractJUnit5` for `@SpringBootTest`/`@WebMvcTest`/`@WebFluxTest` test classes, emitting `SCOPE.Operation` entities with `test_annotation` property and `OWNS` edges from test class → test method.

**`internal/custom/java/spring_boot.go`** — added `spring_webflux`/`spring-webflux`/`springwebflux` to `springBootFrameworks`. Spring WebFlux shares the same DI model (`@Autowired`, `@Bean`, `@Component`) as Spring Boot — `ExtractSpringBoot` now handles field/setter/constructor injection and `@Bean` extraction for WebFlux apps. No `@Qualifier` resolution yet.

**`internal/custom/java/extractors_test.go`** — 3 new proving fixtures:
- `TestSpringBoot_TestsLinkage_Issue2991` — `@SpringBootTest` class with `@Test` methods
- `TestSpringWebFlux_DIBinding_Issue2991` — `@Autowired` field injection + `@Bean` for `spring_webflux`
- `TestSpringWebFlux_TestsLinkage_Issue2991` — `@WebFluxTest` class with `@Test` methods

## Test plan

- [x] `go test ./internal/custom/java/ ./internal/engine/ ./tools/coverage/ ./internal/types/` — all green
- [x] `go build ./...` — clean
- [x] `coverage validate` — 0 errors (pre-existing warnings only)
- [x] `coverage fmt --check` — canonical
- [x] `coverage gen` — docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)