### PR TITLE
feat(coverage): JS/TS substrate backfill — meta-frameworks batch 1 (Next.js, Remix, Nuxt, SvelteKit)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -177,10 +177,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 0/21 | ❌ 0/7 | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 11/11 | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 17/21 | ✅ 11/11 | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 17/21 | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 17/21 | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ⚠️ 21/21 | ✅ 8/8 | |
 | [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | ❌ 0/2 | ❌ 0/3 | ❌ 0/1 | ❌ 14/21 | ❌ 0/7 | |
 
 

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -44,10 +44,10 @@ Back to [summary](../summary.md).
 |---|---|---|---|---|---|---|
 | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 7/7 | |
 | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 11/11 | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 0/21 | ✅ 8/8 | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 4/21 | ✅ 8/8 | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 17/21 | ✅ 11/11 | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 17/21 | ✅ 8/8 | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ❌ 17/21 | ✅ 8/8 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | ⚠️ 21/21 | ✅ 8/8 | |
 
 
 ### Mobile

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -68,26 +68,26 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Constant propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DB effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Dead code detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Env fallback recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Fs effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| HTTP effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Import resolution quality | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Mutation effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Response shape extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Confidence overlay | ✅ `full` | `2026-05-29` | 3055 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Constant propagation | ✅ `full` | `2026-05-29` | 3055 | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| DB effect | ✅ `full` | `2026-05-29` | 3055 | `internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Dead code detection | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/reachability.go`<br>`internal/links/reachability_test.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| Def use chain extraction | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/def_use_jsts.go`<br>`internal/substrate/def_use_test.go` | — |
+| Env fallback recognition | ✅ `full` | `2026-05-29` | 3055 | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| Fs effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| HTTP effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Import resolution quality | ✅ `full` | `2026-05-29` | 3055 | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| Module cycle detection | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/module_cycle_pass.go` | — |
+| Mutation effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Pure function tagging | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| Reachability analysis | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/reachability.go`<br>`internal/links/reachability_test.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| Request shape extraction | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
+| Response shape extraction | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | Sanitizer recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Schema drift detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | Taint sink detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint source detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/template_pattern_jsts.go`<br>`internal/substrate/template_pattern_test.go` | — |
 | Vulnerability finding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Framework-specific

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -68,26 +68,26 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Constant propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DB effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Dead code detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Env fallback recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Fs effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| HTTP effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Import resolution quality | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Mutation effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Response shape extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Confidence overlay | ✅ `full` | `2026-05-29` | 3055 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Constant propagation | ✅ `full` | `2026-05-29` | 3055 | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| DB effect | ✅ `full` | `2026-05-29` | 3055 | `internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Dead code detection | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/reachability.go`<br>`internal/links/reachability_test.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| Def use chain extraction | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/def_use_jsts.go`<br>`internal/substrate/def_use_test.go` | — |
+| Env fallback recognition | ✅ `full` | `2026-05-29` | 3055 | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| Fs effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| HTTP effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Import resolution quality | ✅ `full` | `2026-05-29` | 3055 | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| Module cycle detection | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/module_cycle_pass.go` | — |
+| Mutation effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Pure function tagging | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| Reachability analysis | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/reachability.go`<br>`internal/links/reachability_test.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| Request shape extraction | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
+| Response shape extraction | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | Sanitizer recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Schema drift detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | Taint sink detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint source detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/template_pattern_jsts.go`<br>`internal/substrate/template_pattern_test.go` | — |
 | Vulnerability finding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Framework-specific

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -68,26 +68,26 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Constant propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DB effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Dead code detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Env fallback recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Fs effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| HTTP effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Import resolution quality | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Mutation effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Response shape extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Confidence overlay | ✅ `full` | `2026-05-29` | 3055 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Constant propagation | ✅ `full` | `2026-05-29` | 3055 | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| DB effect | ✅ `full` | `2026-05-29` | 3055 | `internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Dead code detection | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/reachability.go`<br>`internal/links/reachability_test.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| Def use chain extraction | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/def_use_jsts.go`<br>`internal/substrate/def_use_test.go` | — |
+| Env fallback recognition | ✅ `full` | `2026-05-29` | 3055 | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| Fs effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| HTTP effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Import resolution quality | ✅ `full` | `2026-05-29` | 3055 | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| Module cycle detection | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/module_cycle_pass.go` | — |
+| Mutation effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Pure function tagging | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| Reachability analysis | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/reachability.go`<br>`internal/links/reachability_test.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| Request shape extraction | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
+| Response shape extraction | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | Sanitizer recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Schema drift detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | Taint sink detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Taint source detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Template pattern catalog | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/template_pattern_jsts.go`<br>`internal/substrate/template_pattern_test.go` | — |
 | Vulnerability finding | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Framework-specific

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -68,26 +68,26 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Confidence overlay | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Constant propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DB effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Dead code detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Def use chain extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Env fallback recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Fs effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| HTTP effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Import resolution quality | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Module cycle detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Mutation effect | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pure function tagging | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Reachability analysis | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request shape extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Response shape extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Confidence overlay | ✅ `full` | `2026-05-29` | 3055 | `internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/jsts.go` | — |
+| Constant propagation | ✅ `full` | `2026-05-29` | 3055 | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| DB effect | ✅ `full` | `2026-05-29` | 3055 | `internal/substrate/backend_db_effect_test.go`<br>`internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Dead code detection | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/reachability.go`<br>`internal/links/reachability_test.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| Def use chain extraction | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/def_use_jsts.go`<br>`internal/substrate/def_use_test.go` | — |
+| Env fallback recognition | ✅ `full` | `2026-05-29` | 3055 | `internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| Fs effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| HTTP effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Import resolution quality | ✅ `full` | `2026-05-29` | 3055 | `internal/extractors/javascript/testdata/substrate_import_resolution/app.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/config.ts`<br>`internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts`<br>`internal/links/constant_propagation.go`<br>`internal/substrate/jsts.go`<br>`internal/substrate/substrate.go` | — |
+| Module cycle detection | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/module_cycle_pass.go` | — |
+| Mutation effect | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effects_test.go` | — |
+| Pure function tagging | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/pure_function_pass.go`<br>`internal/substrate/effect_sinks_jsts.go` | — |
+| Reachability analysis | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/links/reachability.go`<br>`internal/links/reachability_test.go`<br>`internal/substrate/entry_points_jsts.go` | — |
+| Request shape extraction | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
+| Response shape extraction | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | Sanitizer recognition | ✅ `full` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/substrate.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_sveltekit/+page.server.ts` | — |
-| Schema drift detection | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | ✅ `full` | `2026-05-29` | 3055 | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_jsts.go` | — |
 | Taint sink detection | ✅ `full` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/substrate.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_sveltekit/+page.server.ts` | — |
 | Taint source detection | ✅ `full` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/substrate.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_sveltekit/+page.server.ts` | — |
-| Template pattern catalog | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | ⚠️ `partial` | `2026-05-29` | 3055 | `internal/substrate/template_pattern_jsts.go`<br>`internal/substrate/template_pattern_test.go` | — |
 | Vulnerability finding | ✅ `full` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/substrate.go`<br>`internal/substrate/taint_sites_jsts.go`<br>`internal/substrate/uimm_substrate_test.go`<br>`testdata/fixtures/typescript/substrate_sveltekit/+page.server.ts` | — |
 
 ## Framework-specific

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -23251,72 +23251,104 @@
         },
         "Substrate": {
           "confidence_overlay": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/effect_propagation.go","internal/links/taint_flow.go","internal/substrate/jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "constant_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "db_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/substrate/backend_db_effect_test.go","internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/links/reachability_test.go","internal/substrate/entry_points_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/def_use_jsts.go","internal/substrate/def_use_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "env_fallback_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "fs_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "import_resolution_quality": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/testdata/substrate_import_resolution/app.ts","internal/extractors/javascript/testdata/substrate_import_resolution/config.ts","internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts","internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go","internal/substrate/effect_sinks_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/links/reachability_test.go","internal/substrate/entry_points_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "sanitizer_recognition": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "taint_sink_detection": {
             "status": "missing",
@@ -23327,8 +23359,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_jsts.go","internal/substrate/template_pattern_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
             "status": "missing",
@@ -23453,72 +23487,104 @@
         },
         "Substrate": {
           "confidence_overlay": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/effect_propagation.go","internal/links/taint_flow.go","internal/substrate/jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "constant_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "db_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/substrate/backend_db_effect_test.go","internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/links/reachability_test.go","internal/substrate/entry_points_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/def_use_jsts.go","internal/substrate/def_use_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "env_fallback_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "fs_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "import_resolution_quality": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/testdata/substrate_import_resolution/app.ts","internal/extractors/javascript/testdata/substrate_import_resolution/config.ts","internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts","internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go","internal/substrate/effect_sinks_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/links/reachability_test.go","internal/substrate/entry_points_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "sanitizer_recognition": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "taint_sink_detection": {
             "status": "missing",
@@ -23529,8 +23595,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_jsts.go","internal/substrate/template_pattern_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
             "status": "missing",
@@ -24431,72 +24499,104 @@
         },
         "Substrate": {
           "confidence_overlay": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/effect_propagation.go","internal/links/taint_flow.go","internal/substrate/jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "constant_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "db_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/substrate/backend_db_effect_test.go","internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/links/reachability_test.go","internal/substrate/entry_points_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/def_use_jsts.go","internal/substrate/def_use_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "env_fallback_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "fs_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "import_resolution_quality": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/testdata/substrate_import_resolution/app.ts","internal/extractors/javascript/testdata/substrate_import_resolution/config.ts","internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts","internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go","internal/substrate/effect_sinks_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/links/reachability_test.go","internal/substrate/entry_points_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "sanitizer_recognition": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "taint_sink_detection": {
             "status": "missing",
@@ -24507,8 +24607,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_jsts.go","internal/substrate/template_pattern_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
             "status": "missing",
@@ -25366,64 +25468,94 @@
         },
         "Substrate": {
           "confidence_overlay": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/effect_propagation.go","internal/links/taint_flow.go","internal/substrate/jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "constant_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "db_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/substrate/backend_db_effect_test.go","internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "dead_code_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/links/reachability_test.go","internal/substrate/entry_points_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/def_use_jsts.go","internal/substrate/def_use_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "env_fallback_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "fs_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "http_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "import_resolution_quality": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/javascript/testdata/substrate_import_resolution/app.ts","internal/extractors/javascript/testdata/substrate_import_resolution/config.ts","internal/extractors/javascript/testdata/substrate_import_resolution/nest_app.ts","internal/links/constant_propagation.go","internal/substrate/jsts.go","internal/substrate/substrate.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "mutation_effect": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/effect_sinks_jsts.go","internal/substrate/effects_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go","internal/substrate/effect_sinks_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "reachability_analysis": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/reachability.go","internal/links/reachability_test.go","internal/substrate/entry_points_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "sanitizer_recognition": {
             "status": "full",
@@ -25431,8 +25563,10 @@
             "verified_at": "2026-05-28"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_jsts.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "taint_sink_detection": {
             "status": "full",
@@ -25445,8 +25579,10 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_jsts.go","internal/substrate/template_pattern_test.go"],
+            "issue": "3055",
+            "verified_at": "2026-05-29"
           },
           "vulnerability_finding": {
             "status": "full",


### PR DESCRIPTION
## Summary

- Flips 68 registry cells from `missing` to `full`/`partial` for the four JS/TS meta-framework records: `lang.jsts.framework.next-api`, `lang.jsts.framework.remix`, `lang.jsts.framework.nuxt`, `lang.jsts.framework.sveltekit`.
- No Go code changes — recording-win only. The substrate sniffers (`internal/substrate/jsts.go`, `def_use_jsts.go`, `effect_sinks_jsts.go`, `entry_points_jsts.go`, `template_pattern_jsts.go`, `payload_shapes_jsts.go`) and link passes (`constant_propagation.go`, `effect_propagation.go`, `module_cycle_pass.go`, `pure_function_pass.go`, `reachability.go`, `payload_drift.go`) are framework-blind and fire on any JS/TS content.
- Status classification mirrors the established pattern from the prior feathers/restify/sails substrate sweep (#3048): 8 caps `full` (comprehensive pipeline with multi-file tests), 9 caps `partial` (sniffer confirmed but no meta-framework-specific fixture).

**Cells flipped (17 caps × 4 records = 68 total):**
- `full` (×8): `confidence_overlay`, `constant_propagation`, `db_effect`, `env_fallback_recognition`, `import_resolution_quality`, `request_shape_extraction`, `response_shape_extraction`, `schema_drift_detection`
- `partial` (×9): `dead_code_detection`, `def_use_chain_extraction`, `fs_effect`, `http_effect`, `module_cycle_detection`, `mutation_effect`, `pure_function_tagging`, `reachability_analysis`, `template_pattern_catalog`

## Test plan

- [x] `coverage validate` — 0 errors
- [x] `coverage fmt --check` — canonical
- [x] `coverage gen` — byte-stable (same 558 records)
- [x] `go build ./...` — clean
- [x] `go test ./internal/substrate/ ./tools/coverage/` — both pass

Closes #3055

🤖 Generated with [Claude Code](https://claude.com/claude-code)