### PR TITLE
feat(python): aiohttp + Bottle endpoint synthesis (#2979)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -80,7 +80,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/8 | |
@@ -96,7 +96,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -12,7 +12,7 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/8 | |
@@ -28,7 +28,7 @@ Back to [summary](../summary.md).
 | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -15,9 +15,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2979 | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
-| Handler attribution | ❌ `missing` | `2026-05-28` | 2979 | `internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/aiohttp.yaml` | — |
+| Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -15,9 +15,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ❌ `missing` | `2026-05-28` | 2979 | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
-| Handler attribution | ❌ `missing` | `2026-05-28` | 2979 | `internal/engine/rules/python/frameworks/bottle.yaml` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/bottle.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/bottle.yaml` | — |
+| Route extraction | ✅ `full` | `2026-05-29` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | — |
 
 ### Auth
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -31819,20 +31819,19 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
-            "issue": "2979",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/aiohttp.yaml"],
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/aiohttp.yaml"],
-            "issue": "2979",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/aiohttp.yaml"],
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/httproutes/canonicalize.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
@@ -32026,20 +32025,19 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
-            "issue": "2979",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/bottle.yaml"],
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "missing",
-            "cites": ["internal/engine/rules/python/frameworks/bottle.yaml"],
-            "issue": "2979",
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/bottle.yaml"],
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/httproutes/canonicalize.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -346,6 +346,17 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeSanic(string(content), emitDef)
 		synthesizeLitestar(string(content), emitDef)
 		synthesizeRobyn(string(content), emitDef)
+		// #2979 — aiohttp / Bottle run BEFORE Flask / FastAPI for the same
+		// label-correctness reason. aiohttp's `@routes.get(...)` decorator and
+		// Bottle's `@route(...)` / `@get(...)` decorators overlap Flask's
+		// shorthand/generic shapes, so the file-signal-gated synthesizers must
+		// claim each (verb, path) ID first to stamp `aiohttp` / `bottle`. The
+		// side-scoped dedup in makeEmit then suppresses duplicate Flask
+		// emission. aiohttp additionally gates on a server-routing signal
+		// (`app.router.add_` / RouteTableDef) so pure-`ClientSession` files
+		// no-op (dual-use skip).
+		synthesizeAiohttp(string(content), emitDef)
+		synthesizeBottle(string(content), emitDef)
 		// Producer side: Flask + FastAPI run FIRST so their synthetics —
 		// which carry a real handler function name as source_handler —
 		// claim each ID before the Django composed-route pass walks the
@@ -1865,6 +1876,216 @@ func synthesizeRobyn(content string, emit emitDefFn) {
 		canonical := httproutes.Canonicalize(httproutes.FrameworkRobyn, raw)
 		defLine := lineOfOffset(content, idx[8])
 		emit(verb, canonical, "robyn", "Controller", handler, defLine)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// aiohttp (Python) — #2979
+// ---------------------------------------------------------------------------
+//
+// aiohttp is a dual-use library: it ships BOTH an async HTTP server and an
+// async HTTP client (`ClientSession`). Server-side routing has two idioms:
+//
+//	app = web.Application()
+//	app.router.add_get("/users/{user_id}", handler)
+//	app.router.add_route("GET", "/items", handler)
+//
+//	routes = web.RouteTableDef()
+//	@routes.get("/users/{user_id}")
+//	async def get_user(request): ...
+//	app.add_routes(routes)
+//
+// Path parameters use the FastAPI-style `{name}` / `{name:regex}` curly-brace
+// convention (FrameworkAiohttp is grouped with FastAPI in Canonicalize, which
+// strips the `:regex` suffix).
+//
+// Dual-use gate: a file that only uses `ClientSession` (HTTP client) must NOT
+// synthesize endpoints. We require an explicit server-routing signal
+// (`app.router.add_` or `RouteTableDef` / `@routes.`) before emitting, so
+// client-only modules no-op.
+
+// aiohttpAddVerbRe captures `<recv>.router.add_get("/path", handler)` and the
+// other verb-specific add_* methods. The handler is the second positional arg
+// (a bare function reference); we capture it for handler attribution.
+//
+// Capture groups: 1 = verb, 2 = path, 3 = handler reference.
+var aiohttpAddVerbRe = regexp.MustCompile(
+	`\.router\.add_(get|post|put|patch|delete|head|options)\s*\(\s*["']([^"'\n\r]+)["']\s*,\s*([A-Za-z_][\w.]*)`,
+)
+
+// aiohttpAddRouteRe captures the generic `<recv>.router.add_route("GET",
+// "/path", handler)` form where the verb is the first string argument.
+//
+// Capture groups: 1 = verb, 2 = path, 3 = handler reference.
+var aiohttpAddRouteRe = regexp.MustCompile(
+	`\.router\.add_route\s*\(\s*["'](\w+)["']\s*,\s*["']([^"'\n\r]+)["']\s*,\s*([A-Za-z_][\w.]*)`,
+)
+
+// aiohttpRoutesDecoratorRe captures `@routes.get("/path")` RouteTableDef
+// decorators and the following handler def. The receiver name is captured so
+// it can be matched against a RouteTableDef() assignment for the gate; in
+// practice `@routes.` is the dominant idiom and the RouteTableDef presence is
+// asserted by the file-level gate.
+//
+// Capture groups: 1 = receiver, 2 = verb, 3 = path, 4 = handler name.
+var aiohttpRoutesDecoratorRe = regexp.MustCompile(
+	`@(\w+)\.(get|post|put|patch|delete|head|options)\s*\(\s*["']([^"'\n\r]+)["'][^)]*\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`,
+)
+
+func synthesizeAiohttp(content string, emit emitDefFn) {
+	// Server-routing gate. A file that imports aiohttp purely as a client
+	// (`ClientSession`) carries none of these markers, so it no-ops — this is
+	// the dual-use skip the aiohttp.yaml rule pack calls out.
+	hasAddRouter := strings.Contains(content, ".router.add_")
+	hasRouteTable := strings.Contains(content, "RouteTableDef") || strings.Contains(content, "@routes.")
+	if !hasAddRouter && !hasRouteTable {
+		return
+	}
+
+	// `app.router.add_get("/path", handler)` shorthand verbs.
+	for _, idx := range aiohttpAddVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[2]:idx[3]])
+		raw := content[idx[4]:idx[5]]
+		handler := content[idx[6]:idx[7]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkAiohttp, raw)
+		defLine := lineOfOffset(content, idx[6])
+		emit(verb, canonical, "aiohttp", "Controller", handler, defLine)
+	}
+
+	// `app.router.add_route("GET", "/path", handler)` generic form.
+	for _, idx := range aiohttpAddRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[2]:idx[3]])
+		raw := content[idx[4]:idx[5]]
+		handler := content[idx[6]:idx[7]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkAiohttp, raw)
+		defLine := lineOfOffset(content, idx[6])
+		emit(verb, canonical, "aiohttp", "Controller", handler, defLine)
+	}
+
+	// `@routes.get("/path")` RouteTableDef decorators.
+	for _, idx := range aiohttpRoutesDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[4]:idx[5]])
+		raw := content[idx[6]:idx[7]]
+		handler := content[idx[8]:idx[9]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkAiohttp, raw)
+		defLine := lineOfOffset(content, idx[8])
+		emit(verb, canonical, "aiohttp", "Controller", handler, defLine)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Bottle (Python) — #2979
+// ---------------------------------------------------------------------------
+//
+// Bottle is a single-file WSGI micro-framework. Routes are declared with the
+// module-level decorator functions (or app-bound equivalents):
+//
+//	@route("/users/<id>")            # default GET
+//	@route("/items", method="POST")  # explicit verb
+//	@route("/x", method=["GET","POST"])
+//	@get("/users/<id:int>")
+//	@post("/items")
+//	def handler(): ...
+//
+// Path parameters use the Flask-style `<name>` / `<name:filter>` angle-bracket
+// convention (FrameworkBottle is grouped with Flask in Canonicalize).
+//
+// The verb decorators may be bare (`@get(...)`) or app-bound
+// (`@app.get(...)`); both are handled. Method composition for the generic
+// `@route(..., method=...)` form mirrors Flask's `methods=[...]` parsing.
+
+// bottleVerbDecoratorRe captures `@get("/path")` / `@app.post("/path")`
+// shorthand verb decorators and the following handler def. The receiver
+// portion (`app.`) is optional.
+//
+// Capture groups: 1 = verb, 2 = path, 3 = handler name.
+var bottleVerbDecoratorRe = regexp.MustCompile(
+	`(?m)^[ \t]*@(?:\w+\.)?(get|post|put|patch|delete|head|options)\s*\(\s*["']([^"'\n\r]+)["'][^)]*\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`,
+)
+
+// bottleRouteRe captures the generic `@route("/path", method="POST")` /
+// `@app.route("/path", method=["GET","POST"])` form. The receiver is optional.
+//
+// Capture groups: 1 = path, 2 = kwargs tail, 3 = handler name.
+var bottleRouteRe = regexp.MustCompile(
+	`(?m)^[ \t]*@(?:\w+\.)?route\s*\(\s*["']([^"'\n\r]+)["']([^\n\r]*)\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`,
+)
+
+// bottleMethodKwargRe extracts the verb(s) from a `method="POST"` or
+// `method=["GET", "POST"]` kwarg on a @route decorator (Bottle uses the
+// singular `method=`, unlike Flask's `methods=`).
+var bottleMethodKwargRe = regexp.MustCompile(`method\s*=\s*(\[[^\]]*\]|["'][^"'\n\r]*["'])`)
+
+// parseBottleMethods returns the verbs declared in a Bottle `@route` decorator
+// `method=` kwarg (string or list form). Empty result means the default (GET).
+func parseBottleMethods(args string) []string {
+	mm := bottleMethodKwargRe.FindStringSubmatch(args)
+	if len(mm) < 2 {
+		return nil
+	}
+	body := strings.Trim(mm[1], "[]")
+	var out []string
+	for _, tok := range strings.Split(body, ",") {
+		tok = strings.TrimSpace(tok)
+		tok = strings.Trim(tok, `"'`)
+		if tok == "" {
+			continue
+		}
+		out = append(out, strings.ToUpper(tok))
+	}
+	return out
+}
+
+func synthesizeBottle(content string, emit emitDefFn) {
+	// File-signal gate: require a Bottle marker. The bare `@get(...)` /
+	// `@route(...)` decorator shapes are generic, so without this gate the
+	// synthesizer could fire on unrelated Python files. `bottle.py` in repo
+	// root is the definitive single-file signal; `from bottle import` /
+	// `import bottle` / `Bottle(` cover the imported-app idioms.
+	if !strings.Contains(content, "bottle") && !strings.Contains(content, "Bottle") {
+		return
+	}
+
+	// Shorthand verb decorators first — unambiguous verb.
+	for _, idx := range bottleVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[2]:idx[3]])
+		raw := content[idx[4]:idx[5]]
+		handler := content[idx[6]:idx[7]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkBottle, raw)
+		defLine := lineOfOffset(content, idx[6])
+		emit(verb, canonical, "bottle", "Controller", handler, defLine)
+	}
+
+	// Generic @route(..., method=...) form.
+	for _, idx := range bottleRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 8 {
+			continue
+		}
+		raw := content[idx[2]:idx[3]]
+		extras := content[idx[4]:idx[5]]
+		handler := content[idx[6]:idx[7]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkBottle, raw)
+		defLine := lineOfOffset(content, idx[6])
+		methods := parseBottleMethods(extras)
+		if len(methods) == 0 {
+			// Bottle's default for @route without method= is GET.
+			methods = []string{"GET"}
+		}
+		for _, verb := range methods {
+			emit(verb, canonical, "bottle", "Controller", handler, defLine)
+		}
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis_aiohttp_bottle_test.go
+++ b/internal/engine/http_endpoint_synthesis_aiohttp_bottle_test.go
@@ -1,0 +1,176 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestSynth_Aiohttp covers the three aiohttp server-routing idioms:
+// `app.router.add_get(...)`, `app.router.add_route("GET", ...)`, and the
+// `@routes.get(...)` RouteTableDef decorator — all with FastAPI-style
+// `{name}` curly-brace path params. #2979.
+func TestSynth_Aiohttp(t *testing.T) {
+	src := `from aiohttp import web
+
+routes = web.RouteTableDef()
+
+@routes.get("/users/{user_id}")
+async def get_user(request):
+    return web.json_response({})
+
+@routes.post("/items")
+async def create_item(request):
+    return web.json_response({})
+
+async def list_health(request):
+    return web.Response(text="ok")
+
+async def update_item(request):
+    return web.Response(text="ok")
+
+app = web.Application()
+app.add_routes(routes)
+app.router.add_get("/health", list_health)
+app.router.add_route("PUT", "/items/{item_id}", update_item)
+`
+	got, res := runDetect(t, "python", "server.py", src)
+	want := []string{
+		"http:GET:/users/{user_id}",
+		"http:POST:/items",
+		"http:GET:/health",
+		"http:PUT:/items/{item_id}",
+	}
+	requireContains(t, got, want, "aiohttp")
+
+	// Framework label + handler attribution + def-line stamping proof for the
+	// RouteTableDef decorator form.
+	e := findSynthDef(res, "http:GET:/users/{user_id}")
+	if e == nil {
+		t.Fatalf("aiohttp: missing http:GET:/users/{user_id}")
+	}
+	if e.Properties["framework"] != "aiohttp" {
+		t.Errorf("aiohttp: framework = %q, want aiohttp", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "Controller:get_user" {
+		t.Errorf("aiohttp: source_handler = %q, want Controller:get_user", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("aiohttp: StartLine not stamped on get_user endpoint")
+	}
+
+	// add_route generic form: verb taken from the first string argument; the
+	// handler reference is the third positional arg.
+	r := findSynthDef(res, "http:PUT:/items/{item_id}")
+	if r == nil {
+		t.Fatalf("aiohttp: missing http:PUT:/items/{item_id}")
+	}
+	if r.Properties["framework"] != "aiohttp" {
+		t.Errorf("aiohttp: add_route framework = %q, want aiohttp", r.Properties["framework"])
+	}
+	if r.Properties["source_handler"] != "Controller:update_item" {
+		t.Errorf("aiohttp: add_route source_handler = %q, want Controller:update_item", r.Properties["source_handler"])
+	}
+}
+
+// TestSynth_Aiohttp_ClientOnlyNoOp asserts that a file using aiohttp purely as
+// an HTTP client (`ClientSession`) — with no server-routing signal — does NOT
+// synthesize any endpoint. Guards the dual-use skip the aiohttp.yaml rule pack
+// calls out. #2979.
+func TestSynth_Aiohttp_ClientOnlyNoOp(t *testing.T) {
+	src := `import aiohttp
+
+async def fetch(url):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            return await resp.json()
+`
+	_, res := runDetect(t, "python", "client.py", src)
+	for i := range res.Entities {
+		e := &res.Entities[i]
+		if e.Properties != nil && e.Properties["framework"] == "aiohttp" {
+			t.Errorf("aiohttp: client-only file synthesized an endpoint %q (must no-op)", e.ID)
+		}
+	}
+}
+
+// TestSynth_Bottle covers `@route` (default GET + explicit method= string /
+// list), `@get`, and `@post` decorators with Flask-style `<name>` /
+// `<name:filter>` angle-bracket path params. #2979.
+func TestSynth_Bottle(t *testing.T) {
+	src := `from bottle import route, get, post, run
+
+@route("/")
+def index():
+    return "home"
+
+@get("/users/<id:int>")
+def get_user(id):
+    return {}
+
+@post("/items")
+def create_item():
+    return {}
+
+@route("/legacy", method="DELETE")
+def legacy():
+    return ""
+
+@route("/multi", method=["GET", "POST"])
+def multi():
+    return ""
+
+run(host="localhost", port=8080)
+`
+	got, res := runDetect(t, "python", "bottle_app.py", src)
+	want := []string{
+		"http:GET:/",
+		"http:GET:/users/{id}",
+		"http:POST:/items",
+		"http:DELETE:/legacy",
+		"http:GET:/multi",
+		"http:POST:/multi",
+	}
+	requireContains(t, got, want, "Bottle")
+
+	// Framework label + handler attribution + def-line stamping proof.
+	e := findSynthDef(res, "http:GET:/users/{id}")
+	if e == nil {
+		t.Fatalf("Bottle: missing http:GET:/users/{id}")
+	}
+	if e.Properties["framework"] != "bottle" {
+		t.Errorf("Bottle: framework = %q, want bottle", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "Controller:get_user" {
+		t.Errorf("Bottle: source_handler = %q, want Controller:get_user", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("Bottle: StartLine not stamped on get_user endpoint")
+	}
+
+	// Generic @route with method=[...] list composes both verbs.
+	if findSynthDef(res, "http:POST:/multi") == nil {
+		t.Errorf("Bottle: method=[...] list form did not synthesize POST verb")
+	}
+}
+
+// TestSynth_AiohttpBottle_NoOpOnFlask asserts the aiohttp/Bottle synthesizers
+// do not fire on a plain Flask file (no aiohttp/bottle marker), so the endpoint
+// is labelled flask. Guards the framework-label correctness that the dispatch
+// ordering depends on. #2979.
+func TestSynth_AiohttpBottle_NoOpOnFlask(t *testing.T) {
+	src := `from flask import Flask
+
+app = Flask(__name__)
+
+@app.route("/ping")
+def ping():
+    return "pong"
+`
+	_, res := runDetect(t, "python", "flask_app.py", src)
+	e := findSynthDef(res, "http:GET:/ping")
+	if e == nil {
+		t.Fatalf("expected http:GET:/ping endpoint")
+	}
+	if e.Properties["framework"] != "flask" {
+		t.Errorf("framework = %q, want flask (aiohttp/Bottle synthesizers must no-op without their markers)", e.Properties["framework"])
+	}
+}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -95,6 +95,15 @@ const (
 	// FrameworkRobyn (#2980) — Robyn `@app.get("/users/:id")` uses the
 	// Express-style `:name` colon-prefixed path parameter convention.
 	FrameworkRobyn = "robyn"
+	// FrameworkAiohttp (#2979) — aiohttp `app.router.add_get("/users/{user_id}")`
+	// and `@routes.get("/users/{user_id}")` use the FastAPI-style `{name}` /
+	// `{name:regex}` curly-brace path parameter convention; the `:regex`
+	// suffix is stripped by canonicalizeCurlyBraces.
+	FrameworkAiohttp = "aiohttp"
+	// FrameworkBottle (#2979) — Bottle `@route("/users/<id>")` / `@get(...)`
+	// use the Flask-style `<name>` / `<name:filter>` angle-bracket path
+	// parameter convention. Canonicalisation reuses the angle-bracket walker.
+	FrameworkBottle = "bottle"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -114,6 +123,13 @@ func Canonicalize(framework, raw string) string {
 
 	var out string
 	switch framework {
+	case FrameworkBottle:
+		// Bottle path params are `<name>` / `<name:filter>` — the NAME comes
+		// FIRST, before the optional filter (the inverse of Flask's
+		// `<converter:name>`). Strip the `:filter` suffix so the shared
+		// angle-bracket walker (which keeps the post-colon segment for Flask)
+		// receives a bare `<name>` and emits `{name}`.
+		out = canonicalizeAngleBrackets(stripBottleFilters(raw))
 	case FrameworkDjango, FrameworkFlask, FrameworkRocket, FrameworkSanic:
 		// #2669 — Django re_path and DRF @action(url_path=…) frequently embed
 		// Python named-group regex `(?P<name>charclass)` inside the URL. Pre-strip
@@ -125,7 +141,7 @@ func Canonicalize(framework, raw string) string {
 		out = canonicalizeAngleBrackets(out)
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum,
 		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore, FrameworkHapi,
-		FrameworkLitestar:
+		FrameworkLitestar, FrameworkAiohttp:
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkTornado:
 		// Tornado paths arrive already pre-processed by the synthesizer
@@ -245,6 +261,41 @@ func stripPythonNamedGroups(raw string) string {
 // `{name}`. Used for Django and Flask which both use angle-bracket syntax
 // with optional converter prefixes (Django: `int`, `str`, `slug`, `uuid`,
 // `path`; Flask: `int`, `float`, `path`, `uuid`, `string` — default).
+// stripBottleFilters rewrites Bottle path params from `<name:filter>` to
+// `<name>` (Bottle puts the name FIRST, then an optional `:filter` such as
+// `:int` / `:re:[0-9]+` / `:path`). This inverts Flask's `<converter:name>`
+// ordering, so it must run BEFORE the shared angle-bracket walker — which keeps
+// the post-colon segment — to avoid mangling the param name into the filter.
+// A bare `<name>` (no colon) passes through untouched.
+func stripBottleFilters(raw string) string {
+	var b strings.Builder
+	b.Grow(len(raw))
+	i := 0
+	for i < len(raw) {
+		c := raw[i]
+		if c != '<' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		end := strings.IndexByte(raw[i+1:], '>')
+		if end < 0 {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		inner := raw[i+1 : i+1+end]
+		if idx := strings.IndexByte(inner, ':'); idx >= 0 {
+			inner = inner[:idx]
+		}
+		b.WriteByte('<')
+		b.WriteString(strings.TrimSpace(inner))
+		b.WriteByte('>')
+		i += 1 + end + 1
+	}
+	return b.String()
+}
+
 func canonicalizeAngleBrackets(raw string) string {
 	var b strings.Builder
 	b.Grow(len(raw))

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -944,6 +944,72 @@ records:
           issues_implemented: ["2980"]
           verified_at: "2026-05-29"
 
+  lang.python.framework.aiohttp:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeAiohttp]
+            - file: internal/engine/rules/python/frameworks/aiohttp.yaml
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_aiohttp_bottle_test.go
+          issues_implemented: ["2979"]
+          verified_at: "2026-05-29"
+        handler_attribution:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeAiohttp]
+            - file: internal/engine/rules/python/frameworks/aiohttp.yaml
+          issues_implemented: ["2979"]
+          verified_at: "2026-05-29"
+        route_extraction:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeAiohttp]
+            - file: internal/engine/httproutes/canonicalize.go
+              functions: [Canonicalize]
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_aiohttp_bottle_test.go
+          issues_implemented: ["2979"]
+          verified_at: "2026-05-29"
+
+  lang.python.framework.bottle:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeBottle]
+            - file: internal/engine/rules/python/frameworks/bottle.yaml
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_aiohttp_bottle_test.go
+          issues_implemented: ["2979"]
+          verified_at: "2026-05-29"
+        handler_attribution:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeBottle]
+            - file: internal/engine/rules/python/frameworks/bottle.yaml
+          issues_implemented: ["2979"]
+          verified_at: "2026-05-29"
+        route_extraction:
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_synthesis.go
+              functions: [synthesizeBottle]
+            - file: internal/engine/httproutes/canonicalize.go
+              functions: [Canonicalize, stripBottleFilters]
+          tests:
+            - file: internal/engine/http_endpoint_synthesis_aiohttp_bottle_test.go
+          issues_implemented: ["2979"]
+          verified_at: "2026-05-29"
+
   lang.python.framework.fastapi:
     capabilities:
       Routing:


### PR DESCRIPTION
## Summary

Real producer-side HTTP endpoint synthesis for **aiohttp** and **Bottle** — two Python web frameworks that had no synthesizer and were honestly downgraded to `missing` in #2978. Same engine-synthesis pattern as the just-merged #2980 (Sanic/Litestar/Robyn).

### `synthesizeAiohttp`
- `app.router.add_get(...)` shorthand verbs
- generic `app.router.add_route("GET", "/path", handler)`
- `@routes.get(...)` RouteTableDef decorators
- FastAPI-style `{name}` / `{name:regex}` path params (`FrameworkAiohttp`, curly-brace)
- **Dual-use skip**: gated on a server-routing signal (`app.router.add_` / `RouteTableDef` / `@routes.`), so files that only use `ClientSession` no-op — exactly the note in `aiohttp.yaml`.

### `synthesizeBottle`
- `@route` (default GET + `method="X"` and `method=[...]` list)
- `@get` / `@post` / ... shorthand, both bare and `@app.`-bound
- Bottle's `<name>` / `<name:filter>` angle-bracket params (NAME first — inverse of Flask's `<converter:name>`), normalised by a dedicated `stripBottleFilters` pre-pass before the shared angle-bracket walker (`FrameworkBottle`).

### Dispatch
Both run **before** Flask/FastAPI in `applyHTTPEndpointSynthesis` so their overlapping decorator shapes (`@routes.get`, `@route`, `@get`) claim each `(verb, path)` ID with the correct `framework` label; the side-scoped dedup then suppresses duplicate Flask emission. Each is file-signal-gated to no-op on plain Flask/FastAPI files.

### Tests — `internal/engine/http_endpoint_synthesis_aiohttp_bottle_test.go`
- aiohttp: all three idioms, add_route generic verb, framework label, handler attribution, def-line stamping
- aiohttp client-only no-op (dual-use)
- Bottle: `@route`/`@get`/`@post`, `method=[...]` list composition, `<id:int>` → `{id}`, label/attribution/def-line
- aiohttp+Bottle no-op on a plain Flask file (label stays `flask`)

### Coverage matrix
Flips `endpoint_synthesis` / `handler_attribution` / `route_extraction` **missing → full** for `lang.python.framework.{aiohttp,bottle}` with cites; adds capability-map entries; regenerates docs. `coverage validate` passes.

No new entity Kind — synthetics use the existing `http_endpoint_definition` kind + `Controller` scope.

Closes #2979

🤖 Generated with [Claude Code](https://claude.com/claude-code)