### PR TITLE
coverage(java): Spring AOP / AspectJ extraction (AOP lane, spring-boot + spring-webflux)

### DIFF
--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -73,9 +73,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3004) | `internal/custom/java/spring_aop.go` | Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect->advice/pointcut and REFERENCES advice->named pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented. |
+| Aspect extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3004) | `internal/custom/java/spring_aop.go` | Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect->advice/pointcut and REFERENCES advice->named pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented. |
+| Pointcut resolution | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3004) | `internal/custom/java/spring_aop.go` | Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect->advice/pointcut and REFERENCES advice->named pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -73,9 +73,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3004) | `internal/custom/java/spring_aop.go` | Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect->advice/pointcut and REFERENCES advice->named pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented. |
+| Aspect extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3004) | `internal/custom/java/spring_aop.go` | Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect->advice/pointcut and REFERENCES advice->named pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented. |
+| Pointcut resolution | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3004) | `internal/custom/java/spring_aop.go` | Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect->advice/pointcut and REFERENCES advice->named pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented. |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -17052,16 +17052,25 @@
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3004",
+            "notes": "Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect-\u003eadvice/pointcut and REFERENCES advice-\u003enamed pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented.",
+            "verified_at": "2026-05-29"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3004",
+            "notes": "Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect-\u003eadvice/pointcut and REFERENCES advice-\u003enamed pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented.",
+            "verified_at": "2026-05-29"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3004",
+            "notes": "Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect-\u003eadvice/pointcut and REFERENCES advice-\u003enamed pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented.",
+            "verified_at": "2026-05-29"
           }
         },
         "Observability": {
@@ -17332,16 +17341,25 @@
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3004",
+            "notes": "Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect-\u003eadvice/pointcut and REFERENCES advice-\u003enamed pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented.",
+            "verified_at": "2026-05-29"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3004",
+            "notes": "Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect-\u003eadvice/pointcut and REFERENCES advice-\u003enamed pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented.",
+            "verified_at": "2026-05-29"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_aop.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3004",
+            "notes": "Spring AOP / AspectJ: @Aspect classes, @Pointcut declarations, and @Before/@After/@Around/@AfterReturning/@AfterThrowing advice extracted as SCOPE.Pattern entities (subtype aspect/pointcut/advice) with advice_type + pointcut expression; OWNS aspect-\u003eadvice/pointcut and REFERENCES advice-\u003enamed pointcut. Regex-based, single-file scope; cross-file pointcut resolution not implemented.",
+            "verified_at": "2026-05-29"
           }
         },
         "Observability": {

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -3175,3 +3175,246 @@ public void doWork() {}
 		t.Errorf("[#3003 gating] non-java should no-op, got %d entities", len(r.Entities))
 	}
 }
+
+// ============================================================================
+// Spring AOP / AspectJ tests (#3004)
+// ============================================================================
+
+// aopEntityByName returns the AOP entity with the given subtype and name.
+func aopEntityByName(r PatternResult, subtype, name string) (SecondaryEntity, bool) {
+	for _, e := range r.Entities {
+		if e.Subtype == subtype && e.Name == name {
+			return e, true
+		}
+	}
+	return SecondaryEntity{}, false
+}
+
+func aopHasRel(r PatternResult, src, tgt, kind string) bool {
+	for _, rel := range r.Relationships {
+		if rel.SourceRef == src && rel.TargetRef == tgt && rel.RelationshipType == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSpringAOP_Aspect_Pointcut_Advice_Issue3004 is the proving fixture for the
+// AOP lane: an @Aspect class with a @Pointcut, an @Around advice that names the
+// pointcut, a @Before with an inline execution() expression, and the
+// @AfterReturning attribute form.
+// Registry target: lang.java.framework.spring-boot AOP/* = partial.
+func TestSpringAOP_Aspect_Pointcut_Advice_Issue3004(t *testing.T) {
+	source := `
+package com.example.aop;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class LoggingAspect {
+
+    @Pointcut("execution(* com.example.service.*.*(..))")
+    public void serviceMethods() {}
+
+    @Around("serviceMethods()")
+    public Object logAround(ProceedingJoinPoint pjp) throws Throwable {
+        return pjp.proceed();
+    }
+
+    @Before("execution(* com.example.web.*.*(..))")
+    public void logBefore(JoinPoint jp) {
+    }
+
+    @AfterReturning(pointcut = "serviceMethods()", returning = "result")
+    public void logReturn(JoinPoint jp, Object result) {
+    }
+}
+`
+	r := ExtractSpringAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_boot",
+		FilePath:  "LoggingAspect.java",
+	})
+
+	// aspect_extraction.
+	asp, ok := aopEntityByName(r, "aspect", "LoggingAspect")
+	if !ok {
+		t.Fatalf("[#3004 aspect] expected aspect entity LoggingAspect; got %v", entityNames(r.Entities))
+	}
+	if asp.Kind != "SCOPE.Pattern" {
+		t.Errorf("[#3004 aspect] aspect Kind = %q, want SCOPE.Pattern", asp.Kind)
+	}
+	if asp.Properties["kind"] != "aspect" {
+		t.Errorf("[#3004 aspect] aspect kind property = %v, want aspect", asp.Properties["kind"])
+	}
+	if asp.Properties["framework"] != "spring_boot" {
+		t.Errorf("[#3004 aspect] aspect framework = %v, want spring_boot", asp.Properties["framework"])
+	}
+
+	// pointcut_resolution.
+	pc, ok := aopEntityByName(r, "pointcut", "LoggingAspect.serviceMethods")
+	if !ok {
+		t.Fatalf("[#3004 pointcut] expected pointcut LoggingAspect.serviceMethods; got %v", entityNames(r.Entities))
+	}
+	if pc.Properties["pointcut_expression"] != "execution(* com.example.service.*.*(..))" {
+		t.Errorf("[#3004 pointcut] expression = %v", pc.Properties["pointcut_expression"])
+	}
+	if pc.Properties["aspect"] != "LoggingAspect" {
+		t.Errorf("[#3004 pointcut] aspect = %v, want LoggingAspect", pc.Properties["aspect"])
+	}
+
+	// advice_attribution: @Around naming the pointcut.
+	around, ok := aopEntityByName(r, "advice", "LoggingAspect.logAround")
+	if !ok {
+		t.Fatalf("[#3004 advice] expected advice LoggingAspect.logAround; got %v", entityNames(r.Entities))
+	}
+	if around.Properties["advice_type"] != "around" {
+		t.Errorf("[#3004 advice] logAround advice_type = %v, want around", around.Properties["advice_type"])
+	}
+	if around.Properties["pointcut_expression"] != "serviceMethods()" {
+		t.Errorf("[#3004 advice] logAround pointcut_expression = %v, want serviceMethods()", around.Properties["pointcut_expression"])
+	}
+	if around.Properties["aspect"] != "LoggingAspect" {
+		t.Errorf("[#3004 advice] logAround aspect = %v, want LoggingAspect", around.Properties["aspect"])
+	}
+
+	// advice_attribution: @Before with inline execution() expression.
+	before, ok := aopEntityByName(r, "advice", "LoggingAspect.logBefore")
+	if !ok {
+		t.Fatalf("[#3004 advice] expected advice LoggingAspect.logBefore")
+	}
+	if before.Properties["advice_type"] != "before" {
+		t.Errorf("[#3004 advice] logBefore advice_type = %v, want before", before.Properties["advice_type"])
+	}
+
+	// advice_attribution: @AfterReturning attribute (pointcut=...) form.
+	ret, ok := aopEntityByName(r, "advice", "LoggingAspect.logReturn")
+	if !ok {
+		t.Fatalf("[#3004 advice] expected advice LoggingAspect.logReturn")
+	}
+	if ret.Properties["advice_type"] != "after_returning" {
+		t.Errorf("[#3004 advice] logReturn advice_type = %v, want after_returning", ret.Properties["advice_type"])
+	}
+	if ret.Properties["pointcut_expression"] != "serviceMethods()" {
+		t.Errorf("[#3004 advice] logReturn pointcut_expression = %v, want serviceMethods()", ret.Properties["pointcut_expression"])
+	}
+
+	// OWNS: aspect -> pointcut, aspect -> each advice.
+	if !aopHasRel(r, asp.Ref, pc.Ref, "OWNS") {
+		t.Errorf("[#3004 aspect] expected OWNS edge aspect -> pointcut")
+	}
+	for _, adv := range []SecondaryEntity{around, before, ret} {
+		if !aopHasRel(r, asp.Ref, adv.Ref, "OWNS") {
+			t.Errorf("[#3004 advice] expected OWNS edge aspect -> %s", adv.Name)
+		}
+	}
+
+	// REFERENCES (pointcut_resolution): advice naming a declared pointcut links
+	// to it; advice with an inline execution() expression does not.
+	if !aopHasRel(r, around.Ref, pc.Ref, "REFERENCES") {
+		t.Errorf("[#3004 pointcut] expected REFERENCES edge logAround -> serviceMethods pointcut")
+	}
+	if !aopHasRel(r, ret.Ref, pc.Ref, "REFERENCES") {
+		t.Errorf("[#3004 pointcut] expected REFERENCES edge logReturn -> serviceMethods pointcut")
+	}
+	if aopHasRel(r, before.Ref, pc.Ref, "REFERENCES") {
+		t.Errorf("[#3004 pointcut] logBefore uses inline execution(); must NOT REFERENCES a named pointcut")
+	}
+}
+
+// TestSpringAOP_AllAdviceTypes_Issue3004 proves every advice annotation maps to
+// the right advice_type, on the spring-webflux framework.
+func TestSpringAOP_AllAdviceTypes_Issue3004(t *testing.T) {
+	source := `
+import org.aspectj.lang.annotation.Aspect;
+
+@Aspect
+public class AuditAspect {
+
+    @Before("execution(* *(..))")
+    public void b() {}
+
+    @After("execution(* *(..))")
+    public void a() {}
+
+    @Around("execution(* *(..))")
+    public Object ar(ProceedingJoinPoint p) throws Throwable { return p.proceed(); }
+
+    @AfterReturning("execution(* *(..))")
+    public void retn() {}
+
+    @AfterThrowing("execution(* *(..))")
+    public void thr() {}
+}
+`
+	r := ExtractSpringAOP(PatternContext{Source: source, Language: "java", Framework: "spring-webflux", FilePath: "AuditAspect.java"})
+
+	want := map[string]string{
+		"AuditAspect.b":    "before",
+		"AuditAspect.a":    "after",
+		"AuditAspect.ar":   "around",
+		"AuditAspect.retn": "after_returning",
+		"AuditAspect.thr":  "after_throwing",
+	}
+	for name, adviceType := range want {
+		e, ok := aopEntityByName(r, "advice", name)
+		if !ok {
+			t.Fatalf("[#3004 advice] expected advice %s; got %v", name, entityNames(r.Entities))
+		}
+		if e.Properties["advice_type"] != adviceType {
+			t.Errorf("[#3004 advice] %s advice_type = %v, want %s", name, e.Properties["advice_type"], adviceType)
+		}
+		if e.Properties["framework"] != "spring_webflux" {
+			t.Errorf("[#3004 advice] %s framework = %v, want spring_webflux", name, e.Properties["framework"])
+		}
+	}
+}
+
+// TestSpringAOP_NonAspectFile_Issue3004 proves advice annotations outside an
+// @Aspect class produce nothing (no phantom advice/aspect entities).
+func TestSpringAOP_NonAspectFile_Issue3004(t *testing.T) {
+	source := `
+@Service
+public class PlainService {
+    @Before("execution(* *(..))")
+    public void notReallyAdvice() {}
+}
+`
+	r := ExtractSpringAOP(PatternContext{Source: source, Language: "java", Framework: "spring_boot", FilePath: "PlainService.java"})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3004] non-aspect file should emit no AOP entities, got %v", entityNames(r.Entities))
+	}
+}
+
+// TestSpringAOP_FrameworkGating_Issue3004 proves the extractor runs only for the
+// Spring frameworks and no-ops elsewhere / for non-java.
+func TestSpringAOP_FrameworkGating_Issue3004(t *testing.T) {
+	source := `
+@Aspect
+public class A {
+    @Around("execution(* *(..))")
+    public Object x(ProceedingJoinPoint p) throws Throwable { return p.proceed(); }
+}
+`
+	for _, fw := range []string{"spring_boot", "spring-boot", "spring_webflux", "spring-webflux"} {
+		r := ExtractSpringAOP(PatternContext{Source: source, Language: "java", Framework: fw, FilePath: "A.java"})
+		if len(r.Entities) == 0 {
+			t.Errorf("[#3004 gating] framework %q expected AOP entities, got none", fw)
+		}
+	}
+	for _, fw := range []string{"quarkus", "micronaut", "jakarta_ee", "jaxrs", "django"} {
+		if r := ExtractSpringAOP(PatternContext{Source: source, Language: "java", Framework: fw, FilePath: "A.java"}); len(r.Entities) != 0 {
+			t.Errorf("[#3004 gating] framework %q should no-op, got %d entities", fw, len(r.Entities))
+		}
+	}
+	if r := ExtractSpringAOP(PatternContext{Source: source, Language: "python", Framework: "spring_boot", FilePath: "A.py"}); len(r.Entities) != 0 {
+		t.Errorf("[#3004 gating] non-java should no-op, got %d entities", len(r.Entities))
+	}
+}

--- a/internal/custom/java/spring_aop.go
+++ b/internal/custom/java/spring_aop.go
@@ -1,0 +1,302 @@
+package java
+
+import "regexp"
+
+// Spring AOP / AspectJ custom extractor: @Aspect / @Pointcut / advice
+// (@Before/@After/@Around/@AfterReturning/@AfterThrowing) extraction for the
+// Spring backend frameworks (#3004, epic #2847).
+//
+// Covers the AOP lane:
+//   - aspect_extraction: detect @Aspect-annotated classes and emit a
+//     SCOPE.Pattern(subtype=aspect) entity (kind=aspect property).
+//   - advice_attribution: detect advice methods inside an @Aspect class and
+//     emit a SCOPE.Pattern(subtype=advice) entity carrying the advice_type
+//     (before/after/around/after_returning/after_throwing) plus the pointcut
+//     expression string; link each advice to its enclosing aspect via OWNS.
+//   - pointcut_resolution: detect @Pointcut methods and emit a
+//     SCOPE.Pattern(subtype=pointcut) entity carrying the pointcut expression;
+//     link advice methods to their named pointcut via REFERENCES when the
+//     advice annotation names a pointcut method declared in the same file.
+//
+// Reuses the SCOPE.Pattern entity Kind (matching transactional.go) so no new
+// entity Kind needs registering. Aspect/advice/pointcut role is recorded in the
+// `kind` property and in the entity Subtype.
+
+// aopFrameworks gates the frameworks for which Spring AOP extraction runs.
+// Spring AOP / AspectJ proxying is idiomatic only on the Spring frameworks;
+// other JVM frameworks are intentionally left red (see issue #3004).
+var aopFrameworks = map[string]bool{
+	"spring_boot": true, "spring-boot": true, "springboot": true,
+	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
+}
+
+var (
+	// aopAspectClassRE matches an @Aspect-annotated class declaration, capturing
+	// the class name (group 1). The `(?s)` flag lets the annotation and the class
+	// keyword span intervening lines (e.g. an interleaved @Component). Matching
+	// stops before the class body `{` so unrelated annotations between @Aspect
+	// and `class` are tolerated but a method body is not crossed.
+	aopAspectClassRE = regexp.MustCompile(
+		`(?s)@Aspect\b[^{]*?\bclass\s+(\w+)`)
+
+	// aopAdviceRE matches an advice annotation with a pointcut expression string,
+	// capturing the advice annotation name (group 1) and the expression / named
+	// pointcut reference (group 2). Handles the explicit attribute forms
+	// @AfterReturning(pointcut="...", returning="x") and
+	// @Around(value="...") by anchoring on the first double-quoted string.
+	aopAdviceRE = regexp.MustCompile(
+		`@(Before|After|Around|AfterReturning|AfterThrowing)\s*\(\s*` +
+			`(?:value\s*=\s*|pointcut\s*=\s*)?"([^"]*)"`)
+
+	// aopPointcutRE matches a @Pointcut method declaration, capturing the
+	// pointcut expression (group 1) and the declaring method name (group 2).
+	aopPointcutRE = regexp.MustCompile(
+		`@Pointcut\s*\(\s*"([^"]*)"\s*\)\s*` +
+			`(?:(?:public|protected|private)\s+)?(?:abstract\s+)?void\s+(\w+)`)
+
+	// aopAdviceMethodNameRE captures the method name that follows an advice
+	// annotation (skipping modifiers / return type) so an advice entity can be
+	// named <Aspect>.<method>.
+	aopAdviceMethodNameRE = regexp.MustCompile(
+		`(?s)^[^{(]*?` +
+			`(?:(?:public|protected|private|final|static|synchronized)\s+)*` +
+			`(?:<[^>]*>\s*)?` +
+			`(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)` +
+			`(\w+)\s*\(`)
+
+	// aopPointcutRefRE pulls a bare pointcut method reference out of an advice
+	// expression, e.g. "serviceMethods()" or "com.x.Aspect.serviceMethods()".
+	// Captures the simple method name (group 1).
+	aopPointcutRefRE = regexp.MustCompile(`(?:\b\w+\.)*(\w+)\s*\(\s*\)`)
+)
+
+// aopAdviceType normalises an advice annotation name to a snake_case
+// advice_type property value.
+func aopAdviceType(annotation string) string {
+	switch annotation {
+	case "Before":
+		return "before"
+	case "After":
+		return "after"
+	case "Around":
+		return "around"
+	case "AfterReturning":
+		return "after_returning"
+	case "AfterThrowing":
+		return "after_throwing"
+	default:
+		return annotation
+	}
+}
+
+// canonicalAOPFramework normalises a framework alias to its canonical name for
+// the entity `framework` property.
+func canonicalAOPFramework(framework string) string {
+	switch framework {
+	case "spring_boot", "spring-boot", "springboot":
+		return "spring_boot"
+	case "spring_webflux", "spring-webflux", "springwebflux":
+		return "spring_webflux"
+	default:
+		return framework
+	}
+}
+
+// aopReferencedPointcut extracts a named pointcut reference from an advice
+// pointcut expression. It returns the simple method name when the expression is
+// a single bare pointcut reference (the form that resolves to a @Pointcut in
+// the same aspect), or "" when the expression is an inline AspectJ designator
+// (execution(...), within(...), @annotation(...), etc.) that does not name a
+// declared pointcut.
+func aopReferencedPointcut(expr string) string {
+	// Inline designators contain a designator keyword followed by args; they are
+	// not simple pointcut references. Heuristic: a named reference is exactly one
+	// `name()` token with nothing else of substance.
+	m := aopPointcutRefRE.FindStringSubmatch(expr)
+	if m == nil {
+		return ""
+	}
+	name := m[1]
+	// Reject AspectJ pointcut designators that share the call() shape.
+	switch name {
+	case "execution", "within", "withincode", "this", "target", "args",
+		"bean", "annotation", "call", "get", "set", "handler",
+		"initialization", "preinitialization", "staticinitialization",
+		"cflow", "cflowbelow", "adviceexecution":
+		return ""
+	}
+	return name
+}
+
+// ExtractSpringAOP runs the Spring AOP / AspectJ extractor.
+func ExtractSpringAOP(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !aopFrameworks[ctx.Framework] {
+		return result
+	}
+
+	source := ctx.Source
+	fp := ctx.FilePath
+	framework := canonicalAOPFramework(ctx.Framework)
+	seenRefs := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// 1. aspect_extraction: @Aspect classes.
+	aspects := make(map[string]aspectInfo)
+	for _, m := range aopAspectClassRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		ref := "scope:pattern:aspect:" + fp + ":" + className
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Pattern", Subtype: "aspect",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_ASPECT", Ref: ref,
+			Properties: map[string]any{
+				"kind":      "aspect",
+				"aspect":    className,
+				"framework": framework,
+			},
+		}) {
+			if _, ok := aspects[className]; !ok {
+				aspects[className] = aspectInfo{offset: m[0], ref: ref}
+			}
+		}
+	}
+
+	// Only emit advice / pointcut entities for files that actually declare an
+	// aspect; advice annotations are meaningless outside an @Aspect class.
+	if len(aspects) == 0 {
+		return result
+	}
+
+	// 2. pointcut_resolution: @Pointcut methods. Map method name -> ref so advice
+	//    can link to a named pointcut declared in the same file.
+	pointcutRefByName := make(map[string]string)
+	for _, m := range aopPointcutRE.FindAllStringSubmatchIndex(source, -1) {
+		expr := source[m[2]:m[3]]
+		pcName := source[m[4]:m[5]]
+		owner := findEnclosingAspect(source, m[0], aspects)
+		name := pcName
+		if owner != "" {
+			name = owner + "." + pcName
+		}
+		ref := "scope:pattern:pointcut:" + fp + ":" + name
+		props := map[string]any{
+			"kind":                "pointcut",
+			"pointcut":            pcName,
+			"pointcut_expression": expr,
+			"framework":           framework,
+		}
+		if owner != "" {
+			props["aspect"] = owner
+		}
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "pointcut",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_POINTCUT", Ref: ref,
+			Properties: props,
+		}) {
+			pointcutRefByName[pcName] = ref
+			// OWNS edge: aspect owns its pointcut.
+			if owner != "" {
+				if ai, ok := aspects[owner]; ok {
+					addRel(&result, seenRels, Relationship{
+						SourceRef: ai.ref, TargetRef: ref, RelationshipType: "OWNS",
+					})
+				}
+			}
+		}
+	}
+
+	// 3. advice_attribution: advice methods inside an @Aspect class.
+	for _, m := range aopAdviceRE.FindAllStringSubmatchIndex(source, -1) {
+		annotation := source[m[2]:m[3]]
+		expr := source[m[4]:m[5]]
+		owner := findEnclosingAspect(source, m[0], aspects)
+		if owner == "" {
+			// Advice annotation outside any aspect in this file; skip.
+			continue
+		}
+
+		// Resolve the advice method name from the text following the annotation.
+		methodName := aopAdviceMethodName(source, m[1])
+		name := owner + "." + annotation
+		if methodName != "" {
+			name = owner + "." + methodName
+		}
+
+		props := map[string]any{
+			"kind":                "advice",
+			"advice_type":         aopAdviceType(annotation),
+			"pointcut_expression": expr,
+			"aspect":              owner,
+			"framework":           framework,
+		}
+		if methodName != "" {
+			props["method"] = methodName
+		}
+
+		ref := "scope:pattern:advice:" + fp + ":" + name
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "advice",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_ADVICE", Ref: ref,
+			Properties: props,
+		}) {
+			// OWNS edge: aspect owns its advice.
+			if ai, ok := aspects[owner]; ok {
+				addRel(&result, seenRels, Relationship{
+					SourceRef: ai.ref, TargetRef: ref, RelationshipType: "OWNS",
+				})
+			}
+			// REFERENCES edge: advice -> named pointcut (pointcut_resolution).
+			if pcName := aopReferencedPointcut(expr); pcName != "" {
+				if pcRef, ok := pointcutRefByName[pcName]; ok {
+					addRel(&result, seenRels, Relationship{
+						SourceRef: ref, TargetRef: pcRef, RelationshipType: "REFERENCES",
+					})
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// findEnclosingAspect returns the name of the @Aspect class whose declaration
+// most closely precedes offset, or "" if offset is not inside a known aspect.
+func findEnclosingAspect(source string, offset int, aspects map[string]aspectInfo) string {
+	best := ""
+	bestOff := -1
+	for name, ai := range aspects {
+		if ai.offset <= offset && ai.offset > bestOff {
+			best = name
+			bestOff = ai.offset
+		}
+	}
+	return best
+}
+
+// aspectInfo is the per-aspect bookkeeping used to attribute advice/pointcuts.
+type aspectInfo struct {
+	offset int
+	ref    string
+}
+
+// aopAdviceMethodName extracts the method name declared immediately after an
+// advice annotation. `from` is the offset just past the matched annotation. It
+// scans a bounded window so a malformed annotation cannot run away.
+func aopAdviceMethodName(source string, from int) string {
+	end := from + 400
+	if end > len(source) {
+		end = len(source)
+	}
+	window := source[from:end]
+	m := aopAdviceMethodNameRE.FindStringSubmatch(window)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -1782,6 +1782,28 @@ records:
 
   lang.java.framework.spring-boot:
     capabilities:
+      AOP:
+        aspect_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/spring_aop.go
+              functions: [ExtractSpringAOP]
+          issues_implemented: ["3004"]
+          verified_at: "2026-05-29"
+        advice_attribution:
+          status: partial
+          symbols:
+            - file: internal/custom/java/spring_aop.go
+              functions: [ExtractSpringAOP, aopAdviceType, aopAdviceMethodName, findEnclosingAspect]
+          issues_implemented: ["3004"]
+          verified_at: "2026-05-29"
+        pointcut_resolution:
+          status: partial
+          symbols:
+            - file: internal/custom/java/spring_aop.go
+              functions: [ExtractSpringAOP, aopReferencedPointcut]
+          issues_implemented: ["3004"]
+          verified_at: "2026-05-29"
       Transactions:
         transaction_boundary_extraction:
           status: partial
@@ -2155,6 +2177,31 @@ records:
             - file: internal/substrate/template_pattern_golang.go
           issues_implemented: ["2774"]
           verified_at: "2026-05-28"
+
+  lang.java.framework.spring-webflux:
+    capabilities:
+      AOP:
+        aspect_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/spring_aop.go
+              functions: [ExtractSpringAOP]
+          issues_implemented: ["3004"]
+          verified_at: "2026-05-29"
+        advice_attribution:
+          status: partial
+          symbols:
+            - file: internal/custom/java/spring_aop.go
+              functions: [ExtractSpringAOP, aopAdviceType, aopAdviceMethodName, findEnclosingAspect]
+          issues_implemented: ["3004"]
+          verified_at: "2026-05-29"
+        pointcut_resolution:
+          status: partial
+          symbols:
+            - file: internal/custom/java/spring_aop.go
+              functions: [ExtractSpringAOP, aopReferencedPointcut]
+          issues_implemented: ["3004"]
+          verified_at: "2026-05-29"
 
   lang.ruby.framework.rails:
     capabilities:


### PR DESCRIPTION
## Summary

Implements **#3004** (epic #2847): B-build extractor for Spring AOP / AspectJ. New `internal/custom/java/spring_aop.go` (`ExtractSpringAOP`) detects `@Aspect` / `@Pointcut` / advice annotations and emits `SCOPE.Pattern` entities (reusing the existing Kind — no new entity Kind required, consistent with the just-merged `transactional.go`).

### AOP lane coverage (missing → partial)

| Capability | What it extracts |
|---|---|
| `aspect_extraction` | `@Aspect` classes → `SCOPE.Pattern(subtype=aspect, kind=aspect)` |
| `advice_attribution` | `@Before/@After/@Around/@AfterReturning/@AfterThrowing` methods in an aspect → `SCOPE.Pattern(subtype=advice)` with `advice_type` + pointcut expression; `OWNS` aspect→advice |
| `pointcut_resolution` | `@Pointcut` methods → `SCOPE.Pattern(subtype=pointcut)` with expression; `OWNS` aspect→pointcut; `REFERENCES` advice→named pointcut |

Handles the bare, `value=`, and `pointcut=` advice annotation forms. Inline AspectJ designators (`execution(...)`, `within(...)`, ...) do not emit a spurious `REFERENCES`. Advice outside any `@Aspect` class is ignored (no phantom entities).

### Gating
Gated to **spring-boot** + **spring-webflux** (where Spring AOP is idiomatic). Other JVM frameworks intentionally left red per the issue.

### Registry
`AOP/{aspect_extraction,advice_attribution,pointcut_resolution}` flipped missing → partial for both frameworks, with cites, `capability-map.yaml` entries, and notes. `coverage validate` = 0 errors; `gen` byte-stable.

### Tests
`internal/custom/java/extractors_test.go`: proving fixture (`@Aspect` + `@Pointcut` + `@Around` naming the pointcut + `@Before` inline expression + `@AfterReturning` attribute form), all five advice types, non-aspect-file no-op, framework/language gating.

### Gates
`go test ./internal/custom/java/ ./internal/engine/ ./tools/coverage/ ./internal/types/` green · `go build ./...` · `go vet` · `gofmt` clean · `coverage validate` 0 errors · `gen` byte-stable.

Closes #3004

🤖 Generated with [Claude Code](https://claude.com/claude-code)