### PR TITLE
feat(python/pydantic): @field_validator + constraint + coercion extraction (#2984)

### DIFF
--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -105,6 +105,6 @@ Back to [summary](../summary.md).
 
 | Name | Testing | Other capabilities | Notes |
 |---|---|---|---|
-| [Pydantic](../detail/lang.python.validation.pydantic.md) | ❌ 0/1 | ❌ 0/5 | |
+| [Pydantic](../detail/lang.python.validation.pydantic.md) | ⚠️ 0/1 | ⚠️ 3/5 | |
 | [attrs](../detail/lang.python.validation.attrs.md) | ❌ 0/1 | ❌ 0/5 | |
 | [marshmallow](../detail/lang.python.validation.marshmallow.md) | ❌ 0/1 | ❌ 0/5 | |

--- a/docs/coverage/detail/lang.python.validation.pydantic.md
+++ b/docs/coverage/detail/lang.python.validation.pydantic.md
@@ -16,26 +16,26 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Nested model extraction | ⚠️ `partial` | `2026-05-29` | — | `internal/extractors/python/discriminator.go`<br>`internal/extractors/python/nested_ctor_refs.go` | Discriminated-union tags captured via DISCRIMINATES_ON (discriminator.go); nested model construction referenced via nested_ctor_refs. No structured nested-schema tree. |
-| Schema extraction | ⚠️ `partial` | `2026-05-29` | — | `internal/extractors/python/extractor.go`<br>`internal/extractors/python/extractor_test.go` | Base Python extractor emits the model class (SCOPE.Component) and its annotated fields (SCOPE.Schema/field) via extractClassFields; no Pydantic-specific Field()/constraint parsing. |
+| Schema extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/python/extractor.go`<br>`internal/patterns/patterns_test.go`<br>`internal/patterns/schema_detector.go` | Base Python extractor emits the model class (SCOPE.Component) and its annotated fields (SCOPE.Schema/field) via extractClassFields; schema_detector.go classifies the BaseModel subclass as a pydantic schema_validation entity, exercised by TestSchemaDetector_PydanticBaseModel. |
 
 ### Constraints
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Constraint extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Custom validator extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Constraint extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/python/extractors_test.go`<br>`internal/custom/python/pydantic.go`<br>`internal/custom/python/testdata/pydantic_validators.py` | python_pydantic extractor parses Field(gt=, ge=, lt=, le=, min_length=, max_length=, min_items=, max_items=, multiple_of=, max_digits=, decimal_places=, pattern=, regex=) into a SCOPE.Pattern entity per field with constraint_* properties; constraint-free Field(default=...) is skipped. Issue #2984. |
+| Custom validator extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/python/extractors_test.go`<br>`internal/custom/python/pydantic.go`<br>`internal/custom/python/testdata/pydantic_validators.py` | python_pydantic extractor emits SCOPE.Pattern entities for @field_validator / @validator (v1) and @model_validator / @root_validator (v1), capturing target fields, mode (before/after, pre=True), validator fn, and dialect. Issue #2984. |
 
 ### Coercion
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Type coercion recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Type coercion recognition | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/python/extractors_test.go`<br>`internal/custom/python/pydantic.go` | python_pydantic recognizes model-level coercion config (model_config = ConfigDict(...) in v2, inner class Config in v1) and surfaces coercion-affecting flags (strict, coerce_numbers_to_str, str_strip_whitespace, validate_assignment, use_enum_values, ...) as a SCOPE.Pattern model_config entity. Per-field type-coercion inference (annotation-driven int/str/datetime coercion) is not modeled. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | `2026-05-29` | — | `internal/custom/python/pytest.go` | python_pytest extracts pytest test functions/classes/fixtures; tests exercising Pydantic models are captured as test entities but no validator-to-test linkage edge is emitted. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -36352,32 +36352,40 @@
             "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "partial",
-            "cites": ["internal/extractors/python/extractor.go","internal/extractors/python/extractor_test.go"],
-            "notes": "Base Python extractor emits the model class (SCOPE.Component) and its annotated fields (SCOPE.Schema/field) via extractClassFields; no Pydantic-specific Field()/constraint parsing.",
+            "status": "full",
+            "cites": ["internal/extractors/python/extractor.go","internal/patterns/patterns_test.go","internal/patterns/schema_detector.go"],
+            "notes": "Base Python extractor emits the model class (SCOPE.Component) and its annotated fields (SCOPE.Schema/field) via extractClassFields; schema_detector.go classifies the BaseModel subclass as a pydantic schema_validation entity, exercised by TestSchemaDetector_PydanticBaseModel.",
             "verified_at": "2026-05-29"
           }
         },
         "Constraints": {
           "constraint_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/python/extractors_test.go","internal/custom/python/pydantic.go","internal/custom/python/testdata/pydantic_validators.py"],
+            "notes": "python_pydantic extractor parses Field(gt=, ge=, lt=, le=, min_length=, max_length=, min_items=, max_items=, multiple_of=, max_digits=, decimal_places=, pattern=, regex=) into a SCOPE.Pattern entity per field with constraint_* properties; constraint-free Field(default=...) is skipped. Issue #2984.",
+            "verified_at": "2026-05-29"
           },
           "custom_validator_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/python/extractors_test.go","internal/custom/python/pydantic.go","internal/custom/python/testdata/pydantic_validators.py"],
+            "notes": "python_pydantic extractor emits SCOPE.Pattern entities for @field_validator / @validator (v1) and @model_validator / @root_validator (v1), capturing target fields, mode (before/after, pre=True), validator fn, and dialect. Issue #2984.",
+            "verified_at": "2026-05-29"
           }
         },
         "Coercion": {
           "type_coercion_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/extractors_test.go","internal/custom/python/pydantic.go"],
+            "notes": "python_pydantic recognizes model-level coercion config (model_config = ConfigDict(...) in v2, inner class Config in v1) and surfaces coercion-affecting flags (strict, coerce_numbers_to_str, str_strip_whitespace, validate_assignment, use_enum_values, ...) as a SCOPE.Pattern model_config entity. Per-field type-coercion inference (annotation-driven int/str/datetime coercion) is not modeled.",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/pytest.go"],
+            "notes": "python_pytest extracts pytest test functions/classes/fixtures; tests exercising Pydantic models are captured as test entities but no validator-to-test linkage edge is emitted.",
+            "verified_at": "2026-05-29"
           }
         }
       }

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -2060,7 +2060,7 @@ func TestAllExtractors_EmptyInput(t *testing.T) {
 		"python_django", "python_fastapi", "python_flask", "python_celery",
 		"python_pytest", "python_langchain", "python_mongodb", "python_redis",
 		"python_sqlalchemy", "python_fastapi_reqresp", "python_flask_reqresp",
-		"python_dramatiq", "python_rq",
+		"python_dramatiq", "python_rq", "python_pydantic",
 	}
 	for _, key := range keys {
 		ext, ok := extractor.Get(key)
@@ -2080,6 +2080,244 @@ func TestAllExtractors_EmptyInput(t *testing.T) {
 }
 
 // ============================================================================
+// Pydantic tests (issue #2984)
+// ============================================================================
+
+// findByName returns the first entity with the given Name, or a zero value and
+// false if none matched.
+func findByName(ents []extractResult, name string) (extractResult, bool) {
+	for _, e := range ents {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return extractResult{}, false
+}
+
+func TestPydantic_FieldValidator(t *testing.T) {
+	src := `from pydantic import BaseModel, field_validator
+
+class User(BaseModel):
+    email: str
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def normalize_email(cls, v):
+        return v.lower()
+`
+	ents := extract(t, "python_pydantic", src)
+	e, ok := findByName(ents, "validate_normalize_email")
+	if !ok {
+		t.Fatalf("expected validate_normalize_email entity, got %+v", ents)
+	}
+	if e.Kind != "SCOPE.Pattern" {
+		t.Fatalf("kind = %q, want SCOPE.Pattern", e.Kind)
+	}
+	if e.Props["pattern_type"] != "field_validator" {
+		t.Fatalf("pattern_type = %q", e.Props["pattern_type"])
+	}
+	if e.Props["fields"] != "email" {
+		t.Fatalf("fields = %q, want email", e.Props["fields"])
+	}
+	if e.Props["mode"] != "before" {
+		t.Fatalf("mode = %q, want before", e.Props["mode"])
+	}
+	if e.Props["dialect"] != "v2" {
+		t.Fatalf("dialect = %q, want v2", e.Props["dialect"])
+	}
+}
+
+func TestPydantic_V1Validator(t *testing.T) {
+	src := `from pydantic import BaseModel, validator
+
+class Score(BaseModel):
+    value: int
+
+    @validator("value", pre=True)
+    def coerce(cls, v):
+        return int(v)
+`
+	ents := extract(t, "python_pydantic", src)
+	e, ok := findByName(ents, "validate_coerce")
+	if !ok {
+		t.Fatalf("expected validate_coerce entity, got %+v", ents)
+	}
+	if e.Props["dialect"] != "v1" {
+		t.Fatalf("dialect = %q, want v1", e.Props["dialect"])
+	}
+	if e.Props["mode"] != "before" {
+		t.Fatalf("mode = %q (pre=True should map to before)", e.Props["mode"])
+	}
+}
+
+func TestPydantic_ModelValidator(t *testing.T) {
+	src := `from pydantic import BaseModel, model_validator
+
+class Pair(BaseModel):
+    a: int
+    b: int
+
+    @model_validator(mode="after")
+    def check(self):
+        return self
+`
+	ents := extract(t, "python_pydantic", src)
+	e, ok := findByName(ents, "validate_check")
+	if !ok {
+		t.Fatalf("expected validate_check entity, got %+v", ents)
+	}
+	if e.Props["pattern_type"] != "model_validator" {
+		t.Fatalf("pattern_type = %q", e.Props["pattern_type"])
+	}
+	if e.Props["mode"] != "after" {
+		t.Fatalf("mode = %q, want after", e.Props["mode"])
+	}
+}
+
+func TestPydantic_Constraints(t *testing.T) {
+	src := `from pydantic import BaseModel, Field
+
+class Account(BaseModel):
+    username: str = Field(min_length=3, max_length=32, pattern=r"^[a-z]+$")
+    age: int = Field(gt=0, le=150)
+    note: str = Field(default="")
+`
+	ents := extract(t, "python_pydantic", src)
+	u, ok := findByName(ents, "constraint_username")
+	if !ok {
+		t.Fatalf("expected constraint_username, got %+v", ents)
+	}
+	if u.Props["constraint_min_length"] != "3" {
+		t.Fatalf("min_length = %q", u.Props["constraint_min_length"])
+	}
+	if u.Props["constraint_max_length"] != "32" {
+		t.Fatalf("max_length = %q", u.Props["constraint_max_length"])
+	}
+	if u.Props["constraint_pattern"] == "" {
+		t.Fatalf("expected pattern constraint, got %+v", u.Props)
+	}
+	a, ok := findByName(ents, "constraint_age")
+	if !ok {
+		t.Fatalf("expected constraint_age")
+	}
+	if a.Props["constraint_gt"] != "0" || a.Props["constraint_le"] != "150" {
+		t.Fatalf("age constraints = %+v", a.Props)
+	}
+	// A bare Field(default=...) carries no constraint and must not be emitted.
+	if _, ok := findByName(ents, "constraint_note"); ok {
+		t.Fatal("constraint_note should not be emitted for a constraint-free Field()")
+	}
+}
+
+func TestPydantic_ModelConfig(t *testing.T) {
+	src := `from pydantic import BaseModel, ConfigDict
+
+class S(BaseModel):
+    model_config = ConfigDict(strict=True, str_strip_whitespace=True)
+    x: int
+`
+	ents := extract(t, "python_pydantic", src)
+	e, ok := findByName(ents, "model_config_model_config")
+	if !ok {
+		t.Fatalf("expected model_config entity, got %+v", ents)
+	}
+	if e.Props["dialect"] != "v2" {
+		t.Fatalf("dialect = %q, want v2", e.Props["dialect"])
+	}
+	if !strings.Contains(e.Props["coercion_flags"], "strict") ||
+		!strings.Contains(e.Props["coercion_flags"], "str_strip_whitespace") {
+		t.Fatalf("coercion_flags = %q", e.Props["coercion_flags"])
+	}
+}
+
+func TestPydantic_V1ConfigClass(t *testing.T) {
+	src := `from pydantic import BaseModel
+
+class S(BaseModel):
+    x: int
+
+    class Config:
+        allow_population_by_field_name = True
+        use_enum_values = True
+`
+	ents := extract(t, "python_pydantic", src)
+	e, ok := findByName(ents, "model_config_Config")
+	if !ok {
+		t.Fatalf("expected v1 Config entity, got %+v", ents)
+	}
+	if e.Props["dialect"] != "v1" {
+		t.Fatalf("dialect = %q, want v1", e.Props["dialect"])
+	}
+	if !strings.Contains(e.Props["coercion_flags"], "use_enum_values") {
+		t.Fatalf("coercion_flags = %q", e.Props["coercion_flags"])
+	}
+}
+
+func TestPydantic_NoClassDuplicate(t *testing.T) {
+	// Issue #1501 discipline: the Pydantic extractor must never emit an entity
+	// named after the model class itself (the base Python extractor owns that).
+	src := `from pydantic import BaseModel, Field
+
+class Widget(BaseModel):
+    size: int = Field(gt=0)
+`
+	ents := extract(t, "python_pydantic", src)
+	if _, ok := findByName(ents, "Widget"); ok {
+		t.Fatal("python_pydantic must not emit an entity named after the class (issue #1501)")
+	}
+}
+
+func TestPydantic_NonPydanticNoMatch(t *testing.T) {
+	// A file that calls a function named Field() / validator() but never
+	// references Pydantic must not produce constraint/validator nodes.
+	src := `def Field(**kwargs):
+    return None
+
+x = Field(gt=0)
+`
+	ents := extract(t, "python_pydantic", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities for non-Pydantic code, got %d: %+v", len(ents), ents)
+	}
+}
+
+func TestPydantic_Fixture(t *testing.T) {
+	content, err := os.ReadFile("testdata/pydantic_validators.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ext, _ := extractor.Get("python_pydantic")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "testdata/pydantic_validators.py",
+		Content:  content,
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("extract fixture: %v", err)
+	}
+	want := map[string]bool{
+		"validate_normalize_email":   false, // @field_validator
+		"validate_check_consistency": false, // @model_validator
+		"validate_coerce_score":      false, // v1 @validator
+		"constraint_username":        false, // Field(min_length, max_length, pattern)
+		"constraint_age":             false, // Field(gt, le)
+		"constraint_score":           false, // Field(ge, le)
+		"model_config_model_config":  false, // ConfigDict (v2)
+		"model_config_Config":        false, // class Config (v1)
+	}
+	for _, e := range ents {
+		if _, tracked := want[e.Name]; tracked {
+			want[e.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("fixture: expected entity %q not emitted", name)
+		}
+	}
+}
+
+// ============================================================================
 // Registration test
 // ============================================================================
 
@@ -2088,7 +2326,7 @@ func TestAllExtractors_Registered(t *testing.T) {
 		"python_django", "python_fastapi", "python_flask", "python_celery",
 		"python_pytest", "python_langchain", "python_mongodb", "python_redis",
 		"python_sqlalchemy", "python_fastapi_reqresp", "python_flask_reqresp",
-		"python_dramatiq", "python_rq",
+		"python_dramatiq", "python_rq", "python_pydantic",
 	}
 	for _, key := range keys {
 		_, ok := extractor.Get(key)

--- a/internal/custom/python/pydantic.go
+++ b/internal/custom/python/pydantic.go
@@ -1,0 +1,315 @@
+package python
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_pydantic", &PydanticExtractor{})
+}
+
+// PydanticExtractor extracts Pydantic validation patterns that the base Python
+// extractor and the schema_detector do not model: custom validators
+// (@field_validator / @validator / @model_validator), Field(...) constraints
+// (gt=, max_length=, regex=, ...), and model-level coercion/config
+// (model_config / Config inner class).
+//
+// It deliberately does NOT emit a second entity for the model class itself —
+// the base Python extractor already emits one SCOPE.Component/class node per
+// class definition, and emitting a duplicate inflates node counts (issue #1501,
+// mirrored by the FastAPI extractor's same restraint). Every entity this
+// extractor emits carries a synthetic, non-colliding name (e.g.
+// "validate_<field>", "constraint_<field>") and the SCOPE.Pattern kind so it
+// never shadows a real class/function node.
+//
+// Issue #2984 — Pydantic field_validator / constraint / coercion extraction.
+type PydanticExtractor struct{}
+
+func (e *PydanticExtractor) Language() string { return "python_pydantic" }
+
+var (
+	// @field_validator('a', 'b', mode='before')  (Pydantic v2)
+	// @validator('a', pre=True)                  (Pydantic v1)
+	// followed by an optional @classmethod and the validator def.
+	pydValidatorRe = regexp.MustCompile(
+		`(?m)^[ \t]*@(field_validator|validator)\s*\(([^)]*)\)\s*\n` +
+			`(?:[ \t]*@\w[\w.]*\s*(?:\([^)]*\))?\s*\n)*` +
+			`[ \t]*(?:async\s+)?def\s+(\w+)\s*\(`)
+	// @model_validator(mode='after')  (v2) / @root_validator (v1) on a def.
+	pydModelValidatorRe = regexp.MustCompile(
+		`(?m)^[ \t]*@(model_validator|root_validator)\s*(?:\(([^)]*)\))?\s*\n` +
+			`(?:[ \t]*@\w[\w.]*\s*(?:\([^)]*\))?\s*\n)*` +
+			`[ \t]*(?:async\s+)?def\s+(\w+)\s*\(`)
+	// field: type = Field(...)  — capture field name + the Field(...) arg blob.
+	pydFieldRe = regexp.MustCompile(
+		`(?m)^[ \t]+(\w+)\s*:\s*[^=\n]+=\s*Field\s*\(([^)]*)\)`)
+	// mode= / pre=True quote-tolerant extraction for validator dialect.
+	pydModeKwargRe = regexp.MustCompile(`mode\s*=\s*["'](\w+)["']`)
+	// model_config = ConfigDict(...) (v2) or `class Config:` inner class (v1).
+	pydModelConfigRe = regexp.MustCompile(`(?m)^[ \t]+model_config\s*=\s*ConfigDict\s*\(([^)]*)\)`)
+	pydConfigClassRe = regexp.MustCompile(`(?m)^[ \t]+class\s+Config\s*:`)
+)
+
+// pydConstraintKeys are the Field() keyword constraints we surface. Order is
+// deterministic for stable property emission.
+var pydConstraintKeys = []string{
+	"gt", "ge", "lt", "le",
+	"min_length", "max_length", "min_items", "max_items",
+	"multiple_of", "max_digits", "decimal_places",
+	"pattern", "regex",
+}
+
+// pydCoercionConfigKeys are model_config / Config flags that affect type
+// coercion behavior. Presence of any flags the model as coercion-aware.
+var pydCoercionConfigKeys = []string{
+	"strict", "coerce_numbers_to_str", "str_strip_whitespace",
+	"validate_assignment", "populate_by_name", "allow_population_by_field_name",
+	"use_enum_values", "arbitrary_types_allowed", "extra",
+}
+
+// pydFirstQuotedRe pulls quoted string literals out of a Field/decorator
+// argument blob, e.g. `'name', 'email'` -> ["name","email"].
+var pydFirstQuotedRe = regexp.MustCompile(`["']([^"']+)["']`)
+
+// pydKwargStartRe matches the first keyword argument in a decorator call (a
+// bareword identifier followed by a single "=", not "=="). Used to drop the
+// kwarg tail before harvesting positional field-name string args.
+var pydKwargStartRe = regexp.MustCompile(`\b\w+\s*=\s*[^=]`)
+
+func (e *PydanticExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_pydantic")
+	_, span := tracer.Start(ctx, "custom.python_pydantic")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	source := string(file.Content)
+
+	// Gate: only run when the file actually references Pydantic. This avoids
+	// emitting spurious "constraint"/"validator" nodes for unrelated code that
+	// happens to call a function named Field() or validator().
+	if !pydanticReferenced(source) {
+		return nil, nil
+	}
+
+	dialect := pydanticDialect(source)
+	var out []types.EntityRecord
+
+	// 1. Field-level custom validators: @field_validator / @validator.
+	for _, idx := range allMatchesIndex(pydValidatorRe, source) {
+		decorator := source[idx[2]:idx[3]]
+		args := source[idx[4]:idx[5]]
+		fnName := source[idx[6]:idx[7]]
+		line := lineOf(source, idx[0])
+		fields := quotedArgs(args)
+		props := map[string]string{
+			"framework":    "pydantic",
+			"pattern_type": "field_validator",
+			"decorator":    decorator,
+			"validator_fn": fnName,
+			"dialect":      validatorDialect(decorator, dialect),
+		}
+		if len(fields) > 0 {
+			props["fields"] = strings.Join(fields, ",")
+		}
+		if m := pydModeKwargRe.FindStringSubmatch(args); m != nil {
+			props["mode"] = m[1]
+		} else if strings.Contains(args, "pre=True") || strings.Contains(args, "pre = True") {
+			props["mode"] = "before"
+		}
+		out = append(out, entity("validate_"+fnName, "SCOPE.Pattern", "", file.Path, line, props))
+	}
+
+	// 2. Model-level validators: @model_validator / @root_validator.
+	for _, idx := range allMatchesIndex(pydModelValidatorRe, source) {
+		decorator := source[idx[2]:idx[3]]
+		var args string
+		if idx[4] >= 0 {
+			args = source[idx[4]:idx[5]]
+		}
+		fnName := source[idx[6]:idx[7]]
+		line := lineOf(source, idx[0])
+		props := map[string]string{
+			"framework":    "pydantic",
+			"pattern_type": "model_validator",
+			"decorator":    decorator,
+			"validator_fn": fnName,
+			"dialect":      validatorDialect(decorator, dialect),
+		}
+		if m := pydModeKwargRe.FindStringSubmatch(args); m != nil {
+			props["mode"] = m[1]
+		}
+		out = append(out, entity("validate_"+fnName, "SCOPE.Pattern", "", file.Path, line, props))
+	}
+
+	// 3. Field(...) constraints.
+	for _, idx := range allMatchesIndex(pydFieldRe, source) {
+		fieldName := source[idx[2]:idx[3]]
+		args := source[idx[4]:idx[5]]
+		constraints := extractConstraints(args)
+		if len(constraints) == 0 {
+			continue // a bare Field(...) / Field(default=...) carries no constraint.
+		}
+		line := lineOf(source, idx[0])
+		props := map[string]string{
+			"framework":    "pydantic",
+			"pattern_type": "constraint",
+			"field":        fieldName,
+			"dialect":      dialect,
+		}
+		for k, v := range constraints {
+			props["constraint_"+k] = v
+		}
+		out = append(out, entity("constraint_"+fieldName, "SCOPE.Pattern", "", file.Path, line, props))
+	}
+
+	// 4. Model config / coercion recognition. v2 ConfigDict and v1 inner
+	// `class Config:` can both appear in one file (different models), so emit
+	// every occurrence rather than just the first.
+	for _, m := range allMatchesIndex(pydModelConfigRe, source) {
+		args := source[m[2]:m[3]]
+		line := lineOf(source, m[0])
+		out = append(out, configEntity("v2", "model_config", args, file.Path, line))
+	}
+	for _, m := range allMatchesIndex(pydConfigClassRe, source) {
+		// v1 inner `class Config:` — capture the flags from the indented body.
+		body := configClassBody(source, m[1])
+		line := lineOf(source, m[0])
+		out = append(out, configEntity("v1", "Config", body, file.Path, line))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// configEntity builds the model-config / coercion pattern entity from a config
+// argument/body blob, recording any recognized coercion-affecting flags.
+func configEntity(configDialect, configForm, blob, path string, line int) types.EntityRecord {
+	props := map[string]string{
+		"framework":    "pydantic",
+		"pattern_type": "model_config",
+		"config_form":  configForm,
+		"dialect":      configDialect,
+	}
+	var flags []string
+	for _, k := range pydCoercionConfigKeys {
+		if regexp.MustCompile(`\b` + regexp.QuoteMeta(k) + `\s*=`).MatchString(blob) {
+			flags = append(flags, k)
+		}
+	}
+	if len(flags) > 0 {
+		props["coercion_flags"] = strings.Join(flags, ",")
+	}
+	return entity("model_config_"+configForm, "SCOPE.Pattern", "", path, line, props)
+}
+
+// extractConstraints pulls recognized Field() keyword constraints into a map.
+func extractConstraints(args string) map[string]string {
+	out := map[string]string{}
+	for _, k := range pydConstraintKeys {
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(k) + `\s*=\s*([^,)]+)`)
+		if m := re.FindStringSubmatch(args); m != nil {
+			out[k] = strings.TrimSpace(m[1])
+		}
+	}
+	return out
+}
+
+// quotedArgs returns the positional quoted string literals in a decorator
+// argument blob, in source order. It stops at the first keyword argument
+// (a top-level `name=`), so `'a', 'b', mode='before'` yields ["a","b"] and not
+// "before". Used to recover the field names a validator targets.
+func quotedArgs(args string) []string {
+	// Truncate at the first keyword argument: a bareword identifier followed by
+	// "=" that is not "==". Positional string args always precede kwargs in a
+	// decorator call.
+	if loc := pydKwargStartRe.FindStringIndex(args); loc != nil {
+		args = args[:loc[0]]
+	}
+	var out []string
+	for _, m := range pydFirstQuotedRe.FindAllStringSubmatch(args, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// configClassBody returns the indented body following a `class Config:` header
+// starting at byte offset start, up to the first dedent (a non-blank line whose
+// indentation is <= the class header's). Best-effort, regex-free scan.
+func configClassBody(source string, start int) string {
+	rest := source[start:]
+	lines := strings.Split(rest, "\n")
+	var body []string
+	for i, ln := range lines {
+		if i == 0 {
+			continue // the remainder of the `class Config:` line
+		}
+		trimmed := strings.TrimSpace(ln)
+		if trimmed == "" {
+			continue
+		}
+		// First indented body line establishes membership; a line with no
+		// leading whitespace marks the dedent that ends the inner class.
+		if ln == trimmed {
+			break
+		}
+		body = append(body, ln)
+	}
+	return strings.Join(body, "\n")
+}
+
+// pydanticReferenced reports whether the source references Pydantic at all.
+func pydanticReferenced(source string) bool {
+	return strings.Contains(source, "pydantic") ||
+		strings.Contains(source, "BaseModel") ||
+		strings.Contains(source, "BaseSettings") ||
+		strings.Contains(source, "field_validator") ||
+		strings.Contains(source, "ConfigDict")
+}
+
+// pydanticDialect infers the dominant Pydantic major version from the source.
+// v2 markers (field_validator, model_validator, ConfigDict, pattern=) win over
+// v1 markers; ambiguous files report "unknown".
+func pydanticDialect(source string) string {
+	v2 := strings.Contains(source, "field_validator") ||
+		strings.Contains(source, "model_validator") ||
+		strings.Contains(source, "ConfigDict") ||
+		strings.Contains(source, "model_config")
+	v1 := strings.Contains(source, "@validator") ||
+		strings.Contains(source, "@root_validator") ||
+		regexp.MustCompile(`(?m)^[ \t]+class\s+Config\s*:`).MatchString(source)
+	switch {
+	case v2 && !v1:
+		return "v2"
+	case v1 && !v2:
+		return "v1"
+	case v2 && v1:
+		return "mixed"
+	default:
+		return "unknown"
+	}
+}
+
+// validatorDialect maps a specific decorator to its Pydantic dialect, falling
+// back to the file-level dialect when the decorator is version-neutral.
+func validatorDialect(decorator, fileDialect string) string {
+	switch decorator {
+	case "field_validator", "model_validator":
+		return "v2"
+	case "validator", "root_validator":
+		return "v1"
+	default:
+		return fileDialect
+	}
+}

--- a/internal/custom/python/testdata/pydantic_validators.py
+++ b/internal/custom/python/testdata/pydantic_validators.py
@@ -1,0 +1,37 @@
+"""Dependency-free proving fixture for the Pydantic extractor (issue #2984).
+
+Exercises Pydantic v2 field/model validators, Field(...) constraints, and
+ConfigDict-based coercion config, plus a v1-style class for dialect coverage.
+The imports are written so the file parses but needs no installed packages.
+"""
+
+from pydantic import BaseModel, Field, field_validator, model_validator, ConfigDict
+
+
+class SignupRequest(BaseModel):
+    model_config = ConfigDict(strict=True, str_strip_whitespace=True)
+
+    username: str = Field(min_length=3, max_length=32, pattern=r"^[a-z0-9_]+$")
+    age: int = Field(gt=0, le=150)
+    email: str
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def normalize_email(cls, v):
+        return v.strip().lower()
+
+    @model_validator(mode="after")
+    def check_consistency(self):
+        return self
+
+
+class LegacyModel(BaseModel):
+    score: int = Field(ge=0, le=100)
+
+    class Config:
+        allow_population_by_field_name = True
+        use_enum_values = True
+
+    @validator("score", pre=True)
+    def coerce_score(cls, v):
+        return int(v)

--- a/internal/patterns/patterns_test.go
+++ b/internal/patterns/patterns_test.go
@@ -1849,3 +1849,52 @@ func TestLineOf(t *testing.T) {
 		t.Errorf("expected line 3 for offset 12, got %d", lineOf(src, 12))
 	}
 }
+
+// ============================================================
+// Schema detector — Pydantic (issue #2984 A-win)
+// ============================================================
+
+func TestSchemaDetector_PydanticBaseModel(t *testing.T) {
+	d := &schemaDetector{}
+	src := `from pydantic import BaseModel, Field
+
+class SignupRequest(BaseModel):
+    username: str = Field(min_length=3)
+    age: int
+`
+	if !d.AppliesTo(src) {
+		t.Fatal("schemaDetector should apply to a Pydantic BaseModel file")
+	}
+	results := d.Detect("schemas.py", "python", src)
+	found := false
+	for _, e := range results {
+		if e.Properties["library"] == "pydantic" {
+			found = true
+			if e.Kind != "SCOPE.Component" {
+				t.Errorf("kind = %q, want SCOPE.Component", e.Kind)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected a pydantic schema_validation entity, got %+v", results)
+	}
+}
+
+func TestSchemaDetector_QualifiedPydanticBaseModel(t *testing.T) {
+	d := &schemaDetector{}
+	src := `import pydantic
+
+class Order(pydantic.BaseModel):
+    id: int
+`
+	results := d.Detect("order.py", "python", src)
+	found := false
+	for _, e := range results {
+		if e.Properties["library"] == "pydantic" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected pydantic detection for qualified BaseModel, got %+v", results)
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3006,3 +3006,55 @@ records:
             - file: internal/custom/python/extractors_test.go
           issues_implemented: ["2986"]
           verified_at: "2026-05-29"
+
+  lang.python.validation.pydantic:
+    capabilities:
+      Constraints:
+        custom_validator_extraction:
+          # @field_validator / @validator (v1) / @model_validator / @root_validator
+          # emitted as SCOPE.Pattern entities with target fields, mode, dialect;
+          # issue #2984.
+          status: full
+          symbols:
+            - file: internal/custom/python/pydantic.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/python/extractors_test.go
+          issues_implemented: ["2984"]
+          verified_at: "2026-05-29"
+        constraint_extraction:
+          # Field(gt=, ge=, lt=, le=, min_length=, max_length=, pattern=, ...)
+          # constraints emitted as SCOPE.Pattern entities per field; issue #2984.
+          status: full
+          symbols:
+            - file: internal/custom/python/pydantic.go
+              functions: [Extract, extractConstraints]
+          tests:
+            - file: internal/custom/python/extractors_test.go
+          issues_implemented: ["2984"]
+          verified_at: "2026-05-29"
+      Coercion:
+        type_coercion_recognition:
+          # model_config = ConfigDict(...) (v2) and inner class Config (v1)
+          # coercion flags recognized as a SCOPE.Pattern model_config entity;
+          # per-field coercion not modeled. issue #2984.
+          status: partial
+          symbols:
+            - file: internal/custom/python/pydantic.go
+              functions: [Extract, configEntity]
+          tests:
+            - file: internal/custom/python/extractors_test.go
+          issues_implemented: ["2984"]
+          verified_at: "2026-05-29"
+      Schema:
+        schema_extraction:
+          # BaseModel subclass classified as a pydantic schema_validation entity
+          # by schema_detector.go; issue #2984.
+          status: full
+          symbols:
+            - file: internal/patterns/schema_detector.go
+              functions: [Detect]
+          tests:
+            - file: internal/patterns/patterns_test.go
+          issues_implemented: ["2984"]
+          verified_at: "2026-05-29"


### PR DESCRIPTION
## Summary
New `python_pydantic` custom extractor for Pydantic validation patterns the base Python extractor and `schema_detector` did not model. This is a real extractor build (new detection), not a record-only change.

### What it extracts
- **Custom validators** — `@field_validator` / `@validator` (v1) / `@model_validator` / `@root_validator` (v1) → `SCOPE.Pattern` entities (`pattern_type=field_validator|model_validator`) carrying target `fields`, `mode` (before/after; `pre=True`→before), `validator_fn`, and inferred `dialect` (v1/v2/mixed).
- **Field constraints** — `Field(gt=, ge=, lt=, le=, min_length=, max_length=, min_items=, max_items=, multiple_of=, max_digits=, decimal_places=, pattern=, regex=)` → one `SCOPE.Pattern` per constrained field with `constraint_*` props. A constraint-free `Field(default=...)` is skipped.
- **Coercion config** — `model_config = ConfigDict(...)` (v2) and inner `class Config:` (v1) → `SCOPE.Pattern` `model_config` entity surfacing coercion-affecting flags.

### Discipline
- Never emits an entity named after the model class (issue #1501) — the base extractor owns that node, so no within-file duplication.
- Gated on a Pydantic reference; unrelated `Field()` / `validator()` calls produce nothing.
- No new entity/edge Kinds — reuses `SCOPE.Pattern`.
- Auto-dispatched via the `python_` prefix in `RunCustomExtractors` (no wiring change needed).

### Coverage matrix (`lang.python.validation.pydantic`)
| capability | before | after | proof |
|---|---|---|---|
| custom_validator_extraction | missing | **full** | pydantic.go + tests + fixture |
| constraint_extraction | missing | **full** | pydantic.go + tests + fixture |
| type_coercion_recognition | missing | **partial** | model_config flags (per-field coercion not modeled) |
| schema_extraction | partial | **full** | schema_detector.go + new patterns_test fixture |
| tests_linkage | missing | **partial** | pytest.go cite |

### Validation
- `coverage validate` → ok, 0 errors
- `gofmt` clean; `coverage gen` byte-stable
- `go test ./internal/extractors/python/ ./internal/custom/python/ ./tools/coverage/ ./internal/types/ ./internal/patterns/` + determinism test green
- `go vet` + `go build ./...` clean

Closes #2984

🤖 Generated with [Claude Code](https://claude.com/claude-code)