### PR TITLE
coverage(java): @Transactional extraction (Transactions lane, JVM frameworks)

### DIFF
--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -65,9 +65,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
+| Transaction propagation | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
+| Transaction rollback rules | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
 
 ### AOP
 

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -65,9 +65,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
+| Transaction propagation | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
+| Transaction rollback rules | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
 
 ### AOP
 

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -65,9 +65,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
+| Transaction propagation | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
+| Transaction rollback rules | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
 
 ### AOP
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -65,9 +65,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
+| Transaction propagation | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
+| Transaction rollback rules | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
 
 ### AOP
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -65,9 +65,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
+| Transaction propagation | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
+| Transaction rollback rules | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
 
 ### AOP
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -65,9 +65,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | @Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface |
+| Transaction propagation | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | propagation=Propagation.<MODE> (Spring) and TxType.<MODE> (JTA) captured into propagation property; isolation + readOnly also captured |
+| Transaction rollback rules | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3003) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/transactional.go` | rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties |
 
 ### AOP
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15238,16 +15238,25 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "@Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface",
+            "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) captured into propagation property; isolation + readOnly also captured",
+            "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties",
+            "verified_at": "2026-05-29"
           }
         },
         "AOP": {
@@ -15744,16 +15753,25 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "@Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface",
+            "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) captured into propagation property; isolation + readOnly also captured",
+            "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties",
+            "verified_at": "2026-05-29"
           }
         },
         "AOP": {
@@ -16041,16 +16059,25 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "@Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface",
+            "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) captured into propagation property; isolation + readOnly also captured",
+            "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties",
+            "verified_at": "2026-05-29"
           }
         },
         "AOP": {
@@ -16723,16 +16750,25 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "@Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface",
+            "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) captured into propagation property; isolation + readOnly also captured",
+            "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties",
+            "verified_at": "2026-05-29"
           }
         },
         "AOP": {
@@ -16993,16 +17029,25 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "@Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface",
+            "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) captured into propagation property; isolation + readOnly also captured",
+            "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties",
+            "verified_at": "2026-05-29"
           }
         },
         "AOP": {
@@ -17264,16 +17309,25 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "@Transactional on class/method detected; SCOPE.Pattern(subtype=transaction_boundary) emitted with declaring_class + OWNS link from class-level boundary; Spring + Jakarta/JTA annotation surface",
+            "verified_at": "2026-05-29"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "propagation=Propagation.\u003cMODE\u003e (Spring) and TxType.\u003cMODE\u003e (JTA) captured into propagation property; isolation + readOnly also captured",
+            "verified_at": "2026-05-29"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/transactional.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3003",
+            "notes": "rollbackFor / noRollbackFor X.class single + {A.class,B.class} list captured into rollback_for / no_rollback_for properties",
+            "verified_at": "2026-05-29"
           }
         },
         "AOP": {

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -2974,3 +2974,204 @@ public class InvoiceResourceTest {
 			len(testMethods), entityNames(r.Entities))
 	}
 }
+
+// ============================================================================
+// @Transactional tests (#3003 — Transactions lane, JVM frameworks)
+// ============================================================================
+
+// txProp returns the named property of the first SCOPE.Pattern transaction
+// boundary entity matching name, or "" if not found.
+func txEntityByName(r PatternResult, name string) (SecondaryEntity, bool) {
+	for _, e := range r.Entities {
+		if e.Subtype == "transaction_boundary" && e.Name == name {
+			return e, true
+		}
+	}
+	return SecondaryEntity{}, false
+}
+
+// TestTransactional_Boundary_Propagation_Rollback_Issue3003 is the proving
+// fixture from the issue: a Spring service with a class-level @Transactional
+// and a method-level @Transactional(propagation=REQUIRES_NEW,
+// rollbackFor=RuntimeException.class). Proves all three Transactions-lane
+// cells: transaction_boundary_extraction, transaction_propagation,
+// transaction_rollback_rules.
+// Registry target: lang.java.framework.spring-boot Transactions/* = partial.
+// Cite: internal/custom/java/transactional.go.
+func TestTransactional_Boundary_Propagation_Rollback_Issue3003(t *testing.T) {
+	source := `
+package com.example.order;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Isolation;
+
+@Service
+@Transactional(readOnly = true)
+public class OrderService {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = RuntimeException.class)
+    public void placeOrder(Order order) {
+        repository.save(order);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY, isolation = Isolation.SERIALIZABLE,
+                   rollbackFor = {IllegalStateException.class, java.io.IOException.class},
+                   noRollbackFor = ValidationException.class)
+    public Order updateOrder(Long id) {
+        return null;
+    }
+
+    @Transactional
+    public void plainTx() {
+    }
+}
+`
+	r := ExtractTransactional(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_boot",
+		FilePath:  "OrderService.java",
+	})
+
+	// transaction_boundary_extraction: class-level boundary entity.
+	cls, ok := txEntityByName(r, "OrderService")
+	if !ok {
+		t.Fatalf("[#3003 boundary] expected class-level transaction_boundary entity for OrderService; got %v", entityNames(r.Entities))
+	}
+	if cls.Kind != "SCOPE.Pattern" {
+		t.Errorf("[#3003 boundary] class boundary Kind = %q, want SCOPE.Pattern", cls.Kind)
+	}
+	if cls.Properties["transaction_boundary"] != "class" {
+		t.Errorf("[#3003 boundary] class boundary transaction_boundary = %v, want class", cls.Properties["transaction_boundary"])
+	}
+	if cls.Properties["read_only"] != "true" {
+		t.Errorf("[#3003 boundary] class boundary read_only = %v, want true", cls.Properties["read_only"])
+	}
+
+	// transaction_boundary_extraction: method-level boundary entities.
+	place, ok := txEntityByName(r, "OrderService.placeOrder")
+	if !ok {
+		t.Fatalf("[#3003 boundary] expected method boundary OrderService.placeOrder; got %v", entityNames(r.Entities))
+	}
+	if place.Properties["transaction_boundary"] != "method" {
+		t.Errorf("[#3003 boundary] placeOrder transaction_boundary = %v, want method", place.Properties["transaction_boundary"])
+	}
+	if place.Properties["declaring_class"] != "OrderService" {
+		t.Errorf("[#3003 boundary] placeOrder declaring_class = %v, want OrderService", place.Properties["declaring_class"])
+	}
+
+	// transaction_propagation.
+	if place.Properties["propagation"] != "REQUIRES_NEW" {
+		t.Errorf("[#3003 propagation] placeOrder propagation = %v, want REQUIRES_NEW", place.Properties["propagation"])
+	}
+	upd, _ := txEntityByName(r, "OrderService.updateOrder")
+	if upd.Properties["propagation"] != "MANDATORY" {
+		t.Errorf("[#3003 propagation] updateOrder propagation = %v, want MANDATORY", upd.Properties["propagation"])
+	}
+	if upd.Properties["isolation"] != "SERIALIZABLE" {
+		t.Errorf("[#3003 propagation] updateOrder isolation = %v, want SERIALIZABLE", upd.Properties["isolation"])
+	}
+
+	// transaction_rollback_rules: single class.
+	if place.Properties["rollback_for"] != "RuntimeException" {
+		t.Errorf("[#3003 rollback] placeOrder rollback_for = %v, want RuntimeException", place.Properties["rollback_for"])
+	}
+	// transaction_rollback_rules: list form + noRollbackFor.
+	rb, _ := upd.Properties["rollback_for"].(string)
+	if !strings.Contains(rb, "IllegalStateException") || !strings.Contains(rb, "IOException") {
+		t.Errorf("[#3003 rollback] updateOrder rollback_for = %q, want IllegalStateException + IOException", rb)
+	}
+	if upd.Properties["no_rollback_for"] != "ValidationException" {
+		t.Errorf("[#3003 rollback] updateOrder no_rollback_for = %v, want ValidationException", upd.Properties["no_rollback_for"])
+	}
+
+	// OWNS edge from class boundary to each method boundary.
+	wantOwns := "scope:pattern:transaction_boundary:OrderService.java:OrderService"
+	var ownsCount int
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "OWNS" && rel.SourceRef == wantOwns {
+			ownsCount++
+		}
+	}
+	if ownsCount != 3 {
+		t.Errorf("[#3003 boundary] expected 3 OWNS edges from class boundary, got %d", ownsCount)
+	}
+
+	// plainTx: boundary with no attributes.
+	plain, ok := txEntityByName(r, "OrderService.plainTx")
+	if !ok {
+		t.Fatalf("[#3003 boundary] expected method boundary OrderService.plainTx")
+	}
+	if _, has := plain.Properties["propagation"]; has {
+		t.Errorf("[#3003 propagation] plainTx should have no propagation property, got %v", plain.Properties["propagation"])
+	}
+}
+
+// TestTransactional_JakartaJTA_Issue3003 proves the Jakarta/JTA @Transactional
+// surface (jakarta.transaction.Transactional with positional TxType) extracts a
+// boundary + propagation for the jakarta-ee framework.
+// Registry target: lang.java.framework.jakarta-ee Transactions/* = partial.
+func TestTransactional_JakartaJTA_Issue3003(t *testing.T) {
+	source := `
+package com.example.billing;
+
+import jakarta.transaction.Transactional;
+
+public class PaymentBean {
+
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public void charge(long amount) {
+    }
+
+    @Transactional(rollbackFor = PaymentException.class)
+    public void refund(long amount) {
+    }
+}
+`
+	r := ExtractTransactional(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "jakarta_ee",
+		FilePath:  "PaymentBean.java",
+	})
+
+	charge, ok := txEntityByName(r, "PaymentBean.charge")
+	if !ok {
+		t.Fatalf("[#3003 jakarta boundary] expected PaymentBean.charge boundary; got %v", entityNames(r.Entities))
+	}
+	if charge.Properties["framework"] != "jakarta_ee" {
+		t.Errorf("[#3003 jakarta] framework = %v, want jakarta_ee", charge.Properties["framework"])
+	}
+	if charge.Properties["propagation"] != "REQUIRES_NEW" {
+		t.Errorf("[#3003 jakarta propagation] charge propagation = %v, want REQUIRES_NEW (JTA TxType)", charge.Properties["propagation"])
+	}
+	refund, _ := txEntityByName(r, "PaymentBean.refund")
+	if refund.Properties["rollback_for"] != "PaymentException" {
+		t.Errorf("[#3003 jakarta rollback] refund rollback_for = %v, want PaymentException", refund.Properties["rollback_for"])
+	}
+}
+
+// TestTransactional_FrameworkGating_Issue3003 proves the extractor runs for the
+// registered JVM frameworks and no-ops for unrelated ones / non-java.
+func TestTransactional_FrameworkGating_Issue3003(t *testing.T) {
+	source := `
+@Transactional(propagation = Propagation.REQUIRED)
+public void doWork() {}
+`
+	for _, fw := range []string{"spring_boot", "spring_webflux", "quarkus", "micronaut", "jakarta_ee", "jaxrs"} {
+		r := ExtractTransactional(PatternContext{Source: source, Language: "java", Framework: fw, FilePath: "X.java"})
+		if len(r.Entities) == 0 {
+			t.Errorf("[#3003 gating] framework %q expected a boundary entity, got none", fw)
+		}
+	}
+	// Unrelated framework: no-op.
+	if r := ExtractTransactional(PatternContext{Source: source, Language: "java", Framework: "django", FilePath: "X.java"}); len(r.Entities) != 0 {
+		t.Errorf("[#3003 gating] framework django should no-op, got %d entities", len(r.Entities))
+	}
+	// Non-java language: no-op.
+	if r := ExtractTransactional(PatternContext{Source: source, Language: "python", Framework: "spring_boot", FilePath: "X.py"}); len(r.Entities) != 0 {
+		t.Errorf("[#3003 gating] non-java should no-op, got %d entities", len(r.Entities))
+	}
+}

--- a/internal/custom/java/transactional.go
+++ b/internal/custom/java/transactional.go
@@ -1,0 +1,261 @@
+package java
+
+import "regexp"
+
+// Transactional custom extractor: @Transactional boundary, propagation, and
+// rollback-rule extraction for JVM backend frameworks (#3003, epic #2847).
+//
+// Covers the Transactions lane:
+//   - transaction_boundary_extraction: detect @Transactional on a class or
+//     method and emit a SCOPE.Pattern(subtype=transaction_boundary) entity
+//     linking the annotated method to its declaring class via OWNS.
+//   - transaction_propagation: capture propagation=Propagation.<MODE> from the
+//     annotation body (REQUIRED / REQUIRES_NEW / MANDATORY / SUPPORTS /
+//     NOT_SUPPORTED / NEVER / NESTED).
+//   - transaction_rollback_rules: capture rollbackFor / noRollbackFor class
+//     lists from the annotation body.
+//
+// Both the Spring (org.springframework.transaction.annotation.Transactional)
+// and Jakarta/JTA (jakarta.transaction.Transactional /
+// javax.transaction.Transactional) annotations share the same simple name
+// `@Transactional`; this extractor matches on the simple name and records the
+// captured attributes regardless of which import supplied them.
+
+// txFrameworks gates the frameworks for which @Transactional extraction runs.
+// All entries share the Spring/JTA @Transactional annotation surface.
+var txFrameworks = map[string]bool{
+	"spring_boot": true, "spring-boot": true, "springboot": true,
+	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
+	"quarkus":   true,
+	"micronaut": true, "micronaut-core": true, "micronaut_core": true,
+	"jakarta_ee": true, "jakarta-ee": true, "jakartaee": true,
+	"java_ee": true, "javaee": true,
+	"jaxrs": true, "jax-rs": true, "jax_rs": true,
+}
+
+var (
+	// txMethodRE matches @Transactional (with optional attribute body) on a
+	// method declaration, capturing the optional annotation body (group 1) and
+	// the method name (group 2). Modifiers/return type are skipped between the
+	// annotation and the method name. The negative-lookahead-free form keeps
+	// the regexp Go-RE2 compatible: a class declaration is filtered out by
+	// rejecting the `class`/`interface`/`enum` keywords as the method name.
+	txMethodRE = regexp.MustCompile(
+		`(?s)@Transactional\b\s*(?:\(([^)]*)\))?\s*` +
+			`(?:(?:public|protected|private|static|final|abstract|synchronized|default)\s+)*` +
+			`(?:<[^>]*>\s*)?` +
+			`(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)` +
+			`(\w+)\s*\(`)
+
+	// txClassRE matches @Transactional (with optional attribute body) on a
+	// class/interface declaration, capturing the optional annotation body
+	// (group 1) and the class name (group 2).
+	txClassRE = regexp.MustCompile(
+		`(?s)@Transactional\b\s*(?:\(([^)]*)\))?\s*` +
+			`(?:(?:public|protected|private|abstract|final)\s+)*` +
+			`(?:class|interface)\s+(\w+)`)
+
+	// txPropagationRE extracts propagation=Propagation.<MODE> (Spring) or the
+	// bare propagation=<MODE> form. Group 1 is the propagation mode.
+	txPropagationRE = regexp.MustCompile(`propagation\s*=\s*(?:Propagation\.)?(\w+)`)
+	// txJTATxTypeRE extracts the Jakarta/JTA positional propagation form
+	// @Transactional(Transactional.TxType.REQUIRES_NEW) / TxType.MANDATORY etc.
+	txJTATxTypeRE = regexp.MustCompile(`TxType\.(\w+)`)
+
+	// txRollbackRE extracts rollbackFor=X.class (single) and the leading class
+	// of a rollbackFor={A.class, B.class} list. All classes are captured by
+	// scanning the matched body separately via txClassRefRE.
+	txRollbackRE   = regexp.MustCompile(`rollbackFor\s*=\s*\{?([^}]*?)\}?(?:,\s*\w+\s*=|\)|$)`)
+	txNoRollbackRE = regexp.MustCompile(`noRollbackFor\s*=\s*\{?([^}]*?)\}?(?:,\s*\w+\s*=|\)|$)`)
+	// txClassRefRE pulls each `Foo.class` token out of a rollbackFor list body.
+	txClassRefRE = regexp.MustCompile(`(\w+)\.class`)
+
+	// txReadOnlyRE extracts readOnly=true|false.
+	txReadOnlyRE = regexp.MustCompile(`readOnly\s*=\s*(true|false)`)
+	// txIsolationRE extracts isolation=Isolation.<LEVEL> or bare isolation=<LEVEL>.
+	txIsolationRE = regexp.MustCompile(`isolation\s*=\s*(?:Isolation\.)?(\w+)`)
+)
+
+// classRefList scans a rollbackFor/noRollbackFor body for all `X.class`
+// tokens and returns the bare class names (e.g. "RuntimeException").
+func classRefList(body string) []string {
+	var out []string
+	for _, m := range txClassRefRE.FindAllStringSubmatch(body, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// txParseAttributes parses the @Transactional attribute body into structured
+// properties: propagation, rollback_for, no_rollback_for, read_only, isolation.
+// Empty values are omitted. rollback_for / no_rollback_for are comma-joined.
+func txParseAttributes(body string) map[string]any {
+	props := map[string]any{}
+	if body == "" {
+		return props
+	}
+	if m := txPropagationRE.FindStringSubmatch(body); m != nil {
+		props["propagation"] = m[1]
+	} else if m := txJTATxTypeRE.FindStringSubmatch(body); m != nil {
+		// Jakarta/JTA positional propagation: @Transactional(TxType.REQUIRES_NEW).
+		props["propagation"] = m[1]
+	}
+	if m := txRollbackRE.FindStringSubmatch(body); m != nil {
+		if refs := classRefList(m[1]); len(refs) > 0 {
+			props["rollback_for"] = joinComma(refs)
+		}
+	}
+	if m := txNoRollbackRE.FindStringSubmatch(body); m != nil {
+		if refs := classRefList(m[1]); len(refs) > 0 {
+			props["no_rollback_for"] = joinComma(refs)
+		}
+	}
+	if m := txReadOnlyRE.FindStringSubmatch(body); m != nil {
+		props["read_only"] = m[1]
+	}
+	if m := txIsolationRE.FindStringSubmatch(body); m != nil {
+		props["isolation"] = m[1]
+	}
+	return props
+}
+
+// joinComma joins a slice of strings with ", " without importing strings
+// (kept consistent with the regexp-only style of this package's siblings).
+func joinComma(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+// methodNameStopwords are keywords that txMethodRE can spuriously capture as a
+// "method name" when @Transactional sits directly on a class declaration; they
+// are filtered so a class-level annotation never emits a phantom method.
+var methodNameStopwords = map[string]bool{
+	"class": true, "interface": true, "enum": true, "record": true,
+}
+
+// ExtractTransactional runs the @Transactional extractor.
+func ExtractTransactional(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !txFrameworks[ctx.Framework] {
+		return result
+	}
+
+	source := ctx.Source
+	fp := ctx.FilePath
+	seenRefs := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// 1. Class-level @Transactional. Record offsets so class-level boundaries
+	//    are not double-counted as methods, and so method boundaries can link
+	//    OWNS edges to the right declaring class.
+	type txClassInfo struct {
+		offset int
+		body   string
+	}
+	classBoundaries := make(map[string]txClassInfo)
+	for _, m := range txClassRE.FindAllStringSubmatchIndex(source, -1) {
+		var body string
+		if m[2] >= 0 {
+			body = source[m[2]:m[3]]
+		}
+		className := source[m[4]:m[5]]
+		if _, ok := classBoundaries[className]; !ok {
+			classBoundaries[className] = txClassInfo{m[0], body}
+		}
+
+		props := map[string]any{
+			"transaction_boundary": "class",
+			"declaring_class":      className,
+			"framework":            canonicalTxFramework(ctx.Framework),
+		}
+		for k, v := range txParseAttributes(body) {
+			props[k] = v
+		}
+		ref := "scope:pattern:transaction_boundary:" + fp + ":" + className
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Pattern", Subtype: "transaction_boundary",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_TRANSACTIONAL", Ref: ref,
+			Properties: props,
+		})
+	}
+
+	// 2. Method-level @Transactional.
+	for _, m := range txMethodRE.FindAllStringSubmatchIndex(source, -1) {
+		var body string
+		if m[2] >= 0 {
+			body = source[m[2]:m[3]]
+		}
+		methodName := source[m[4]:m[5]]
+		if methodNameStopwords[methodName] {
+			// @Transactional sat on a class declaration; handled in pass 1.
+			continue
+		}
+
+		ownerClass := findEnclosingClass(source, m[0])
+		name := methodName
+		if ownerClass != "" {
+			name = ownerClass + "." + methodName
+		}
+
+		props := map[string]any{
+			"transaction_boundary": "method",
+			"method":               methodName,
+			"framework":            canonicalTxFramework(ctx.Framework),
+		}
+		if ownerClass != "" {
+			props["declaring_class"] = ownerClass
+		}
+		for k, v := range txParseAttributes(body) {
+			props[k] = v
+		}
+
+		ref := "scope:pattern:transaction_boundary:" + fp + ":" + name
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "transaction_boundary",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_TRANSACTIONAL", Ref: ref,
+			Properties: props,
+		}) {
+			// Link the boundary to its declaring class when that class itself
+			// carries a (class-level) transaction boundary entity.
+			if ci, ok := classBoundaries[ownerClass]; ok {
+				_ = ci
+				classRef := "scope:pattern:transaction_boundary:" + fp + ":" + ownerClass
+				addRel(&result, seenRels, Relationship{
+					SourceRef: classRef, TargetRef: ref, RelationshipType: "OWNS",
+				})
+			}
+		}
+	}
+
+	return result
+}
+
+// canonicalTxFramework normalises a framework alias to its canonical name for
+// the entity `framework` property, matching the convention used by the
+// sibling extractors.
+func canonicalTxFramework(framework string) string {
+	switch framework {
+	case "spring_boot", "spring-boot", "springboot":
+		return "spring_boot"
+	case "spring_webflux", "spring-webflux", "springwebflux":
+		return "spring_webflux"
+	case "micronaut", "micronaut-core", "micronaut_core":
+		return "micronaut"
+	case "jakarta_ee", "jakarta-ee", "jakartaee", "java_ee", "javaee":
+		return "jakarta_ee"
+	case "jaxrs", "jax-rs", "jax_rs":
+		return "jaxrs"
+	default:
+		return framework
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -1547,6 +1547,28 @@ records:
 
   lang.java.framework.jakarta-ee:
     capabilities:
+      Transactions:
+        transaction_boundary_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/transactional.go
+              functions: [ExtractTransactional, txParseAttributes, classRefList]
+          issues_implemented: ["3003"]
+          verified_at: "2026-05-29"
+        transaction_propagation:
+          status: partial
+          symbols:
+            - file: internal/custom/java/transactional.go
+              functions: [txParseAttributes]
+          issues_implemented: ["3003"]
+          verified_at: "2026-05-29"
+        transaction_rollback_rules:
+          status: partial
+          symbols:
+            - file: internal/custom/java/transactional.go
+              functions: [txParseAttributes, classRefList]
+          issues_implemented: ["3003"]
+          verified_at: "2026-05-29"
       Auth:
         auth_coverage:
           status: partial
@@ -1694,6 +1716,28 @@ records:
 
   lang.java.framework.spring-boot:
     capabilities:
+      Transactions:
+        transaction_boundary_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/transactional.go
+              functions: [ExtractTransactional, txParseAttributes, classRefList]
+          issues_implemented: ["3003"]
+          verified_at: "2026-05-29"
+        transaction_propagation:
+          status: partial
+          symbols:
+            - file: internal/custom/java/transactional.go
+              functions: [txParseAttributes]
+          issues_implemented: ["3003"]
+          verified_at: "2026-05-29"
+        transaction_rollback_rules:
+          status: partial
+          symbols:
+            - file: internal/custom/java/transactional.go
+              functions: [txParseAttributes, classRefList]
+          issues_implemented: ["3003"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full


### PR DESCRIPTION
## Summary

B-build for epic #2847. Adds a real custom extractor for Java `@Transactional` boundaries, propagation, and rollback rules — the 3 previously-missing **Transactions** lane cells across the JVM backend frameworks.

New `internal/custom/java/transactional.go` (`ExtractTransactional`):

- **transaction_boundary_extraction** — detects `@Transactional` on class and method declarations; emits `SCOPE.Pattern(subtype=transaction_boundary)` entities with a `declaring_class` property and an `OWNS` edge from a class-level boundary to each method boundary. Handles both the Spring (`org.springframework...Transactional`) and Jakarta/JTA (`jakarta/javax.transaction.Transactional`) annotation surfaces.
- **transaction_propagation** — captures `propagation=Propagation.<MODE>` (Spring) and the positional `TxType.<MODE>` (JTA) forms into a `propagation` property; also captures `isolation` and `readOnly`.
- **transaction_rollback_rules** — captures `rollbackFor` / `noRollbackFor` in both single `X.class` and `{A.class, B.class}` list forms into `rollback_for` / `no_rollback_for` properties.

## Registry

Flips `Transactions/{transaction_boundary_extraction, transaction_propagation, transaction_rollback_rules}` from `missing` → `partial` for: **spring-boot, spring-webflux, quarkus, micronaut, jakarta-ee, jaxrs**. capability-map entries added for spring-boot and jakarta-ee (functions: `ExtractTransactional`, `txParseAttributes`, `classRefList`).

Reuses the existing `SCOPE.Pattern` kind — **no new entity Kind required**.

Left as `missing` (honest): dropwizard, helidon, javalin, vertx, struts, akka-http, vaadin, gwt, android — these frameworks do not use the `@Transactional` annotation surface this extractor matches, so no cell was flipped for them.

## Tests

`internal/custom/java/extractors_test.go`:
- `TestTransactional_Boundary_Propagation_Rollback_Issue3003` — the proving fixture (`@Transactional(propagation=REQUIRES_NEW, rollbackFor=RuntimeException.class)`) plus class-level boundary, list-form rollbackFor, noRollbackFor, isolation/readOnly, and the 3 OWNS edges.
- `TestTransactional_JakartaJTA_Issue3003` — Jakarta JTA `TxType` positional propagation + rollbackFor.
- `TestTransactional_FrameworkGating_Issue3003` — all 6 frameworks extract; django + non-java no-op.

## Gates

- `coverage validate` → 0 errors (pre-existing warnings unchanged)
- `coverage fmt --check` → canonical
- `coverage gen` → byte-stable
- `go test ./internal/custom/java/ ./internal/engine/ ./tools/coverage/ ./internal/types/` → pass
- `go build ./...`, `go vet` → clean

Closes #3003

🤖 Generated with [Claude Code](https://claude.com/claude-code)