### PR TITLE
coverage(python/orm): promote SQLModel schema_extraction to partial; audit minor ORM families

### DIFF
--- a/docs/coverage/detail/lang.python.orm.alembic.md
+++ b/docs/coverage/detail/lang.python.orm.alembic.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/alembic.yaml` | — |
+| Migration parsing | ⚠️ `partial` | `2026-05-29` | — | `internal/engine/rules/python/orms/alembic.yaml`<br>`internal/enrichers/migration_sequence_enricher.go` | YAML rule detects alembic.ini and versions/*.py files; migration_sequence_enricher.go parses Alembic filename convention ([A-Za-z0-9]{12}_<name>.py). upgrade()/downgrade() operation content is not yet parsed (full would require a dedicated alembic migration extractor analogous to django_migration.go). |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Beanie Document field definitions (via Pydantic annotations) are not extracted at the ORM level; the schema_detector.go detects Pydantic usage generally but does not emit per-field ORM schema entities. |
 
 ### Relationships
 
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Beanie (Motor-based async ODM) does not have a lazy-loading mechanism; all queries are explicit async calls. |
 | Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | MongoEngine Document field definitions (StringField, IntField etc.) are not extracted at the ORM schema level; the MongoDB custom extractor handles aggregations/change streams but not model field schema. |
 
 ### Relationships
 
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | MongoEngine uses ReferenceField with lazy loading but no extractor tracks lazy_loading strategy properties. |
 | Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.python.orm.peewee.md
+++ b/docs/coverage/detail/lang.python.orm.peewee.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/peewee.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Peewee field definitions (CharField, IntegerField etc.) are not extracted; only model class detection and query attribution are handled. |
 
 ### Relationships
 
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Peewee does not support lazy loading; all queries are explicit. DeferredForeignKey is a different concept not tracked here. |
 | Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.python.orm.pony.md
+++ b/docs/coverage/detail/lang.python.orm.pony.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/pony_orm.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Pony ORM entity field definitions (Required, Optional etc.) are not extracted; only model class detection and query attribution are handled. |
 
 ### Relationships
 
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Pony ORM lazy loading is implicit via @db_session but not tracked structurally; no extractor emits lazy-load relationship entities. |
 | Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.python.orm.sqlmodel.md
+++ b/docs/coverage/detail/lang.python.orm.sqlmodel.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/sqlmodel.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/extractors_test.go`<br>`internal/custom/python/sqlalchemy.go` | SQLModel table=True class detection added to python_sqlalchemy extractor (issue #2990). Only classes with both SQLModel base and table=True kwarg are emitted; schema-only classes are excluded. |
 
 ### Relationships
 
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | SQLModel delegates to SQLAlchemy relationship() for lazy loading, but the sqlalchemy extractor's lazy_strategy detection (issue #2986) applies only when the SQLAlchemy extractor fires on a SQLModel file. SQLModel-specific lazy loading is not yet explicitly tracked. |
 | Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.python.orm.tortoise.md
+++ b/docs/coverage/detail/lang.python.orm.tortoise.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/tortoise_orm.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Tortoise ORM field definitions (fields.CharField etc.) are not parsed by any Go extractor; only model class detection (model_extraction) is handled via YAML rules. |
 
 ### Relationships
 
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Tortoise ORM does not have a lazy-loading concept comparable to SQLAlchemy; prefetch_related is async-explicit and tracked under query_attribution only. |
 | Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Queries

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -35588,8 +35588,9 @@
         "Migrations": {
           "migration_parsing": {
             "status": "partial",
-            "cites": ["internal/engine/rules/python/orms/alembic.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/engine/rules/python/orms/alembic.yaml","internal/enrichers/migration_sequence_enricher.go"],
+            "notes": "YAML rule detects alembic.ini and versions/*.py files; migration_sequence_enricher.go parses Alembic filename convention ([A-Za-z0-9]{12}_\u003cname\u003e.py). upgrade()/downgrade() operation content is not yet parsed (full would require a dedicated alembic migration extractor analogous to django_migration.go).",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -35609,7 +35610,9 @@
           },
           "schema_extraction": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Beanie Document field definitions (via Pydantic annotations) are not extracted at the ORM level; the schema_detector.go detects Pydantic usage generally but does not emit per-field ORM schema entities.",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
@@ -35623,7 +35626,9 @@
           },
           "lazy_loading_recognition": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Beanie (Motor-based async ODM) does not have a lazy-loading mechanism; all queries are explicit async calls.",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "missing",
@@ -35720,7 +35725,9 @@
           },
           "schema_extraction": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "MongoEngine Document field definitions (StringField, IntField etc.) are not extracted at the ORM schema level; the MongoDB custom extractor handles aggregations/change streams but not model field schema.",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
@@ -35734,7 +35741,9 @@
           },
           "lazy_loading_recognition": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "MongoEngine uses ReferenceField with lazy loading but no extractor tracks lazy_loading strategy properties.",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "missing",
@@ -35770,7 +35779,9 @@
           },
           "schema_extraction": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Peewee field definitions (CharField, IntegerField etc.) are not extracted; only model class detection and query attribution are handled.",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
@@ -35784,7 +35795,9 @@
           },
           "lazy_loading_recognition": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Peewee does not support lazy loading; all queries are explicit. DeferredForeignKey is a different concept not tracked here.",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "missing",
@@ -35820,7 +35833,9 @@
           },
           "schema_extraction": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Pony ORM entity field definitions (Required, Optional etc.) are not extracted; only model class detection and query attribution are handled.",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
@@ -35834,7 +35849,9 @@
           },
           "lazy_loading_recognition": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Pony ORM lazy loading is implicit via @db_session but not tracked structurally; no extractor emits lazy-load relationship entities.",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "missing",
@@ -35930,8 +35947,11 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/extractors_test.go","internal/custom/python/sqlalchemy.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "SQLModel table=True class detection added to python_sqlalchemy extractor (issue #2990). Only classes with both SQLModel base and table=True kwarg are emitted; schema-only classes are excluded.",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
@@ -35945,7 +35965,9 @@
           },
           "lazy_loading_recognition": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "SQLModel delegates to SQLAlchemy relationship() for lazy loading, but the sqlalchemy extractor's lazy_strategy detection (issue #2986) applies only when the SQLAlchemy extractor fires on a SQLModel file. SQLModel-specific lazy loading is not yet explicitly tracked.",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "missing",
@@ -35981,7 +36003,9 @@
           },
           "schema_extraction": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Tortoise ORM field definitions (fields.CharField etc.) are not parsed by any Go extractor; only model class detection (model_extraction) is handled via YAML rules.",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
@@ -35995,7 +36019,9 @@
           },
           "lazy_loading_recognition": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Tortoise ORM does not have a lazy-loading concept comparable to SQLAlchemy; prefetch_related is async-explicit and tracked under query_attribution only.",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "missing",

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -1563,6 +1563,51 @@ class AppConfig(BaseSettings):
 	}
 }
 
+// TestSQLModel_TableClass verifies that a SQLModel table=True class is
+// extracted as a SCOPE.Schema ORM entity with framework=sqlmodel.
+// Issue #2990 — schema_extraction partial promotion for SQLModel.
+func TestSQLModel_TableClass(t *testing.T) {
+	src := `from sqlmodel import SQLModel, Field
+
+class Hero(SQLModel, table=True):
+    id: int = Field(default=None, primary_key=True)
+    name: str
+    age: int
+`
+	ents := extract(t, "python_sqlalchemy", src)
+	var found *extractResult
+	for i := range ents {
+		if ents[i].Name == "Hero" && ents[i].Kind == "SCOPE.Schema" {
+			found = &ents[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected SQLModel table class entity for Hero")
+	}
+	if found.Props["framework"] != "sqlmodel" {
+		t.Errorf("expected framework=sqlmodel, got %q", found.Props["framework"])
+	}
+}
+
+// TestSQLModel_SchemaOnlyClass verifies that a SQLModel schema-only class
+// (no table=True) is NOT emitted as a DB-table entity.
+// Issue #2990 — schema-only classes must not be false-positive DB model entities.
+func TestSQLModel_SchemaOnlyClass(t *testing.T) {
+	src := `from sqlmodel import SQLModel, Field
+
+class HeroCreate(SQLModel):
+    name: str
+    age: int
+`
+	ents := extract(t, "python_sqlalchemy", src)
+	for _, e := range ents {
+		if e.Name == "HeroCreate" {
+			t.Fatalf("python_sqlalchemy must not emit entity for SQLModel schema-only class %q", e.Name)
+		}
+	}
+}
+
 // ============================================================================
 // FastAPI Request/Response tests
 // ============================================================================

--- a/internal/custom/python/sqlalchemy.go
+++ b/internal/custom/python/sqlalchemy.go
@@ -59,6 +59,17 @@ var saBaseIndicators = []string{"Base", "DeclarativeBase", "db.Model"}
 // Pydantic DTOs next to ORM classes).
 var saPydanticBases = []string{"BaseModel", "BaseSettings", "RootModel", "GenericModel"}
 
+// isSQLModelTableClass reports whether a class declaration's base list
+// identifies a SQLModel DB-table model: the base list must contain "SQLModel"
+// AND the keyword argument "table=True". SQLModel schema-only classes (which
+// lack "table=True") are NOT DB-table models and must not be emitted as
+// SCOPE.Schema ORM entities.
+// Issue #2990 — SQLModel schema_extraction partial promotion.
+func isSQLModelTableClass(bases string) bool {
+	return strings.Contains(bases, "SQLModel") &&
+		strings.Contains(bases, "table=True")
+}
+
 func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("custom.python_sqlalchemy")
 	_, span := tracer.Start(ctx, "custom.python_sqlalchemy")
@@ -92,12 +103,18 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 			continue
 		}
 
-		// Check if this looks like a SQLAlchemy model
-		isModel := false
-		for _, indicator := range saBaseIndicators {
-			if strings.Contains(bases, indicator) {
-				isModel = true
-				break
+		// Check if this looks like a SQLAlchemy / SQLModel model.
+		//
+		// SQLModel table classes use `class Hero(SQLModel, table=True):`
+		// — they match the "SQLModel" base name AND carry the table=True kwarg.
+		// Issue #2990 — promote schema_extraction to partial for SQLModel.
+		isModel := isSQLModelTableClass(bases)
+		if !isModel {
+			for _, indicator := range saBaseIndicators {
+				if strings.Contains(bases, indicator) {
+					isModel = true
+					break
+				}
 			}
 		}
 		if !isModel {
@@ -112,7 +129,11 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 		}
 
 		line := lineOf(source, idx[0])
-		props := map[string]string{"framework": "sqlalchemy", "pattern_type": "model", "class_name": className}
+		framework := "sqlalchemy"
+		if isSQLModelTableClass(bases) {
+			framework = "sqlmodel"
+		}
+		props := map[string]string{"framework": framework, "pattern_type": "model", "class_name": className}
 		body := extractClassBody(source, idx[0])
 		if tm := saTablenameRe.FindStringSubmatch(body); tm != nil {
 			props["tablename"] = tm[1]


### PR DESCRIPTION
## Summary

- **SQLModel `schema_extraction`: `missing` → `partial`** — Added `isSQLModelTableClass()` to `internal/custom/python/sqlalchemy.go` to detect `class Hero(SQLModel, table=True):` patterns. The check guards on both the `SQLModel` base name and the `table=True` keyword argument in the class declaration, so schema-only SQLModel classes are excluded. Two proving fixtures added: `TestSQLModel_TableClass` and `TestSQLModel_SchemaOnlyClass`.
- **All 7 ORM records audited** — `schema_extraction` and `lazy_loading_recognition` cells for Tortoise, Beanie, Peewee, Pony, MongoEngine and Alembic confirmed `missing` with honest notes explaining what would be needed to promote them.
- **Alembic `migration_parsing` stays `partial`** — YAML rule detection and `migration_sequence_enricher.go` filename parsing are confirmed; `upgrade()/downgrade()` operation-level content is not yet parsed (would require a dedicated extractor analogous to `django_migration.go`).

## Cells flipped

| Record | Capability | Before | After | Proof |
|---|---|---|---|---|
| `lang.python.orm.sqlmodel` | `schema_extraction` | missing | **partial** | `internal/custom/python/sqlalchemy.go` + `extractors_test.go` |
| `lang.python.orm.alembic` | `migration_parsing` | partial | partial (notes added) | `migration_sequence_enricher.go` + `alembic.yaml` |
| All 7 records | `schema_extraction` + `lazy_loading_recognition` | missing | missing (verified_at + notes) | honest audit |

## Verified honest / missing

- `schema_extraction` for Tortoise/Beanie/Peewee/Pony/MongoEngine: field-level extraction not implemented in any Go extractor
- `lazy_loading_recognition` for Tortoise/Beanie/Peewee/Pony/MongoEngine/SQLModel: either not applicable or not implemented
- Alembic `migration_parsing` stays `partial`: filename convention covered, op content not parsed

## Test plan

- [x] `go test ./internal/custom/python/ ./internal/extractors/python/ ./tools/coverage/` — all pass
- [x] `go build ./...` — clean
- [x] `go run ./tools/coverage validate` — 0 errors
- [x] `go run ./tools/coverage fmt --check` — canonical
- [x] `go run ./tools/coverage gen` — 7 ORM detail files + registry.json updated (minimal diff)
- [x] Rebased onto `origin/main`

Closes #2990

🤖 Generated with [Claude Code](https://claude.com/claude-code)