### PR TITLE
feat(coverage): overview digest counts covered (full+partial)/applicable

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,218 +11,218 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 3/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ❌ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ❌ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/6 | |
-| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ❌ 1/2 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/5 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ❌ 1/2 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/5 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 20/21 | ❌ 0/6 | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Hono](../detail/lang.jsts.framework.hono.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Koa](../detail/lang.jsts.framework.koa.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
 | [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 5/9 | |
-| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |
-| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/21 | ❌ 0/8 | |
-| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ❌ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |
+| [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 7/8 | |
+| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/17 | ❌ 0/6 | |
+| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/17 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 3/7 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/8 | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ❌ 1/2 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/5 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 
 
 ## JVM Backend
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 2/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 0/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 0/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 2/3 | ✅ 1/1 | ✅ 3/4 | ⚠️ 0/1 | ⚠️ 8/21 | ❌ 0/18 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 6/20 | ❌ 3/16 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 6/20 | ❌ 3/16 | |
+| [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 3/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 3/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 9/16 | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ❌ 14/18 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 14/16 | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 1/1 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/3 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ❌ 2/3 | ⚠️ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 1/1 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/3 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 1/1 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/3 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
 
 
 ## UI Frontend
 
 | Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/8 | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/8 | |
-| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/8 | |
-| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ❌ 3/21 | ✅ 17/17 | |
-| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 20/21 | ✅ 21/23 | |
-| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 11/21 | ⚠️ 16/17 | |
-| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 11/21 | ⚠️ 18/20 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/8 | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/8 | |
+| [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ❌ 20/21 | ✅ 17/17 | |
+| [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 21/21 | ✅ 21/21 | |
+| [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 21/21 | ⚠️ 17/17 | |
+| [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 21/21 | ⚠️ 19/19 | |
 
 
 ## Meta Framework
 
 | Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/7 | |
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/7 | |
 | [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/21 | ❌ 0/7 | |
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 7/9 | |
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 11/11 | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/9 | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 8/9 | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/7 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 8/8 | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/7 | |
 
 
 ## Mobile
 
 | Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/9 | |
-| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/9 | |
-| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/9 | |
-| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/9 | |
-| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/9 | |
+| [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/9 | |
+| [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/9 | |
+| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/9 | |
+| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/9 | |
+| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/9 | |
 | [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 3/3 | ✅ 1/1 | ❌ 3/21 | ✅ 13/13 | |
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | ❌ 3/21 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | ❌ 3/21 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 3/3 | ✅ 1/1 | ❌ 3/21 | ✅ 19/19 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/9 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/9 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/9 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/9 | |
 
 
 ## Desktop
 
 | Language | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 3/10 | ❌ 0/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 3/10 | ❌ 0/3 | |
-| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 3/10 | ❌ 0/3 | |
-| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 3/10 | ❌ 0/3 | |
-| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 3/10 | ❌ 0/3 | |
+| [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 7/10 | ❌ 0/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 7/10 | ❌ 0/3 | |
+| [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 7/10 | ❌ 0/3 | |
+| [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 7/10 | ❌ 0/3 | |
+| [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 7/10 | ❌ 0/3 | |
 | [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | ❌ 0/10 | ❌ 0/3 | |
 | [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | ❌ 0/10 | ✅ 3/3 | |
-| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 3/10 | ❌ 0/3 | |
-| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 3/10 | ❌ 0/3 | |
-| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 3/10 | ❌ 0/3 | |
+| [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 7/10 | ❌ 0/3 | |
+| [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 7/10 | ❌ 0/3 | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 7/10 | ❌ 0/3 | |
 
 
 ## RPC Framework
 
 | Language | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|
-| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 5/21 | ❌ 0/4 | |
-| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ 0/21 | ✅ 3/4 | |
+| [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 14/21 | ❌ 0/4 | |
+| [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ 0/21 | ✅ 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | ❌ 0/21 | ✅ 4/4 | |
 
 
@@ -230,7 +230,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Other capabilities | Notes |
 |---|---|---|---|
-| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ⚠️ 0/3 | |
+| [java](../by-language/java.md) | [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ⚠️ 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [LangChain.js](../detail/lang.jsts.framework.langchain.md) | ✅ 3/3 | |
 | [python](../by-language/python.md) | [LangChain (LLM agent framework)](../detail/lang.python.framework.langchain.md) | ❌ 0/3 | |
 
@@ -239,6 +239,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ⚠️ 0/1 | ❌ 5/21 | ❌ 4/6 | |
-| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [python](../by-language/python.md) | [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | ⚠️ 0/1 | ❌ 0/21 | ❌ 0/6 | |
+| [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/6 | |
+| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 1/1 | ❌ 20/21 | ❌ 1/6 | |
+| [python](../by-language/python.md) | [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | ⚠️ 1/1 | ❌ 20/21 | ❌ 2/6 | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -18,147 +18,147 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [C/C++](../by-language/c-cpp.md) | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | ❌ 0/8 | |
 | [C/C++](../by-language/c-cpp.md) | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ❌ 0/8 | |
 | [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ 2/8 | |
 | [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ 2/8 | |
-| [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ 2/8 | |
 | [C#](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | ❌ 0/8 | |
-| [C#](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | ❌ 0/8 | |
+| [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ 2/8 | |
+| [C#](../by-language/csharp.md) | [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | ❌ 1/6 | |
+| [C#](../by-language/csharp.md) | [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | ❌ 1/6 | |
 | [elixir](../by-language/elixir.md) | [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ 2/8 | |
-| [elixir](../by-language/elixir.md) | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | ❌ 0/8 | |
-| [elixir](../by-language/elixir.md) | [MyXQL](../detail/lang.elixir.driver.myxql.md) | ❌ 0/8 | |
-| [elixir](../by-language/elixir.md) | [Postgrex](../detail/lang.elixir.driver.postgrex.md) | ❌ 0/8 | |
-| [elixir](../by-language/elixir.md) | [Redix](../detail/lang.elixir.driver.redix.md) | ❌ 0/8 | |
-| [elixir](../by-language/elixir.md) | [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | ❌ 0/8 | |
-| [elixir](../by-language/elixir.md) | [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | ❌ 0/8 | |
-| [elixir](../by-language/elixir.md) | [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ 0/8 | |
-| [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | ❌ 0/8 | |
-| [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ 0/8 | |
+| [elixir](../by-language/elixir.md) | [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | ❌ 1/6 | |
+| [elixir](../by-language/elixir.md) | [MyXQL](../detail/lang.elixir.driver.myxql.md) | ❌ 1/6 | |
+| [elixir](../by-language/elixir.md) | [Postgrex](../detail/lang.elixir.driver.postgrex.md) | ❌ 1/6 | |
+| [elixir](../by-language/elixir.md) | [Redix](../detail/lang.elixir.driver.redix.md) | ❌ 1/6 | |
+| [elixir](../by-language/elixir.md) | [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | ❌ 1/6 | |
+| [elixir](../by-language/elixir.md) | [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | ❌ 1/6 | |
+| [elixir](../by-language/elixir.md) | [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ 2/8 | |
+| [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | ❌ 1/6 | |
+| [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ 2/8 | |
 | [go](../by-language/go.md) | [GORM](../detail/lang.go.orm.gorm.md) | ❌ 2/8 | |
 | [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | ❌ 2/8 | |
 | [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ❌ 0/8 | |
-| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ 0/8 | |
+| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | ❌ 1/6 | |
+| [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ❌ 3/8 | |
+| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ 2/8 | |
 | [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | ❌ 0/8 | |
-| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | ❌ 0/8 | |
-| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ 4/8 | |
-| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ 4/8 | |
-| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ 2/8 | |
-| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ 1/8 | |
-| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 1/8 | |
-| [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 0/8 | |
-| [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | ❌ 1/8 | |
-| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 1/8 | |
-| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 1/8 | |
-| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 2/8 | |
-| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 1/8 | |
-| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 1/8 | |
-| [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ 0/8 | |
-| [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ❌ 1/8 | |
-| [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ❌ 1/8 | |
+| [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | ❌ 2/7 | |
+| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ 5/8 | |
+| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ 5/8 | |
+| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ 5/8 | |
+| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ 5/8 | |
+| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 5/8 | |
+| [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 2/8 | |
+| [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | ❌ 5/8 | |
+| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 3/4 | |
+| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 3/4 | |
+| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 5/8 | |
+| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 3/4 | |
+| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 3/4 | |
+| [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ 2/8 | |
+| [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ❌ 1/6 | |
+| [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ❌ 1/6 | |
 | [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ❌ 3/8 | |
-| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/8 | |
+| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/7 | |
 | [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ 3/8 | |
-| [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ❌ 1/8 | |
-| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ❌ 2/8 | |
+| [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ❌ 1/6 | |
+| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ❌ 2/7 | |
 | [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 4/9 | |
 | [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | ❌ 3/8 | |
 | [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ 3/8 | |
 | [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 4/8 | |
-| [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ❌ 1/8 | |
-| [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ❌ 1/8 | |
-| [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ❌ 1/8 | |
-| [JS/TS](../by-language/jsts.md) | [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | ❌ 1/8 | |
-| [JS/TS](../by-language/jsts.md) | [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | ❌ 1/8 | |
-| [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ❌ 1/8 | |
-| [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | ❌ 1/8 | |
+| [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ❌ 1/6 | |
+| [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ❌ 1/6 | |
+| [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ❌ 1/6 | |
+| [JS/TS](../by-language/jsts.md) | [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | ❌ 1/6 | |
+| [JS/TS](../by-language/jsts.md) | [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | ❌ 1/6 | |
+| [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ❌ 1/6 | |
+| [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | ❌ 1/6 | |
 | [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ 2/8 | |
-| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ 0/8 | |
-| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ 0/8 | |
-| [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | ❌ 0/8 | |
-| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ 0/8 | |
-| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ 0/8 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | ❌ 0/8 | |
+| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | ❌ 2/7 | |
+| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ 2/8 | |
+| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | ❌ 1/6 | |
 | [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ 0/8 | |
 | [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ❌ 2/8 | |
 | [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | ❌ 2/8 | |
-| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | ❌ 0/8 | |
-| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ⚠️ 6/8 | |
-| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ 5/8 | |
-| [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ 2/8 | |
-| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 1/8 | |
-| [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ⚠️ 0/8 | |
-| [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ⚠️ 0/8 | |
-| [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ⚠️ 0/8 | |
-| [python](../by-language/python.md) | [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | ⚠️ 0/8 | |
-| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | ❌ 0/8 | |
-| [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | ⚠️ 0/8 | |
-| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | ❌ 0/8 | |
+| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | ❌ 1/6 | |
+| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | ❌ 1/6 | |
+| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | ❌ 1/6 | |
+| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | ❌ 2/8 | |
+| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ 2/8 | |
+| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | ❌ 1/6 | |
+| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | ❌ 1/6 | |
+| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | ❌ 1/6 | |
+| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | ❌ 1/6 | |
+| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 1/6 | |
+| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 1/6 | |
+| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ⚠️ 8/8 | |
+| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 2/7 | |
+| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 1/2 | |
+| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 2/8 | |
+| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 2/8 | |
+| [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ 8/8 | |
+| [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ 3/8 | |
+| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 2/8 | |
+| [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ⚠️ 1/1 | |
+| [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ⚠️ 1/1 | |
+| [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ⚠️ 1/1 | |
+| [python](../by-language/python.md) | [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | ⚠️ 1/1 | |
+| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | ❌ 1/2 | |
+| [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | ⚠️ 1/1 | |
+| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | ❌ 1/2 | |
+| [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | ❌ 1/6 | |
 | [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ 2/8 | |
-| [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | ❌ 0/8 | |
-| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | ❌ 0/8 | |
+| [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ 2/8 | |
+| [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | ❌ 2/7 | |
+| [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ 2/8 | |
+| [ruby](../by-language/ruby.md) | [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ 2/8 | |
+| [ruby](../by-language/ruby.md) | [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | ❌ 1/6 | |
+| [ruby](../by-language/ruby.md) | [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | ❌ 1/6 | |
+| [ruby](../by-language/ruby.md) | [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | ❌ 1/6 | |
+| [ruby](../by-language/ruby.md) | [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | ❌ 1/6 | |
+| [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | ❌ 1/6 | |
+| [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | ❌ 1/6 | |
+| [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | ❌ 1/6 | |
 | [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ 2/8 | |
 | [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ 0/8 | |
 | [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | ❌ 2/8 | |
-| [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [neo4rs](../detail/lang.rust.driver.neo4j.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ 0/8 | |
-| [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | ❌ 0/8 | |
-| [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ 0/8 | |
-| [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | ❌ 0/8 | |
-| [scala](../by-language/scala.md) | [Quill](../detail/lang.scala.orm.quill.md) | ❌ 0/8 | |
-| [scala](../by-language/scala.md) | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ 0/8 | |
-| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | ❌ 0/8 | |
-| [scala](../by-language/scala.md) | [Slick](../detail/lang.scala.orm.slick.md) | ❌ 0/8 | |
+| [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [neo4rs](../detail/lang.rust.driver.neo4j.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | ❌ 1/6 | |
+| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ 2/8 | |
+| [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | ❌ 1/6 | |
+| [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ 2/8 | |
+| [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | ❌ 2/7 | |
+| [scala](../by-language/scala.md) | [Quill](../detail/lang.scala.orm.quill.md) | ❌ 2/8 | |
+| [scala](../by-language/scala.md) | [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ 2/8 | |
+| [scala](../by-language/scala.md) | [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | ❌ 2/7 | |
+| [scala](../by-language/scala.md) | [Slick](../detail/lang.scala.orm.slick.md) | ❌ 2/8 | |

--- a/docs/coverage/by-language/assembly.md
+++ b/docs/coverage/by-language/assembly.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Other
 
 | Name | Category | Status | Notes |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,35 +14,35 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 3/21 | ❌ 0/6 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/21 | ❌ 0/6 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/8 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/8 | |
 
 
 ### Desktop
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 3/10 | ❌ 0/3 | |
-| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 3/10 | ❌ 0/3 | |
+| [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | ❌ 7/10 | ❌ 0/3 | |
+| [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | ❌ 7/10 | ❌ 0/3 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/cobol.md
+++ b/docs/coverage/by-language/cobol.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Other
 
 | Name | Category | Status | Notes |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,45 +14,45 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 1/6 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/8 | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/8 | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/8 | |
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/8 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/8 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/8 | |
 
 
 ### Mobile
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/9 | |
-| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/9 | |
+| [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/9 | |
+| [Xamarin](../detail/lang.csharp.framework.xamarin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/9 | |
 
 
 ### Desktop
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 3/10 | ❌ 0/3 | |
-| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 3/10 | ❌ 0/3 | |
-| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 3/10 | ❌ 0/3 | |
+| [Uno Platform](../detail/lang.csharp.framework.uno.md) | ❌ 7/10 | ❌ 0/3 | |
+| [WPF](../detail/lang.csharp.framework.wpf.md) | ❌ 7/10 | ❌ 0/3 | |
+| [Windows Forms](../detail/lang.csharp.framework.winforms.md) | ❌ 7/10 | ❌ 0/3 | |
 
 
 ### RPC Framework
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 5/21 | ❌ 0/4 | |
+| [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ❌ 14/21 | ❌ 0/4 | |
 
 
 ## Tools
@@ -72,17 +74,17 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | ❌ 0/8 | |
-| [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | ❌ 0/8 | |
-| [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ 0/8 | |
+| [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | ❌ 1/6 | |
+| [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | ❌ 1/6 | |
+| [Dapper](../detail/lang.csharp.orm.dapper.md) | ❌ 2/8 | |
 | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ❌ 2/8 | |
-| [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ 0/8 | |
+| [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | ❌ 2/8 | |
 | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | ❌ 0/8 | |
-| [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | ❌ 0/8 | |
-| [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | ❌ 0/8 | |
-| [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | ❌ 0/8 | |
-| [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | ❌ 0/8 | |
-| [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ 0/8 | |
-| [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | ❌ 0/8 | |
-| [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | ❌ 0/8 | |
-| [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | ❌ 0/8 | |
+| [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | ❌ 1/6 | |
+| [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | ❌ 1/6 | |
+| [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | ❌ 1/6 | |
+| [NEST (Elasticsearch .NET)](../detail/lang.csharp.driver.elastic.md) | ❌ 1/6 | |
+| [NHibernate](../detail/lang.csharp.orm.nhibernate.md) | ❌ 2/8 | |
+| [Neo4j.Driver (C#)](../detail/lang.csharp.driver.neo4j.md) | ❌ 1/6 | |
+| [Npgsql (PostgreSQL)](../detail/lang.csharp.driver.npgsql.md) | ❌ 1/6 | |
+| [StackExchange.Redis](../detail/lang.csharp.driver.redis.md) | ❌ 1/6 | |

--- a/docs/coverage/by-language/dart.md
+++ b/docs/coverage/by-language/dart.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Tools
 
 | Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,21 +14,21 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ❌ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ❌ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | ❌ 1/2 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/5 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | ❌ 1/2 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/5 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/7 | |
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/7 | |
 
 
 ## Tools
@@ -47,12 +49,12 @@ Back to [summary](../summary.md).
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [Ecto](../detail/lang.elixir.orm.ecto.md) | ❌ 2/8 | |
-| [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | ❌ 0/8 | |
-| [MyXQL](../detail/lang.elixir.driver.myxql.md) | ❌ 0/8 | |
-| [Postgrex](../detail/lang.elixir.driver.postgrex.md) | ❌ 0/8 | |
-| [Redix](../detail/lang.elixir.driver.redix.md) | ❌ 0/8 | |
-| [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | ❌ 0/8 | |
-| [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | ❌ 0/8 | |
-| [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ 0/8 | |
-| [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | ❌ 0/8 | |
-| [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | ❌ 0/8 | |
+| [ExAws DynamoDB](../detail/lang.elixir.driver.dynamodb.md) | ❌ 1/6 | |
+| [MyXQL](../detail/lang.elixir.driver.myxql.md) | ❌ 1/6 | |
+| [Postgrex](../detail/lang.elixir.driver.postgrex.md) | ❌ 1/6 | |
+| [Redix](../detail/lang.elixir.driver.redix.md) | ❌ 1/6 | |
+| [Xandra (Cassandra)](../detail/lang.elixir.driver.xandra.md) | ❌ 1/6 | |
+| [bolt_sips (Neo4j)](../detail/lang.elixir.driver.neo4j.md) | ❌ 1/6 | |
+| [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | ❌ 2/8 | |
+| [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | ❌ 1/6 | |
+| [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | ❌ 1/6 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,28 +14,28 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Echo](../detail/lang.go.framework.echo.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Fiber](../detail/lang.go.framework.fiber.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Gin](../detail/lang.go.framework.gin.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/21 | ❌ 0/6 | |
-| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Huma](../detail/lang.go.framework.huma.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Iris](../detail/lang.go.framework.iris.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Revel](../detail/lang.go.framework.revel.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [chi](../detail/lang.go.framework.chi.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [go-zero](../detail/lang.go.framework.go-zero.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Beego](../detail/lang.go.framework.beego.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Echo](../detail/lang.go.framework.echo.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Fiber](../detail/lang.go.framework.fiber.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Gin](../detail/lang.go.framework.gin.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 20/21 | ❌ 0/6 | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Huma](../detail/lang.go.framework.huma.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Iris](../detail/lang.go.framework.iris.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [Revel](../detail/lang.go.framework.revel.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [chi](../detail/lang.go.framework.chi.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [go-zero](../detail/lang.go.framework.go-zero.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/20 | ❌ 0/7 | |
 
 
 ### Mobile
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/9 | |
+| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/9 | |
 
 
 ### Desktop
@@ -63,20 +65,20 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | ❌ 0/8 | |
-| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ 0/8 | |
+| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | ❌ 1/6 | |
+| [Bun (uptrace)](../detail/lang.go.orm.bun.md) | ❌ 2/8 | |
 | [GORM](../detail/lang.go.orm.gorm.md) | ❌ 2/8 | |
 | [ent (Facebook)](../detail/lang.go.orm.ent.md) | ❌ 2/8 | |
 | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | ❌ 0/8 | |
-| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | ❌ 0/8 | |
-| [go-redis](../detail/lang.go.driver.redis.md) | ❌ 0/8 | |
-| [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | ❌ 0/8 | |
-| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | ❌ 0/8 | |
-| [golang-migrate](../detail/lang.go.orm.migrate.md) | ❌ 0/8 | |
-| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | ❌ 0/8 | |
-| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | ❌ 0/8 | |
-| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | ❌ 0/8 | |
-| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | ❌ 0/8 | |
-| [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ❌ 0/8 | |
-| [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ 0/8 | |
+| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | ❌ 1/6 | |
+| [go-redis](../detail/lang.go.driver.redis.md) | ❌ 1/6 | |
+| [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | ❌ 1/6 | |
+| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | ❌ 1/6 | |
+| [golang-migrate](../detail/lang.go.orm.migrate.md) | ❌ 1/6 | |
+| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | ❌ 1/6 | |
+| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | ❌ 1/6 | |
+| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | ❌ 1/6 | |
+| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | ❌ 1/6 | |
+| [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | ❌ 3/8 | |
+| [sqlx](../detail/lang.go.orm.sqlx.md) | ❌ 2/8 | |
 | [xo (codegen)](../detail/lang.go.orm.xo.md) | ❌ 0/8 | |

--- a/docs/coverage/by-language/groovy.md
+++ b/docs/coverage/by-language/groovy.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Tools
 
 | Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,27 +14,27 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 2/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 0/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 0/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 2/3 | ✅ 1/1 | ✅ 3/4 | ⚠️ 0/1 | ⚠️ 8/21 | ❌ 0/18 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 0/1 | ✅ 3/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/16 | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/16 | |
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 6/20 | ❌ 3/16 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 6/20 | ❌ 3/16 | |
+| [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 3/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 3/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 9/16 | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ❌ 14/18 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 14/16 | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/8 | |
-| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/8 | |
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/8 | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/8 | |
 
 
 ### Meta Framework
@@ -46,15 +48,15 @@ Back to [summary](../summary.md).
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/9 | |
-| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/3 | ❌ 0/1 | ❌ 2/21 | ❌ 0/9 | |
+| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/9 | |
+| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/9 | |
 
 
 ### AI Integration
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ⚠️ 0/3 | |
+| [LangChain4J (LLM agent framework)](../detail/lang.java.framework.langchain4j.md) | ⚠️ 3/3 | |
 
 
 ## Tools
@@ -79,20 +81,20 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | ❌ 0/8 | |
-| [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ 4/8 | |
-| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ 4/8 | |
-| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ 2/8 | |
-| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ 1/8 | |
-| [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 1/8 | |
-| [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 0/8 | |
-| [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | ❌ 1/8 | |
-| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 1/8 | |
-| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 1/8 | |
-| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 2/8 | |
-| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 1/8 | |
-| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 1/8 | |
-| [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ 0/8 | |
+| [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | ❌ 2/7 | |
+| [Ebean ORM](../detail/lang.java.orm.ebean.md) | ❌ 5/8 | |
+| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | ❌ 5/8 | |
+| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | ❌ 5/8 | |
+| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | ❌ 5/8 | |
+| [MyBatis](../detail/lang.java.orm.mybatis.md) | ❌ 5/8 | |
+| [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | ❌ 2/8 | |
+| [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | ❌ 5/8 | |
+| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | ❌ 3/4 | |
+| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | ❌ 3/4 | |
+| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | ❌ 5/8 | |
+| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | ❌ 3/4 | |
+| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | ❌ 3/4 | |
+| [jOOQ](../detail/lang.java.orm.jooq.md) | ❌ 2/8 | |
 
 
 ## Other
@@ -106,4 +108,4 @@ Back to [summary](../summary.md).
 
 | Name | Testing | Other capabilities | Notes |
 |---|---|---|---|
-| [Bean Validation (Jakarta/javax)](../detail/lang.java.validation.bean-validation.md) | ⚠️ 0/1 | ❌ 0/5 | |
+| [Bean Validation (Jakarta/javax)](../detail/lang.java.validation.bean-validation.md) | ⚠️ 1/1 | ❌ 3/5 | |

--- a/docs/coverage/by-language/jcl.md
+++ b/docs/coverage/by-language/jcl.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Other
 
 | Name | Category | Status | Notes |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,40 +14,40 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Express](../detail/lang.jsts.framework.express.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Hono](../detail/lang.jsts.framework.hono.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Koa](../detail/lang.jsts.framework.koa.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
+| [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Express](../detail/lang.jsts.framework.express.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Fastify](../detail/lang.jsts.framework.fastify.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Feathers](../detail/lang.jsts.framework.feathers.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Hapi](../detail/lang.jsts.framework.hapi.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Hono](../detail/lang.jsts.framework.hono.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Koa](../detail/lang.jsts.framework.koa.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Marble.js](../detail/lang.jsts.framework.marblejs.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
 | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ❌ 2/3 | ✅ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 7/20 | ❌ 4/7 | |
-| [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 4/7 | |
-| [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 7/20 | ❌ 5/9 | |
+| [Polka](../detail/lang.jsts.framework.polka.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Restify](../detail/lang.jsts.framework.restify.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 6/7 | |
+| [Sails](../detail/lang.jsts.framework.sails.md) | ❌ 2/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ⚠️ 20/20 | ❌ 7/8 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ❌ 3/21 | ✅ 17/17 | |
-| [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 20/21 | ✅ 21/23 | |
-| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 11/21 | ⚠️ 16/17 | |
-| [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 11/21 | ⚠️ 18/20 | |
+| [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | ❌ 20/21 | ✅ 17/17 | |
+| [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 21/21 | ✅ 21/21 | |
+| [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 21/21 | ⚠️ 17/17 | |
+| [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 21/21 | ⚠️ 19/19 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 7/9 | |
+| [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 7/7 | |
 | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
 | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 11/11 | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/9 | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
 | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 8/9 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 8/8 | |
 
 
 ### Mobile
@@ -69,7 +71,7 @@ Back to [summary](../summary.md).
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ 0/21 | ✅ 3/4 | |
+| [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | ❌ 0/21 | ✅ 3/3 | |
 | [tRPC](../detail/lang.jsts.framework.trpc.md) | ❌ 0/21 | ✅ 4/4 | |
 
 
@@ -113,24 +115,24 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ❌ 1/8 | |
-| [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ❌ 1/8 | |
+| [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ❌ 1/6 | |
+| [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ❌ 1/6 | |
 | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ❌ 3/8 | |
-| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/8 | |
+| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/7 | |
 | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ 3/8 | |
-| [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ❌ 1/8 | |
-| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ❌ 2/8 | |
+| [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ❌ 1/6 | |
+| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ❌ 2/7 | |
 | [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 4/9 | |
 | [Prisma](../detail/lang.jsts.orm.prisma.md) | ❌ 3/8 | |
 | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ 3/8 | |
 | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 4/8 | |
-| [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ❌ 1/8 | |
-| [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ❌ 1/8 | |
-| [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ❌ 1/8 | |
-| [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | ❌ 1/8 | |
-| [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | ❌ 1/8 | |
-| [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ❌ 1/8 | |
-| [supabase-js](../detail/lang.jsts.driver.supabase.md) | ❌ 1/8 | |
+| [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ❌ 1/6 | |
+| [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ❌ 1/6 | |
+| [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ❌ 1/6 | |
+| [mysql / mysql2](../detail/lang.jsts.driver.mysql.md) | ❌ 1/6 | |
+| [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | ❌ 1/6 | |
+| [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ❌ 1/6 | |
+| [supabase-js](../detail/lang.jsts.driver.supabase.md) | ❌ 1/6 | |
 
 
 ## Other

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,30 +14,30 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ❌ 2/3 | ⚠️ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/15 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 1/1 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/3 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ❌ 2/3 | ⚠️ 1/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | ⚠️ 1/1 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/3 | |
 
 
 ### Mobile
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/9 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 5/21 | ❌ 0/9 | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/9 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/9 | |
 
 
 ### Desktop
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 3/10 | ❌ 0/3 | |
-| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 3/10 | ❌ 0/3 | |
+| [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | ❌ 7/10 | ❌ 0/3 | |
+| [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | ❌ 7/10 | ❌ 0/3 | |
 
 
 ## ORMs
@@ -46,9 +48,9 @@ Back to [summary](../summary.md).
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | ❌ 2/8 | |
-| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ 0/8 | |
-| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ 0/8 | |
-| [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | ❌ 0/8 | |
-| [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ 0/8 | |
-| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ 0/8 | |
-| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ 0/8 | |
+| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | ❌ 2/8 | |
+| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | ❌ 2/8 | |
+| [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | ❌ 2/7 | |
+| [Room (Android)](../detail/lang.kotlin.orm.room.md) | ❌ 2/8 | |
+| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | ❌ 2/8 | |
+| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | ❌ 2/8 | |

--- a/docs/coverage/by-language/lua.md
+++ b/docs/coverage/by-language/lua.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,5 +14,5 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |
-| [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |
+| [Lapis](../detail/lang.lua.framework.lapis.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/17 | ❌ 0/6 | |
+| [OpenResty](../detail/lang.lua.framework.openresty.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/17 | ❌ 0/6 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,18 +14,18 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Drupal](../detail/lang.php.framework.drupal.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Magento](../detail/lang.php.framework.magento.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Slim](../detail/lang.php.framework.slim.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Yii](../detail/lang.php.framework.yii.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
+| [CakePHP](../detail/lang.php.framework.cakephp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Drupal](../detail/lang.php.framework.drupal.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Lumen](../detail/lang.php.framework.lumen.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Magento](../detail/lang.php.framework.magento.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Phalcon](../detail/lang.php.framework.phalcon.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Slim](../detail/lang.php.framework.slim.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Yii](../detail/lang.php.framework.yii.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 
 
 ## Tools
@@ -44,17 +46,17 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | ❌ 0/8 | |
+| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | ❌ 1/6 | |
 | [CycleORM](../detail/lang.php.orm.cycleorm.md) | ❌ 0/8 | |
 | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | ❌ 2/8 | |
 | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | ❌ 2/8 | |
-| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | ❌ 0/8 | |
-| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | ❌ 0/8 | |
-| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | ❌ 0/8 | |
-| [Propel](../detail/lang.php.orm.propel.md) | ❌ 0/8 | |
-| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ 0/8 | |
-| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | ❌ 0/8 | |
-| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | ❌ 0/8 | |
-| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | ❌ 0/8 | |
-| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | ❌ 0/8 | |
-| [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 0/8 | |
+| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | ❌ 1/6 | |
+| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | ❌ 1/6 | |
+| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | ❌ 1/6 | |
+| [Propel](../detail/lang.php.orm.propel.md) | ❌ 2/8 | |
+| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | ❌ 2/8 | |
+| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | ❌ 1/6 | |
+| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | ❌ 1/6 | |
+| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | ❌ 1/6 | |
+| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | ❌ 1/6 | |
+| [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 1/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,23 +14,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/21 | ❌ 0/8 | |
-| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ❌ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 0/4 | ⚠️ 0/1 | ❌ 5/20 | ❌ 0/7 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 3/7 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/8 | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
+| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
+| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
 
 
 ### AI Integration
@@ -42,9 +44,9 @@ Back to [summary](../summary.md).
 
 | Name | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|
-| [Celery (task queue)](../detail/lang.python.framework.celery.md) | ⚠️ 0/1 | ❌ 5/21 | ❌ 4/6 | |
-| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 0/1 | ❌ 5/21 | ❌ 0/6 | |
-| [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | ⚠️ 0/1 | ❌ 0/21 | ❌ 0/6 | |
+| [Celery (task queue)](../detail/lang.python.framework.celery.md) | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/6 | |
+| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | ⚠️ 1/1 | ❌ 20/21 | ❌ 1/6 | |
+| [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | ⚠️ 1/1 | ❌ 20/21 | ❌ 2/6 | |
 
 
 ## Tools
@@ -74,23 +76,23 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 0/8 | |
-| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 0/8 | |
-| [Django ORM](../detail/lang.python.orm.django.md) | ⚠️ 6/8 | |
-| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 0/8 | |
-| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 0/8 | |
-| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 0/8 | |
-| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 0/8 | |
-| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ 5/8 | |
-| [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ 2/8 | |
-| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 1/8 | |
-| [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ⚠️ 0/8 | |
-| [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ⚠️ 0/8 | |
-| [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ⚠️ 0/8 | |
-| [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | ⚠️ 0/8 | |
-| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | ❌ 0/8 | |
-| [redis-py](../detail/lang.python.driver.redis.md) | ⚠️ 0/8 | |
-| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | ❌ 0/8 | |
+| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 1/6 | |
+| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 2/7 | |
+| [Django ORM](../detail/lang.python.orm.django.md) | ⚠️ 8/8 | |
+| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 2/7 | |
+| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 1/2 | |
+| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 2/8 | |
+| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 2/8 | |
+| [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ⚠️ 8/8 | |
+| [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ❌ 3/8 | |
+| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 2/8 | |
+| [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ⚠️ 1/1 | |
+| [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ⚠️ 1/1 | |
+| [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ⚠️ 1/1 | |
+| [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | ⚠️ 1/1 | |
+| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | ❌ 1/2 | |
+| [redis-py](../detail/lang.python.driver.redis.md) | ⚠️ 1/1 | |
+| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | ❌ 1/2 | |
 
 
 ## Other
@@ -105,6 +107,6 @@ Back to [summary](../summary.md).
 
 | Name | Testing | Other capabilities | Notes |
 |---|---|---|---|
-| [Pydantic](../detail/lang.python.validation.pydantic.md) | ⚠️ 0/1 | ⚠️ 3/5 | |
-| [attrs](../detail/lang.python.validation.attrs.md) | ⚠️ 0/1 | ❌ 0/5 | |
-| [marshmallow](../detail/lang.python.validation.marshmallow.md) | ⚠️ 0/1 | ❌ 1/5 | |
+| [Pydantic](../detail/lang.python.validation.pydantic.md) | ⚠️ 1/1 | ⚠️ 5/5 | |
+| [attrs](../detail/lang.python.validation.attrs.md) | ⚠️ 1/1 | ❌ 3/5 | |
+| [marshmallow](../detail/lang.python.validation.marshmallow.md) | ⚠️ 1/1 | ❌ 4/5 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,14 +14,14 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ❌ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | ❌ 1/2 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/5 | |
 
 
 ## Tools
@@ -40,19 +42,19 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | ❌ 0/8 | |
+| [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | ❌ 1/6 | |
 | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ❌ 2/8 | |
-| [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ 0/8 | |
-| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | ❌ 0/8 | |
-| [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ 0/8 | |
-| [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ 0/8 | |
-| [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | ❌ 0/8 | |
-| [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | ❌ 0/8 | |
-| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | ❌ 0/8 | |
-| [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | ❌ 0/8 | |
-| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | ❌ 0/8 | |
-| [redis-rb](../detail/lang.ruby.driver.redis.md) | ❌ 0/8 | |
-| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | ❌ 0/8 | |
+| [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | ❌ 2/8 | |
+| [Mongoid](../detail/lang.ruby.orm.mongoid.md) | ❌ 2/7 | |
+| [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | ❌ 2/8 | |
+| [Sequel](../detail/lang.ruby.orm.sequel.md) | ❌ 2/8 | |
+| [cassandra-driver (Ruby)](../detail/lang.ruby.driver.cassandra.md) | ❌ 1/6 | |
+| [elasticsearch-ruby](../detail/lang.ruby.driver.elastic.md) | ❌ 1/6 | |
+| [mysql2 (Ruby driver)](../detail/lang.ruby.driver.mysql.md) | ❌ 1/6 | |
+| [neo4j-ruby-driver](../detail/lang.ruby.driver.neo4j.md) | ❌ 1/6 | |
+| [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | ❌ 1/6 | |
+| [redis-rb](../detail/lang.ruby.driver.redis.md) | ❌ 1/6 | |
+| [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | ❌ 1/6 | |
 
 
 ## Other

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,23 +14,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 6/21 | ❌ 0/6 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 
 
 ### Desktop
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 3/10 | ❌ 0/3 | |
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | ❌ 7/10 | ❌ 0/3 | |
 
 
 ## Tools
@@ -52,14 +54,14 @@ Back to [summary](../summary.md).
 | [Diesel](../detail/lang.rust.orm.diesel.md) | ❌ 2/8 | |
 | [Rbatis](../detail/lang.rust.orm.rbatis.md) | ❌ 0/8 | |
 | [SeaORM](../detail/lang.rust.orm.seaorm.md) | ❌ 2/8 | |
-| [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | ❌ 0/8 | |
-| [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | ❌ 0/8 | |
-| [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | ❌ 0/8 | |
-| [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | ❌ 0/8 | |
-| [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | ❌ 0/8 | |
-| [neo4rs](../detail/lang.rust.driver.neo4j.md) | ❌ 0/8 | |
-| [redis-rs](../detail/lang.rust.driver.redis.md) | ❌ 0/8 | |
-| [rusqlite](../detail/lang.rust.orm.rusqlite.md) | ❌ 0/8 | |
-| [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | ❌ 0/8 | |
-| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ 0/8 | |
-| [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | ❌ 0/8 | |
+| [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | ❌ 1/6 | |
+| [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | ❌ 1/6 | |
+| [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | ❌ 1/6 | |
+| [mongodb (Rust driver)](../detail/lang.rust.driver.mongodb.md) | ❌ 1/6 | |
+| [mysql / mysql_async](../detail/lang.rust.driver.mysql.md) | ❌ 1/6 | |
+| [neo4rs](../detail/lang.rust.driver.neo4j.md) | ❌ 1/6 | |
+| [redis-rs](../detail/lang.rust.driver.redis.md) | ❌ 1/6 | |
+| [rusqlite](../detail/lang.rust.orm.rusqlite.md) | ❌ 1/6 | |
+| [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | ❌ 1/6 | |
+| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | ❌ 2/8 | |
+| [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | ❌ 1/6 | |

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,21 +14,21 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 0/3 | — 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/15 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | ⚠️ 1/1 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/3 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 3/21 | ❌ 0/7 | |
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/7 | |
 
 
 ## Tools
@@ -44,9 +46,9 @@ Back to [summary](../summary.md).
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ 0/8 | |
-| [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | ❌ 0/8 | |
-| [Quill](../detail/lang.scala.orm.quill.md) | ❌ 0/8 | |
-| [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ 0/8 | |
-| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | ❌ 0/8 | |
-| [Slick](../detail/lang.scala.orm.slick.md) | ❌ 0/8 | |
+| [Doobie](../detail/lang.scala.orm.doobie.md) | ❌ 2/8 | |
+| [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | ❌ 2/7 | |
+| [Quill](../detail/lang.scala.orm.quill.md) | ❌ 2/8 | |
+| [ScalikeJDBC](../detail/lang.scala.orm.scalikejdbc.md) | ❌ 2/8 | |
+| [Scanamo (DynamoDB)](../detail/lang.scala.orm.scanamo.md) | ❌ 2/7 | |
+| [Slick](../detail/lang.scala.orm.slick.md) | ❌ 2/8 | |

--- a/docs/coverage/by-language/swift.md
+++ b/docs/coverage/by-language/swift.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,7 +14,7 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 0/21 | ❌ 0/6 | |
+| [Vapor](../detail/lang.swift.framework.vapor.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 8/21 | ❌ 0/6 | |
 
 
 ## Tools

--- a/tools/coverage/capability_dictionary_test.go
+++ b/tools/coverage/capability_dictionary_test.go
@@ -191,9 +191,10 @@ func TestOtherCapabilitiesDigest(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Other cells = %v, want %v", got, want)
 	}
-	// 3 cells, 0 full, worst = missing → ❌ 0/3.
+	// 3 applicable cells, 1 covered (full+partial), worst = missing →
+	// ❌ 1/3 under the covered/applicable digest convention.
 	view := recordToView(rec)
-	if d := view.GroupDigestByName[OtherCapabilitiesColumn]; d != "❌ 0/3" {
-		t.Errorf("Other digest = %q, want ❌ 0/3", d)
+	if d := view.GroupDigestByName[OtherCapabilitiesColumn]; d != "❌ 1/3" {
+		t.Errorf("Other digest = %q, want ❌ 1/3", d)
 	}
 }

--- a/tools/coverage/generate.go
+++ b/tools/coverage/generate.go
@@ -408,7 +408,7 @@ func buildFrameworkSpecificViews(rec Record) []frameworkSpecificView {
 
 // makeGroupView constructs a groupView from a group name + its cell
 // map. The CapList is sorted alphabetically by key; the digest follows
-// the "<glyph> <full-count>/<total>" convention from #2737.
+// the "<glyph> <covered>/<applicable>" convention (see groupDigest).
 func makeGroupView(name string, caps map[string]Capability) groupView {
 	keys := sortedCapKeys(caps)
 	list := make([]capEntry, 0, len(keys))
@@ -422,17 +422,25 @@ func makeGroupView(name string, caps map[string]Capability) groupView {
 	}
 }
 
-// groupDigest returns the worst-glyph + full-count/total summary for a
+// groupDigest returns the worst-glyph + covered/applicable summary for a
 // group's capability cells. Empty groups (no cells declared) render as
 // "—" so pivot rows for sparsely-populated records still align under
-// every group column. The full-count counts StatusFull only — partials
-// are folded into the glyph severity but not the numerator (the cell
-// already differentiates ✅/⚠️/❌).
+// every group column. The numerator counts COVERED cells (StatusFull +
+// StatusPartial — any capability that has real extraction, comprehensive
+// or heuristic); the denominator counts APPLICABLE cells (full + partial
+// + missing), EXCLUDING not_applicable so capabilities that genuinely
+// don't apply to the framework neither help nor hurt the fraction. The
+// glyph still reflects the WORST cell status, so the fraction and glyph
+// together read honestly: "20/20 ⚠️" = every applicable capability is
+// extracted but some only heuristically; "✅" only when all are full;
+// any shortfall in the fraction is exactly the count of missing cells.
+// A group with no applicable cells (all not_applicable, or empty) → "—".
 func groupDigest(caps map[string]Capability) string {
 	if len(caps) == 0 {
 		return "—"
 	}
-	full := 0
+	covered := 0    // full + partial
+	applicable := 0 // full + partial + missing (excludes not_applicable)
 	worst := ""
 	worstRank := -1
 	rank := map[string]int{
@@ -443,15 +451,22 @@ func groupDigest(caps map[string]Capability) string {
 		"":                  0,
 	}
 	for _, c := range caps {
-		if c.Status == StatusFull {
-			full++
+		switch c.Status {
+		case StatusFull, StatusPartial:
+			covered++
+			applicable++
+		case StatusMissing:
+			applicable++
 		}
 		if r := rank[c.Status]; r > worstRank {
 			worstRank = r
 			worst = c.Status
 		}
 	}
-	return fmt.Sprintf("%s %d/%d", statusGlyph(worst), full, len(caps))
+	if applicable == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%s %d/%d", statusGlyph(worst), covered, applicable)
 }
 
 // languageDisplay maps a language slug to its human-facing label. The

--- a/tools/coverage/subcategory_test.go
+++ b/tools/coverage/subcategory_test.go
@@ -416,15 +416,40 @@ func TestGroupForCapability(t *testing.T) {
 	}
 }
 
-// TestGroupDigest checks the worst-glyph + full-count/total digest.
+// TestGroupDigest checks the worst-glyph + covered/applicable digest:
+// numerator = full+partial (covered), denominator = full+partial+missing
+// (applicable; not_applicable excluded), glyph = worst cell status.
 func TestGroupDigest(t *testing.T) {
+	// full + partial + missing → covered 2 / applicable 3, worst missing.
 	caps := map[string]Capability{
 		"a": {Status: StatusFull},
 		"b": {Status: StatusPartial},
 		"c": {Status: StatusMissing},
 	}
-	if got := groupDigest(caps); got != "❌ 1/3" {
-		t.Errorf("groupDigest = %q, want ❌ 1/3", got)
+	if got := groupDigest(caps); got != "❌ 2/3" {
+		t.Errorf("groupDigest = %q, want ❌ 2/3", got)
+	}
+	// not_applicable is excluded from the denominator entirely.
+	naCaps := map[string]Capability{
+		"a": {Status: StatusFull},
+		"b": {Status: StatusPartial},
+		"c": {Status: StatusNotApplicable},
+	}
+	if got := groupDigest(naCaps); got != "⚠️ 2/2" {
+		t.Errorf("groupDigest w/ N/A = %q, want ⚠️ 2/2", got)
+	}
+	// all full (after excluding N/A) → green, fraction saturated.
+	allFull := map[string]Capability{
+		"a": {Status: StatusFull},
+		"b": {Status: StatusFull},
+		"c": {Status: StatusNotApplicable},
+	}
+	if got := groupDigest(allFull); got != "✅ 2/2" {
+		t.Errorf("groupDigest all-full = %q, want ✅ 2/2", got)
+	}
+	// all not_applicable (no applicable cells) → em-dash.
+	if got := groupDigest(map[string]Capability{"a": {Status: StatusNotApplicable}}); got != "—" {
+		t.Errorf("all-N/A groupDigest = %q, want —", got)
 	}
 	if got := groupDigest(map[string]Capability{}); got != "—" {
 		t.Errorf("empty groupDigest = %q, want —", got)

--- a/tools/coverage/templates/by-language.md.tmpl
+++ b/tools/coverage/templates/by-language.md.tmpl
@@ -4,6 +4,8 @@
 **Frameworks**: {{.Frameworks}} · **Tools**: {{.Tools}} · **ORMs**: {{.ORMs}} · **Other**: {{.Other}}
 
 Back to [summary](../summary.md).
+
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
 {{range .Sections}}
 ## {{.Name}}
 {{if eq .Name "Other"}}

--- a/tools/coverage/testdata/fixture-out/by-category/http_framework.md
+++ b/tools/coverage/testdata/fixture-out/by-category/http_framework.md
@@ -11,7 +11,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 0/1 | ✅ 1/1 | ❌ 0/3 | |
+| [JS/TS](../by-language/jsts.md) | [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 1/1 | ✅ 1/1 | ❌ 1/3 | |
 
 
 ## Other

--- a/tools/coverage/testdata/fixture-out/by-language/jsts.md
+++ b/tools/coverage/testdata/fixture-out/by-language/jsts.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 
@@ -12,7 +14,7 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 0/1 | ✅ 1/1 | ❌ 0/3 | |
+| [NestJS](../detail/lang.jsts.framework.nestjs.md) | ✅ 2/2 | ⚠️ 1/1 | ✅ 1/1 | ❌ 1/3 | |
 
 
 ### Other

--- a/tools/coverage/testdata/fixture-out/by-language/python.md
+++ b/tools/coverage/testdata/fixture-out/by-language/python.md
@@ -5,6 +5,8 @@
 
 Back to [summary](../summary.md).
 
+> Group columns show `glyph covered/applicable`: **covered** = capabilities with extraction (✅ full + ⚠️ partial), **applicable** = covered + ❌ missing (not-applicable cells are excluded). The glyph is the group's worst cell — ✅ all full · ⚠️ some heuristic/partial · ❌ some missing. So `20/20 ⚠️` means every applicable capability is extracted, some only heuristically.
+
 ## Frameworks
 
 | Name | Auth coverage | Endpoint synthesis | Handler attribution | Middleware coverage | Notes |
@@ -21,4 +23,4 @@ Back to [summary](../summary.md).
 
 | Name | Testing | Other capabilities | Notes |
 |---|---|---|---|
-| [Pydantic](../detail/lang.python.validation.pydantic.md) | ❌ 0/1 | ❌ 0/5 | |
+| [Pydantic](../detail/lang.python.validation.pydantic.md) | ❌ 0/1 | ❌ 1/5 | |


### PR DESCRIPTION
The by-language/by-category group-column digest counted StatusFull only,
so honest partial-flips never moved the numbers — a framework with all 20
substrate capabilities extracted heuristically still read "⚠️ 7/20",
looking 65% uncovered.

Now: numerator = covered (full+partial), denominator = applicable
(full+partial+missing, excluding not_applicable), glyph = worst cell.
So "20/20 ⚠️" = every applicable capability extracted, some heuristically;
"✅" only when all full; the fraction shortfall is exactly the missing
count; not_applicable cells (NoSQL/raw-driver) no longer tank fractions.
Adds a one-line legend to the by-language overview; regenerates docs +
golden fixtures.

Closes #3109

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
