### PR TITLE
feat(coverage): Spring Data NoSQL recording-win backfill — Cassandra/Elastic/Mongo/Redis (12 cells)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -67,11 +67,11 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 1/8 | |
 | [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 0/8 | |
 | [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | ❌ 1/8 | |
-| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 0/8 | |
-| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 1/8 | |
+| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 1/8 | |
 | [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 2/8 | |
-| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 0/8 | |
-| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 1/8 | |
+| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 1/8 | |
 | [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ 0/8 | |
 | [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ❌ 1/8 | |
 | [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ❌ 1/8 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -87,11 +87,11 @@ Back to [summary](../summary.md).
 | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 1/8 | |
 | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 0/8 | |
 | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | ❌ 1/8 | |
-| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 0/8 | |
-| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 0/8 | |
+| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 1/8 | |
+| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 1/8 | |
 | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 2/8 | |
-| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 0/8 | |
-| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 0/8 | |
+| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 1/8 | |
+| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 1/8 | |
 | [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ 0/8 | |
 
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
-| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_ecosystem.go` | — |
+| Model extraction | ⚠️ `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
+| Schema extraction | ✅ `full` | `2026-05-29` | 3095 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Foreign key extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Lazy loading recognition | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Relationship extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
+| Query attribution | ⚠️ `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_cassandra.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
-| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_ecosystem.go` | — |
+| Model extraction | ⚠️ `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
+| Schema extraction | ✅ `full` | `2026-05-29` | 3095 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Foreign key extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Lazy loading recognition | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Relationship extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
+| Query attribution | ⚠️ `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_elasticsearch.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
-| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_ecosystem.go` | — |
+| Model extraction | ⚠️ `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
+| Schema extraction | ✅ `full` | `2026-05-29` | 3095 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Foreign key extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Lazy loading recognition | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Relationship extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
+| Query attribution | ⚠️ `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_mongodb.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
-| Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_ecosystem.go` | — |
+| Model extraction | ⚠️ `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
+| Schema extraction | ✅ `full` | `2026-05-29` | 3095 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Foreign key extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Lazy loading recognition | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
+| Relationship extraction | — `not_applicable` | — | 3095 | — | NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
+| Query attribution | ⚠️ `partial` | `2026-05-29` | 3095 | `internal/custom/java/spring_ecosystem.go`<br>`internal/engine/rules/java/orms/spring_data_redis.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -18719,39 +18719,45 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+            "issue": "3095",
+            "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
+            "issue": "3095",
             "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_cassandra.yaml"],
+            "issue": "3095",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -18772,39 +18778,45 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+            "issue": "3095",
+            "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
+            "issue": "3095",
             "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_elasticsearch.yaml"],
+            "issue": "3095",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -18881,39 +18893,45 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+            "issue": "3095",
+            "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
+            "issue": "3095",
             "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_mongodb.yaml"],
+            "issue": "3095",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -18934,39 +18952,45 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_redis.yaml"],
+            "issue": "3095",
+            "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/java/spring_ecosystem.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
+            "issue": "3095",
             "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3095",
+            "notes": "NoSQL store has no relational join/FK/lazy-load concept; not_applicable by design."
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/spring_data_redis.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/spring_ecosystem.go","internal/engine/rules/java/orms/spring_data_redis.yaml"],
+            "issue": "3095",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {


### PR DESCRIPTION
- schema_extraction: partial → full for all 4 stores (fixture-proven by
  TestSpringDataCassandra/Elastic/Mongo/Redis_SchemaExtraction_Issue3001)
- model_extraction + query_attribution: cites updated to include
  spring_ecosystem.go (stays partial — no store-specific test yet)
- foreign_key/lazy_loading/association/relationship: missing → not_applicable
  for all 4 NoSQL stores (relational concepts don't exist in these stores)

Closes #3095

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
