### PR TITLE
coverage(python): substrate sweep for pyramid→rq batch — 18 missing→partial

### DIFF
--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -50,24 +50,24 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | language-wide Python effect sniffer detects Django ORM / SQLAlchemy db writes and reads; partial because Celery-specific task context is not disambiguated |
-| Dead code detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | dead code derived from reachability.go + entry_points_python.go; fires on all Python; partial because Celery task entry wiring via @app.task is not modelled |
 | Def use chain extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/def_use_python.go` | language-wide Python def-use sniffer captures variable defs/uses; partial for Celery task argument flows |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| Fs effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| HTTP effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | language-wide Python effect sniffer (open/pathlib/os/shutil) fires on any Python file; partial because Celery task file I/O is not disambiguated from worker code |
+| HTTP effect | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | language-wide Python HTTP-effect sniffer (requests/httpx/boto3) fires on any Python file; partial because Celery task outbound HTTP is not separated from unrelated code |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Mutation effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/module_cycle_pass.go` | language-agnostic Tarjan SCC over IMPORTS edges; fires on all Python modules; partial because task module cycles are not distinguished from app-level cycles |
+| Mutation effect | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_python.go` | language-wide Python mutation sniffer (self.attr=) fires on any Python file; partial for Celery task class attribute mutations |
+| Pure function tagging | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | derivative of effect propagation: any entity with no detected effect is tagged pure; fires on all Python entities; partial because task functions may have side effects missed by heuristic sniffers |
 | Reachability analysis | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/entry_points_python.go` | language-wide Python entry-point sniffer detects module-level test/main/lifecycle entry points; partial for Celery worker entry wiring |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
-| Sanitizer recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | language-wide Python sanitizer sniffer (parameterised SQL, bleach, pydantic schemas) fires on any Python file; partial for Celery task context |
 | Schema drift detection | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | Taint sink detection | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | language-wide Python effect sniffer recognises SQL/command-injection sink shapes; partial for Celery task context |
 | Taint source detection | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/taint_sites_python.go` | language-wide Python taint sniffer recognises request/env sources; partial for Celery task context |
 | Template pattern catalog | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/template_pattern_python.go` | language-wide Python template-pattern sniffer covers i18n/log/SQL patterns; partial for Celery-specific message formatting |
-| Vulnerability finding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | vulnerability_finding derives from taint_source+taint_sink co-occurrence (taint_flow.go); fires on all Python; partial for task queue context |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.dramatiq.md
+++ b/docs/coverage/detail/lang.python.framework.dramatiq.md
@@ -50,16 +50,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ✅ `full` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | — |
-| Dead code detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | dead code derived from reachability + entry-point sniffer; partial because dramatiq @actor entry wiring is not modelled |
 | Def use chain extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/def_use_python.go` | — |
 | Env fallback recognition | ✅ `full` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-28` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/module_cycle_pass.go` | language-agnostic Tarjan SCC over IMPORTS edges; fires on all Python modules; partial because task/actor module cycles are not distinguished from app-level cycles |
 | Mutation effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | — |
-| Pure function tagging | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | derivative of effect propagation; fires on all Python entities; partial because actor functions may have side effects missed by heuristic sniffers |
+| Reachability analysis | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | language-wide Python entry-point sniffer covers module-level __main__/test/lifecycle; partial because @dramatiq.actor entry wiring is not modelled |
 | Request shape extraction | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-27` | — | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_python.go` | — |
 | Sanitizer recognition | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/taint_sites_python.go` | — |
@@ -67,7 +67,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Taint sink detection | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/taint_sites_python.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/taint_sites_python.go` | — |
 | Template pattern catalog | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/template_pattern_python.go` | — |
-| Vulnerability finding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | derives from taint source+sink co-occurrence; fires on all Python; partial for dramatiq actor context |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.python.framework.rq.md
+++ b/docs/coverage/detail/lang.python.framework.rq.md
@@ -50,16 +50,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Constant propagation | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go` | — |
 | DB effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | — |
-| Dead code detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | dead code derived from reachability + entry-point sniffer; partial because RQ @job entry wiring is not modelled |
 | Def use chain extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/def_use_python.go` | — |
 | Env fallback recognition | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/constant_propagation.go`<br>`internal/substrate/python.go` | — |
 | Fs effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | — |
 | HTTP effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | — |
 | Import resolution quality | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/python.go` | — |
-| Module cycle detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/module_cycle_pass.go` | language-agnostic Tarjan SCC over IMPORTS edges; fires on all Python modules; partial because RQ job module cycles are not distinguished from app-level cycles |
 | Mutation effect | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/effect_sinks_python.go` | — |
-| Pure function tagging | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | derivative of effect propagation; fires on all Python entities; partial because RQ job functions may have side effects missed by heuristic sniffers |
+| Reachability analysis | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_python.go` | language-wide Python entry-point sniffer covers module-level __main__/test/lifecycle; partial because RQ @job entry wiring is not modelled |
 | Request shape extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/payload_shapes_python.go` | — |
 | Response shape extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/payload_shapes_python.go` | — |
 | Sanitizer recognition | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/taint_sites_python.go` | — |
@@ -67,7 +67,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Taint sink detection | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/taint_sites_python.go` | — |
 | Taint source detection | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/taint_sites_python.go` | — |
 | Template pattern catalog | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/substrate/template_pattern_python.go` | — |
-| Vulnerability finding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | ⚠️ `partial` | `2026-05-29` | 3047 | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_python.go` | derives from taint source+sink co-occurrence; fires on all Python; partial for RQ job context |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -32921,8 +32921,11 @@
             "verified_at": "2026-05-29"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3047",
+            "notes": "dead code derived from reachability.go + entry_points_python.go; fires on all Python; partial because Celery task entry wiring via @app.task is not modelled",
+            "verified_at": "2026-05-29"
           },
           "def_use_chain_extraction": {
             "status": "partial",
@@ -32937,12 +32940,18 @@
             "verified_at": "2026-05-28"
           },
           "fs_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3047",
+            "notes": "language-wide Python effect sniffer (open/pathlib/os/shutil) fires on any Python file; partial because Celery task file I/O is not disambiguated from worker code",
+            "verified_at": "2026-05-29"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3047",
+            "notes": "language-wide Python HTTP-effect sniffer (requests/httpx/boto3) fires on any Python file; partial because Celery task outbound HTTP is not separated from unrelated code",
+            "verified_at": "2026-05-29"
           },
           "import_resolution_quality": {
             "status": "partial",
@@ -32950,16 +32959,25 @@
             "verified_at": "2026-05-28"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3047",
+            "notes": "language-agnostic Tarjan SCC over IMPORTS edges; fires on all Python modules; partial because task module cycles are not distinguished from app-level cycles",
+            "verified_at": "2026-05-29"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/substrate/effect_sinks_python.go"],
+            "issue": "3047",
+            "notes": "language-wide Python mutation sniffer (self.attr=) fires on any Python file; partial for Celery task class attribute mutations",
+            "verified_at": "2026-05-29"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
+            "issue": "3047",
+            "notes": "derivative of effect propagation: any entity with no detected effect is tagged pure; fires on all Python entities; partial because task functions may have side effects missed by heuristic sniffers",
+            "verified_at": "2026-05-29"
           },
           "reachability_analysis": {
             "status": "partial",
@@ -32979,8 +32997,11 @@
             "verified_at": "2026-05-27"
           },
           "sanitizer_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
+            "issue": "3047",
+            "notes": "language-wide Python sanitizer sniffer (parameterised SQL, bleach, pydantic schemas) fires on any Python file; partial for Celery task context",
+            "verified_at": "2026-05-29"
           },
           "schema_drift_detection": {
             "status": "full",
@@ -33009,8 +33030,11 @@
             "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
+            "issue": "3047",
+            "notes": "vulnerability_finding derives from taint_source+taint_sink co-occurrence (taint_flow.go); fires on all Python; partial for task queue context",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -33740,8 +33764,11 @@
             "verified_at": "2026-05-29"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3047",
+            "notes": "dead code derived from reachability + entry-point sniffer; partial because dramatiq @actor entry wiring is not modelled",
+            "verified_at": "2026-05-29"
           },
           "def_use_chain_extraction": {
             "status": "partial",
@@ -33772,8 +33799,11 @@
             "verified_at": "2026-05-28"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3047",
+            "notes": "language-agnostic Tarjan SCC over IMPORTS edges; fires on all Python modules; partial because task/actor module cycles are not distinguished from app-level cycles",
+            "verified_at": "2026-05-29"
           },
           "mutation_effect": {
             "status": "partial",
@@ -33782,12 +33812,18 @@
             "verified_at": "2026-05-29"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
+            "issue": "3047",
+            "notes": "derivative of effect propagation; fires on all Python entities; partial because actor functions may have side effects missed by heuristic sniffers",
+            "verified_at": "2026-05-29"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3047",
+            "notes": "language-wide Python entry-point sniffer covers module-level __main__/test/lifecycle; partial because @dramatiq.actor entry wiring is not modelled",
+            "verified_at": "2026-05-29"
           },
           "request_shape_extraction": {
             "status": "full",
@@ -33829,8 +33865,11 @@
             "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
+            "issue": "3047",
+            "notes": "derives from taint source+sink co-occurrence; fires on all Python; partial for dramatiq actor context",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -35654,8 +35693,11 @@
             "verified_at": "2026-05-29"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3047",
+            "notes": "dead code derived from reachability + entry-point sniffer; partial because RQ @job entry wiring is not modelled",
+            "verified_at": "2026-05-29"
           },
           "def_use_chain_extraction": {
             "status": "partial",
@@ -35688,8 +35730,11 @@
             "verified_at": "2026-05-29"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3047",
+            "notes": "language-agnostic Tarjan SCC over IMPORTS edges; fires on all Python modules; partial because RQ job module cycles are not distinguished from app-level cycles",
+            "verified_at": "2026-05-29"
           },
           "mutation_effect": {
             "status": "partial",
@@ -35698,12 +35743,18 @@
             "verified_at": "2026-05-29"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/effect_propagation.go","internal/links/pure_function_pass.go"],
+            "issue": "3047",
+            "notes": "derivative of effect propagation; fires on all Python entities; partial because RQ job functions may have side effects missed by heuristic sniffers",
+            "verified_at": "2026-05-29"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/substrate/entry_points.go","internal/substrate/entry_points_python.go"],
+            "issue": "3047",
+            "notes": "language-wide Python entry-point sniffer covers module-level __main__/test/lifecycle; partial because RQ @job entry wiring is not modelled",
+            "verified_at": "2026-05-29"
           },
           "request_shape_extraction": {
             "status": "partial",
@@ -35748,8 +35799,11 @@
             "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_python.go"],
+            "issue": "3047",
+            "notes": "derives from taint source+sink co-occurrence; fires on all Python; partial for RQ job context",
+            "verified_at": "2026-05-29"
           }
         }
       }


### PR DESCRIPTION
## Summary

- Flips 18 Substrate capability cells from `missing` → `partial` for celery (8 cells), dramatiq (5), and rq (5) — the three `task_queue` subcategory frameworks in the issue #3047 scope that still had gaps after the prior substrate wave (#2983).
- The 7 `http_backend` frameworks in scope (pyramid, quart, robyn, sanic, starlette, strawberry-graphql, tornado) already had all 14 substrate cells at `partial` from the prior wave; no changes made to those records.

## Honest classification rationale

All cells are recorded as **partial**, not `full`. The Python substrate sniffers are framework-blind regex heuristics:

- `effect_sinks_python.go`: fires on `open()`/`requests.*`/`self.x=` patterns in any Python file; does not disambiguate Celery task I/O from unrelated worker code.
- `module_cycle_pass.go`: language-agnostic Tarjan SCC over IMPORTS edges; fires on all Python modules.
- `pure_function_pass.go`: tags entities with no detected effect as pure; misses effects the heuristic sniffers don't see.
- `taint_sites_python.go` + `taint_flow.go`: vulnerability_finding derives from source+sink co-occurrence; `sanitizer_recognition` is limited to parameterised SQL, bleach, pydantic schemas.
- `entry_points_python.go`: covers `__main__`/test/lifecycle entry points; does **not** model `@app.task` / `@dramatiq.actor` / `@job` worker entry wiring, so `reachability_analysis` and `dead_code_detection` are incomplete for task-queue frameworks.

`full` would require comprehensive fixtures proving precision for task-queue-specific constructs — not verified.

## Cells flipped

| Framework | Cells flipped (missing → partial) |
|---|---|
| celery | fs_effect, http_effect, mutation_effect, module_cycle_detection, pure_function_tagging, sanitizer_recognition, vulnerability_finding, dead_code_detection |
| dramatiq | module_cycle_detection, pure_function_tagging, vulnerability_finding, dead_code_detection, reachability_analysis |
| rq | module_cycle_detection, pure_function_tagging, vulnerability_finding, dead_code_detection, reachability_analysis |

## Honestly left missing

- celery/dramatiq/rq: `confidence_overlay` — no sniffer for task-queue confidence scoring exists; left missing with issue `backfill:dictionary-completeness`.
- All task_queue frameworks: broker_binding, schedule_extraction, retry_policy_extraction, task_routing — require framework-specific extractors (tracked separately).

## Verification

- `coverage validate` → 0 errors
- `coverage fmt --check` → ok
- `coverage gen` → byte-stable
- `go build ./...` → ok
- `go test ./internal/substrate/ ./tools/coverage/` → ok

Closes #3047

🤖 Generated with [Claude Code](https://claude.com/claude-code)