### PR TITLE
feat(coverage): Python observability extractor — log/metric/trace × 17 frameworks (51 cells)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -80,23 +80,23 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
-| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 3/7 | |
-| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 20/21 | ❌ 4/8 | |
-| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 6/7 | |
+| [python](../by-language/python.md) | [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 20/21 | ❌ 7/8 | |
+| [python](../by-language/python.md) | [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ⚠️ 7/7 | |
+| [python](../by-language/python.md) | [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ⚠️ 7/7 | |
+| [python](../by-language/python.md) | [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
 | [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -14,23 +14,23 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 3/7 | |
-| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 20/21 | ❌ 4/8 | |
-| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 4/7 | |
-| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 2/7 | |
-| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 2/7 | |
+| [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [CherryPy](../detail/lang.python.framework.cherrypy.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 6/7 | |
+| [Django REST Framework](../detail/lang.python.framework.django-drf.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 20/21 | ❌ 7/8 | |
+| [Falcon](../detail/lang.python.framework.falcon.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [FastAPI](../detail/lang.python.framework.fastapi.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ⚠️ 7/7 | |
+| [Flask](../detail/lang.python.framework.flask.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ⚠️ 7/7 | |
+| [Hug](../detail/lang.python.framework.hug.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Litestar](../detail/lang.python.framework.litestar.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Pyramid](../detail/lang.python.framework.pyramid.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Quart](../detail/lang.python.framework.quart.md) | ❌ 0/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ⚠️ 1/1 | ❌ 19/20 | ❌ 5/7 | |
+| [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | ⚠️ 1/1 | ✅ 4/4 | ✅ 1/1 | ❌ 19/20 | ❌ 5/7 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.python.framework.aiohttp.md
+++ b/docs/coverage/detail/lang.python.framework.aiohttp.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.bottle.md
+++ b/docs/coverage/detail/lang.python.framework.bottle.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.cherrypy.md
+++ b/docs/coverage/detail/lang.python.framework.cherrypy.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.falcon.md
+++ b/docs/coverage/detail/lang.python.framework.falcon.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.hug.md
+++ b/docs/coverage/detail/lang.python.framework.hug.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.litestar.md
+++ b/docs/coverage/detail/lang.python.framework.litestar.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.pyramid.md
+++ b/docs/coverage/detail/lang.python.framework.pyramid.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.quart.md
+++ b/docs/coverage/detail/lang.python.framework.quart.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.robyn.md
+++ b/docs/coverage/detail/lang.python.framework.robyn.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.sanic.md
+++ b/docs/coverage/detail/lang.python.framework.sanic.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.starlette.md
+++ b/docs/coverage/detail/lang.python.framework.starlette.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.tornado.md
+++ b/docs/coverage/detail/lang.python.framework.tornado.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Metric extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Trace extraction | ⚠️ `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -33169,16 +33169,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -33394,16 +33397,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -33807,16 +33813,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -34035,16 +34044,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -34263,16 +34275,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Substrate": {
@@ -34669,16 +34684,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -34897,16 +34915,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -35125,16 +35146,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -35345,16 +35369,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -35592,16 +35619,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -35817,16 +35847,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -36036,16 +36069,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -36260,16 +36296,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -36666,16 +36705,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -36890,16 +36932,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -37113,16 +37158,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {
@@ -37337,16 +37385,19 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/observability.go"],
+            "issue": "3063"
           }
         },
         "Data": {

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -2719,3 +2719,297 @@ func TestAttrs_FullFixture(t *testing.T) {
 		}
 	}
 }
+
+// ============================================================================
+// Observability tests (log/metric/trace) — Issue #3063
+// ============================================================================
+
+func TestObservability_StdlibLogging(t *testing.T) {
+	src := `import logging
+
+logger = logging.getLogger(__name__)
+app_log = logging.getLogger("myapp")
+
+logger.info("Server started")
+logger.debug("Debug message")
+logger.error("Error occurred")
+app_log.warning("Rate limit exceeded")
+`
+	ents := extract(t, "python_observability", src)
+
+	var loggers, logStmts int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			switch e.Subtype {
+			case "logger":
+				loggers++
+				if e.Props["library"] != "logging" {
+					t.Errorf("logger entity: expected library=logging, got %q", e.Props["library"])
+				}
+			case "log_statement":
+				logStmts++
+			}
+		}
+	}
+	if loggers == 0 {
+		t.Error("expected at least one logger entity for stdlib logging")
+	}
+	if logStmts == 0 {
+		t.Error("expected at least one log_statement entity for stdlib logging")
+	}
+}
+
+func TestObservability_Loguru(t *testing.T) {
+	src := `from loguru import logger
+
+logger.info("App started")
+logger.debug("debug msg")
+logger.error("Something went wrong")
+`
+	ents := extract(t, "python_observability", src)
+
+	var loggers int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "logger" && e.Props["library"] == "loguru" {
+			loggers++
+		}
+	}
+	if loggers == 0 {
+		t.Error("expected at least one logger entity for loguru")
+	}
+}
+
+func TestObservability_Structlog(t *testing.T) {
+	src := `import structlog
+
+structlog.configure(processors=[structlog.processors.JSONRenderer()])
+log = structlog.get_logger()
+log.info("structlog info")
+`
+	ents := extract(t, "python_observability", src)
+
+	var loggers int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "logger" && e.Props["library"] == "structlog" {
+			loggers++
+		}
+	}
+	if loggers == 0 {
+		t.Error("expected at least one logger entity for structlog")
+	}
+}
+
+func TestObservability_PrometheusClient(t *testing.T) {
+	src := `from prometheus_client import Counter, Gauge, Histogram
+
+REQUEST_COUNT = Counter("http_requests_total", "Total HTTP requests")
+LATENCY = Histogram("http_request_duration_seconds", "Request latency")
+IN_PROGRESS = Gauge("http_requests_in_progress", "In-progress requests")
+`
+	ents := extract(t, "python_observability", src)
+
+	metricNames := map[string]bool{}
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "metric" {
+			metricNames[e.Name] = true
+		}
+	}
+	for _, want := range []string{"http_requests_total", "http_request_duration_seconds", "http_requests_in_progress"} {
+		if !metricNames[want] {
+			t.Errorf("expected metric entity %q, got: %v", want, metricNames)
+		}
+	}
+}
+
+func TestObservability_Statsd(t *testing.T) {
+	src := `import statsd
+
+client = statsd.StatsClient("localhost", 8125)
+client.incr("page.views")
+client.gauge("queue.size", 42)
+client.timing("query.duration", 250)
+`
+	ents := extract(t, "python_observability", src)
+
+	var metrics int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "metric" && e.Props["library"] == "statsd" {
+			metrics++
+		}
+	}
+	if metrics == 0 {
+		t.Error("expected at least one metric entity for statsd")
+	}
+}
+
+func TestObservability_Datadog(t *testing.T) {
+	src := `from datadog import statsd
+
+statsd.increment("web.page_views")
+statsd.gauge("system.cpu.usage", 83.5)
+statsd.histogram("api.response.time", 0.12)
+`
+	ents := extract(t, "python_observability", src)
+
+	var metrics int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "metric" && e.Props["library"] == "datadog" {
+			metrics++
+		}
+	}
+	if metrics == 0 {
+		t.Error("expected at least one metric entity for datadog")
+	}
+}
+
+func TestObservability_OpenTelemetry(t *testing.T) {
+	src := `from opentelemetry import trace
+
+tracer = trace.get_tracer(__name__)
+
+@tracer.start_as_current_span("process_request")
+def handle_request(request):
+    pass
+
+def process_order(order_id):
+    with tracer.start_as_current_span("process_order") as span:
+        return fetch(order_id)
+`
+	ents := extract(t, "python_observability", src)
+
+	spanNames := map[string]bool{}
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "trace_span" {
+			spanNames[e.Name] = true
+		}
+	}
+	for _, want := range []string{"process_request", "process_order"} {
+		if !spanNames[want] {
+			t.Errorf("expected trace_span entity %q, got: %v", want, spanNames)
+		}
+	}
+}
+
+func TestObservability_DDTrace(t *testing.T) {
+	src := `from ddtrace import tracer
+
+@tracer.wrap("order_service.place")
+def place_order(order):
+    with tracer.trace("order_service.validate") as span:
+        return validate(order)
+`
+	ents := extract(t, "python_observability", src)
+
+	var spans int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "trace_span" && e.Props["library"] == "ddtrace" {
+			spans++
+		}
+	}
+	if spans == 0 {
+		t.Error("expected at least one trace_span entity for ddtrace")
+	}
+}
+
+func TestObservability_JaegerClient(t *testing.T) {
+	src := `import jaeger_client
+from opentracing import tracer
+
+config = jaeger_client.Config(
+    config={"sampler": {"type": "const"}},
+    service_name="order-service",
+)
+
+with tracer.start_span("order_lookup") as span:
+    span.set_tag("order.id", "123")
+`
+	ents := extract(t, "python_observability", src)
+
+	var spans int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "trace_span" && e.Props["library"] == "jaeger_client" {
+			spans++
+		}
+	}
+	if spans == 0 {
+		t.Error("expected at least one trace_span entity for jaeger_client")
+	}
+}
+
+func TestObservability_NoFalsePositive(t *testing.T) {
+	src := `from django.db import models
+
+class Order(models.Model):
+    amount = models.DecimalField(max_digits=10, decimal_places=2)
+    status = models.CharField(max_length=20)
+`
+	ents := extract(t, "python_observability", src)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && (e.Subtype == "logger" || e.Subtype == "metric" || e.Subtype == "trace_span" || e.Subtype == "log_statement") {
+			t.Errorf("unexpected observability entity in non-observability file: %+v", e)
+		}
+	}
+}
+
+func TestObservability_FixtureLogging(t *testing.T) {
+	content, err := os.ReadFile("testdata/observability_logging.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := extract(t, "python_observability", string(content))
+
+	var loggers, logStmts int
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Pattern" {
+			continue
+		}
+		switch e.Subtype {
+		case "logger":
+			loggers++
+		case "log_statement":
+			logStmts++
+		}
+	}
+	if loggers == 0 {
+		t.Error("fixture: expected logger entities")
+	}
+	if logStmts == 0 {
+		t.Error("fixture: expected log_statement entities")
+	}
+}
+
+func TestObservability_FixtureMetrics(t *testing.T) {
+	content, err := os.ReadFile("testdata/observability_metrics.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := extract(t, "python_observability", string(content))
+
+	var metrics int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "metric" {
+			metrics++
+		}
+	}
+	if metrics == 0 {
+		t.Error("fixture: expected metric entities")
+	}
+}
+
+func TestObservability_FixtureTracing(t *testing.T) {
+	content, err := os.ReadFile("testdata/observability_tracing.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := extract(t, "python_observability", string(content))
+
+	var spans int
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "trace_span" {
+			spans++
+		}
+	}
+	if spans == 0 {
+		t.Error("fixture: expected trace_span entities")
+	}
+}

--- a/internal/custom/python/observability.go
+++ b/internal/custom/python/observability.go
@@ -1,0 +1,635 @@
+// observability.go — Python observability extractor (log/metric/trace).
+//
+// Covers the Observability lane for all 17 Python http_backend frameworks:
+//
+//   log_extraction   — stdlib logging, loguru, structlog
+//   metric_extraction — prometheus_client, statsd, datadog
+//   trace_extraction  — opentelemetry-sdk, ddtrace, jaeger-client
+//
+// Detection is import-heuristic: the extractor recognises library imports and
+// canonical call-site patterns (logger.info, Counter("name").inc(), tracer.start_as_current_span)
+// but does NOT perform cross-file dataflow, so all cells are flipped to
+// `partial` rather than `full`. This matches the honesty discipline established
+// by the Java observability extractor (internal/custom/java/observability.go).
+//
+// A single extractor key "python_observability" is registered; the extractor
+// runs on any Python file regardless of framework. Framework attribution in
+// the emitted entity Properties is left blank when the file does not contain
+// a recognisable framework import — the engine-layer enrichment pass fills it
+// from the project manifest.
+//
+// Issue #3063.
+package python
+
+import (
+	"context"
+	"strings"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_observability", &ObservabilityExtractor{})
+}
+
+// ObservabilityExtractor detects log, metric, and trace instrumentation
+// across all Python HTTP-backend framework files.
+type ObservabilityExtractor struct{}
+
+func (e *ObservabilityExtractor) Language() string { return "python_observability" }
+
+// ---------------------------------------------------------------------------
+// Compiled regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// --------------- log_extraction ---------------
+
+	// stdlib logging: import logging / from logging import ...
+	obsLogImportRe = regexp.MustCompile(
+		`(?m)^(?:import logging\b|from logging import)`)
+
+	// loguru: import loguru / from loguru import logger
+	obsLoguruImportRe = regexp.MustCompile(
+		`(?m)^(?:import loguru\b|from loguru import)`)
+
+	// structlog: import structlog / from structlog import ...
+	obsStructlogImportRe = regexp.MustCompile(
+		`(?m)^(?:import structlog\b|from structlog import)`)
+
+	// logging.getLogger("name") or logging.getLogger(__name__)
+	obsGetLoggerRe = regexp.MustCompile(
+		`(?m)\blogging\.getLogger\s*\(\s*(?:"([^"]*?)"|'([^']*?)'|([^)]+?))\s*\)`)
+
+	// logger = structlog.get_logger() / structlog.getLogger()
+	obsStructlogGetLoggerRe = regexp.MustCompile(
+		`(?m)\bstructlog\.(?:get_logger|getLogger)\s*\(`)
+
+	// structlog.configure(...) — configures the logging pipeline
+	obsStructlogConfigureRe = regexp.MustCompile(
+		`(?m)\bstructlog\.configure\s*\(`)
+
+	// loguru: logger.bind(...) / logger.opt(...) — loguru-specific enrichment calls
+	obsLoguruBindRe = regexp.MustCompile(
+		`(?m)\blogger\.(?:bind|opt|patch|contextualize)\s*\(`)
+
+	// Log call sites: <logger>.debug/info/warning/warn/error/critical/exception(...)
+	// Matches: log.info(...), logger.error(...), LOG.warning(...), app_log.debug(...)
+	obsLogCallRe = regexp.MustCompile(
+		`(?m)\b(\w+)\.(debug|info|warning|warn|error|critical|exception|trace)\s*\(`)
+
+	// --------------- metric_extraction ---------------
+
+	// prometheus_client: import prometheus_client / from prometheus_client import ...
+	obsPrometheusImportRe = regexp.MustCompile(
+		`(?m)^(?:import prometheus_client\b|from prometheus_client import)`)
+
+	// statsd: import statsd / from statsd import ...
+	obsStatsdImportRe = regexp.MustCompile(
+		`(?m)^(?:import statsd\b|from statsd import)`)
+
+	// datadog: import datadog / from datadog import / from ddsketch import
+	obsDatadogMetricImportRe = regexp.MustCompile(
+		`(?m)^(?:import datadog\b|from datadog(?:\.dogstatsd)? import)`)
+
+	// prometheus_client metric construction:
+	// Counter("name", ...) / Gauge(...) / Histogram(...) / Summary(...)
+	obsPromMetricRe = regexp.MustCompile(
+		`(?m)\b(Counter|Gauge|Histogram|Summary|Info|Enum|REGISTRY)\s*\(\s*["']([^"']*)["']`)
+
+	// prometheus_client push / generate:
+	// push_to_gateway(...) / generate_latest(...)
+	obsPromGatewayRe = regexp.MustCompile(
+		`(?m)\b(?:push_to_gateway|generate_latest|write_to_textfile)\s*\(`)
+
+	// statsd calls: statsd.incr / statsd.gauge / statsd.timing / statsd.histogram
+	obsStatsdCallRe = regexp.MustCompile(
+		`(?m)\b(\w+)\.(incr|decr|gauge|timing|histogram|set|event)\s*\(\s*["']([^"']*)["']`)
+
+	// datadog API: statsd.increment / statsd.gauge / api.Metric.send
+	obsDatadogCallRe = regexp.MustCompile(
+		`(?m)\b(?:statsd|DogStatsd)\.(increment|decrement|gauge|histogram|timing|set|distribution|event|service_check)\s*\(`)
+
+	// --------------- trace_extraction ---------------
+
+	// opentelemetry: import opentelemetry / from opentelemetry import ... / from opentelemetry.trace import
+	obsOtelImportRe = regexp.MustCompile(
+		`(?m)^(?:import opentelemetry\b|from opentelemetry(?:\.\w+)* import)`)
+
+	// ddtrace: import ddtrace / from ddtrace import ...
+	obsDdtraceImportRe = regexp.MustCompile(
+		`(?m)^(?:import ddtrace\b|from ddtrace import)`)
+
+	// jaeger-client: import jaeger_client / from jaeger_client import ...
+	obsJaegerImportRe = regexp.MustCompile(
+		`(?m)^(?:import jaeger_client\b|from jaeger_client import)`)
+
+	// OTel tracer.start_as_current_span("name") or tracer.start_span("name")
+	obsOtelStartSpanRe = regexp.MustCompile(
+		`(?m)\b(\w+)\.start_as_current_span\s*\(\s*["']([^"']*)["']`)
+	obsOtelStartSpanPlainRe = regexp.MustCompile(
+		`(?m)\b(\w+)\.start_span\s*\(\s*["']([^"']*)["']`)
+
+	// OTel @tracer.start_as_current_span("name") decorator
+	obsOtelSpanDecoratorRe = regexp.MustCompile(
+		`(?m)@(\w+)\.start_as_current_span\s*\(\s*["']([^"']*)["']`)
+
+	// ddtrace: @tracer.wrap("name") or ddtrace.tracer.trace("name")
+	obsDdtraceWrapRe = regexp.MustCompile(
+		`(?m)@(?:tracer|ddtrace\.tracer)\.wrap\s*\(\s*(?:["']([^"']*)["'])?`)
+	obsDdtraceTraceRe = regexp.MustCompile(
+		`(?m)\b(?:tracer|ddtrace\.tracer)\.trace\s*\(\s*["']([^"']*)["']`)
+
+	// jaeger: opentracing.tracer.start_span("name") / config.initialize_tracer()
+	obsJaegerStartSpanRe = regexp.MustCompile(
+		`(?m)\b(?:opentracing\.tracer|tracer)\.start_span\s*\(\s*["']([^"']*)["']`)
+	obsJaegerInitRe = regexp.MustCompile(
+		`(?m)\bConfig\s*\([^)]*service_name\s*=\s*["']([^"']*)["']`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *ObservabilityExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_observability")
+	_, span := tracer.Start(ctx, "custom.python_observability")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	var out []types.EntityRecord
+
+	// Guard: skip files that contain none of the observability library tokens.
+	// This is a fast heuristic to avoid running all regexes on every Python file.
+	hasLog := strings.Contains(src, "logging") || strings.Contains(src, "loguru") || strings.Contains(src, "structlog")
+	hasMetric := strings.Contains(src, "prometheus_client") || strings.Contains(src, "statsd") ||
+		strings.Contains(src, "datadog") || strings.Contains(src, "DogStatsd")
+	hasTrace := strings.Contains(src, "opentelemetry") || strings.Contains(src, "ddtrace") ||
+		strings.Contains(src, "jaeger_client") || strings.Contains(src, "opentracing")
+
+	if !hasLog && !hasMetric && !hasTrace {
+		return nil, nil
+	}
+
+	out = append(out, extractPyLogging(src, file.Path)...)
+	out = append(out, extractPyMetrics(src, file.Path)...)
+	out = append(out, extractPyTracing(src, file.Path)...)
+
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// log_extraction
+// ---------------------------------------------------------------------------
+
+func extractPyLogging(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// --- stdlib logging ---
+	if obsLogImportRe.MatchString(src) {
+		// logging.getLogger("name") declarations
+		for _, idx := range allMatchesIndex(obsGetLoggerRe, src) {
+			// capture groups: 2=double-quoted, 4=single-quoted, 6=bare (e.g. __name__)
+			name := ""
+			for _, gi := range []int{2, 4, 6} {
+				if idx[gi] >= 0 {
+					name = src[idx[gi]:idx[gi+1]]
+					break
+				}
+			}
+			if name == "" {
+				name = "logger"
+			}
+			line := lineOf(src, idx[0])
+			out = append(out, entity(name, string(types.EntityKindPattern), "logger", fp, line,
+				map[string]string{
+					"signal":    "log",
+					"library":   "logging",
+					"kind":      "logger",
+					"logger_name": name,
+				}))
+		}
+		// if there's no explicit getLogger but logging is imported, emit a file-level signal
+		if !obsGetLoggerRe.MatchString(src) {
+			loc := obsLogImportRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("logging", string(types.EntityKindPattern), "logger", fp, line,
+				map[string]string{
+					"signal":  "log",
+					"library": "logging",
+					"kind":    "import",
+				}))
+		}
+	}
+
+	// --- loguru ---
+	if obsLoguruImportRe.MatchString(src) {
+		loc := obsLoguruImportRe.FindStringIndex(src)
+		line := lineOf(src, loc[0])
+		out = append(out, entity("loguru.logger", string(types.EntityKindPattern), "logger", fp, line,
+			map[string]string{
+				"signal":  "log",
+				"library": "loguru",
+				"kind":    "logger",
+			}))
+		// loguru bind/opt calls — enrichment hints
+		for _, idx := range allMatchesIndex(obsLoguruBindRe, src) {
+			line := lineOf(src, idx[0])
+			out = append(out, entity("logger.bind", string(types.EntityKindPattern), "log_statement", fp, line,
+				map[string]string{
+					"signal":    "log",
+					"library":   "loguru",
+					"kind":      "log_statement",
+				}))
+		}
+	}
+
+	// --- structlog ---
+	if obsStructlogImportRe.MatchString(src) {
+		// structlog.get_logger() calls
+		for _, idx := range allMatchesIndex(obsStructlogGetLoggerRe, src) {
+			line := lineOf(src, idx[0])
+			out = append(out, entity("structlog.get_logger", string(types.EntityKindPattern), "logger", fp, line,
+				map[string]string{
+					"signal":  "log",
+					"library": "structlog",
+					"kind":    "logger",
+				}))
+		}
+		// structlog.configure(...)
+		if obsStructlogConfigureRe.MatchString(src) {
+			loc := obsStructlogConfigureRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("structlog.configure", string(types.EntityKindPattern), "logger", fp, line,
+				map[string]string{
+					"signal":  "log",
+					"library": "structlog",
+					"kind":    "configure",
+				}))
+		}
+		// file-level signal when no explicit get_logger
+		if !obsStructlogGetLoggerRe.MatchString(src) && !obsStructlogConfigureRe.MatchString(src) {
+			loc := obsStructlogImportRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("structlog", string(types.EntityKindPattern), "logger", fp, line,
+				map[string]string{
+					"signal":  "log",
+					"library": "structlog",
+					"kind":    "import",
+				}))
+		}
+	}
+
+	// --- log call sites (any logger variable) ---
+	// Only emit when we have a recognised log library to avoid false positives.
+	hasLogLib := obsLogImportRe.MatchString(src) || obsLoguruImportRe.MatchString(src) || obsStructlogImportRe.MatchString(src)
+	if hasLogLib {
+		for _, idx := range allMatchesIndex(obsLogCallRe, src) {
+			receiver := src[idx[2]:idx[3]]
+			level := src[idx[4]:idx[5]]
+			// Basic heuristic: skip common false positives (test assertions, HTTP client methods)
+			if receiver == "response" || receiver == "resp" || receiver == "res" || receiver == "request" || receiver == "req" {
+				continue
+			}
+			line := lineOf(src, idx[0])
+			library := "logging"
+			if obsLoguruImportRe.MatchString(src) && !obsLogImportRe.MatchString(src) {
+				library = "loguru"
+			} else if obsStructlogImportRe.MatchString(src) && !obsLogImportRe.MatchString(src) {
+				library = "structlog"
+			}
+			out = append(out, entity(receiver+"."+level, string(types.EntityKindPattern), "log_statement", fp, line,
+				map[string]string{
+					"signal":    "log",
+					"library":   library,
+					"kind":      "log_statement",
+					"log_level": level,
+					"receiver":  receiver,
+				}))
+		}
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// metric_extraction
+// ---------------------------------------------------------------------------
+
+func extractPyMetrics(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// --- prometheus_client ---
+	if obsPrometheusImportRe.MatchString(src) {
+		// Counter/Gauge/Histogram/Summary construction
+		for _, idx := range allMatchesIndex(obsPromMetricRe, src) {
+			meterType := src[idx[2]:idx[3]]
+			metricName := src[idx[4]:idx[5]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(metricName, string(types.EntityKindPattern), "metric", fp, line,
+				map[string]string{
+					"signal":      "metric",
+					"library":     "prometheus_client",
+					"kind":        "metric",
+					"metric_type": strings.ToLower(meterType),
+					"metric_name": metricName,
+				}))
+		}
+		// push / generate as file-level metric signal
+		if obsPromGatewayRe.MatchString(src) {
+			loc := obsPromGatewayRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("prometheus_client.export", string(types.EntityKindPattern), "metric", fp, line,
+				map[string]string{
+					"signal":      "metric",
+					"library":     "prometheus_client",
+					"kind":        "export",
+					"metric_type": "registry",
+				}))
+		}
+		// file-level signal when only import found
+		if !obsPromMetricRe.MatchString(src) && !obsPromGatewayRe.MatchString(src) {
+			loc := obsPrometheusImportRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("prometheus_client", string(types.EntityKindPattern), "metric", fp, line,
+				map[string]string{
+					"signal":  "metric",
+					"library": "prometheus_client",
+					"kind":    "import",
+				}))
+		}
+	}
+
+	// --- statsd ---
+	if obsStatsdImportRe.MatchString(src) {
+		for _, idx := range allMatchesIndex(obsStatsdCallRe, src) {
+			receiver := src[idx[2]:idx[3]]
+			method := src[idx[4]:idx[5]]
+			metricName := src[idx[6]:idx[7]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(metricName, string(types.EntityKindPattern), "metric", fp, line,
+				map[string]string{
+					"signal":      "metric",
+					"library":     "statsd",
+					"kind":        "metric",
+					"metric_type": obsStatsdType(method),
+					"metric_name": metricName,
+					"receiver":    receiver,
+				}))
+		}
+		// file-level signal when no call sites
+		if !obsStatsdCallRe.MatchString(src) {
+			loc := obsStatsdImportRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("statsd", string(types.EntityKindPattern), "metric", fp, line,
+				map[string]string{
+					"signal":  "metric",
+					"library": "statsd",
+					"kind":    "import",
+				}))
+		}
+	}
+
+	// --- datadog ---
+	if obsDatadogMetricImportRe.MatchString(src) {
+		for _, idx := range allMatchesIndex(obsDatadogCallRe, src) {
+			method := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity("datadog."+method, string(types.EntityKindPattern), "metric", fp, line,
+				map[string]string{
+					"signal":      "metric",
+					"library":     "datadog",
+					"kind":        "metric",
+					"metric_type": obsDatadogType(method),
+				}))
+		}
+		// file-level signal when no call sites
+		if !obsDatadogCallRe.MatchString(src) {
+			loc := obsDatadogMetricImportRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("datadog", string(types.EntityKindPattern), "metric", fp, line,
+				map[string]string{
+					"signal":  "metric",
+					"library": "datadog",
+					"kind":    "import",
+				}))
+		}
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// trace_extraction
+// ---------------------------------------------------------------------------
+
+func extractPyTracing(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// --- opentelemetry ---
+	if obsOtelImportRe.MatchString(src) {
+		// @tracer.start_as_current_span("name") decorator
+		for _, idx := range allMatchesIndex(obsOtelSpanDecoratorRe, src) {
+			tracerVar := src[idx[2]:idx[3]]
+			spanName := src[idx[4]:idx[5]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(spanName, string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":     "trace",
+					"library":    "opentelemetry",
+					"kind":       "trace_span",
+					"span_kind":  "decorator",
+					"span_name":  spanName,
+					"tracer_var": tracerVar,
+				}))
+		}
+		// tracer.start_as_current_span("name") context-manager
+		for _, idx := range allMatchesIndex(obsOtelStartSpanRe, src) {
+			tracerVar := src[idx[2]:idx[3]]
+			spanName := src[idx[4]:idx[5]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(spanName, string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":     "trace",
+					"library":    "opentelemetry",
+					"kind":       "trace_span",
+					"span_kind":  "context_manager",
+					"span_name":  spanName,
+					"tracer_var": tracerVar,
+				}))
+		}
+		// tracer.start_span("name")
+		for _, idx := range allMatchesIndex(obsOtelStartSpanPlainRe, src) {
+			tracerVar := src[idx[2]:idx[3]]
+			spanName := src[idx[4]:idx[5]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(spanName, string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":     "trace",
+					"library":    "opentelemetry",
+					"kind":       "trace_span",
+					"span_kind":  "programmatic",
+					"span_name":  spanName,
+					"tracer_var": tracerVar,
+				}))
+		}
+		// file-level signal when only import
+		if !obsOtelSpanDecoratorRe.MatchString(src) && !obsOtelStartSpanRe.MatchString(src) && !obsOtelStartSpanPlainRe.MatchString(src) {
+			loc := obsOtelImportRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("opentelemetry", string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":  "trace",
+					"library": "opentelemetry",
+					"kind":    "import",
+				}))
+		}
+	}
+
+	// --- ddtrace ---
+	if obsDdtraceImportRe.MatchString(src) {
+		// @tracer.wrap("name") decorator
+		for _, idx := range allMatchesIndex(obsDdtraceWrapRe, src) {
+			spanName := ""
+			if idx[2] >= 0 {
+				spanName = src[idx[2]:idx[3]]
+			}
+			if spanName == "" {
+				spanName = "ddtrace.wrap"
+			}
+			line := lineOf(src, idx[0])
+			out = append(out, entity(spanName, string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":    "trace",
+					"library":   "ddtrace",
+					"kind":      "trace_span",
+					"span_kind": "decorator",
+					"span_name": spanName,
+				}))
+		}
+		// tracer.trace("name") context-manager
+		for _, idx := range allMatchesIndex(obsDdtraceTraceRe, src) {
+			spanName := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(spanName, string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":    "trace",
+					"library":   "ddtrace",
+					"kind":      "trace_span",
+					"span_kind": "context_manager",
+					"span_name": spanName,
+				}))
+		}
+		// file-level signal when only import
+		if !obsDdtraceWrapRe.MatchString(src) && !obsDdtraceTraceRe.MatchString(src) {
+			loc := obsDdtraceImportRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("ddtrace", string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":  "trace",
+					"library": "ddtrace",
+					"kind":    "import",
+				}))
+		}
+	}
+
+	// --- jaeger-client ---
+	if obsJaegerImportRe.MatchString(src) {
+		// Config(service_name="name") tracer initialization
+		for _, idx := range allMatchesIndex(obsJaegerInitRe, src) {
+			svcName := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(svcName, string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":       "trace",
+					"library":      "jaeger_client",
+					"kind":         "trace_span",
+					"span_kind":    "init",
+					"service_name": svcName,
+				}))
+		}
+		// tracer.start_span("name")
+		for _, idx := range allMatchesIndex(obsJaegerStartSpanRe, src) {
+			spanName := src[idx[2]:idx[3]]
+			line := lineOf(src, idx[0])
+			out = append(out, entity(spanName, string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":    "trace",
+					"library":   "jaeger_client",
+					"kind":      "trace_span",
+					"span_kind": "programmatic",
+					"span_name": spanName,
+				}))
+		}
+		// file-level signal when only import
+		if !obsJaegerInitRe.MatchString(src) && !obsJaegerStartSpanRe.MatchString(src) {
+			loc := obsJaegerImportRe.FindStringIndex(src)
+			line := lineOf(src, loc[0])
+			out = append(out, entity("jaeger_client", string(types.EntityKindPattern), "trace_span", fp, line,
+				map[string]string{
+					"signal":  "trace",
+					"library": "jaeger_client",
+					"kind":    "import",
+				}))
+		}
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Helper: metric-type normalisation
+// ---------------------------------------------------------------------------
+
+// obsStatsdType normalises a statsd method name to a metric_type value.
+func obsStatsdType(method string) string {
+	switch method {
+	case "incr", "decr":
+		return "counter"
+	case "gauge":
+		return "gauge"
+	case "timing":
+		return "timer"
+	case "histogram":
+		return "histogram"
+	case "set":
+		return "set"
+	case "event":
+		return "event"
+	default:
+		return method
+	}
+}
+
+// obsDatadogType normalises a datadog statsd method name to a metric_type value.
+func obsDatadogType(method string) string {
+	switch method {
+	case "increment", "decrement":
+		return "counter"
+	case "gauge":
+		return "gauge"
+	case "histogram":
+		return "histogram"
+	case "timing":
+		return "timer"
+	case "distribution":
+		return "distribution"
+	case "set":
+		return "set"
+	case "event":
+		return "event"
+	case "service_check":
+		return "service_check"
+	default:
+		return method
+	}
+}

--- a/internal/custom/python/testdata/observability_logging.py
+++ b/internal/custom/python/testdata/observability_logging.py
@@ -1,0 +1,28 @@
+"""Fixture: Python logging with stdlib logging, loguru, and structlog."""
+
+# --- stdlib logging ---
+import logging
+
+logger = logging.getLogger(__name__)
+app_log = logging.getLogger("myapp")
+
+logger.info("Server started on port %d", 8080)
+logger.debug("Incoming request: %s %s", method, path)
+logger.warning("Rate limit exceeded for user %s", user_id)
+logger.error("Database connection failed: %s", exc)
+app_log.critical("Unrecoverable error, shutting down")
+
+# --- loguru ---
+from loguru import logger as log
+
+log.info("loguru info message")
+log.debug("loguru debug")
+bound = logger.bind(request_id="abc")
+
+# --- structlog ---
+import structlog
+
+structlog.configure(processors=[structlog.processors.JSONRenderer()])
+struct_logger = structlog.get_logger()
+struct_logger.info("structlog info", user=user_id)
+struct_logger.warning("structlog warn")

--- a/internal/custom/python/testdata/observability_metrics.py
+++ b/internal/custom/python/testdata/observability_metrics.py
@@ -1,0 +1,31 @@
+"""Fixture: Python metrics with prometheus_client, statsd, and datadog."""
+
+# --- prometheus_client ---
+from prometheus_client import Counter, Gauge, Histogram, Summary, push_to_gateway
+
+REQUEST_COUNT = Counter("http_requests_total", "Total HTTP requests", ["method", "endpoint"])
+REQUEST_LATENCY = Histogram("http_request_duration_seconds", "HTTP request duration")
+IN_PROGRESS = Gauge("http_requests_in_progress", "In-progress HTTP requests")
+REQUEST_SUMMARY = Summary("request_processing_seconds", "Time spent processing request")
+
+REQUEST_COUNT.labels(method="GET", endpoint="/api/users").inc()
+REQUEST_LATENCY.observe(0.5)
+IN_PROGRESS.inc()
+IN_PROGRESS.dec()
+
+push_to_gateway("localhost:9091", job="my_app")
+
+# --- statsd ---
+import statsd
+
+client = statsd.StatsClient("localhost", 8125)
+client.incr("page.views")
+client.gauge("queue.size", 42)
+client.timing("query.duration", 250)
+
+# --- datadog ---
+from datadog import statsd as dog_statsd
+
+dog_statsd.increment("web.page_views", tags=["page:home"])
+dog_statsd.gauge("system.cpu.usage", 83.5)
+dog_statsd.histogram("api.response.time", 0.12)

--- a/internal/custom/python/testdata/observability_tracing.py
+++ b/internal/custom/python/testdata/observability_tracing.py
@@ -1,0 +1,56 @@
+"""Fixture: Python tracing with opentelemetry, ddtrace, and jaeger-client."""
+
+# --- opentelemetry ---
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind
+
+tracer = trace.get_tracer(__name__)
+
+
+@tracer.start_as_current_span("process_request")
+def handle_request(request):
+    pass
+
+
+def process_order(order_id):
+    with tracer.start_as_current_span("process_order") as span:
+        span.set_attribute("order.id", order_id)
+        return _fetch(order_id)
+
+
+def _fetch(order_id):
+    span = tracer.start_span("db_fetch")
+    try:
+        return db.get(order_id)
+    finally:
+        span.end()
+
+
+# --- ddtrace ---
+from ddtrace import tracer as dd_tracer
+from ddtrace import patch_all
+
+patch_all()
+
+
+@dd_tracer.wrap("order_service.place")
+def place_order(order):
+    with dd_tracer.trace("order_service.validate") as span:
+        span.set_tag("order.id", order.id)
+        return validate(order)
+
+
+# --- jaeger-client ---
+import jaeger_client
+from opentracing import tracer as opentracing_tracer
+
+config = jaeger_client.Config(
+    config={"sampler": {"type": "const", "param": 1}},
+    service_name="order-service",
+    validate=True,
+)
+jaeger_tracer = config.initialize_tracer()
+
+with opentracing_tracer.start_span("order_lookup") as span:
+    span.set_tag("order.id", "12345")
+    result = db.lookup(span)


### PR DESCRIPTION
## Summary

- Adds `internal/custom/python/observability.go`: new `python_observability` extractor detecting logging, metrics, and tracing instrumentation via import-heuristic regex across all Python files
- Covers 3 libraries per signal: `logging`/`loguru`/`structlog` (log), `prometheus_client`/`statsd`/`datadog` (metric), `opentelemetry-sdk`/`ddtrace`/`jaeger-client` (trace)
- Flips 51 cells from `missing` → `partial` across all 17 Python http_backend frameworks; all `partial` (file-local detection only, no cross-file dataflow — honest)
- No new entity Kind needed; emits `SCOPE.Pattern` with subtypes `logger`, `log_statement`, `metric`, `trace_span`

## Verification

- `go build ./...` — PASS
- `go test ./internal/custom/python/` — PASS (13 new observability tests + all existing)
- `go test ./internal/types/` — PASS
- `go test ./tools/coverage/` — PASS
- `coverage validate` — 0 errors
- `coverage fmt --check` — canonical
- `coverage gen` — byte-stable

## Test plan

- [ ] All 13 new `TestObservability_*` tests pass (`go test ./internal/custom/python/ -run TestObservability`)
- [ ] Fixture tests exercise `testdata/observability_{logging,metrics,tracing}.py`
- [ ] `TestObservability_NoFalsePositive` confirms no spurious entities on plain Django model file
- [ ] `coverage validate` exits 0 errors
- [ ] `coverage fmt --check` clean

Closes #3063

🤖 Generated with [Claude Code](https://claude.com/claude-code)