### PR TITLE
feat(coverage): Python Type System recording-win — flip 68 cells partial→full

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -80,23 +80,23 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 3/7 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/8 | |
-| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 3/7 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/8 | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
 | [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -14,23 +14,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 3/7 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/8 | |
-| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ⚠️ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 3/7 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/8 | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
+| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
+| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Interface extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type alias extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
-| Type extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/2989) | `internal/extractors/python/types.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
+| Type extraction | ✅ `full` | `2026-05-29` | 3049 | `internal/extractors/python/types.go` | — |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -32672,27 +32672,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -32890,27 +32890,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -33293,27 +33293,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -33517,27 +33517,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -33745,27 +33745,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -34144,27 +34144,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -34367,27 +34367,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -34593,27 +34593,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -34806,27 +34806,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -35043,27 +35043,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -35261,27 +35261,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -35472,27 +35472,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -35689,27 +35689,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -36088,27 +36088,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -36305,27 +36305,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -36521,27 +36521,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },
@@ -36738,27 +36738,27 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/python/types.go"],
-            "issue": "https://github.com/cajasmota/archigraph/issues/2989",
+            "issue": "3049",
             "verified_at": "2026-05-29"
           }
         },


### PR DESCRIPTION
The Python type-system extractor (internal/extractors/python/types.go,
introduced in #2989) already handles every shape needed for the four
capabilities across all 17 non-task-queue http_backend frameworks:

  - enum_extraction     — class X(Enum/IntEnum/StrEnum/Flag/IntFlag)
  - interface_extraction — class X(Protocol)
  - type_alias_extraction — X: TypeAlias=…, type X=… (PEP 695), X=Union[…]
  - type_extraction      — TypedDict, NamedTuple, @dataclass

All 13 TestTypeSystem_* unit tests pass (go test ./internal/extractors/python/).
No Go code changes required — recording-win flip only.

Closes #3049

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
