### PR TITLE
feat(java): observability extraction (SLF4J, Micrometer, OTel) (#3006)

### DIFF
--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.dropwizard.md
+++ b/docs/coverage/detail/lang.java.framework.dropwizard.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.helidon.md
+++ b/docs/coverage/detail/lang.java.framework.helidon.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3006) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14068,16 +14068,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -14599,16 +14605,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -15000,16 +15012,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -15275,16 +15293,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -15521,16 +15545,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -15790,16 +15820,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -16096,16 +16132,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -16362,16 +16404,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -16787,16 +16835,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -17075,16 +17129,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Substrate": {
@@ -17364,16 +17424,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -17614,16 +17680,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -17982,16 +18054,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/observability.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3006",
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -3418,3 +3418,238 @@ public class A {
 		t.Errorf("[#3004 gating] non-java should no-op, got %d entities", len(r.Entities))
 	}
 }
+
+// ============================================================================
+// Observability tests (#3006)
+// ============================================================================
+
+// findObsEntity returns the first SCOPE.Pattern entity with the given subtype
+// whose properties include kvWant (all keys must match), or nil.
+func findObsEntity(r PatternResult, subtype string, kvWant map[string]string) *SecondaryEntity {
+	for i := range r.Entities {
+		e := &r.Entities[i]
+		if e.Kind != "SCOPE.Pattern" || e.Subtype != subtype {
+			continue
+		}
+		ok := true
+		for k, v := range kvWant {
+			if got, _ := e.Properties[k].(string); got != v {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return e
+		}
+	}
+	return nil
+}
+
+func countObsSubtype(r PatternResult, subtype string) int {
+	n := 0
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == subtype {
+			n++
+		}
+	}
+	return n
+}
+
+// TestObservability_Slf4jLogging proves log_extraction detects @Slf4j loggers
+// and the log.<level>(...) statement call surface.
+func TestObservability_Slf4jLogging_Issue3006(t *testing.T) {
+	source := `
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class OrderService {
+    public void place(Order o) {
+        log.info("placing order {}", o.getId());
+        if (o.isInvalid()) {
+            log.error("invalid order");
+        }
+        log.debug("done");
+    }
+}
+`
+	r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: "spring_boot", FilePath: "OrderService.java"})
+
+	logger := findObsEntity(r, "logger", map[string]string{"library": "slf4j", "holder": "OrderService"})
+	if logger == nil {
+		t.Fatalf("[#3006 log] expected @Slf4j logger entity, got %v", entityNames(r.Entities))
+	}
+	if logger.Properties["framework"] != "spring_boot" {
+		t.Errorf("[#3006 log] logger framework = %v, want spring_boot", logger.Properties["framework"])
+	}
+
+	if n := countObsSubtype(r, "log_statement"); n != 3 {
+		t.Errorf("[#3006 log] expected 3 log statements, got %d", n)
+	}
+	if findObsEntity(r, "log_statement", map[string]string{"log_level": "info"}) == nil {
+		t.Errorf("[#3006 log] missing info statement")
+	}
+	if findObsEntity(r, "log_statement", map[string]string{"log_level": "error"}) == nil {
+		t.Errorf("[#3006 log] missing error statement")
+	}
+}
+
+// TestObservability_LoggerFactoryVariants proves SLF4J / Log4j2 / JUL logger
+// factories are recognised with the right backing library.
+func TestObservability_LoggerFactoryVariants_Issue3006(t *testing.T) {
+	cases := []struct {
+		decl    string
+		library string
+	}{
+		{`private static final Logger slf = LoggerFactory.getLogger(Foo.class);`, "slf4j"},
+		{`private static final Logger l4j = LogManager.getLogger(Foo.class);`, "log4j"},
+		{`private static final java.util.logging.Logger jul = Logger.getLogger("Foo");`, "jul"},
+	}
+	for _, c := range cases {
+		source := "@Service\npublic class Foo {\n  " + c.decl + "\n}\n"
+		r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: "quarkus", FilePath: "Foo.java"})
+		if findObsEntity(r, "logger", map[string]string{"library": c.library}) == nil {
+			t.Errorf("[#3006 log] decl %q expected library %q, got %v", c.decl, c.library, r.Entities)
+		}
+	}
+}
+
+// TestObservability_MicrometerMetrics proves metric_extraction detects
+// Micrometer builders, MeterRegistry, and @Timed.
+func TestObservability_MicrometerMetrics_Issue3006(t *testing.T) {
+	source := `
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Service
+public class CheckoutService {
+    private final MeterRegistry registry;
+    private final Counter orders = Counter.builder("orders.count").register(registry);
+
+    @Timed(value = "checkout.latency")
+    public void checkout() { orders.increment(); }
+}
+`
+	r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: "spring_boot", FilePath: "CheckoutService.java"})
+
+	if e := findObsEntity(r, "metric", map[string]string{"metric_name": "orders.count", "metric_type": "counter"}); e == nil {
+		t.Errorf("[#3006 metric] expected Counter.builder metric, got %v", r.Entities)
+	}
+	if findObsEntity(r, "metric", map[string]string{"metric_type": "registry"}) == nil {
+		t.Errorf("[#3006 metric] expected MeterRegistry signal")
+	}
+	if e := findObsEntity(r, "metric", map[string]string{"metric_type": "timer", "method": "checkout"}); e == nil {
+		t.Errorf("[#3006 metric] expected @Timed metric, got %v", r.Entities)
+	} else if e.Properties["metric_name"] != "checkout.latency" {
+		t.Errorf("[#3006 metric] @Timed metric_name = %v, want checkout.latency", e.Properties["metric_name"])
+	}
+}
+
+// TestObservability_MicroProfileMetrics proves @Counted / @Metered / @Gauge are
+// mapped to metric_type values.
+func TestObservability_MicroProfileMetrics_Issue3006(t *testing.T) {
+	source := `
+@ApplicationScoped
+public class Metrics {
+    @Counted(value = "calls.total")
+    public void counted() {}
+
+    @Metered
+    public void metered() {}
+
+    @Gauge(unit = "none")
+    public long gauged() { return 1; }
+}
+`
+	r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: "quarkus", FilePath: "Metrics.java"})
+	for _, want := range []struct{ mtype, method string }{
+		{"counter", "counted"}, {"meter", "metered"}, {"gauge", "gauged"},
+	} {
+		if findObsEntity(r, "metric", map[string]string{"metric_type": want.mtype, "method": want.method}) == nil {
+			t.Errorf("[#3006 metric] expected %s metric on %s, got %v", want.mtype, want.method, r.Entities)
+		}
+	}
+}
+
+// TestObservability_OtelTracing proves trace_extraction detects @WithSpan and
+// programmatic tracer.spanBuilder spans.
+func TestObservability_OtelTracing_Issue3006(t *testing.T) {
+	source := `
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.opentelemetry.api.trace.Tracer;
+
+@Service
+public class PaymentService {
+    private final Tracer tracer;
+
+    @WithSpan("charge-card")
+    public void charge() {
+        var span = tracer.spanBuilder("downstream-call").startSpan();
+        span.setAttribute("amount", 10);
+    }
+}
+`
+	r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: "spring_boot", FilePath: "PaymentService.java"})
+
+	if e := findObsEntity(r, "trace_span", map[string]string{"span_kind": "annotation", "method": "charge", "library": "otel"}); e == nil {
+		t.Errorf("[#3006 trace] expected @WithSpan span, got %v", r.Entities)
+	} else if e.Properties["span_name"] != "charge-card" {
+		t.Errorf("[#3006 trace] @WithSpan span_name = %v, want charge-card", e.Properties["span_name"])
+	}
+	if findObsEntity(r, "trace_span", map[string]string{"span_kind": "programmatic", "span_name": "downstream-call"}) == nil {
+		t.Errorf("[#3006 trace] expected programmatic spanBuilder span")
+	}
+}
+
+// TestObservability_MicrometerTracing proves @Observed and tracer.nextSpan are
+// detected as Micrometer Tracing spans.
+func TestObservability_MicrometerTracing_Issue3006(t *testing.T) {
+	source := `
+import io.micrometer.observation.annotation.Observed;
+
+@Service
+public class InventoryService {
+    @Observed(name = "inventory.check")
+    public boolean check() {
+        var span = tracer.nextSpan().name("reserve");
+        return true;
+    }
+}
+`
+	r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: "spring_boot", FilePath: "InventoryService.java"})
+
+	if e := findObsEntity(r, "trace_span", map[string]string{"span_kind": "annotation", "library": "micrometer", "method": "check"}); e == nil {
+		t.Errorf("[#3006 trace] expected @Observed span, got %v", r.Entities)
+	} else if e.Properties["span_name"] != "inventory.check" {
+		t.Errorf("[#3006 trace] @Observed span_name = %v, want inventory.check", e.Properties["span_name"])
+	}
+	if findObsEntity(r, "trace_span", map[string]string{"span_kind": "programmatic", "library": "micrometer"}) == nil {
+		t.Errorf("[#3006 trace] expected nextSpan() span")
+	}
+}
+
+// TestObservability_FrameworkGating proves the extractor runs for JVM backend
+// frameworks and no-ops for non-JVM-backend frameworks and non-java languages.
+func TestObservability_FrameworkGating_Issue3006(t *testing.T) {
+	source := `
+@Slf4j
+public class S {
+    public void m() { log.info("hi"); }
+}
+`
+	for _, fw := range []string{"spring_boot", "spring-boot", "quarkus", "micronaut", "microprofile", "jakarta_ee", "jaxrs", "dropwizard", "helidon", "javalin", "vertx"} {
+		r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: fw, FilePath: "S.java"})
+		if len(r.Entities) == 0 {
+			t.Errorf("[#3006 gating] framework %q expected observability entities, got none", fw)
+		}
+	}
+	for _, fw := range []string{"django", "rails", "express"} {
+		if r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: fw, FilePath: "S.java"}); len(r.Entities) != 0 {
+			t.Errorf("[#3006 gating] framework %q should no-op, got %d entities", fw, len(r.Entities))
+		}
+	}
+	if r := ExtractObservability(PatternContext{Source: source, Language: "python", Framework: "spring_boot", FilePath: "S.py"}); len(r.Entities) != 0 {
+		t.Errorf("[#3006 gating] non-java should no-op, got %d entities", len(r.Entities))
+	}
+}

--- a/internal/custom/java/observability.go
+++ b/internal/custom/java/observability.go
@@ -1,0 +1,534 @@
+package java
+
+import "regexp"
+
+// Java observability custom extractor: structured logging, metrics, and
+// distributed tracing instrumentation across the JVM backend frameworks
+// (#3006, epic #2847).
+//
+// Covers the Observability lane:
+//   - log_extraction: SLF4J / Log4j / java.util.logging logger acquisition
+//     (@Slf4j, LoggerFactory.getLogger, LogManager.getLogger,
+//     Logger.getLogger) and the log statement call surface
+//     (log.info/debug/warn/error/trace(...)). Emits a SCOPE.Pattern
+//     (subtype=log_statement) per log call carrying log_level + framework,
+//     plus a SCOPE.Pattern(subtype=logger) per declared logger.
+//   - metric_extraction: Micrometer (@Timed, Counter/Timer/Gauge.builder,
+//     MeterRegistry) and MicroProfile Metrics (@Counted/@Timed/@Metered/
+//     @Gauge). Emits a SCOPE.Pattern(subtype=metric) carrying metric_type +
+//     framework.
+//   - trace_extraction: OpenTelemetry (@WithSpan, tracer.spanBuilder,
+//     span.setAttribute) and Micrometer Tracing (@Observed, Tracer.nextSpan).
+//     Emits a SCOPE.Pattern(subtype=trace_span) carrying span_kind + framework.
+//
+// Reuses the SCOPE.Pattern entity Kind (matching spring_aop.go /
+// transactional.go / microprofile.go) so no new entity Kind is registered, per
+// the #2839 "prefer decorating over inventing Kinds" discipline. The
+// observability role is recorded in the entity Subtype and `kind` property.
+//
+// This is regex-based, file-local detection (no cross-file dataflow), so the
+// registry cells are flipped to `partial`, not `full` — honest about the limit
+// (a logger imported in one file and used in another is not correlated, and we
+// do not resolve the metric/span *name* expression when it is a non-literal).
+
+// obsFrameworks gates the JVM backend frameworks for which observability
+// extraction runs. These are the http_framework / microprofile records that
+// carry the log/metric/trace cells in the coverage registry.
+var obsFrameworks = map[string]bool{
+	"spring_boot": true, "spring-boot": true, "springboot": true,
+	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
+	"quarkus":      true,
+	"micronaut":    true,
+	"microprofile": true,
+	"jakarta_ee":   true, "jakarta-ee": true, "jakartaee": true,
+	"jaxrs": true, "jax-rs": true, "jax_rs": true,
+	"dropwizard": true,
+	"helidon":    true,
+	"javalin":    true,
+	"vertx":      true, "vert.x": true,
+	"akka_http": true, "akka-http": true,
+	"struts":       true,
+	"open_liberty": true, "payara": true,
+}
+
+var (
+	// --- log_extraction ---
+
+	// obsLoggerSlf4jAnnoRE matches the Lombok @Slf4j class-level annotation,
+	// capturing the annotated class name. @Slf4j injects a `log` field, so the
+	// declaring class is the logger holder.
+	obsLoggerSlf4jAnnoRE = regexp.MustCompile(
+		`(?s)@Slf4j\b[^{]*?\bclass\s+(\w+)`)
+
+	// obsLoggerFactoryRE matches an explicit logger field acquired via SLF4J
+	// LoggerFactory.getLogger, Log4j2 LogManager.getLogger, or JUL
+	// Logger.getLogger. Captures the factory call site so we can derive the
+	// framework, plus the field name (group 2).
+	obsLoggerFactoryRE = regexp.MustCompile(
+		`\b(LoggerFactory|LogManager|Logger)\.getLogger\s*\(`)
+
+	// obsLoggerFieldRE matches `... Logger <name> = ...getLogger(...)` to name
+	// the logger field. Used after a getLogger call site is found on a line.
+	obsLoggerFieldRE = regexp.MustCompile(
+		`\bLogger\s+(\w+)\s*=`)
+
+	// obsLogStmtRE matches a log statement call: a receiver identifier ending in
+	// a log level method. We anchor on a small set of receiver names commonly
+	// used for loggers (log, logger, LOG, LOGGER, <Class>.log) to avoid matching
+	// unrelated `.error(` style calls. Group 1 = receiver, group 2 = level.
+	obsLogStmtRE = regexp.MustCompile(
+		`\b([lL][oO][gG](?:[gG][eE][rR])?)\s*\.\s*(trace|debug|info|warn|error|fatal)\s*\(`)
+
+	// --- metric_extraction ---
+
+	// obsMicrometerBuilderRE matches Micrometer meter construction:
+	// Counter.builder(...), Timer.builder(...), Gauge.builder(...),
+	// DistributionSummary.builder(...). Group 1 = meter type.
+	obsMicrometerBuilderRE = regexp.MustCompile(
+		`\b(Counter|Timer|Gauge|DistributionSummary|LongTaskTimer)\.builder\s*\(\s*"([^"]*)"`)
+
+	// obsMeterRegistryRE matches use of a Micrometer MeterRegistry: the type
+	// reference or a `.counter(` / `.timer(` / `.gauge(` registry call.
+	obsMeterRegistryRE = regexp.MustCompile(
+		`\bMeterRegistry\b|\bmeterRegistry\s*\.\s*(?:counter|timer|gauge|summary)\s*\(`)
+
+	// obsTimedAnnoRE matches the @Timed metric annotation (Micrometer or
+	// MicroProfile) on a method, capturing the method name. Optional value
+	// attribute string is captured as group 1 (metric name) when present.
+	obsTimedAnnoRE = regexp.MustCompile(
+		`(?s)@Timed\s*(?:\(\s*(?:value\s*=\s*)?(?:"([^"]*)")?[^)]*\))?\s*` +
+			`(?:(?:@\w+(?:\s*\([^)]*\))?)\s*)*` +
+			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?(?:<[^>]*>\s*)?` +
+			`(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)(\w+)\s*\(`)
+
+	// obsMetricAnnoRE matches the remaining MicroProfile / Micrometer metric
+	// annotations (@Counted, @Metered, @Gauge) on a method. Group 1 = annotation
+	// name, group 2 = optional metric-name string, group 3 = method name.
+	obsMetricAnnoRE = regexp.MustCompile(
+		`(?s)@(Counted|Metered|Gauge)\s*(?:\(\s*(?:value\s*=\s*)?(?:"([^"]*)")?[^)]*\))?\s*` +
+			`(?:(?:@\w+(?:\s*\([^)]*\))?)\s*)*` +
+			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?(?:<[^>]*>\s*)?` +
+			`(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)(\w+)\s*\(`)
+
+	// --- trace_extraction ---
+
+	// obsWithSpanRE matches the OpenTelemetry @WithSpan annotation on a method,
+	// capturing an optional span-name string (group 1) and the method name
+	// (group 2). @WithSpan with no value defaults the span name to the method.
+	obsWithSpanRE = regexp.MustCompile(
+		`(?s)@WithSpan\s*(?:\(\s*(?:value\s*=\s*)?(?:"([^"]*)")?[^)]*\))?\s*` +
+			`(?:(?:@\w+(?:\s*\([^)]*\))?)\s*)*` +
+			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?(?:<[^>]*>\s*)?` +
+			`(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)(\w+)\s*\(`)
+
+	// obsObservedRE matches the Micrometer Tracing @Observed annotation on a
+	// method (group 1 = optional name string, group 2 = method name).
+	obsObservedRE = regexp.MustCompile(
+		`(?s)@Observed\s*(?:\(\s*(?:name\s*=\s*)?(?:"([^"]*)")?[^)]*\))?\s*` +
+			`(?:(?:@\w+(?:\s*\([^)]*\))?)\s*)*` +
+			`(?:(?:public|protected|private)\s+)?(?:static\s+)?(?:final\s+)?(?:<[^>]*>\s*)?` +
+			`(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)(\w+)\s*\(`)
+
+	// obsSpanBuilderRE matches a programmatic OpenTelemetry span:
+	// tracer.spanBuilder("name") . Group 1 = span name.
+	obsSpanBuilderRE = regexp.MustCompile(
+		`\.\s*spanBuilder\s*\(\s*"([^"]*)"`)
+
+	// obsNextSpanRE matches Micrometer Tracing programmatic span creation:
+	// tracer.nextSpan() / Tracer.nextSpan().
+	obsNextSpanRE = regexp.MustCompile(
+		`\.\s*nextSpan\s*\(\s*\)`)
+)
+
+// canonicalObsFramework normalises a framework alias to its canonical name for
+// the entity `framework` property.
+func canonicalObsFramework(framework string) string {
+	switch framework {
+	case "spring_boot", "spring-boot", "springboot":
+		return "spring_boot"
+	case "spring_webflux", "spring-webflux", "springwebflux":
+		return "spring_webflux"
+	case "jakarta_ee", "jakarta-ee", "jakartaee":
+		return "jakarta_ee"
+	case "jaxrs", "jax-rs", "jax_rs":
+		return "jaxrs"
+	case "akka_http", "akka-http":
+		return "akka_http"
+	case "vertx", "vert.x":
+		return "vertx"
+	default:
+		return framework
+	}
+}
+
+// ExtractObservability runs the Java observability extractor.
+func ExtractObservability(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !obsFrameworks[ctx.Framework] {
+		return result
+	}
+
+	source := ctx.Source
+	fp := ctx.FilePath
+	fw := canonicalObsFramework(ctx.Framework)
+	seenRefs := make(map[string]bool)
+
+	extractLogging(&result, seenRefs, source, fp, fw)
+	extractMetrics(&result, seenRefs, source, fp, fw)
+	extractTracing(&result, seenRefs, source, fp, fw)
+
+	return result
+}
+
+// logLibraryFor maps a logger factory call name to the backing framework.
+func logLibraryFor(factory string) string {
+	switch factory {
+	case "LoggerFactory":
+		return "slf4j"
+	case "LogManager":
+		return "log4j"
+	case "Logger":
+		return "jul"
+	default:
+		return "slf4j"
+	}
+}
+
+// extractLogging handles the log_extraction cell.
+func extractLogging(result *PatternResult, seen map[string]bool, source, fp, fw string) {
+	// @Slf4j-annotated classes declare an injected `log` logger.
+	for _, m := range obsLoggerSlf4jAnnoRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		ref := "scope:pattern:obs_logger:" + fp + ":" + className
+		addEntity(result, seen, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Pattern", Subtype: "logger",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_LOG", Ref: ref,
+			Properties: map[string]any{
+				"kind":      "logger",
+				"signal":    "log",
+				"library":   "slf4j",
+				"holder":    className,
+				"framework": fw,
+			},
+		})
+	}
+
+	// Explicit logger fields via *.getLogger(...).
+	for _, m := range obsLoggerFactoryRE.FindAllStringSubmatchIndex(source, -1) {
+		factory := source[m[2]:m[3]]
+		library := logLibraryFor(factory)
+		// Resolve the logger field name from a bounded window around the call.
+		name := obsFieldNameNear(source, m[0])
+		entName := name
+		if entName == "" {
+			entName = library + "_logger"
+		}
+		ref := "scope:pattern:obs_logger:" + fp + ":" + library + ":" + entName
+		props := map[string]any{
+			"kind":      "logger",
+			"signal":    "log",
+			"library":   library,
+			"framework": fw,
+		}
+		if name != "" {
+			props["field"] = name
+		}
+		addEntity(result, seen, SecondaryEntity{
+			Name: entName, Kind: "SCOPE.Pattern", Subtype: "logger",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_LOG", Ref: ref,
+			Properties: props,
+		})
+	}
+
+	// Log statement calls: log.info(...), logger.error(...), etc.
+	for _, m := range obsLogStmtRE.FindAllStringSubmatchIndex(source, -1) {
+		receiver := source[m[2]:m[3]]
+		level := source[m[4]:m[5]]
+		line := lineOf(source, m[0])
+		// Distinguish multiple statements on the same logger by line number.
+		ref := "scope:pattern:obs_log_statement:" + fp + ":" + receiver + ":" + level + ":" + itoa(line)
+		addEntity(result, seen, SecondaryEntity{
+			Name: receiver + "." + level, Kind: "SCOPE.Pattern", Subtype: "log_statement",
+			SourceFile: fp,
+			LineStart:  line, LineEnd: line,
+			Provenance: "INFERRED_FROM_OBSERVABILITY_LOG", Ref: ref,
+			Properties: map[string]any{
+				"kind":      "log_statement",
+				"signal":    "log",
+				"log_level": level,
+				"receiver":  receiver,
+				"framework": fw,
+			},
+		})
+	}
+}
+
+// extractMetrics handles the metric_extraction cell.
+func extractMetrics(result *PatternResult, seen map[string]bool, source, fp, fw string) {
+	// Micrometer builder calls: Counter.builder("name"), Timer.builder("name").
+	for _, m := range obsMicrometerBuilderRE.FindAllStringSubmatchIndex(source, -1) {
+		meterType := source[m[2]:m[3]]
+		metricName := source[m[4]:m[5]]
+		ref := "scope:pattern:obs_metric:" + fp + ":micrometer:" + metricName
+		addEntity(result, seen, SecondaryEntity{
+			Name: metricName, Kind: "SCOPE.Pattern", Subtype: "metric",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_METRIC", Ref: ref,
+			Properties: map[string]any{
+				"kind":        "metric",
+				"signal":      "metric",
+				"metric_type": obsMeterType(meterType),
+				"metric_name": metricName,
+				"library":     "micrometer",
+				"framework":   fw,
+			},
+		})
+	}
+
+	// MeterRegistry usage (type ref or registry call) — a file-level signal that
+	// metrics are wired even when no literal builder name is present.
+	if obsMeterRegistryRE.MatchString(source) {
+		loc := obsMeterRegistryRE.FindStringIndex(source)
+		ref := "scope:pattern:obs_metric:" + fp + ":micrometer:meter_registry"
+		addEntity(result, seen, SecondaryEntity{
+			Name: "MeterRegistry", Kind: "SCOPE.Pattern", Subtype: "metric",
+			SourceFile: fp,
+			LineStart:  lineOf(source, loc[0]), LineEnd: lineOf(source, loc[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_METRIC", Ref: ref,
+			Properties: map[string]any{
+				"kind":        "metric",
+				"signal":      "metric",
+				"metric_type": "registry",
+				"library":     "micrometer",
+				"framework":   fw,
+			},
+		})
+	}
+
+	// @Timed annotation (Micrometer + MicroProfile share the name).
+	for _, m := range obsTimedAnnoRE.FindAllStringSubmatchIndex(source, -1) {
+		metricName := ""
+		if m[2] >= 0 {
+			metricName = source[m[2]:m[3]]
+		}
+		methodName := source[m[4]:m[5]]
+		name := metricName
+		if name == "" {
+			name = methodName
+		}
+		ref := "scope:pattern:obs_metric:" + fp + ":timed:" + methodName
+		props := map[string]any{
+			"kind":        "metric",
+			"signal":      "metric",
+			"metric_type": "timer",
+			"library":     "annotation",
+			"method":      methodName,
+			"framework":   fw,
+		}
+		if metricName != "" {
+			props["metric_name"] = metricName
+		}
+		addEntity(result, seen, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "metric",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_METRIC", Ref: ref,
+			Properties: props,
+		})
+	}
+
+	// @Counted / @Metered / @Gauge annotations.
+	for _, m := range obsMetricAnnoRE.FindAllStringSubmatchIndex(source, -1) {
+		anno := source[m[2]:m[3]]
+		metricName := ""
+		if m[4] >= 0 {
+			metricName = source[m[4]:m[5]]
+		}
+		methodName := source[m[6]:m[7]]
+		name := metricName
+		if name == "" {
+			name = methodName
+		}
+		ref := "scope:pattern:obs_metric:" + fp + ":" + obsMetricAnnoType(anno) + ":" + methodName
+		props := map[string]any{
+			"kind":        "metric",
+			"signal":      "metric",
+			"metric_type": obsMetricAnnoType(anno),
+			"library":     "annotation",
+			"method":      methodName,
+			"framework":   fw,
+		}
+		if metricName != "" {
+			props["metric_name"] = metricName
+		}
+		addEntity(result, seen, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "metric",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_METRIC", Ref: ref,
+			Properties: props,
+		})
+	}
+}
+
+// extractTracing handles the trace_extraction cell.
+func extractTracing(result *PatternResult, seen map[string]bool, source, fp, fw string) {
+	// @WithSpan (OpenTelemetry).
+	for _, m := range obsWithSpanRE.FindAllStringSubmatchIndex(source, -1) {
+		spanName := ""
+		if m[2] >= 0 {
+			spanName = source[m[2]:m[3]]
+		}
+		methodName := source[m[4]:m[5]]
+		name := spanName
+		if name == "" {
+			name = methodName
+		}
+		ref := "scope:pattern:obs_trace_span:" + fp + ":withspan:" + methodName
+		props := map[string]any{
+			"kind":      "trace_span",
+			"signal":    "trace",
+			"span_kind": "annotation",
+			"library":   "otel",
+			"method":    methodName,
+			"framework": fw,
+		}
+		if spanName != "" {
+			props["span_name"] = spanName
+		}
+		addEntity(result, seen, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "trace_span",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_TRACE", Ref: ref,
+			Properties: props,
+		})
+	}
+
+	// @Observed (Micrometer Tracing).
+	for _, m := range obsObservedRE.FindAllStringSubmatchIndex(source, -1) {
+		spanName := ""
+		if m[2] >= 0 {
+			spanName = source[m[2]:m[3]]
+		}
+		methodName := source[m[4]:m[5]]
+		name := spanName
+		if name == "" {
+			name = methodName
+		}
+		ref := "scope:pattern:obs_trace_span:" + fp + ":observed:" + methodName
+		props := map[string]any{
+			"kind":      "trace_span",
+			"signal":    "trace",
+			"span_kind": "annotation",
+			"library":   "micrometer",
+			"method":    methodName,
+			"framework": fw,
+		}
+		if spanName != "" {
+			props["span_name"] = spanName
+		}
+		addEntity(result, seen, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "trace_span",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_TRACE", Ref: ref,
+			Properties: props,
+		})
+	}
+
+	// Programmatic OTel spans: tracer.spanBuilder("name").
+	for _, m := range obsSpanBuilderRE.FindAllStringSubmatchIndex(source, -1) {
+		spanName := source[m[2]:m[3]]
+		ref := "scope:pattern:obs_trace_span:" + fp + ":otel:" + spanName
+		addEntity(result, seen, SecondaryEntity{
+			Name: spanName, Kind: "SCOPE.Pattern", Subtype: "trace_span",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_TRACE", Ref: ref,
+			Properties: map[string]any{
+				"kind":      "trace_span",
+				"signal":    "trace",
+				"span_kind": "programmatic",
+				"library":   "otel",
+				"span_name": spanName,
+				"framework": fw,
+			},
+		})
+	}
+
+	// Programmatic Micrometer Tracing spans: tracer.nextSpan().
+	if obsNextSpanRE.MatchString(source) {
+		loc := obsNextSpanRE.FindStringIndex(source)
+		ref := "scope:pattern:obs_trace_span:" + fp + ":micrometer:next_span"
+		addEntity(result, seen, SecondaryEntity{
+			Name: "nextSpan", Kind: "SCOPE.Pattern", Subtype: "trace_span",
+			SourceFile: fp,
+			LineStart:  lineOf(source, loc[0]), LineEnd: lineOf(source, loc[0]),
+			Provenance: "INFERRED_FROM_OBSERVABILITY_TRACE", Ref: ref,
+			Properties: map[string]any{
+				"kind":      "trace_span",
+				"signal":    "trace",
+				"span_kind": "programmatic",
+				"library":   "micrometer",
+				"framework": fw,
+			},
+		})
+	}
+}
+
+// obsMeterType normalises a Micrometer builder type to a metric_type value.
+func obsMeterType(meterType string) string {
+	switch meterType {
+	case "Counter":
+		return "counter"
+	case "Timer", "LongTaskTimer":
+		return "timer"
+	case "Gauge":
+		return "gauge"
+	case "DistributionSummary":
+		return "summary"
+	default:
+		return meterType
+	}
+}
+
+// obsMetricAnnoType normalises a metric annotation name to a metric_type value.
+func obsMetricAnnoType(anno string) string {
+	switch anno {
+	case "Counted":
+		return "counter"
+	case "Metered":
+		return "meter"
+	case "Gauge":
+		return "gauge"
+	default:
+		return anno
+	}
+}
+
+// obsFieldNameNear resolves the logger field name declared on the same
+// statement as a *.getLogger(...) call site. It scans backward to the start of
+// the statement (previous `;`, `{`, or `}` or start of file) and looks for a
+// `Logger <name> =` declaration. Returns "" when the call is not part of a
+// field declaration (e.g. an inline `LoggerFactory.getLogger(x).info(...)`).
+func obsFieldNameNear(source string, callOffset int) string {
+	start := callOffset
+	for start > 0 {
+		c := source[start-1]
+		if c == ';' || c == '{' || c == '}' || c == '\n' {
+			break
+		}
+		start--
+	}
+	stmt := source[start:callOffset]
+	if m := obsLoggerFieldRE.FindStringSubmatch(stmt); m != nil {
+		return m[1]
+	}
+	return ""
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3906,7 +3906,6 @@ records:
           issues_implemented: ["2985"]
           verified_at: "2026-05-29"
 
-<<<<<<< HEAD
   lang.java.orm.eclipselink:
     capabilities:
       Models:
@@ -4049,7 +4048,6 @@ records:
           tests:
             - file: internal/custom/java/orm_extractors_test.go
           issues_implemented: ["3007"]
-=======
   lang.java.framework.akka-http:
     capabilities:
       Observability:
@@ -4319,7 +4317,6 @@ records:
           tests:
             - file: internal/custom/java/extractors_test.go
           issues_implemented: ["3006"]
->>>>>>> 9473df6e0 (feat(java): observability extraction (SLF4J, Micrometer, OTel) (#3006))
           verified_at: "2026-05-29"
   lang.python.framework.cherrypy:
     capabilities:

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -1976,6 +1976,34 @@ records:
 
   lang.java.framework.jakarta-ee:
     capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
       Transactions:
         transaction_boundary_extraction:
           status: partial
@@ -2063,6 +2091,34 @@ records:
 
   lang.java.framework.microprofile:
     capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
       Auth:
         auth_coverage:
           status: partial
@@ -2145,6 +2201,34 @@ records:
 
   lang.java.framework.spring-boot:
     capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
       AOP:
         aspect_extraction:
           status: partial
@@ -2543,6 +2627,34 @@ records:
 
   lang.java.framework.spring-webflux:
     capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
       AOP:
         aspect_extraction:
           status: partial
@@ -3794,6 +3906,7 @@ records:
           issues_implemented: ["2985"]
           verified_at: "2026-05-29"
 
+<<<<<<< HEAD
   lang.java.orm.eclipselink:
     capabilities:
       Models:
@@ -3936,6 +4049,277 @@ records:
           tests:
             - file: internal/custom/java/orm_extractors_test.go
           issues_implemented: ["3007"]
+=======
+  lang.java.framework.akka-http:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+  lang.java.framework.dropwizard:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+  lang.java.framework.helidon:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+  lang.java.framework.javalin:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+  lang.java.framework.jaxrs:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+  lang.java.framework.micronaut:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+  lang.java.framework.quarkus:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+  lang.java.framework.struts:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+  lang.java.framework.vertx:
+    capabilities:
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractLogging, logLibraryFor, obsFieldNameNear]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractMetrics, obsMeterType, obsMetricAnnoType]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+          verified_at: "2026-05-29"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/observability.go
+              functions: [ExtractObservability, extractTracing, canonicalObsFramework]
+          tests:
+            - file: internal/custom/java/extractors_test.go
+          issues_implemented: ["3006"]
+>>>>>>> 9473df6e0 (feat(java): observability extraction (SLF4J, Micrometer, OTel) (#3006))
           verified_at: "2026-05-29"
   lang.python.framework.cherrypy:
     capabilities:


### PR DESCRIPTION
## Summary

B-build (#3006, epic #2847): adds a Java observability custom extractor wiring the **Observability lane** (`log_extraction` / `metric_extraction` / `trace_extraction`) which was entirely missing across the JVM backend frameworks.

New file `internal/custom/java/observability.go` (`ExtractObservability`), modelled on `spring_aop.go` / `microprofile.go`. **No new entity Kind** — reuses `SCOPE.Pattern` per the #2839 decorate-don't-invent discipline; observability role lives in the entity `Subtype` + `kind` property.

## Detection

- **log_extraction** — `@Slf4j`, `LoggerFactory.getLogger` (slf4j), `LogManager.getLogger` (log4j), `Logger.getLogger` (jul) logger acquisition; `log.<level>(...)` / `logger.<level>(...)` statement calls carrying `log_level`.
- **metric_extraction** — Micrometer `Counter/Timer/Gauge/DistributionSummary.builder("name")`, `MeterRegistry`, `@Timed`; MicroProfile `@Counted`/`@Metered`/`@Gauge`. Emits `metric_type` + `metric_name`.
- **trace_extraction** — OpenTelemetry `@WithSpan` + `tracer.spanBuilder("name")`; Micrometer Tracing `@Observed` + `tracer.nextSpan()`. Emits `span_name` + `span_kind` (annotation/programmatic).

Framework-gated to the JVM backends; no-ops for non-JVM-backend frameworks and non-java languages.

## Coverage matrix

Flips `log_extraction` / `metric_extraction` / `trace_extraction` from `missing` → **`partial`** on 13 JVM backend records: akka-http, dropwizard, helidon, jakarta-ee, javalin, jaxrs, micronaut, microprofile, quarkus, spring-boot, spring-webflux, struts, vertx (39 cells).

**Honest `partial`, not `full`**: detection is regex-based and file-local — a logger imported in one file and used in another is not correlated, and non-literal metric/span name expressions are not resolved.

`capability-map.yaml` + generated `docs/coverage/detail/*.md` + `registry.json` updated. `coverage validate` → **0 errors**; `coverage fmt --check` canonical; `gen` byte-stable.

## Tests

`internal/custom/java/extractors_test.go` — 7 new tests: SLF4J logging, logger-factory variants (slf4j/log4j/jul), Micrometer metrics, MicroProfile metrics, OTel tracing, Micrometer tracing, framework gating.

Closes #3006

🤖 Generated with [Claude Code](https://claude.com/claude-code)