### PR TITLE
feat(coverage): Python middleware recording-win — 13 http_backend cells missing→partial

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -80,23 +80,23 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 2/7 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 3/7 | |
 | [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/8 | |
-| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 2/7 | |
 | [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
 | [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
 | [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -14,23 +14,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 2/7 | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 2/7 | |
 | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 3/7 | |
 | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 20/21 | ❌ 4/8 | |
-| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 2/7 | |
 | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
 | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 1/7 | |
+| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ❌ 0/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ❌ 0/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3054 | `internal/custom/python/http_middleware.go` | — |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -32944,7 +32944,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -33162,7 +33165,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -33565,7 +33571,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -34416,7 +34425,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -35078,7 +35090,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -35315,7 +35330,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -35533,7 +35551,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -35744,7 +35765,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -35961,7 +35985,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -36360,7 +36387,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -36577,7 +36607,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -36793,7 +36826,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -37010,7 +37046,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/python/http_middleware.go"],
+            "issue": "3054",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {

--- a/internal/custom/python/http_middleware.go
+++ b/internal/custom/python/http_middleware.go
@@ -1,0 +1,404 @@
+// http_middleware.go — Python HTTP-framework middleware detection.
+//
+// Extracts middleware registration patterns for the Python http_backend
+// frameworks that do NOT have a dedicated custom extractor with middleware
+// support (Django/FastAPI/Flask are handled by their own extractors).
+//
+// Covered frameworks and their canonical middleware patterns:
+//
+//   aiohttp      — app.middlewares=[mw1, mw2] list assignment
+//   bottle       — @bottle.hook('before_request') / @app.hook(...)
+//   cherrypy     — cherrypy.tools.<name> = cherrypy.Tool(...) / @cherrypy.expose
+//                  pipeline via ['/'].tools.<name>.on = True
+//   falcon       — falcon.App(middleware=[...]) / app.add_middleware(mw)
+//   hug          — @hug.request_middleware / @hug.response_middleware
+//   litestar     — Litestar(middleware=[...]) / app.register(MiddlewareProtocol)
+//   pyramid      — config.add_tween('pkg.Tween') tween factory registration
+//   quart        — @app.before_request / @app.after_request (Flask-compatible)
+//   robyn        — app.before_request() / app.after_request() decorators
+//   sanic        — app.register_middleware(fn, 'request'|'response')
+//                  @app.middleware('request') decorator
+//   starlette    — Starlette(middleware=[...]) / app.add_middleware(Cls) /
+//                  @app.middleware("http") decorator
+//   strawberry   — strawberry.Schema(extensions=[...]) GraphQL middleware list
+//   tornado      — RequestHandler.prepare() + set_default_headers() hooks;
+//                  middleware via Application settings / transform classes
+//
+// Issue #3054.
+package python
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_http_middleware", &HTTPMiddlewareExtractor{})
+}
+
+// HTTPMiddlewareExtractor detects middleware registration patterns across the
+// Python HTTP backend frameworks not covered by dedicated extractors.
+type HTTPMiddlewareExtractor struct{}
+
+func (e *HTTPMiddlewareExtractor) Language() string { return "python_http_middleware" }
+
+// ---------------------------------------------------------------------------
+// Compiled regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// aiohttp: app.middlewares = [mw1, mw2, ...] or web.Application(middlewares=[...])
+	aiohttpMiddlewaresAssignRe = regexp.MustCompile(
+		`(?m)(\w+)\.middlewares\s*=\s*\[`)
+	aiohttpMiddlewaresKwargRe = regexp.MustCompile(
+		`(?m)web\.Application\s*\([^)]*middlewares\s*=\s*\[`)
+
+	// bottle: @bottle.hook('before_request') or @app.hook('after_request')
+	bottleHookRe = regexp.MustCompile(
+		`(?m)@(?:bottle|\w+)\.hook\s*\(\s*["'](before_request|after_request|before_response|after_response)["']\s*\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+	// cherrypy: cherrypy.tools.<name> = cherrypy.Tool(...)
+	cherrypyToolAssignRe = regexp.MustCompile(
+		`(?m)cherrypy\.tools\.(\w+)\s*=\s*cherrypy\.Tool\s*\(`)
+	// cherrypy: ['/'].tools.<name>.on = True in _cp_config or config
+	cherrypyToolOnRe = regexp.MustCompile(
+		`(?m)['"]/[^'"]*['"].*tools\.(\w+)\.on\s*=\s*True`)
+
+	// falcon: falcon.App(middleware=[...]) / falcon.API(middleware=[...])
+	falconAppMiddlewareRe = regexp.MustCompile(
+		`(?m)falcon\.(?:App|API)\s*\([^)]*middleware\s*=\s*\[`)
+	// falcon: app.add_middleware(SomeMW())
+	falconAddMiddlewareRe = regexp.MustCompile(
+		`(?m)(\w+)\.add_middleware\s*\(\s*(\w+)`)
+
+	// hug: @hug.request_middleware / @hug.response_middleware
+	hugMiddlewareRe = regexp.MustCompile(
+		`(?m)@hug\.(request_middleware|response_middleware)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+	// litestar: Litestar(middleware=[...])
+	litestarMiddlewareKwargRe = regexp.MustCompile(
+		`(?m)Litestar\s*\([^)]*middleware\s*=\s*\[`)
+	// litestar: AbstractMiddlewareFactory / MiddlewareProtocol class
+	litestarMiddlewareClassRe = regexp.MustCompile(
+		`(?m)^class\s+(\w+)\s*\([^)]*(?:MiddlewareProtocol|AbstractMiddleware)[^)]*\)\s*:`)
+
+	// pyramid: config.add_tween('pkg.tween_factory')
+	pyramidAddTweenRe = regexp.MustCompile(
+		`(?m)config\.add_tween\s*\(\s*["']([^"']+)["']`)
+
+	// quart: @app.before_request / @app.after_request (Flask-compatible)
+	quartHookRe = regexp.MustCompile(
+		`(?m)@(\w+)\.(before_request|after_request|teardown_request|before_app_request|after_app_request)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+	// quart: Quart() import signal
+	quartImportRe = regexp.MustCompile(`(?m)(?:from quart import|import quart)`)
+
+	// robyn: app.before_request(fn) / app.after_request(fn) / @app.before_request
+	robynBeforeRe = regexp.MustCompile(
+		`(?m)@(\w+)\.(before_request|after_request)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+	robynBeforeCallRe = regexp.MustCompile(
+		`(?m)(\w+)\.(before_request|after_request)\s*\(\s*(\w+)\s*\)`)
+
+	// sanic: app.register_middleware(fn, 'request') / @app.middleware('request')
+	sanicRegisterMiddlewareRe = regexp.MustCompile(
+		`(?m)(\w+)\.register_middleware\s*\(\s*(\w+)\s*,\s*["'](request|response)["']`)
+	sanicMiddlewareDecoratorRe = regexp.MustCompile(
+		`(?m)@(\w+)\.middleware\s*\(\s*["'](request|response)["']\s*\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+	// starlette: Starlette(middleware=[...]) or app.add_middleware(Cls, ...)
+	starletteMiddlewareKwargRe = regexp.MustCompile(
+		`(?m)Starlette\s*\([^)]*middleware\s*=\s*\[`)
+	starletteAddMiddlewareRe = regexp.MustCompile(
+		`(?m)(\w+)\.add_middleware\s*\(\s*(\w+)`)
+	// @app.middleware("http") decorator  — shared with FastAPI
+	starletteMiddlewareDecoratorRe = regexp.MustCompile(
+		`(?m)@(\w+)\.middleware\s*\(\s*["']http["']\s*\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+	// strawberry: strawberry.Schema(extensions=[MyExtension, ...])
+	strawberrySchemaExtRe = regexp.MustCompile(
+		`(?m)strawberry\.Schema\s*\([^)]*extensions\s*=\s*\[`)
+	// GraphQL middleware list on execute
+	strawberryMiddlewareRe = regexp.MustCompile(
+		`(?m)middleware\s*=\s*\[\s*(\w+)`)
+
+	// tornado: def prepare(self) inside a RequestHandler subclass
+	tornadoPrepareRe = regexp.MustCompile(
+		`(?m)^\s{4,}def\s+prepare\s*\(\s*self`)
+	// tornado: Application(settings={'transforms': [...]}) / transform classes
+	tornadoTransformRe = regexp.MustCompile(
+		`(?m)(?:OutputTransform|GZipContentEncoding|ChunkedTransferEncoding)`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *HTTPMiddlewareExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_http_middleware")
+	_, span := tracer.Start(ctx, "custom.python_http_middleware")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	var out []types.EntityRecord
+
+	// -----------------------------------------------------------------------
+	// aiohttp
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "aiohttp") || strings.Contains(src, "web.Application") {
+		for _, idx := range allMatchesIndex(aiohttpMiddlewaresAssignRe, src) {
+			appVar := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(appVar+".middlewares", "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "aiohttp", "pattern_type": "middleware_list", "app_var": appVar}))
+		}
+		for _, idx := range allMatchesIndex(aiohttpMiddlewaresKwargRe, src) {
+			line := lineOf(src, idx[0])
+			out = append(out, entity("web.Application.middlewares", "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "aiohttp", "pattern_type": "middleware_list"}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// bottle
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "bottle") || strings.Contains(src, "Bottle") {
+		for _, idx := range allMatchesIndex(bottleHookRe, src) {
+			hookType := src[idx[2]:idx[3]]
+			funcName := src[idx[4]:idx[5]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(funcName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "bottle", "pattern_type": "hook", "hook_type": hookType}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// cherrypy
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "cherrypy") {
+		for _, idx := range allMatchesIndex(cherrypyToolAssignRe, src) {
+			toolName := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity("cherrypy.tools."+toolName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "cherrypy", "pattern_type": "tool", "tool_name": toolName}))
+		}
+		for _, idx := range allMatchesIndex(cherrypyToolOnRe, src) {
+			toolName := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity("cherrypy.tools."+toolName+".on", "SCOPE.Config", "",
+				file.Path, line,
+				map[string]string{"framework": "cherrypy", "pattern_type": "tool_enable", "tool_name": toolName}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// falcon
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "falcon") {
+		if falconAppMiddlewareRe.MatchString(src) {
+			line := lineOf(src, falconAppMiddlewareRe.FindStringIndex(src)[0])
+			out = append(out, entity("falcon.App.middleware", "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "falcon", "pattern_type": "middleware_list"}))
+		}
+		for _, idx := range allMatchesIndex(falconAddMiddlewareRe, src) {
+			appVar := src[idx[2]:idx[3]]
+			mwClass := src[idx[4]:idx[5]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(mwClass, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "falcon", "pattern_type": "add_middleware", "app_var": appVar, "middleware": mwClass}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// hug
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "hug") {
+		for _, idx := range allMatchesIndex(hugMiddlewareRe, src) {
+			mwType := src[idx[2]:idx[3]]
+			funcName := src[idx[4]:idx[5]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(funcName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "hug", "pattern_type": "middleware", "middleware_type": mwType}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// litestar
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "litestar") || strings.Contains(src, "Litestar") {
+		if litestarMiddlewareKwargRe.MatchString(src) {
+			line := lineOf(src, litestarMiddlewareKwargRe.FindStringIndex(src)[0])
+			out = append(out, entity("Litestar.middleware", "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "litestar", "pattern_type": "middleware_list"}))
+		}
+		for _, idx := range allMatchesIndex(litestarMiddlewareClassRe, src) {
+			className := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(className, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "litestar", "pattern_type": "middleware_class"}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// pyramid
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "pyramid") || strings.Contains(src, "Configurator") {
+		for _, idx := range allMatchesIndex(pyramidAddTweenRe, src) {
+			tweenPath := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(tweenPath, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "pyramid", "pattern_type": "tween", "tween_factory": tweenPath}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// quart (Flask-compatible async — detects quart import + before/after hooks)
+	// -----------------------------------------------------------------------
+	if quartImportRe.MatchString(src) || strings.Contains(src, "Quart(") {
+		for _, idx := range allMatchesIndex(quartHookRe, src) {
+			appVar := src[idx[2]:idx[3]]
+			hookType := src[idx[4]:idx[5]]
+			funcName := src[idx[6]:idx[7]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(funcName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "quart", "pattern_type": "request_hook", "hook_type": hookType, "app_var": appVar}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// robyn
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "robyn") || strings.Contains(src, "Robyn") {
+		for _, idx := range allMatchesIndex(robynBeforeRe, src) {
+			hookType := src[idx[4]:idx[5]]
+			funcName := src[idx[6]:idx[7]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(funcName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "robyn", "pattern_type": "lifecycle_hook", "hook_type": hookType}))
+		}
+		for _, idx := range allMatchesIndex(robynBeforeCallRe, src) {
+			hookType := src[idx[4]:idx[5]]
+			funcName := src[idx[6]:idx[7]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(funcName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "robyn", "pattern_type": "lifecycle_hook_call", "hook_type": hookType}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// sanic
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "sanic") || strings.Contains(src, "Sanic") {
+		for _, idx := range allMatchesIndex(sanicRegisterMiddlewareRe, src) {
+			appVar := src[idx[2]:idx[3]]
+			funcName := src[idx[4]:idx[5]]
+			phase := src[idx[6]:idx[7]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(funcName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "sanic", "pattern_type": "middleware", "phase": phase, "app_var": appVar}))
+		}
+		for _, idx := range allMatchesIndex(sanicMiddlewareDecoratorRe, src) {
+			phase := src[idx[4]:idx[5]]
+			funcName := src[idx[6]:idx[7]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(funcName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "sanic", "pattern_type": "middleware_decorator", "phase": phase}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// starlette
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "starlette") || strings.Contains(src, "Starlette") {
+		if starletteMiddlewareKwargRe.MatchString(src) {
+			line := lineOf(src, starletteMiddlewareKwargRe.FindStringIndex(src)[0])
+			out = append(out, entity("Starlette.middleware", "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "starlette", "pattern_type": "middleware_list"}))
+		}
+		for _, idx := range allMatchesIndex(starletteAddMiddlewareRe, src) {
+			appVar := src[idx[2]:idx[3]]
+			mwClass := src[idx[4]:idx[5]]
+			// skip fastapi.go's own add_middleware if fastapi also present — let fastapi.go own it
+			if strings.Contains(src, "FastAPI") || strings.Contains(src, "fastapi") {
+				continue
+			}
+			line := lineOf(src, idx[0])
+			out = append(out, entity(mwClass, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "starlette", "pattern_type": "add_middleware", "app_var": appVar, "middleware": mwClass}))
+		}
+		for _, idx := range allMatchesIndex(starletteMiddlewareDecoratorRe, src) {
+			appVar := src[idx[2]:idx[3]]
+			funcName := src[idx[4]:idx[5]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(funcName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "starlette", "pattern_type": "middleware_decorator", "app_var": appVar}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// strawberry-graphql
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "strawberry") {
+		if strawberrySchemaExtRe.MatchString(src) {
+			line := lineOf(src, strawberrySchemaExtRe.FindStringIndex(src)[0])
+			out = append(out, entity("strawberry.Schema.extensions", "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "strawberry-graphql", "pattern_type": "schema_extensions"}))
+		}
+		for _, idx := range allMatchesIndex(strawberryMiddlewareRe, src) {
+			mwName := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(mwName, "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "strawberry-graphql", "pattern_type": "graphql_middleware", "middleware": mwName}))
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// tornado
+	// -----------------------------------------------------------------------
+	if strings.Contains(src, "tornado") || strings.Contains(src, "RequestHandler") {
+		for _, idx := range allMatchesIndex(tornadoPrepareRe, src) {
+			line := lineOf(src, idx[0])
+			out = append(out, entity("prepare", "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "tornado", "pattern_type": "prepare_hook"}))
+		}
+		if tornadoTransformRe.MatchString(src) {
+			line := lineOf(src, tornadoTransformRe.FindStringIndex(src)[0])
+			out = append(out, entity("tornado.transform", "SCOPE.Pattern", "",
+				file.Path, line,
+				map[string]string{"framework": "tornado", "pattern_type": "transform_middleware"}))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/python/http_middleware_test.go
+++ b/internal/custom/python/http_middleware_test.go
@@ -1,0 +1,340 @@
+package python_test
+
+import (
+	"testing"
+)
+
+func TestHTTPMiddlewareExtractor_Aiohttp(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+from aiohttp import web
+
+async def my_middleware(app, handler):
+    async def middleware(request):
+        return await handler(request)
+    return middleware
+
+app = web.Application()
+app.middlewares = [my_middleware]
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for aiohttp middleware")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "aiohttp" && e.Props["pattern_type"] == "middleware_list" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected aiohttp middleware_list entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Bottle(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+import bottle
+from bottle import Bottle
+
+app = Bottle()
+
+@bottle.hook('before_request')
+def before():
+    pass
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for bottle hook")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "bottle" && e.Props["pattern_type"] == "hook" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected bottle hook entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Falcon(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+import falcon
+
+class AuthMiddleware:
+    def process_request(self, req, resp):
+        pass
+
+app = falcon.App(middleware=[AuthMiddleware()])
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for falcon middleware")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "falcon" && e.Props["pattern_type"] == "middleware_list" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected falcon middleware_list entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Hug(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+import hug
+
+@hug.request_middleware
+def process_data(request, response):
+    pass
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for hug middleware")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "hug" && e.Name == "process_data" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected hug middleware entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Litestar(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+from litestar import Litestar
+from litestar.middleware import AbstractMiddleware
+
+class LoggingMiddleware(AbstractMiddleware):
+    async def __call__(self, scope, receive, send):
+        pass
+
+app = Litestar(middleware=[LoggingMiddleware])
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for litestar middleware")
+	}
+	var foundList, foundClass bool
+	for _, e := range entities {
+		if e.Props["framework"] == "litestar" && e.Props["pattern_type"] == "middleware_list" {
+			foundList = true
+		}
+		if e.Props["framework"] == "litestar" && e.Props["pattern_type"] == "middleware_class" {
+			foundClass = true
+		}
+	}
+	if !foundList {
+		t.Errorf("expected litestar middleware_list, got %+v", entities)
+	}
+	if !foundClass {
+		t.Errorf("expected litestar middleware_class, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Pyramid(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+from pyramid.config import Configurator
+
+def main(global_config, **settings):
+    config = Configurator(settings=settings)
+    config.add_tween('myapp.tweens.timing_tween_factory')
+    return config.make_wsgi_app()
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for pyramid tween")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "pyramid" && e.Props["pattern_type"] == "tween" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected pyramid tween entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Quart(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+from quart import Quart
+
+app = Quart(__name__)
+
+@app.before_request
+async def before():
+    pass
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for quart hook")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "quart" && e.Props["pattern_type"] == "request_hook" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected quart request_hook entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Robyn(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+from robyn import Robyn
+
+app = Robyn(__file__)
+
+@app.before_request
+async def before(request):
+    return request
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for robyn before_request")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "robyn" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected robyn middleware entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Sanic(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+from sanic import Sanic
+
+app = Sanic(__name__)
+
+@app.middleware('request')
+async def add_start_time(request):
+    pass
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for sanic middleware")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "sanic" && e.Props["pattern_type"] == "middleware_decorator" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected sanic middleware_decorator entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Starlette(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+
+app = Starlette(middleware=[
+    Middleware(CORSMiddleware, allow_origins=["*"]),
+])
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for starlette middleware")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "starlette" && e.Props["pattern_type"] == "middleware_list" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected starlette middleware_list entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Strawberry(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+import strawberry
+from strawberry.extensions import QueryDepthLimiter
+
+schema = strawberry.Schema(
+    query=Query,
+    extensions=[QueryDepthLimiter(max_depth=5)],
+)
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for strawberry extensions")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "strawberry-graphql" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected strawberry-graphql entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_Tornado(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+import tornado.web
+
+class MainHandler(tornado.web.RequestHandler):
+    def prepare(self):
+        self.set_header("X-Request-ID", "123")
+
+    def get(self):
+        self.write("Hello")
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for tornado prepare")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "tornado" && e.Props["pattern_type"] == "prepare_hook" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected tornado prepare_hook entity, got %+v", entities)
+	}
+}
+
+func TestHTTPMiddlewareExtractor_CherryPy(t *testing.T) {
+	entities := extract(t, "python_http_middleware", `
+import cherrypy
+
+cherrypy.tools.auth = cherrypy.Tool('before_handler', check_auth)
+
+class Root:
+    _cp_config = {'/': {'tools.auth.on': True}}
+
+    @cherrypy.expose
+    def index(self):
+        return "Hello"
+`)
+	if len(entities) == 0 {
+		t.Fatal("expected at least one entity for cherrypy tool")
+	}
+	found := false
+	for _, e := range entities {
+		if e.Props["framework"] == "cherrypy" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected cherrypy tool entity, got %+v", entities)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/custom/python/http_middleware.go`: a new custom extractor detecting middleware registration patterns for 13 Python http_backend frameworks (aiohttp, bottle, cherrypy, falcon, hug, litestar, pyramid, quart, robyn, sanic, starlette, strawberry-graphql, tornado)
- Flips all 13 `middleware_coverage` registry cells from `missing → partial`
- Adds 13 passing extractor tests in `http_middleware_test.go` — one per framework

Each framework's canonical middleware pattern is extracted: `app.middlewares=[]` (aiohttp), `@bottle.hook()` (bottle), `cherrypy.tools.X = cherrypy.Tool()` (cherrypy), `falcon.App(middleware=[])` (falcon), `@hug.request_middleware` (hug), `Litestar(middleware=[])` (litestar), `config.add_tween()` (pyramid), `@app.before_request` (quart), `@app.before_request` decorator (robyn), `@app.middleware('request')` (sanic), `Starlette(middleware=[])` (starlette), `strawberry.Schema(extensions=[])` (strawberry-graphql), `prepare()` hook (tornado).

Status is `partial` (not `full`) because: list-item names are captured but not deep-resolved across import boundaries, and some secondary patterns (e.g. CherryPy per-route tool config in INI files, Tornado transform subclassing) remain unextracted.

Closes #3054

## Test plan

- [x] `coverage validate` exits 0 errors
- [x] `coverage fmt --check` clean
- [x] `coverage gen` byte-stable (run twice, same output)
- [x] `go build ./...` passes
- [x] `go test ./internal/custom/python/ ./tools/coverage/` passes (13 new tests all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)