### PR TITLE
feat(coverage): Java ORM recording-win — Panache/JPA/MyBatis cites (9 cells)

### DIFF
--- a/docs/coverage/detail/lang.java.orm.jpa.md
+++ b/docs/coverage/detail/lang.java.orm.jpa.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/orm_queries.go` | — |
+| Query attribution | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3096) | `internal/engine/orm_queries.go`<br>`internal/engine/orm_queries_other.go`<br>`internal/engine/orm_queries_test.go` | Engine pass scanJavaORM handles EntityManager.find/persist/remove/merge and Spring Data repository call patterns (findByX, save, etc.); emits QUERIES edges with orm=jpa or orm=spring_data; inline JPQL string content and @NamedQuery body text not parsed |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.java.orm.mybatis.md
+++ b/docs/coverage/detail/lang.java.orm.mybatis.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/orms/mybatis.yaml` | — |
+| Model extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3096) | `internal/custom/java/mybatis.go`<br>`internal/custom/java/orm_extractors_test.go`<br>`internal/engine/rules/java/orms/mybatis.yaml` | Annotation @Results + XML <resultMap> become result_map schema entities (SCOPE.Schema); column DDL not parsed; model class references extracted from resultMap type attribute only |
 | Schema extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3007) | `internal/custom/java/mybatis.go`<br>`internal/custom/java/orm_extractors_test.go` | Annotation @Results + XML <resultMap> become result_map schema entities; column DDL not parsed. |
 
 ### Relationships

--- a/docs/coverage/detail/lang.java.orm.panache.md
+++ b/docs/coverage/detail/lang.java.orm.panache.md
@@ -15,7 +15,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | — |
+| Model extraction | ✅ `full` | `2026-05-29` | — | `internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Panache entity records synthesized from PanacheEntity/PanacheEntityBase subclasses; field schema parsed via Hibernate extractor (hibernate.go) for JPA annotations; panache.go does not independently extract column-level schema |
 | Schema extraction | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Panache entities use standard JPA @Entity/@Table/@Column annotations parsed by the Hibernate extractor; panache.go synthesizes entity records but does not independently parse field schemas |
 
 ### Relationships
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | ⚠️ `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Synthesizes full static-method and DSL-builder operation entities (findById, count, list, page, stream, etc.) and named query entities; does not parse inline JPQL/HQL string content |
+| Query attribution | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3096) | `internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Synthesizes full static-method and DSL-builder operation entities (findById, count, list, page, stream, etc.) and named query entities; does not parse inline JPQL/HQL string content |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -18528,8 +18528,10 @@
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/orm_queries.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/engine/orm_queries.go","internal/engine/orm_queries_other.go","internal/engine/orm_queries_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3096",
+            "notes": "Engine pass scanJavaORM handles EntityManager.find/persist/remove/merge and Spring Data repository call patterns (findByX, save, etc.); emits QUERIES edges with orm=jpa or orm=spring_data; inline JPQL string content and @NamedQuery body text not parsed",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -18549,8 +18551,10 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/java/orms/mybatis.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/java/mybatis.go","internal/custom/java/orm_extractors_test.go","internal/engine/rules/java/orms/mybatis.yaml"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3096",
+            "notes": "Annotation @Results + XML \u003cresultMap\u003e become result_map schema entities (SCOPE.Schema); column DDL not parsed; model class references extracted from resultMap type attribute only",
+            "verified_at": "2026-05-29"
           },
           "schema_extraction": {
             "status": "partial",
@@ -18664,6 +18668,7 @@
           "model_extraction": {
             "status": "full",
             "cites": ["internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
+            "notes": "Panache entity records synthesized from PanacheEntity/PanacheEntityBase subclasses; field schema parsed via Hibernate extractor (hibernate.go) for JPA annotations; panache.go does not independently extract column-level schema",
             "verified_at": "2026-05-29"
           },
           "schema_extraction": {
@@ -18702,7 +18707,7 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/extractors/java/panache.go","internal/extractors/java/panache_test.go"],
-            "issue": "backfill:dictionary-completeness",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3096",
             "notes": "Synthesizes full static-method and DSL-builder operation entities (findById, count, list, page, stream, etc.) and named query entities; does not parse inline JPQL/HQL string content",
             "verified_at": "2026-05-29"
           }


### PR DESCRIPTION
## Summary

- `lang.java.orm.panache` `query_attribution`: updated cites (`panache.go` + `panache_test.go`), `verified_at` refreshed. Status stays **partial** — emitter synthesizes all static/DSL/named-query op entities but does not parse inline JPQL string content. Issue linked.
- `lang.java.orm.panache` `model_extraction`: restored to **full** with current cites (was incorrectly touched to partial mid-session; corrected before commit).
- `lang.java.orm.jpa` `query_attribution`: cites expanded to `orm_queries.go` + `orm_queries_other.go` (where `scanJavaORM` is defined) + `orm_queries_test.go`. Notes clarify EntityManager and Spring Data call-pattern attribution. Status stays **partial** (no inline JPQL string parsing).
- `lang.java.orm.mybatis` `model_extraction`: cites corrected — was pointing at the detection yaml only; now cites `mybatis.go` + `orm_extractors_test.go` + yaml. Status stays **partial** (result_map entities extracted; column DDL not parsed).

All statuses are honest Class-A recording-wins: no status flip unless tests prove comprehensive extraction.

## Test plan
- [x] `coverage validate` — 0 errors, 5364 warnings (pre-existing)
- [x] `coverage fmt --check` — canonical
- [x] `coverage gen` — byte-stable (4 doc files updated)
- [x] `go build ./...` — clean
- [x] `go test ./internal/custom/java/ ./tools/coverage/` — all pass

Closes #3096

🤖 Generated with [Claude Code](https://claude.com/claude-code)