### PR TITLE
feat(python): Sanic + Litestar + Robyn endpoint synthesis (#2980)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -88,11 +88,11 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -20,11 +20,11 @@ Back to [summary](../summary.md).
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -15,9 +15,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
-| Handler attribution | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/litestar.yaml` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/litestar.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/litestar.yaml` | — |
+| Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -15,9 +15,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
-| Handler attribution | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/robyn.yaml` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/robyn.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/robyn.yaml` | — |
+| Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -15,9 +15,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
-| Handler attribution | ❌ `missing` | `2026-05-28` | 2980 | `internal/engine/rules/python/frameworks/sanic.yaml` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/sanic.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/sanic.yaml` | — |
+| Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
 
 ### Auth
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -33978,20 +33978,19 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
-            "issue": "2980",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/litestar.yaml"],
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/litestar.yaml"],
-            "issue": "2980",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/litestar.yaml"],
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/httproutes/canonicalize.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
@@ -34594,20 +34593,19 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
-            "issue": "2980",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/robyn.yaml"],
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/robyn.yaml"],
-            "issue": "2980",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/robyn.yaml"],
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/httproutes/canonicalize.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
@@ -34936,20 +34934,19 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
-            "issue": "2980",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/sanic.yaml"],
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/sanic.yaml"],
-            "issue": "2980",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/sanic.yaml"],
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/httproutes/canonicalize.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -334,6 +334,18 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// WebClient / OkHttp / Apache HttpClient / Retrofit.
 		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
 	case "python":
+		// #2980 — ASGI frameworks (Sanic / Litestar / Robyn) run BEFORE
+		// Flask / FastAPI. Sanic's `@app.route` / `@app.get` shape overlaps
+		// Flask's, and Robyn's `@app.get` shape overlaps FastAPI's, so the
+		// file-signal-gated ASGI synthesizers must claim each (verb, path) ID
+		// first to stamp the correct `framework` label. The side-scoped dedup
+		// in makeEmit then prevents Flask/FastAPI from re-emitting the same ID.
+		// Each ASGI synthesizer is gated on a framework-specific marker
+		// (Sanic / Robyn / litestar|Controller) so it no-ops on plain
+		// Flask/FastAPI files.
+		synthesizeSanic(string(content), emitDef)
+		synthesizeLitestar(string(content), emitDef)
+		synthesizeRobyn(string(content), emitDef)
 		// Producer side: Flask + FastAPI run FIRST so their synthetics —
 		// which carry a real handler function name as source_handler —
 		// claim each ID before the Django composed-route pass walks the
@@ -1545,6 +1557,315 @@ func parsePyramidMethods(kwargs string) []string {
 		out = append(out, strings.ToUpper(tok))
 	}
 	return out
+}
+
+// ---------------------------------------------------------------------------
+// Sanic (Python) — #2980
+// ---------------------------------------------------------------------------
+//
+// Sanic is an ASGI-native framework whose routing idioms mirror Flask:
+//
+//	app = Sanic("app")
+//	@app.get("/users/<int:user_id>")
+//	@app.route("/items", methods=["GET", "POST"])
+//	async def handler(request): ...
+//
+//	bp = Blueprint("v1", url_prefix="/v1")
+//	@bp.get("/resource")
+//	async def handler(request): ...
+//
+// Path parameters use the Flask-style `<converter:name>` / `<name>` angle-bracket
+// convention, so canonicalisation reuses the Flask/Django angle-bracket walker
+// (FrameworkSanic is grouped with them in Canonicalize).
+//
+// Blueprint prefix composition is handled the same way Flask blueprints are
+// conceptually handled, but Sanic encodes the prefix on the Blueprint
+// constructor (`url_prefix="/v1"`) rather than on the registration site. We
+// build a same-file map of {blueprint receiver → url_prefix} and prepend the
+// prefix to every route decorated on that receiver. The dominant convention
+// (blueprint + its routes in one module) is covered; cross-module blueprints
+// fall back to the unprefixed path, which the byPath linker normalises.
+
+// sanicBlueprintRe captures `bp = Blueprint("name", url_prefix="/v1")`. The
+// url_prefix kwarg may appear before or after other kwargs; we capture the
+// receiver and then scan the tail for url_prefix separately so ordering does
+// not matter.
+//
+// Capture groups: 1 = receiver variable, 2 = constructor argument tail.
+var sanicBlueprintRe = regexp.MustCompile(
+	`(?m)^[ \t]*([A-Za-z_]\w*)\s*=\s*Blueprint\s*\(([^)]*)\)`,
+)
+
+// sanicURLPrefixKwargRe extracts `url_prefix="/v1"` from a Blueprint
+// constructor tail.
+var sanicURLPrefixKwargRe = regexp.MustCompile(`url_prefix\s*=\s*["']([^"'\n\r]*)["']`)
+
+// sanicVerbDecoratorRe captures @<recv>.<verb>("/path") shorthand decorators.
+// Sanic exposes get/post/put/patch/delete/head/options/websocket; we cover the
+// standard HTTP verbs. The handler def follows on the next def/async def line,
+// tolerating stacked decorators.
+//
+// Capture groups: 1 = receiver, 2 = verb, 3 = path, 4 = handler name.
+var sanicVerbDecoratorRe = regexp.MustCompile(
+	`@(\w+)\.(get|post|put|patch|delete|head|options)\s*\(\s*["']([^"'\n\r]+)["'][^)]*\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`,
+)
+
+// sanicRouteRe captures the generic @<recv>.route("/path", methods=[...]) form.
+//
+// Capture groups: 1 = receiver, 2 = path, 3 = kwargs tail, 4 = handler name.
+var sanicRouteRe = regexp.MustCompile(
+	`@(\w+)\.route\s*\(\s*["']([^"'\n\r]+)["']([^\n\r]*)\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`,
+)
+
+func synthesizeSanic(content string, emit emitDefFn) {
+	// File-signal gate: require a Sanic-specific marker so this pass no-ops on
+	// Flask files (which share the @<recv>.route / @<recv>.get decorator shape).
+	if !strings.Contains(content, "Sanic") {
+		return
+	}
+
+	// Build the same-file blueprint receiver → url_prefix map so blueprint
+	// routes compose the prefix (Sanic Blueprint mirrors Flask Blueprint).
+	prefixes := map[string]string{}
+	for _, m := range sanicBlueprintRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		recv := m[1]
+		if pm := sanicURLPrefixKwargRe.FindStringSubmatch(m[2]); len(pm) >= 2 {
+			prefixes[recv] = strings.TrimRight(pm[1], "/")
+		} else {
+			// Blueprint with no url_prefix: record an empty prefix so the
+			// receiver is still recognised as a blueprint (no-op composition).
+			prefixes[recv] = ""
+		}
+	}
+
+	compose := func(recv, raw string) string {
+		if pfx, ok := prefixes[recv]; ok && pfx != "" {
+			return joinPathFragments(pfx, raw)
+		}
+		return raw
+	}
+
+	// Shorthand verbs first — unambiguous verb.
+	for _, idx := range sanicVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 10 {
+			continue
+		}
+		recv := content[idx[2]:idx[3]]
+		verb := strings.ToUpper(content[idx[4]:idx[5]])
+		raw := content[idx[6]:idx[7]]
+		handler := content[idx[8]:idx[9]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSanic, compose(recv, raw))
+		defLine := lineOfOffset(content, idx[8])
+		emit(verb, canonical, "sanic", "Controller", handler, defLine)
+	}
+
+	// Generic .route(...) form with optional methods=[...].
+	for _, idx := range sanicRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 10 {
+			continue
+		}
+		recv := content[idx[2]:idx[3]]
+		raw := content[idx[4]:idx[5]]
+		extras := content[idx[6]:idx[7]]
+		handler := content[idx[8]:idx[9]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSanic, compose(recv, raw))
+		defLine := lineOfOffset(content, idx[8])
+		methods := parseFlaskMethods(extras) // identical methods=[...] shape
+		if len(methods) == 0 {
+			// Sanic's default for app.route without methods is GET.
+			methods = []string{"GET"}
+		}
+		for _, verb := range methods {
+			emit(verb, canonical, "sanic", "Controller", handler, defLine)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Litestar (Python) — #2980
+// ---------------------------------------------------------------------------
+//
+// Litestar (formerly Starlite) differs from FastAPI: route decorators are bare
+// (`@get`, `@post`, ...) rather than receiver-bound (`@app.get`), and handlers
+// are commonly grouped under a `Controller` subclass with a class-level
+// `path = "/base"` attribute, then mounted under a `Router(path="/api",
+// route_handlers=[...])`.
+//
+//	class UserController(Controller):
+//	    path = "/users"
+//	    @get("/{user_id:int}")
+//	    async def get_user(self, user_id: int) -> ...: ...
+//
+//	@post("/items")
+//	async def create_item(data: Item) -> ...: ...
+//
+// Path parameters use the FastAPI-style `{name:type}` curly-brace convention
+// (FrameworkLitestar is grouped with FastAPI in Canonicalize, which strips the
+// `:type` suffix).
+//
+// Prefix composition: a handler's full path is
+// joinPathFragments(routerPath, controllerPath, decoratorPath). The same-file
+// Controller `path` attribute is recovered by scanning each Controller class
+// body. A same-file `Router(path=...)` prefix (dominant single-router
+// convention) is prepended to every handler; multi-router files fall back to no
+// router prefix, which the byPath linker normalises.
+
+// litestarRouterPathRe captures a same-file `Router(path="/api", ...)` prefix.
+var litestarRouterPathRe = regexp.MustCompile(`\bRouter\s*\(\s*path\s*=\s*["']([^"'\n\r]+)["']`)
+
+// litestarControllerClassRe matches a `class X(Controller):` declaration.
+//
+// Capture groups: 1 = class name.
+var litestarControllerClassRe = regexp.MustCompile(
+	`(?m)^class\s+([A-Za-z_]\w*)\s*\([^)]*\bController\b[^)]*\)\s*:`,
+)
+
+// litestarControllerPathRe captures a class-level `path = "/base"` attribute.
+var litestarControllerPathRe = regexp.MustCompile(`(?m)^[ \t]+path\s*=\s*["']([^"'\n\r]+)["']`)
+
+// litestarVerbDecoratorRe captures a bare `@get("/path")` / `@post(...)` route
+// handler decorator and the following handler def. The decorator may be
+// followed by stacked decorators (e.g. `@get(...)` plus a guard decorator).
+//
+// Capture groups: 1 = verb, 2 = path, 3 = handler name.
+var litestarVerbDecoratorRe = regexp.MustCompile(
+	`(?m)^[ \t]*@(get|post|put|patch|delete|head|options)\s*\(\s*["']([^"'\n\r]*)["'][^)]*\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`,
+)
+
+// litestarBareVerbDecoratorRe captures the no-argument decorator form
+// `@get()` / `@post()` (Litestar allows omitting the path, defaulting to the
+// Controller / Router base path). Captured separately so the path-required
+// regex above stays strict.
+//
+// Capture groups: 1 = verb, 2 = handler name.
+var litestarBareVerbDecoratorRe = regexp.MustCompile(
+	`(?m)^[ \t]*@(get|post|put|patch|delete|head|options)\s*\(\s*\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`,
+)
+
+func synthesizeLitestar(content string, emit emitDefFn) {
+	// File-signal gate: require a Litestar marker. The bare `@get(...)`
+	// decorator shape is generic enough that we must avoid firing on unrelated
+	// Python files (e.g. a project-local `get` decorator).
+	if !strings.Contains(content, "litestar") && !strings.Contains(content, "Litestar") &&
+		!strings.Contains(content, "Controller") {
+		return
+	}
+
+	// Single-router prefix (dominant convention).
+	routerPrefix := ""
+	if rm := litestarRouterPathRe.FindStringSubmatch(content); len(rm) >= 2 {
+		routerPrefix = strings.TrimRight(rm[1], "/")
+	}
+
+	// Map each handler-def offset to the enclosing Controller's path prefix by
+	// recording each Controller class body span + its `path` attribute.
+	type ctrlSpan struct {
+		start, end int
+		prefix     string
+	}
+	var ctrls []ctrlSpan
+	for _, cm := range litestarControllerClassRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(cm) < 4 {
+			continue
+		}
+		bodyStart := cm[1]
+		bodyEnd := findPyClassBodyEnd(content, bodyStart)
+		prefix := ""
+		if pm := litestarControllerPathRe.FindStringSubmatch(content[bodyStart:bodyEnd]); len(pm) >= 2 {
+			prefix = strings.TrimRight(pm[1], "/")
+		}
+		ctrls = append(ctrls, ctrlSpan{start: bodyStart, end: bodyEnd, prefix: prefix})
+	}
+	controllerPrefixAt := func(off int) string {
+		for _, c := range ctrls {
+			if off >= c.start && off < c.end {
+				return c.prefix
+			}
+		}
+		return ""
+	}
+
+	compose := func(handlerOff int, raw string) string {
+		full := joinPathFragments(controllerPrefixAt(handlerOff), raw)
+		if routerPrefix != "" {
+			full = joinPathFragments(routerPrefix, full)
+		}
+		return full
+	}
+
+	emitOne := func(verb, raw, handler string, defOff int) {
+		canonical := httproutes.Canonicalize(httproutes.FrameworkLitestar, compose(defOff, raw))
+		defLine := lineOfOffset(content, defOff)
+		emit(strings.ToUpper(verb), canonical, "litestar", "SCOPE.Operation", handler, defLine)
+	}
+
+	// Path-bearing decorators.
+	for _, idx := range litestarVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 8 {
+			continue
+		}
+		verb := content[idx[2]:idx[3]]
+		raw := content[idx[4]:idx[5]]
+		handler := content[idx[6]:idx[7]]
+		emitOne(verb, raw, handler, idx[6])
+	}
+	// Bare decorators (path defaults to the Controller / Router base path).
+	for _, idx := range litestarBareVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 6 {
+			continue
+		}
+		verb := content[idx[2]:idx[3]]
+		handler := content[idx[4]:idx[5]]
+		emitOne(verb, "", handler, idx[4])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Robyn (Python) — #2980
+// ---------------------------------------------------------------------------
+//
+// Robyn is a Rust-backed Python web framework with a FastAPI-like decorator
+// surface bound to a `Robyn(__file__)` app instance:
+//
+//	app = Robyn(__file__)
+//	@app.get("/users/:id")
+//	async def handler(request): ...
+//
+// Path parameters use the Express-style `:name` colon convention
+// (FrameworkRobyn is grouped with Express et al. in Canonicalize). Robyn has no
+// blueprint/router prefix concept in its core API, so no prefix composition is
+// needed.
+
+// robynVerbDecoratorRe captures @<recv>.<verb>("/path") decorators bound to a
+// Robyn app instance. The handler def follows on the next def/async def line.
+//
+// Capture groups: 1 = receiver, 2 = verb, 3 = path, 4 = handler name.
+var robynVerbDecoratorRe = regexp.MustCompile(
+	`@(\w+)\.(get|post|put|patch|delete|head|options)\s*\(\s*["']([^"'\n\r]+)["'][^)]*\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`,
+)
+
+func synthesizeRobyn(content string, emit emitDefFn) {
+	// File-signal gate: require the Robyn marker. The decorator shape overlaps
+	// with FastAPI / Sanic, so without this gate we would double-claim those
+	// frameworks' endpoints (the side-scoped dedup tolerates it, but the
+	// framework label would be wrong).
+	if !strings.Contains(content, "Robyn") {
+		return
+	}
+	for _, idx := range robynVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[4]:idx[5]])
+		raw := content[idx[6]:idx[7]]
+		handler := content[idx[8]:idx[9]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkRobyn, raw)
+		defLine := lineOfOffset(content, idx[8])
+		emit(verb, canonical, "robyn", "Controller", handler, defLine)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/http_endpoint_synthesis_asgi_test.go
+++ b/internal/engine/http_endpoint_synthesis_asgi_test.go
@@ -1,0 +1,176 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findSynthDef returns the http_endpoint_definition entity with the given
+// synthetic ID, or nil. Used by the ASGI synthesis tests to assert per-endpoint
+// properties (framework, source_handler, start line) beyond mere ID presence.
+func findSynthDef(res *DetectResult, id string) *types.EntityRecord {
+	for i := range res.Entities {
+		e := &res.Entities[i]
+		if e.ID == id && (e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointKind) {
+			return e
+		}
+	}
+	return nil
+}
+
+// TestSynth_Sanic covers @app.get / @app.route(methods=[...]) with Flask-style
+// <converter:name> path params, plus Blueprint url_prefix composition. #2980.
+func TestSynth_Sanic(t *testing.T) {
+	src := `from sanic import Sanic, Blueprint
+
+app = Sanic("app")
+bp = Blueprint("v1", url_prefix="/v1")
+
+@app.get("/users/<int:user_id>")
+async def get_user(request, user_id):
+    return {}
+
+@app.route("/items", methods=["GET", "POST"])
+async def items(request):
+    return {}
+
+@bp.get("/resource")
+async def list_resource(request):
+    return []
+
+@app.route("/health")
+async def health(request):
+    return "ok"
+`
+	got, res := runDetect(t, "python", "server.py", src)
+	want := []string{
+		"http:GET:/users/{user_id}",
+		"http:GET:/items",
+		"http:POST:/items",
+		"http:GET:/v1/resource",
+		"http:GET:/health",
+	}
+	requireContains(t, got, want, "Sanic")
+
+	// Framework label + handler attribution proof.
+	e := findSynthDef(res, "http:GET:/users/{user_id}")
+	if e == nil {
+		t.Fatalf("Sanic: missing http:GET:/users/{user_id}")
+	}
+	if e.Properties["framework"] != "sanic" {
+		t.Errorf("Sanic: framework = %q, want sanic", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "Controller:get_user" {
+		t.Errorf("Sanic: source_handler = %q, want Controller:get_user", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("Sanic: StartLine not stamped on get_user endpoint")
+	}
+}
+
+// TestSynth_Litestar covers bare @get/@post route handlers, Controller `path`
+// composition, and Router(path=...) prefix composition with {name:int} params. #2980.
+func TestSynth_Litestar(t *testing.T) {
+	src := `from litestar import Litestar, get, post
+from litestar.controller import Controller
+from litestar.router import Router
+
+class UserController(Controller):
+    path = "/users"
+
+    @get("/{user_id:int}")
+    async def get_user(self, user_id: int) -> dict:
+        return {}
+
+    @post()
+    async def create_user(self, data: dict) -> dict:
+        return {}
+
+@get("/health")
+async def health() -> str:
+    return "ok"
+
+router = Router(path="/api", route_handlers=[UserController])
+`
+	got, res := runDetect(t, "python", "app.py", src)
+	want := []string{
+		"http:GET:/api/users/{user_id}",
+		"http:POST:/api/users",
+		"http:GET:/api/health",
+	}
+	requireContains(t, got, want, "Litestar")
+
+	e := findSynthDef(res, "http:GET:/api/users/{user_id}")
+	if e == nil {
+		t.Fatalf("Litestar: missing http:GET:/api/users/{user_id}")
+	}
+	if e.Properties["framework"] != "litestar" {
+		t.Errorf("Litestar: framework = %q, want litestar", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:get_user" {
+		t.Errorf("Litestar: source_handler = %q, want SCOPE.Operation:get_user", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("Litestar: StartLine not stamped on get_user endpoint")
+	}
+}
+
+// TestSynth_Robyn covers @app.get/@app.post bound to a Robyn(__file__) instance
+// with Express-style :name path params. #2980.
+func TestSynth_Robyn(t *testing.T) {
+	src := `from robyn import Robyn
+
+app = Robyn(__file__)
+
+@app.get("/users/:id")
+async def get_user(request):
+    return {}
+
+@app.post("/users")
+async def create_user(request):
+    return {}
+
+app.start(port=8080)
+`
+	got, res := runDetect(t, "python", "app.py", src)
+	want := []string{
+		"http:GET:/users/{id}",
+		"http:POST:/users",
+	}
+	requireContains(t, got, want, "Robyn")
+
+	e := findSynthDef(res, "http:GET:/users/{id}")
+	if e == nil {
+		t.Fatalf("Robyn: missing http:GET:/users/{id}")
+	}
+	if e.Properties["framework"] != "robyn" {
+		t.Errorf("Robyn: framework = %q, want robyn", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "Controller:get_user" {
+		t.Errorf("Robyn: source_handler = %q, want Controller:get_user", e.Properties["source_handler"])
+	}
+}
+
+// TestSynth_ASGI_NoOpOnFlask asserts the Sanic/Robyn synthesizers do not fire
+// on a plain Flask file (no Sanic/Robyn marker), so the endpoint is labelled
+// flask, not sanic/robyn. Guards the framework-label correctness that the
+// dispatch ordering depends on. #2980.
+func TestSynth_ASGI_NoOpOnFlask(t *testing.T) {
+	src := `from flask import Flask
+
+app = Flask(__name__)
+
+@app.get("/ping")
+def ping():
+    return "pong"
+`
+	_, res := runDetect(t, "python", "flask_app.py", src)
+	e := findSynthDef(res, "http:GET:/ping")
+	if e == nil {
+		t.Fatalf("expected http:GET:/ping endpoint")
+	}
+	if e.Properties["framework"] != "flask" {
+		t.Errorf("framework = %q, want flask (ASGI synthesizers must no-op without their markers)", e.Properties["framework"])
+	}
+}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -83,6 +83,18 @@ const (
 	// FrameworkSails (#2851) — Sails config/routes.js maps `'GET /users/:id':
 	// 'UserController.find'`; the path uses the `:name` colon convention.
 	FrameworkSails = "sails"
+	// FrameworkSanic (#2980) — Sanic `@app.get("/users/<int:user_id>")` and
+	// `@bp.route(...)` use Flask-style `<converter:name>` / `<name>` angle-bracket
+	// path parameters. Canonicalisation reuses the angle-bracket walker.
+	FrameworkSanic = "sanic"
+	// FrameworkLitestar (#2980) — Litestar `@get("/users/{user_id:int}")` route
+	// handlers and `Controller` classes use `{name:type}` curly-brace path
+	// parameters identical to FastAPI; the `:type` suffix is stripped by
+	// canonicalizeCurlyBraces.
+	FrameworkLitestar = "litestar"
+	// FrameworkRobyn (#2980) — Robyn `@app.get("/users/:id")` uses the
+	// Express-style `:name` colon-prefixed path parameter convention.
+	FrameworkRobyn = "robyn"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -102,7 +114,7 @@ func Canonicalize(framework, raw string) string {
 
 	var out string
 	switch framework {
-	case FrameworkDjango, FrameworkFlask, FrameworkRocket:
+	case FrameworkDjango, FrameworkFlask, FrameworkRocket, FrameworkSanic:
 		// #2669 — Django re_path and DRF @action(url_path=…) frequently embed
 		// Python named-group regex `(?P<name>charclass)` inside the URL. Pre-strip
 		// these to `<name>` so the angle-bracket walker can canonicalise them
@@ -112,7 +124,8 @@ func Canonicalize(framework, raw string) string {
 		out = stripPythonNamedGroups(raw)
 		out = canonicalizeAngleBrackets(out)
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum,
-		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore, FrameworkHapi:
+		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore, FrameworkHapi,
+		FrameworkLitestar:
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkTornado:
 		// Tornado paths arrive already pre-processed by the synthesizer
@@ -121,7 +134,8 @@ func Canonicalize(framework, raw string) string {
 		// curly-brace frameworks.
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkExpress, FrameworkGin, FrameworkEcho, FrameworkChi, FrameworkPhoenix,
-		FrameworkAdonis, FrameworkMarble, FrameworkPolka, FrameworkRestify, FrameworkSails:
+		FrameworkAdonis, FrameworkMarble, FrameworkPolka, FrameworkRestify, FrameworkSails,
+		FrameworkRobyn:
 		out = canonicalizeColonParams(raw)
 	default:
 		// Unknown framework: pass through but still normalise slashes.

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -845,6 +845,105 @@ records:
           issues_implemented: ["2977"]
           verified_at: "2026-05-29"
 
+  lang.python.framework.sanic:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeSanic]
+            - file: internal/engine/rules/python/frameworks/sanic.yaml
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_asgi_test.go
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+        handler_attribution:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeSanic]
+            - file: internal/engine/rules/python/frameworks/sanic.yaml
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+        route_extraction:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeSanic]
+            - file: internal/engine/httproutes/canonicalize.go
+              functions: [Canonicalize]
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_asgi_test.go
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+
+  lang.python.framework.litestar:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeLitestar]
+            - file: internal/engine/rules/python/frameworks/litestar.yaml
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_asgi_test.go
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+        handler_attribution:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeLitestar]
+            - file: internal/engine/rules/python/frameworks/litestar.yaml
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+        route_extraction:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeLitestar]
+            - file: internal/engine/httproutes/canonicalize.go
+              functions: [Canonicalize]
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_asgi_test.go
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+
+  lang.python.framework.robyn:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeRobyn]
+            - file: internal/engine/rules/python/frameworks/robyn.yaml
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_asgi_test.go
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+        handler_attribution:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeRobyn]
+            - file: internal/engine/rules/python/frameworks/robyn.yaml
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+        route_extraction:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeRobyn]
+            - file: internal/engine/httproutes/canonicalize.go
+              functions: [Canonicalize]
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_asgi_test.go
+          issues_implemented: ["2980"]
+          verified_at: "2026-05-29"
+
   lang.python.framework.fastapi:
     capabilities:
       Routing:


### PR DESCRIPTION
## Summary

Real engine-synthesis build implementing producer-side HTTP endpoint synthesis for three ASGI/async Python frameworks that had **no synthesizer** (honestly downgraded to `missing` in #2978).

### Synthesizers (`internal/engine/http_endpoint_synthesis.go`)

- **`synthesizeSanic`** — `@app.get` / `@app.route(methods=[...])` shorthand + generic forms, Flask-style `<converter:name>` path params, **Blueprint `url_prefix` composition** (same-file receiver→prefix map, mirrors Flask blueprints per AC).
- **`synthesizeLitestar`** — bare `@get`/`@post` route handlers, **Controller `path` class-attribute composition**, and **`Router(path=...)` prefix composition** with FastAPI-style `{name:type}` params. Handlers attributed via `SCOPE.Operation`.
- **`synthesizeRobyn`** — `@app.<verb>(...)` bound to `Robyn(__file__)`, Express-style `:name` path params.

Dispatched from `applyHTTPEndpointSynthesis()` **before** Flask/FastAPI so the overlapping decorator shapes are claimed with the correct `framework` label; each is file-signal-gated to no-op on non-matching files.

### Canonicalization (`internal/engine/httproutes/canonicalize.go`)
Adds `FrameworkSanic` (angle-bracket), `FrameworkLitestar` (curly-brace), `FrameworkRobyn` (colon) routing.

### Tests (`internal/engine/http_endpoint_synthesis_asgi_test.go`)
Fixture-driven per-framework tests asserting endpoint IDs, prefix composition, framework label, handler attribution, def-line stamping, and ASGI-no-op-on-Flask.

### Coverage matrix
Flips `endpoint_synthesis` / `handler_attribution` / `route_extraction` **missing→full** for `lang.python.framework.{sanic,litestar,robyn}` (9 cells) with cites; adds `capability-map.yaml` entries; regenerates docs. `coverage validate` = 0.

### Kinds
No new entity Kind required — synthetics reuse `http_endpoint_definition`; handler refs reuse existing `Controller` / `SCOPE.Operation` kinds (verified against `producer_kinds_test`).

## Test plan
- `go test ./internal/engine/ ./tools/coverage/ ./internal/types/ ./internal/engine/httproutes/` — green
- `go build ./...`, `go vet`, `gofmt -l` — clean
- `cmd/archigraph` determinism test — green
- `coverage validate` exit 0; `coverage gen` byte-stable

Closes #2980

🤖 Generated with [Claude Code](https://claude.com/claude-code)