### PR TITLE
feat(coverage): JS/TS ORM recording-win — TypeORM assoc+FK, Objection assoc+FK+relation+schema, Mongoose schema+assoc+rel+NA (~11 cells)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -79,11 +79,11 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/7 | |
 | [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ 3/8 | |
 | [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ✅ 1/1 | |
-| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ❌ 2/7 | |
-| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 4/9 | |
+| [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ⚠️ 5/5 | |
+| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 8/9 | |
 | [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | ❌ 3/8 | |
 | [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ 3/8 | |
-| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 4/8 | |
+| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 6/8 | |
 | [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ✅ 1/1 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -121,11 +121,11 @@ Back to [summary](../summary.md).
 | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/7 | |
 | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ 3/8 | |
 | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ✅ 1/1 | |
-| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ❌ 2/7 | |
-| [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 4/9 | |
+| [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ⚠️ 5/5 | |
+| [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 8/9 | |
 | [Prisma](../detail/lang.jsts.orm.prisma.md) | ❌ 3/8 | |
 | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ 3/8 | |
-| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 4/8 | |
+| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 6/8 | |
 | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ✅ 1/1 | |
 | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ✅ 1/1 | |
 | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ✅ 1/1 | |

--- a/docs/coverage/detail/lang.jsts.orm.mongoose.md
+++ b/docs/coverage/detail/lang.jsts.orm.mongoose.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/mongoose.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_test.go`<br>`internal/custom/javascript/mongoose.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mongoose.go` | reMongoosePopulate captures .populate() traversal calls (navigate-to-ref); the definition-side ref: field in Schema() is not extracted, so reference declarations are missing |
+| Foreign key extraction | — `not_applicable` | — | 3064 | — | MongoDB is a document-oriented database; there is no relational FK concept |
+| Lazy loading recognition | — `not_applicable` | — | 3064 | — | Mongoose/MongoDB has no lazy-loading mechanism |
+| Relationship extraction | ⚠️ `partial` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/mongoose.go` | .populate() traversals are captured as query entities; schema-level ref: declarations (the definition side of Mongoose associations) are not parsed |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.jsts.orm.objection.md
+++ b/docs/coverage/detail/lang.jsts.orm.objection.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go`<br>`internal/engine/rules/javascript_typescript/orms/objection.yaml` | — |
-| Schema extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | — |
+| Foreign key extraction | ⚠️ `partial` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | reObjectionRelation captures named relation entries (relation_type+field_name) from relationMappings, which encode FK join topology implicitly; the from/to column-level FK fields are not explicitly parsed |
 | Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.jsts.orm.typeorm.md
+++ b/docs/coverage/detail/lang.jsts.orm.typeorm.md
@@ -22,8 +22,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_test.go`<br>`internal/custom/javascript/typeorm.go` | — |
+| Foreign key extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/typeorm.go` | — |
 | Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Relationship extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/javascript/typeorm.go` | — |
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -26331,26 +26331,33 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_test.go","internal/custom/javascript/mongoose.go"],
+            "issue": "3064"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mongoose.go"],
+            "issue": "3064",
+            "notes": "reMongoosePopulate captures .populate() traversal calls (navigate-to-ref); the definition-side ref: field in Schema() is not extracted, so reference declarations are missing"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3064",
+            "notes": "MongoDB is a document-oriented database; there is no relational FK concept"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3064",
+            "notes": "Mongoose/MongoDB has no lazy-loading mechanism"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/mongoose.go"],
+            "issue": "3064",
+            "notes": ".populate() traversals are captured as query entities; schema-level ref: declarations (the definition side of Mongoose associations) are not parsed"
           }
         },
         "Queries": {
@@ -26381,26 +26388,31 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go"],
+            "issue": "3064"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go"],
+            "issue": "3064"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go"],
+            "issue": "3064",
+            "notes": "reObjectionRelation captures named relation entries (relation_type+field_name) from relationMappings, which encode FK join topology implicitly; the from/to column-level FK fields are not explicitly parsed"
           },
           "lazy_loading_recognition": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/objection.go"],
+            "issue": "3064"
           }
         },
         "Queries": {
@@ -26552,12 +26564,14 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_test.go","internal/custom/javascript/typeorm.go"],
+            "issue": "3064"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/extractors_coverage_test.go","internal/custom/javascript/typeorm.go"],
+            "issue": "3064"
           },
           "lazy_loading_recognition": {
             "status": "missing",


### PR DESCRIPTION
## Summary

Recording-win backfill for #3064: stamps honest `full`/`partial`/`not_applicable` on ORM capability cells that already have working extractors.

**TypeORM** (2 cells → full):
- `association_extraction`: `reTypeORMRelation` decorator parser (`@OneToMany/@ManyToOne/@OneToOne/@ManyToMany`) emits `SCOPE.Component` relation entities; proven by `TestTypeORMRelation`.
- `foreign_key_extraction`: `reTypeORMMigrationOp("createForeignKey")` → `add_foreign_key` evolution entity; proven by `TestTypeORMMigrationOps`.

**Objection** (4 cells):
- `association_extraction` → full: `reObjectionRelation` emits per-relation `SCOPE.Component` entities; proven by `TestObjectionModelAndMigration`.
- `relationship_extraction` → full: same extractor, same test.
- `schema_extraction` → full: `reObjectionJSONSchema` captures `static get jsonSchema()` declarations; proven by `TestObjectionModelAndMigration`.
- `foreign_key_extraction` → partial: `reObjectionRelation` records named relation entries (implicitly encoding FK topology) but does not parse the `from`/`to` column-level fields explicitly.

**Mongoose** (5 cells):
- `schema_extraction` → full: `reMongooseSchemaAssign` captures `new Schema(...)` assignments; proven by `TestMongooseSchema`.
- `association_extraction` → partial: `.populate()` traversals captured via `reMongoosePopulate`; definition-side `ref:` field in `Schema()` is NOT parsed.
- `relationship_extraction` → partial: same populate-only coverage; ref: declarations absent.
- `foreign_key_extraction` → not_applicable: MongoDB is document-oriented; no relational FK concept.
- `lazy_loading_recognition` → not_applicable: Mongoose/MongoDB has no lazy-loading mechanism.

## Verification

- `coverage validate` — 0 errors
- `coverage fmt --check` — clean
- `coverage gen` — byte-stable (only docs/coverage updated)
- `go build ./...` — clean
- `go test ./internal/custom/javascript/...` — all pass
- `go test ./tools/coverage/` — all pass
- `internal/verify.TestHarness_FixturesCorpus` failure is pre-existing (daemon socket conflict); confirmed same failure on `main`.

Closes #3064

🤖 Generated with [Claude Code](https://claude.com/claude-code)