### PR TITLE
feat(python): Type System extraction — Protocol/Enum/TypedDict/dataclass/type-alias (#2989)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -80,23 +80,23 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/8 | |
-| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/8 | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 | [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -12,23 +12,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/8 | |
-| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 7/21 | ❌ 0/8 | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -31896,20 +31896,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -32102,20 +32110,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -32472,20 +32488,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -32687,20 +32711,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -32905,20 +32937,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -33266,20 +33306,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -33480,20 +33528,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -33696,20 +33752,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -33899,20 +33963,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -34127,20 +34199,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -34333,20 +34413,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -34536,20 +34624,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -34742,20 +34838,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -35115,20 +35219,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -35321,20 +35433,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -35528,20 +35648,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -35734,20 +35862,28 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/python/types.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -400,6 +400,18 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		emitGenericDecoratorProperties(root, file, &entities)
 	}()
 
+	// Issue #2989 — Type System extraction. Stamps pattern_type +
+	// structural properties on Protocol / Enum / TypedDict / NamedTuple /
+	// dataclass class entities and emits SCOPE.Schema/type_alias entities for
+	// module-level type aliases (X = Union[...], X: TypeAlias = ..., PEP 695
+	// `type X = ...`). Mirrors the TypeScript type-extraction precedent
+	// (#1343). Runs after the primary walk so the class entities it annotates
+	// already exist. Append-and-annotate only — never removes prior entities.
+	func() {
+		defer func() { _ = recover() }()
+		applyTypeSystemAnnotations(root, file, &entities)
+	}()
+
 	// Issue #1991 — __init__.py re-export annotation.
 	// Stamps re_export / package_init / public / alias properties on
 	// IMPORTS edges of package __init__.py files. Returns the public

--- a/internal/extractors/python/types.go
+++ b/internal/extractors/python/types.go
@@ -1,0 +1,633 @@
+// Python Type System extraction (issue #2989).
+//
+// Mirrors the TypeScript type-extraction precedent (issue #1343) so the two
+// stacks emit comparable SCOPE.Schema entities and cross-stack type-drift
+// detection (Python TypedDict ↔ TypeScript interface) can join on the same
+// kind/subtype taxonomy.
+//
+// The pass is append-and-annotate only — it never removes or re-keys entities
+// emitted by the primary walk:
+//
+//   - class X(Protocol):            → stamp the existing class entity with
+//     pattern_type="protocol" + protocol_methods
+//     (capability: interface_extraction)
+//   - class X(Enum/IntEnum/StrEnum/ → stamp pattern_type="enum" + enum_members
+//     Flag/IntFlag, incl. enum.Enum)  (capability: enum_extraction)
+//   - class X(TypedDict):           → stamp pattern_type="typed_dict" + fields
+//   - @dataclass class X / NamedTuple
+//     → stamp pattern_type="dataclass"/"named_tuple"
+//   - fields  (capability: type_extraction)
+//   - X = Union[...] / X: TypeAlias = ...
+//     / type X = ...  (PEP 695)     → emit a NEW SCOPE.Schema/type_alias entity
+//     (capability: type_alias_extraction)
+//
+// Stamping (rather than synthesising duplicate class nodes) keeps the entity
+// graph deduplicated: the primary walk already emitted exactly one
+// SCOPE.Component/class per Protocol/Enum/TypedDict/dataclass; this pass only
+// adds queryable Properties so archigraph_inspect can surface the type
+// contract and archigraph_find can rank type names. Type aliases are the one
+// shape with no pre-existing entity, so they are emitted fresh as SCOPE.Schema.
+package python
+
+import (
+	"strconv"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// enumBaseNames are the stdlib enum base classes whose presence in a class's
+// base list marks it as an enumeration (enum_extraction). Matched on the leaf
+// identifier so both bare (`Enum`) and dotted (`enum.Enum`) forms qualify.
+var enumBaseNames = map[string]struct{}{
+	"Enum": {}, "IntEnum": {}, "StrEnum": {}, "Flag": {}, "IntFlag": {}, "ReprEnum": {},
+}
+
+// dataclassDecoratorNames are the decorator leaf names that mark a class as a
+// dataclass (type_extraction). attrs (`@attr.s` / `@define`) and pydantic are
+// intentionally out of scope here — they are handled by dedicated framework
+// passes — so we keep this to the stdlib dataclasses decorator.
+var dataclassDecoratorNames = map[string]struct{}{
+	"dataclass": {},
+}
+
+// applyTypeSystemAnnotations is the entry point wired into Extract. It scans
+// every top-level (and nested) class_definition / decorated class for a
+// Type System shape and stamps pattern_type + structural properties on the
+// matching SCOPE.Component/class entity, and emits a fresh SCOPE.Schema entity
+// for every module-level type-alias assignment.
+//
+// Runs after the primary walk so the class entities it annotates already
+// exist in *out. Append-only for type aliases; in-place stamp for classes.
+func applyTypeSystemAnnotations(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+	if root == nil {
+		return
+	}
+
+	// Pass 1 — annotate class-based type constructs in place.
+	for _, cls := range findAll(root, "class_definition") {
+		annotateTypeClass(cls, file, out)
+	}
+
+	// Pass 2 — emit type-alias entities. Both the PEP 695 `type X = ...`
+	// statement and the assignment-based forms (`X = Union[...]`,
+	// `X: TypeAlias = ...`) are scanned at module scope. Class-body
+	// assignments are excluded so a Model field annotated with `TypeAlias`
+	// (vanishingly rare, but possible) inside a class body does not surface
+	// a stray module-level type alias.
+	for _, ts := range findAll(root, "type_alias_statement") {
+		if ent, ok := buildPEP695TypeAlias(ts, file); ok {
+			*out = append(*out, ent)
+		}
+	}
+	for _, asn := range moduleLevelAssignments(root) {
+		if ent, ok := buildAssignmentTypeAlias(asn, file); ok {
+			*out = append(*out, ent)
+		}
+	}
+}
+
+// annotateTypeClass inspects one class_definition node, classifies it against
+// the Type System taxonomy from its base list (+ decorators), and stamps the
+// matching SCOPE.Component/class entity in *out. No-op for ordinary classes.
+func annotateTypeClass(cls *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+	nameNode := cls.ChildByFieldName("name")
+	if nameNode == nil {
+		return
+	}
+	bareName := nodeText(nameNode, file.Content)
+	if bareName == "" {
+		return
+	}
+
+	bases := classBaseLeafNames(cls, file.Content)
+	if len(bases) == 0 && !classHasDataclassDecorator(cls, file.Content) {
+		return
+	}
+
+	var patternType string
+	props := map[string]string{}
+
+	switch {
+	case baseSetContains(bases, "Protocol"):
+		// interface_extraction — a structural-typing contract.
+		patternType = "protocol"
+		if methods := classMethodNames(cls, file.Content); len(methods) > 0 {
+			props["protocol_methods"] = strings.Join(methods, ", ")
+		}
+	case baseSetContainsAny(bases, enumBaseNames):
+		// enum_extraction.
+		patternType = "enum"
+		if members := classEnumMembers(cls, file.Content); len(members) > 0 {
+			props["enum_members"] = strings.Join(members, ", ")
+		}
+	case baseSetContains(bases, "TypedDict"):
+		// type_extraction — a typed dict shape.
+		patternType = "typed_dict"
+		if fields := classAnnotatedFields(cls, file.Content); len(fields) > 0 {
+			props["typed_fields"] = strings.Join(fields, ", ")
+		}
+	case baseSetContains(bases, "NamedTuple"):
+		// type_extraction — a named-tuple shape.
+		patternType = "named_tuple"
+		if fields := classAnnotatedFields(cls, file.Content); len(fields) > 0 {
+			props["typed_fields"] = strings.Join(fields, ", ")
+		}
+	case classHasDataclassDecorator(cls, file.Content):
+		// type_extraction — a @dataclass.
+		patternType = "dataclass"
+		if fields := classAnnotatedFields(cls, file.Content); len(fields) > 0 {
+			props["typed_fields"] = strings.Join(fields, ", ")
+		}
+	default:
+		return
+	}
+
+	if len(bases) > 0 {
+		props["type_bases"] = strings.Join(bases, ", ")
+	}
+	props["pattern_type"] = patternType
+
+	stampClassTypeProps(out, file.Path, bareName, props)
+}
+
+// stampClassTypeProps finds the SCOPE.Component/class entity for bareName in
+// the given file and merges the type-system properties onto it. The primary
+// walk qualifies nested class names with a dotted parent path, so the match is
+// done on the trailing leaf of entity.Name to cover both top-level and nested
+// classes. Existing keys are preserved (specialised framework stamps win).
+func stampClassTypeProps(out *[]types.EntityRecord, filePath, bareName string, props map[string]string) {
+	for i := range *out {
+		e := &(*out)[i]
+		if e.Kind != "SCOPE.Component" || e.Subtype != "class" || e.SourceFile != filePath {
+			continue
+		}
+		leaf := e.Name
+		if dot := strings.LastIndexByte(leaf, '.'); dot >= 0 {
+			leaf = leaf[dot+1:]
+		}
+		if leaf != bareName {
+			continue
+		}
+		if e.Properties == nil {
+			e.Properties = map[string]string{}
+		}
+		for k, v := range props {
+			if _, exists := e.Properties[k]; !exists {
+				e.Properties[k] = v
+			}
+		}
+		return
+	}
+}
+
+// classBaseLeafNames returns the leaf identifier of every base class declared
+// in the class_definition's argument_list. `enum.Enum` → "Enum",
+// `typing.Protocol` → "Protocol", `TypedDict` → "TypedDict". Keyword arguments
+// (metaclass=, total=) are skipped. Generic subscripts (`Protocol[T]`) reduce
+// to the leaf of the value being subscripted.
+func classBaseLeafNames(cls *sitter.Node, src []byte) []string {
+	args := cls.ChildByFieldName("superclasses")
+	if args == nil {
+		// Grammar exposes the base list as an unnamed argument_list child.
+		for i := 0; i < int(cls.NamedChildCount()); i++ {
+			if c := cls.NamedChild(i); c != nil && c.Type() == "argument_list" {
+				args = c
+				break
+			}
+		}
+	}
+	if args == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		arg := args.NamedChild(i)
+		if arg == nil {
+			continue
+		}
+		if leaf := baseLeafName(arg, src); leaf != "" {
+			out = append(out, leaf)
+		}
+	}
+	return out
+}
+
+// baseLeafName reduces a single base-class expression node to its leaf
+// identifier. Returns "" for keyword arguments (metaclass=, total=).
+func baseLeafName(arg *sitter.Node, src []byte) string {
+	switch arg.Type() {
+	case "identifier":
+		return nodeText(arg, src)
+	case "attribute":
+		if a := arg.ChildByFieldName("attribute"); a != nil {
+			return nodeText(a, src)
+		}
+	case "subscript":
+		// Protocol[T], Generic[T] — leaf of the subscripted value.
+		if v := arg.ChildByFieldName("value"); v != nil {
+			return baseLeafName(v, src)
+		}
+	case "keyword_argument":
+		return ""
+	}
+	return ""
+}
+
+// classHasDataclassDecorator reports whether the class_definition is wrapped in
+// a decorated_definition whose decorator list includes @dataclass (bare or
+// `@dataclasses.dataclass`, with or without a call: `@dataclass(frozen=True)`).
+func classHasDataclassDecorator(cls *sitter.Node, src []byte) bool {
+	parent := cls.Parent()
+	if parent == nil || parent.Type() != "decorated_definition" {
+		return false
+	}
+	for i := 0; i < int(parent.NamedChildCount()); i++ {
+		dec := parent.NamedChild(i)
+		if dec == nil || dec.Type() != "decorator" {
+			continue
+		}
+		if leaf := decoratorLeafName(dec, src); leaf != "" {
+			if _, ok := dataclassDecoratorNames[leaf]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// decoratorLeafName extracts the leaf identifier of a decorator node, handling
+// `@name`, `@mod.name`, and the call forms `@name(...)` / `@mod.name(...)`.
+func decoratorLeafName(dec *sitter.Node, src []byte) string {
+	// A decorator's named child is the expression after '@'.
+	for i := 0; i < int(dec.NamedChildCount()); i++ {
+		expr := dec.NamedChild(i)
+		if expr == nil {
+			continue
+		}
+		switch expr.Type() {
+		case "identifier":
+			return nodeText(expr, src)
+		case "attribute":
+			if a := expr.ChildByFieldName("attribute"); a != nil {
+				return nodeText(a, src)
+			}
+		case "call":
+			if fn := expr.ChildByFieldName("function"); fn != nil {
+				return decoratorLeafFromExpr(fn, src)
+			}
+		}
+	}
+	return ""
+}
+
+// decoratorLeafFromExpr reduces a decorator-call function expression to its
+// leaf identifier (`dataclass` from `dataclasses.dataclass(...)`).
+func decoratorLeafFromExpr(fn *sitter.Node, src []byte) string {
+	switch fn.Type() {
+	case "identifier":
+		return nodeText(fn, src)
+	case "attribute":
+		if a := fn.ChildByFieldName("attribute"); a != nil {
+			return nodeText(a, src)
+		}
+	}
+	return ""
+}
+
+// classMethodNames returns the names of methods (function_definition nodes)
+// declared directly in the class body — used for protocol_methods.
+func classMethodNames(cls *sitter.Node, src []byte) []string {
+	body := cls.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		child := body.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		fn := child
+		if child.Type() == "decorated_definition" {
+			fn = child.ChildByFieldName("definition")
+		}
+		if fn != nil && fn.Type() == "function_definition" {
+			if n := fn.ChildByFieldName("name"); n != nil {
+				out = append(out, nodeText(n, src))
+			}
+		}
+	}
+	return out
+}
+
+// classEnumMembers returns the names of enum members declared in the class
+// body (`RED = 1` → "RED", `auto()` assignments included). Dunder assignments
+// and methods are skipped.
+func classEnumMembers(cls *sitter.Node, src []byte) []string {
+	body := cls.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		stmt := body.NamedChild(i)
+		if stmt == nil || stmt.Type() != "expression_statement" {
+			continue
+		}
+		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+			asn := stmt.NamedChild(j)
+			if asn == nil || asn.Type() != "assignment" {
+				continue
+			}
+			left := asn.ChildByFieldName("left")
+			if left == nil || left.Type() != "identifier" {
+				continue
+			}
+			name := nodeText(left, src)
+			if name == "" || strings.HasPrefix(name, "__") {
+				continue
+			}
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// classAnnotatedFields returns the names of annotated class-body fields
+// (`x: int`, `name: str = ""`) used for TypedDict / NamedTuple / dataclass
+// shapes. Only annotated assignments count — a bare `x = 1` is not a field of
+// a TypedDict and is skipped.
+func classAnnotatedFields(cls *sitter.Node, src []byte) []string {
+	body := cls.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(body.NamedChildCount()); i++ {
+		stmt := body.NamedChild(i)
+		if stmt == nil || stmt.Type() != "expression_statement" {
+			continue
+		}
+		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+			asn := stmt.NamedChild(j)
+			if asn == nil || asn.Type() != "assignment" {
+				continue
+			}
+			// Annotated form: left has a sibling `type` field.
+			if asn.ChildByFieldName("type") == nil {
+				continue
+			}
+			left := asn.ChildByFieldName("left")
+			if left == nil || left.Type() != "identifier" {
+				continue
+			}
+			name := nodeText(left, src)
+			if name == "" || strings.HasPrefix(name, "__") {
+				continue
+			}
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// moduleLevelAssignments returns the assignment nodes that live directly at
+// module scope (children of the root module's top-level expression_statements),
+// excluding any assignment nested inside a class or function body.
+func moduleLevelAssignments(root *sitter.Node) []*sitter.Node {
+	var out []*sitter.Node
+	for i := 0; i < int(root.NamedChildCount()); i++ {
+		stmt := root.NamedChild(i)
+		if stmt == nil || stmt.Type() != "expression_statement" {
+			continue
+		}
+		for j := 0; j < int(stmt.NamedChildCount()); j++ {
+			if c := stmt.NamedChild(j); c != nil && c.Type() == "assignment" {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+// buildAssignmentTypeAlias recognises the assignment-based type-alias shapes
+// and, when matched, returns a SCOPE.Schema/type_alias entity:
+//
+//	X: TypeAlias = <rhs>        — explicit PEP 613 annotation (highest signal)
+//	X = Union[...] | Optional[...] | Dict[...] | List[...] | ...  (typing subscript)
+//	X = A | B                   — PEP 604 union of bare type names (PascalCase)
+//
+// A plain `X = SomeValue()` or `X = 3` is NOT a type alias and returns false.
+func buildAssignmentTypeAlias(asn *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	left := asn.ChildByFieldName("left")
+	if left == nil || left.Type() != "identifier" {
+		return types.EntityRecord{}, false
+	}
+	name := nodeText(left, file.Content)
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	right := asn.ChildByFieldName("right")
+	if right == nil {
+		return types.EntityRecord{}, false
+	}
+
+	annotated := false
+	if ann := asn.ChildByFieldName("type"); ann != nil {
+		// `X: TypeAlias = ...` — the annotation leaf must be TypeAlias.
+		if typeAnnotationLeaf(ann, file.Content) == "TypeAlias" {
+			annotated = true
+		}
+	}
+
+	if !annotated && !rhsLooksLikeTypeExpression(right, file.Content) {
+		return types.EntityRecord{}, false
+	}
+
+	return newTypeAliasEntity(name, right, asn, file, annotated), true
+}
+
+// typeAnnotationLeaf reduces an annotation node (the `type` field of an
+// annotated assignment) to its leaf identifier.
+func typeAnnotationLeaf(ann *sitter.Node, src []byte) string {
+	target := ann
+	if ann.Type() == "type" && ann.NamedChildCount() > 0 {
+		target = ann.NamedChild(0)
+	}
+	switch target.Type() {
+	case "identifier":
+		return nodeText(target, src)
+	case "attribute":
+		if a := target.ChildByFieldName("attribute"); a != nil {
+			return nodeText(a, src)
+		}
+	}
+	return ""
+}
+
+// typingAliasHeads are the typing-module constructors that, when used as the
+// head of a subscript RHS, unambiguously mark the assignment as a type alias.
+var typingAliasHeads = map[string]struct{}{
+	"Union": {}, "Optional": {}, "List": {}, "Dict": {}, "Tuple": {}, "Set": {},
+	"FrozenSet": {}, "Sequence": {}, "Mapping": {}, "Iterable": {}, "Callable": {},
+	"Literal": {}, "Annotated": {}, "Type": {}, "ClassVar": {}, "Final": {},
+	"Awaitable": {}, "Coroutine": {}, "AsyncIterable": {}, "AsyncIterator": {},
+	"DefaultDict": {}, "OrderedDict": {}, "Deque": {}, "Counter": {}, "ChainMap": {},
+}
+
+// rhsLooksLikeTypeExpression reports whether the right-hand side of a bare
+// assignment is a type expression worth treating as a type alias. Conservative
+// by design: only the typing-module subscript heads and PEP 604 unions of
+// PascalCase type names qualify, so runtime-value assignments are never
+// misclassified.
+func rhsLooksLikeTypeExpression(rhs *sitter.Node, src []byte) bool {
+	switch rhs.Type() {
+	case "subscript":
+		// Union[...], Dict[str, int], etc. — match the subscripted head leaf.
+		if v := rhs.ChildByFieldName("value"); v != nil {
+			head := baseLeafName(v, src)
+			if _, ok := typingAliasHeads[head]; ok {
+				return true
+			}
+		}
+	case "binary_operator":
+		// PEP 604 union: `A | B`. Require BOTH operands to be PascalCase type
+		// names (or subscripts thereof) so `x = a | b` (bitwise int) is excluded.
+		if op := rhs.ChildByFieldName("operator"); op != nil && nodeText(op, src) == "|" {
+			l := rhs.ChildByFieldName("left")
+			r := rhs.ChildByFieldName("right")
+			return isTypeOperand(l, src) && isTypeOperand(r, src)
+		}
+	}
+	return false
+}
+
+// isTypeOperand reports whether a PEP 604 union operand is a type reference:
+// a PascalCase identifier, a None literal, a dotted attribute whose leaf is
+// PascalCase, or a subscript over one of those.
+func isTypeOperand(n *sitter.Node, src []byte) bool {
+	if n == nil {
+		return false
+	}
+	switch n.Type() {
+	case "none":
+		return true
+	case "identifier":
+		return isPascalCase(nodeText(n, src))
+	case "attribute":
+		if a := n.ChildByFieldName("attribute"); a != nil {
+			return isPascalCase(nodeText(a, src))
+		}
+	case "subscript":
+		if v := n.ChildByFieldName("value"); v != nil {
+			return isTypeOperand(v, src)
+		}
+	case "binary_operator":
+		// Nested union: A | B | C.
+		return isTypeOperand(n.ChildByFieldName("left"), src) &&
+			isTypeOperand(n.ChildByFieldName("right"), src)
+	}
+	return false
+}
+
+// isPascalCase reports whether s begins with an uppercase ASCII letter — a
+// cheap heuristic for "this identifier names a type, not a runtime value".
+func isPascalCase(s string) bool {
+	if s == "" {
+		return false
+	}
+	c := s[0]
+	return c >= 'A' && c <= 'Z'
+}
+
+// buildPEP695TypeAlias builds a SCOPE.Schema/type_alias entity for a PEP 695
+// `type X = ...` statement (Python 3.12+). These are unambiguous type aliases
+// by grammar, so no RHS heuristic is needed.
+func buildPEP695TypeAlias(ts *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	// type_alias_statement children: type (lhs name) '=' type (rhs).
+	left := ts.ChildByFieldName("left")
+	right := ts.ChildByFieldName("right")
+	if left == nil {
+		// Fallback: first `type` named child holds the alias name.
+		for i := 0; i < int(ts.NamedChildCount()); i++ {
+			if c := ts.NamedChild(i); c != nil && c.Type() == "type" {
+				left = c
+				break
+			}
+		}
+	}
+	name := typeAnnotationLeaf(left, file.Content)
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	return newTypeAliasEntity(name, right, ts, file, true), true
+}
+
+// newTypeAliasEntity constructs the SCOPE.Schema/type_alias EntityRecord shared
+// by the PEP 695 and assignment code paths. rhs may be nil (then no type_body
+// property is set). The pep613 flag records whether the alias was explicitly
+// annotated / PEP 695 (vs inferred from a typing subscript heuristic).
+func newTypeAliasEntity(name string, rhs, span *sitter.Node, file extractor.FileInput, explicit bool) types.EntityRecord {
+	mod := filePathToModule(file.Path)
+	qn := name
+	if mod != "" {
+		qn = mod + "." + name
+	}
+
+	props := map[string]string{
+		"kind":         "SCOPE.Schema",
+		"subtype":      "type_alias",
+		"pattern_type": "type_alias",
+	}
+	if explicit {
+		props["explicit"] = "true"
+	}
+	if rhs != nil {
+		body := nodeText(rhs, file.Content)
+		if body != "" && len(body) <= 512 {
+			props["type_body"] = body
+		}
+	}
+
+	start := int(span.StartPoint().Row) + 1
+	end := int(span.EndPoint().Row) + 1
+	props["line"] = strconv.Itoa(start)
+
+	return types.EntityRecord{
+		Name:               name,
+		QualifiedName:      qn,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "type_alias",
+		Language:           "python",
+		SourceFile:         file.Path,
+		StartLine:          start,
+		EndLine:            end,
+		Signature:          "type " + name,
+		Properties:         props,
+		EnrichmentRequired: false,
+	}
+}
+
+// baseSetContains reports whether bases contains the exact leaf name target.
+func baseSetContains(bases []string, target string) bool {
+	for _, b := range bases {
+		if b == target {
+			return true
+		}
+	}
+	return false
+}
+
+// baseSetContainsAny reports whether any base leaf is a key of set.
+func baseSetContainsAny(bases []string, set map[string]struct{}) bool {
+	for _, b := range bases {
+		if _, ok := set[b]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extractors/python/types_test.go
+++ b/internal/extractors/python/types_test.go
@@ -1,0 +1,285 @@
+// Package python_test — issue #2989 Type System extraction tests.
+//
+// Verifies that the Python extractor classifies type-system constructs:
+//   - class X(Protocol)            → SCOPE.Component/class pattern_type="protocol"
+//   - class X(Enum/IntEnum/StrEnum)→ pattern_type="enum" + enum_members
+//   - class X(TypedDict)           → pattern_type="typed_dict" + typed_fields
+//   - @dataclass / NamedTuple      → pattern_type="dataclass"/"named_tuple"
+//   - X = Union[...] / X: TypeAlias = ... / type X = ...
+//     → SCOPE.Schema/type_alias entity
+package python_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findClass returns the SCOPE.Component/class entity whose trailing name leaf
+// matches name, or nil.
+func findClass(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind == "SCOPE.Component" && e.Subtype == "class" && e.Name == name {
+			return e
+		}
+	}
+	return nil
+}
+
+// findTypeAlias returns the SCOPE.Schema/type_alias entity named name, or nil.
+func findTypeAlias(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "type_alias" && e.Name == name {
+			return e
+		}
+	}
+	return nil
+}
+
+func TestTypeSystem_Protocol(t *testing.T) {
+	src := `
+from typing import Protocol
+
+class Serializer(Protocol):
+    def to_dict(self) -> dict: ...
+    def from_dict(self, d: dict) -> "Serializer": ...
+`
+	ents := extractPy(t, src, "app/contracts.py")
+	c := findClass(ents, "Serializer")
+	if c == nil {
+		t.Fatal("Serializer class entity not found")
+	}
+	if got := c.Properties["pattern_type"]; got != "protocol" {
+		t.Fatalf("pattern_type = %q, want protocol", got)
+	}
+	if got := c.Properties["protocol_methods"]; got != "to_dict, from_dict" {
+		t.Fatalf("protocol_methods = %q, want %q", got, "to_dict, from_dict")
+	}
+}
+
+func TestTypeSystem_Enum(t *testing.T) {
+	src := `
+import enum
+
+class Color(enum.Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+`
+	ents := extractPy(t, src, "app/colors.py")
+	c := findClass(ents, "Color")
+	if c == nil {
+		t.Fatal("Color class entity not found")
+	}
+	if got := c.Properties["pattern_type"]; got != "enum" {
+		t.Fatalf("pattern_type = %q, want enum", got)
+	}
+	if got := c.Properties["enum_members"]; got != "RED, GREEN, BLUE" {
+		t.Fatalf("enum_members = %q, want %q", got, "RED, GREEN, BLUE")
+	}
+}
+
+func TestTypeSystem_IntEnumAndStrEnum(t *testing.T) {
+	src := `
+from enum import IntEnum, StrEnum
+
+class Priority(IntEnum):
+    LOW = 1
+    HIGH = 9
+
+class Status(StrEnum):
+    OPEN = "open"
+    CLOSED = "closed"
+`
+	ents := extractPy(t, src, "app/enums.py")
+	for _, name := range []string{"Priority", "Status"} {
+		c := findClass(ents, name)
+		if c == nil {
+			t.Fatalf("%s class entity not found", name)
+		}
+		if got := c.Properties["pattern_type"]; got != "enum" {
+			t.Fatalf("%s pattern_type = %q, want enum", name, got)
+		}
+	}
+}
+
+func TestTypeSystem_TypedDict(t *testing.T) {
+	src := `
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+    year: int
+`
+	ents := extractPy(t, src, "app/schemas.py")
+	c := findClass(ents, "Movie")
+	if c == nil {
+		t.Fatal("Movie class entity not found")
+	}
+	if got := c.Properties["pattern_type"]; got != "typed_dict" {
+		t.Fatalf("pattern_type = %q, want typed_dict", got)
+	}
+	if got := c.Properties["typed_fields"]; got != "title, year" {
+		t.Fatalf("typed_fields = %q, want %q", got, "title, year")
+	}
+}
+
+func TestTypeSystem_Dataclass(t *testing.T) {
+	src := `
+from dataclasses import dataclass
+
+@dataclass
+class Point:
+    x: int
+    y: int = 0
+`
+	ents := extractPy(t, src, "app/geometry.py")
+	c := findClass(ents, "Point")
+	if c == nil {
+		t.Fatal("Point class entity not found")
+	}
+	if got := c.Properties["pattern_type"]; got != "dataclass" {
+		t.Fatalf("pattern_type = %q, want dataclass", got)
+	}
+	if got := c.Properties["typed_fields"]; got != "x, y" {
+		t.Fatalf("typed_fields = %q, want %q", got, "x, y")
+	}
+}
+
+func TestTypeSystem_DataclassWithArgs(t *testing.T) {
+	src := `
+import dataclasses
+
+@dataclasses.dataclass(frozen=True)
+class Config:
+    name: str
+`
+	ents := extractPy(t, src, "app/config.py")
+	c := findClass(ents, "Config")
+	if c == nil {
+		t.Fatal("Config class entity not found")
+	}
+	if got := c.Properties["pattern_type"]; got != "dataclass" {
+		t.Fatalf("pattern_type = %q, want dataclass", got)
+	}
+}
+
+func TestTypeSystem_NamedTuple(t *testing.T) {
+	src := `
+from typing import NamedTuple
+
+class Coordinate(NamedTuple):
+    lat: float
+    lon: float
+`
+	ents := extractPy(t, src, "app/geo.py")
+	c := findClass(ents, "Coordinate")
+	if c == nil {
+		t.Fatal("Coordinate class entity not found")
+	}
+	if got := c.Properties["pattern_type"]; got != "named_tuple" {
+		t.Fatalf("pattern_type = %q, want named_tuple", got)
+	}
+}
+
+func TestTypeSystem_TypeAlias_TypingSubscript(t *testing.T) {
+	src := `
+from typing import Union, Dict
+
+Vector = Union[int, float]
+Registry = Dict[str, int]
+`
+	ents := extractPy(t, src, "app/types.py")
+	v := findTypeAlias(ents, "Vector")
+	if v == nil {
+		t.Fatal("Vector type alias not found")
+	}
+	if got := v.Properties["pattern_type"]; got != "type_alias" {
+		t.Fatalf("Vector pattern_type = %q, want type_alias", got)
+	}
+	if got := v.Properties["type_body"]; got != "Union[int, float]" {
+		t.Fatalf("Vector type_body = %q", got)
+	}
+	if findTypeAlias(ents, "Registry") == nil {
+		t.Fatal("Registry type alias not found")
+	}
+}
+
+func TestTypeSystem_TypeAlias_ExplicitAnnotation(t *testing.T) {
+	src := `
+from typing import TypeAlias
+
+Coord: TypeAlias = tuple[int, int]
+`
+	ents := extractPy(t, src, "app/types.py")
+	c := findTypeAlias(ents, "Coord")
+	if c == nil {
+		t.Fatal("Coord type alias not found")
+	}
+	if got := c.Properties["explicit"]; got != "true" {
+		t.Fatalf("Coord explicit = %q, want true", got)
+	}
+}
+
+func TestTypeSystem_TypeAlias_PEP695(t *testing.T) {
+	src := `
+type Vector = list[float]
+type StringOrInt = str | int
+`
+	ents := extractPy(t, src, "app/types.py")
+	v := findTypeAlias(ents, "Vector")
+	if v == nil {
+		t.Fatal("Vector PEP 695 type alias not found")
+	}
+	if got := v.Properties["explicit"]; got != "true" {
+		t.Fatalf("Vector explicit = %q, want true", got)
+	}
+	if findTypeAlias(ents, "StringOrInt") == nil {
+		t.Fatal("StringOrInt PEP 695 type alias not found")
+	}
+}
+
+func TestTypeSystem_TypeAlias_PEP604Union(t *testing.T) {
+	src := `
+Identifier = UserId | OrderId | None
+`
+	ents := extractPy(t, src, "app/types.py")
+	if findTypeAlias(ents, "Identifier") == nil {
+		t.Fatal("Identifier PEP 604 union alias not found")
+	}
+}
+
+// TestTypeSystem_NoFalsePositiveOnRuntimeAssignment guards against
+// misclassifying ordinary runtime-value assignments as type aliases.
+func TestTypeSystem_NoFalsePositiveOnRuntimeAssignment(t *testing.T) {
+	src := `
+DEBUG = True
+count = compute() + 1
+flags = a | b
+router = Router()
+`
+	ents := extractPy(t, src, "app/settings.py")
+	for _, name := range []string{"DEBUG", "count", "flags", "router"} {
+		if findTypeAlias(ents, name) != nil {
+			t.Fatalf("%s misclassified as a type alias", name)
+		}
+	}
+}
+
+// TestTypeSystem_PlainClassNotAnnotated ensures ordinary classes are untouched.
+func TestTypeSystem_PlainClassNotAnnotated(t *testing.T) {
+	src := `
+class OrderService:
+    def place(self): ...
+`
+	ents := extractPy(t, src, "app/services.py")
+	c := findClass(ents, "OrderService")
+	if c == nil {
+		t.Fatal("OrderService class entity not found")
+	}
+	if got := c.Properties["pattern_type"]; got != "" {
+		t.Fatalf("OrderService unexpectedly stamped pattern_type = %q", got)
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -561,6 +561,43 @@ records:
 
   lang.python.framework.django-drf:
     capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full
@@ -779,6 +816,43 @@ records:
 
   lang.python.framework.flask:
     capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full
@@ -847,6 +921,43 @@ records:
 
   lang.python.framework.sanic:
     capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full
@@ -880,6 +991,43 @@ records:
 
   lang.python.framework.litestar:
     capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full
@@ -913,6 +1061,43 @@ records:
 
   lang.python.framework.robyn:
     capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full
@@ -946,6 +1131,43 @@ records:
 
   lang.python.framework.aiohttp:
     capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full
@@ -979,6 +1201,43 @@ records:
 
   lang.python.framework.bottle:
     capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full
@@ -1012,6 +1271,43 @@ records:
 
   lang.python.framework.fastapi:
     capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
       Routing:
         endpoint_synthesis:
           status: full
@@ -3573,4 +3869,355 @@ records:
           tests:
             - file: internal/custom/java/orm_extractors_test.go
           issues_implemented: ["3007"]
+          verified_at: "2026-05-29"
+  lang.python.framework.cherrypy:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+  lang.python.framework.django:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+  lang.python.framework.falcon:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+  lang.python.framework.hug:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+  lang.python.framework.pyramid:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+  lang.python.framework.quart:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+  lang.python.framework.starlette:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+  lang.python.framework.strawberry-graphql:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+  lang.python.framework.tornado:
+    capabilities:
+      Type System:
+        interface_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [applyTypeSystemAnnotations, annotateTypeClass, classBaseLeafNames]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_alias_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [buildAssignmentTypeAlias, buildPEP695TypeAlias, newTypeAliasEntity, rhsLooksLikeTypeExpression]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        enum_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classEnumMembers]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
+          verified_at: "2026-05-29"
+        type_extraction:
+          status: partial
+          symbols:
+            - file: internal/extractors/python/types.go
+              functions: [annotateTypeClass, classAnnotatedFields, classHasDataclassDecorator]
+          tests:
+            - file: internal/extractors/python/types_test.go
+          issues_implemented: ["2989"]
           verified_at: "2026-05-29"


### PR DESCRIPTION
## Summary

Implements **B-build: Type System** extraction for the Python `http_backend` stack (issue #2989). Adds a new language pass `internal/extractors/python/types.go` that mirrors the TypeScript precedent (#1343), so both stacks emit comparable `SCOPE.Schema` entities and cross-stack type-drift detection (Python `TypedDict` ↔ TypeScript `interface`) can join on the same kind/subtype taxonomy.

## What it extracts

| Construct | Result | Capability |
|---|---|---|
| `class X(Protocol)` | stamp class entity `pattern_type=protocol` + `protocol_methods` | `interface_extraction` |
| `class X(Enum/IntEnum/StrEnum/Flag/IntFlag)` incl. `enum.Enum` | `pattern_type=enum` + `enum_members` | `enum_extraction` |
| `class X(TypedDict)` / `NamedTuple` | `pattern_type=typed_dict`\|`named_tuple` + `typed_fields` | `type_extraction` |
| `@dataclass class X` | `pattern_type=dataclass` + `typed_fields` | `type_extraction` |
| `X = Union[...]` / `X: TypeAlias = ...` / `type X = ...` (PEP 695) / `A \| B` (PEP 604) | new `SCOPE.Schema`/`type_alias` entity | `type_alias_extraction` |

## Design notes

- **Append-and-annotate only.** The pass stamps the class entities the primary walk already emitted (no duplicate class nodes) and emits fresh `SCOPE.Schema`/`type_alias` entities for aliases (the one shape with no pre-existing entity). Wrapped in a `recover()` guard like the other supplemental passes.
- **No new `EntityKind`.** Reuses `SCOPE.Schema` for parity with the JS/TS extractor (#1343).
- **Conservative alias detection.** Bare-assignment RHS only qualifies when the head is a typing-module subscript (`Union`, `Dict`, `Optional`, …) or a PEP 604 union of PascalCase/`None` operands, so runtime-value assignments (`flags = a | b`, `router = Router()`) are never misclassified. Explicit `TypeAlias` annotations and PEP 695 statements always qualify.

## Coverage matrix

Promotes `interface_extraction` / `type_alias_extraction` / `enum_extraction` / `type_extraction` from **missing → partial** across all 17 Python `http_backend` records (django, django-drf, fastapi, flask, starlette, tornado, pyramid, aiohttp, bottle, cherrypy, falcon, hug, litestar, quart, robyn, sanic, strawberry-graphql). Adds `capability-map.yaml` entries (file + functions + tests + issue) for each and regenerates `docs/coverage/`.

## Gates

- `go test ./internal/extractors/python/ ./tools/coverage/ ./internal/types/` ✓
- `go build ./...` ✓ · `go vet ./...` ✓ · `gofmt` clean ✓
- determinism test (`cmd/archigraph`) ✓
- `coverage validate` → **0 errors** · `coverage gen` byte-stable

Closes #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)