### PR TITLE
feat(java/spring-boot): add actuator, autoconfig, profile, di_scope extractors (#3081)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -132,7 +132,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
-| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ❌ 14/18 | |
+| [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 14/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 1/1 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/3 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -24,7 +24,7 @@ Back to [summary](../summary.md).
 | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
-| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ❌ 14/18 | |
+| [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 14/16 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 

--- a/docs/coverage/detail/lang.java.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.java.framework.spring-boot.md
@@ -59,7 +59,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | DI binding extraction | ⚠️ `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/spring_boot.go` | — |
 | DI injection point | ⚠️ `partial` | `2026-05-28` | backfill:dictionary-completeness | `internal/custom/java/spring_boot.go` | — |
-| DI scope resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | ⚠️ `partial` | `2026-05-29` | 3081 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_boot.go` | — |
 
 ### Transactions
 
@@ -122,9 +122,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Actuator detection | ❌ `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| Autoconfiguration detection | ❌ `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
-| Profile detection | ❌ `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/2739) | — | — |
+| Actuator detection | ⚠️ `partial` | `2026-05-29` | 3081 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_boot.go` | — |
+| Autoconfiguration detection | ⚠️ `partial` | `2026-05-29` | 3081 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
+| Profile detection | ⚠️ `partial` | `2026-05-29` | 3081 | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/spring_ecosystem.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -17116,8 +17116,10 @@
             "verified_at": "2026-05-28"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_boot.go"],
+            "issue": "3081",
+            "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
@@ -17300,16 +17302,22 @@
       "framework_specific": {
         "Spring Boot Internals": {
           "actuator_detection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_boot.go"],
+            "issue": "3081",
+            "verified_at": "2026-05-29"
           },
           "autoconfiguration_detection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
+            "issue": "3081",
+            "verified_at": "2026-05-29"
           },
           "profile_detection": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2739"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/spring_ecosystem.go"],
+            "issue": "3081",
+            "verified_at": "2026-05-29"
           }
         }
       }

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -3749,6 +3749,7 @@ public class S {
 }
 
 // ============================================================================
+<<<<<<< HEAD
 // Helidon MP — transactions + CDI DI + middleware + auth + tests (#3088)
 // ============================================================================
 
@@ -4240,5 +4241,255 @@ class FooTest {
 	r := ExtractJUnit5(PatternContext{Source: source, Language: "java", Framework: "helidon", FilePath: "FooTest.java"})
 	if len(r.Entities) == 0 {
 		t.Error("[#3088 tests-gating] expected test entity for framework=helidon, got none")
+=======
+// Issue #3081: Spring Boot missing cells
+// actuator_detection, autoconfiguration_detection, profile_detection, di_scope_resolution
+// ============================================================================
+
+// TestSpringBoot_ActuatorDetection_Issue3081 proves actuator_detection:
+// @Endpoint classes and @ReadOperation/@WriteOperation/@DeleteOperation methods
+// are extracted with correct provenance and operation_kind property.
+// Registry target: lang.java.framework.spring-boot actuator_detection=partial.
+func TestSpringBoot_ActuatorDetection_Issue3081(t *testing.T) {
+	source := `
+package com.example.actuator;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
+
+@Endpoint(id = "health-info")
+public class HealthInfoEndpoint {
+    @ReadOperation
+    public HealthInfo health() {
+        return new HealthInfo("UP");
+    }
+
+    @WriteOperation
+    public void reset(String key) {
+        // reset
+    }
+
+    @DeleteOperation
+    public void clear(String key) {
+        // clear
+    }
+}
+`
+	r := ExtractSpringBoot(PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot",
+		FilePath: "HealthInfoEndpoint.java",
+	})
+
+	// Should have: 1 endpoint class + 3 operations
+	var endpointClass *SecondaryEntity
+	opKinds := make(map[string]bool)
+	for i := range r.Entities {
+		e := &r.Entities[i]
+		if e.Provenance == "INFERRED_FROM_SPRING_ACTUATOR" {
+			if e.Kind == "SCOPE.Component" {
+				endpointClass = e
+			}
+			if e.Kind == "SCOPE.Operation" {
+				if k, ok := e.Properties["operation_kind"].(string); ok {
+					opKinds[k] = true
+				}
+			}
+		}
+	}
+	if endpointClass == nil {
+		t.Fatal("[#3081 actuator_detection] expected SCOPE.Component for @Endpoint class, got none")
+	}
+	if endpointClass.Properties["endpoint_id"] != "health-info" {
+		t.Errorf("[#3081 actuator_detection] endpoint_id=%q, want health-info", endpointClass.Properties["endpoint_id"])
+	}
+	for _, wantKind := range []string{"read", "write", "delete"} {
+		if !opKinds[wantKind] {
+			t.Errorf("[#3081 actuator_detection] missing operation_kind=%q, got %v", wantKind, opKinds)
+		}
+	}
+	// Should have OWNS relationships from endpoint class to each operation
+	ownsCount := 0
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "OWNS" && rel.SourceRef == endpointClass.Ref {
+			ownsCount++
+		}
+	}
+	if ownsCount < 3 {
+		t.Errorf("[#3081 actuator_detection] expected >=3 OWNS relationships from endpoint class, got %d", ownsCount)
+	}
+}
+
+// TestSpringBoot_AutoconfigurationDetection_Issue3081 proves autoconfiguration_detection:
+// @EnableAutoConfiguration, @SpringBootApplication, @AutoConfiguration classes
+// and @ConditionalOn* classes are extracted.
+// Registry target: lang.java.framework.spring-boot autoconfiguration_detection=partial.
+func TestSpringBoot_AutoconfigurationDetection_Issue3081(t *testing.T) {
+	source := `
+package com.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@SpringBootApplication
+public class MyApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MyApplication.class, args);
+    }
+}
+
+@Configuration
+@ConditionalOnMissingBean(DataSource.class)
+public class DataSourceAutoConfig {
+    @Bean
+    public DataSource defaultDataSource() {
+        return new EmbeddedDataSource();
+    }
+}
+`
+	r := ExtractSpringEcosystem(PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot",
+		FilePath: "MyApplication.java",
+	})
+
+	autoConfigNames := make(map[string]string) // name -> autoconfig_annotation
+	conditionalNames := make(map[string]string) // name -> conditional_annotation
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_SPRING_AUTOCONFIG" {
+			if ann, ok := e.Properties["autoconfig_annotation"].(string); ok {
+				autoConfigNames[e.Name] = ann
+			}
+			if cond, ok := e.Properties["conditional_annotation"].(string); ok {
+				conditionalNames[e.Name] = cond
+			}
+		}
+	}
+
+	if ann := autoConfigNames["MyApplication"]; ann != "@SpringBootApplication" {
+		t.Errorf("[#3081 autoconfiguration_detection] MyApplication autoconfig_annotation=%q, want @SpringBootApplication", ann)
+	}
+	if cond := conditionalNames["DataSourceAutoConfig"]; cond != "@ConditionalOnMissingBean" {
+		t.Errorf("[#3081 autoconfiguration_detection] DataSourceAutoConfig conditional_annotation=%q, want @ConditionalOnMissingBean", cond)
+	}
+}
+
+// TestSpringBoot_ProfileDetection_Issue3081 proves profile_detection:
+// @Profile("name") on classes is extracted with the profile value captured.
+// Registry target: lang.java.framework.spring-boot profile_detection=partial.
+func TestSpringBoot_ProfileDetection_Issue3081(t *testing.T) {
+	source := `
+package com.example;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Profile("production")
+@Service
+public class ProductionMailService implements MailService {
+    public void send(String msg) { /* send via SMTP */ }
+}
+
+@Profile("development")
+@Service
+public class MockMailService implements MailService {
+    public void send(String msg) { /* no-op */ }
+}
+`
+	r := ExtractSpringEcosystem(PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot",
+		FilePath: "MailService.java",
+	})
+
+	profileMap := make(map[string]string) // class name -> profile
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_SPRING_PROFILE" {
+			if p, ok := e.Properties["profile"].(string); ok {
+				profileMap[e.Name] = p
+			}
+		}
+	}
+
+	if profileMap["ProductionMailService"] != "production" {
+		t.Errorf("[#3081 profile_detection] ProductionMailService profile=%q, want production; map=%v",
+			profileMap["ProductionMailService"], profileMap)
+	}
+	if profileMap["MockMailService"] != "development" {
+		t.Errorf("[#3081 profile_detection] MockMailService profile=%q, want development; map=%v",
+			profileMap["MockMailService"], profileMap)
+	}
+}
+
+// TestSpringBoot_DIScopeResolution_Issue3081 proves di_scope_resolution:
+// Spring @Scope / @RequestScope / @SessionScope / @ApplicationScope
+// are extracted with the scope captured in spring_scope property.
+// Registry target: lang.java.framework.spring-boot di_scope_resolution=partial.
+func TestSpringBoot_DIScopeResolution_Issue3081(t *testing.T) {
+	source := `
+package com.example;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.web.context.annotation.RequestScope;
+import org.springframework.web.context.annotation.SessionScope;
+import org.springframework.web.context.annotation.ApplicationScope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope("prototype")
+public class PrototypeBean {
+    // new instance per injection
+}
+
+@Component
+@RequestScope
+public class RequestScopedBean {
+    // one per HTTP request
+}
+
+@Component
+@SessionScope
+public class SessionScopedBean {
+    // one per HTTP session
+}
+
+@Component
+@ApplicationScope
+public class ApplicationScopedBean {
+    // singleton within application context
+}
+`
+	r := ExtractSpringBoot(PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot",
+		FilePath: "ScopedBeans.java",
+	})
+
+	scopeMap := make(map[string]string) // class name -> spring_scope
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_SPRING_DI_SCOPE" {
+			if s, ok := e.Properties["spring_scope"].(string); ok {
+				scopeMap[e.Name] = s
+			}
+		}
+	}
+
+	if scopeMap["PrototypeBean"] != "prototype" {
+		t.Errorf("[#3081 di_scope_resolution] PrototypeBean scope=%q, want prototype; map=%v",
+			scopeMap["PrototypeBean"], scopeMap)
+	}
+	if scopeMap["RequestScopedBean"] != "request" {
+		t.Errorf("[#3081 di_scope_resolution] RequestScopedBean scope=%q, want request; map=%v",
+			scopeMap["RequestScopedBean"], scopeMap)
+	}
+	if scopeMap["SessionScopedBean"] != "session" {
+		t.Errorf("[#3081 di_scope_resolution] SessionScopedBean scope=%q, want session; map=%v",
+			scopeMap["SessionScopedBean"], scopeMap)
+	}
+	if scopeMap["ApplicationScopedBean"] != "application" {
+		t.Errorf("[#3081 di_scope_resolution] ApplicationScopedBean scope=%q, want application; map=%v",
+			scopeMap["ApplicationScopedBean"], scopeMap)
+>>>>>>> c810d1fe5 (feat(java/spring-boot): add actuator, autoconfig, profile, di_scope extractors (#3081))
 	}
 }

--- a/internal/custom/java/spring_boot.go
+++ b/internal/custom/java/spring_boot.go
@@ -14,6 +14,24 @@ var springBootFrameworks = map[string]bool{
 }
 
 var (
+	// actuator_detection: @Endpoint/@ReadOperation/@WriteOperation/@DeleteOperation
+	sbActuatorEndpointRE = regexp.MustCompile(
+		`(?s)@Endpoint\s*\(\s*id\s*=\s*"([^"]+)"\s*\)[^{]*?(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+	sbActuatorOperationRE = regexp.MustCompile(
+		`(?s)(@(?:ReadOperation|WriteOperation|DeleteOperation))\b[^{]*?` +
+			`(?:public|protected|private|)\s+(?:static\s+)?(?:<[^>]*>\s*)?(?:\w+(?:\s*<[^>]*>)?\s+)(\w+)\s*\(`)
+
+	// di_scope_resolution: Spring @Scope / @RequestScope / @SessionScope / @ApplicationScope
+	sbScopeAnnotationRE = regexp.MustCompile(
+		`(?s)@Scope\s*\(\s*(?:value\s*=\s*)?(?:ConfigurableBeanFactory\.SCOPE_(\w+)|"([^"]+)")\s*\)` +
+			`\s*(?:@\w+[^{]*?)*(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+	sbRequestScopeRE = regexp.MustCompile(
+		`(?s)@RequestScope\b[^{]*?(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+	sbSessionScopeRE = regexp.MustCompile(
+		`(?s)@SessionScope\b[^{]*?(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+	sbApplicationScopeRE = regexp.MustCompile(
+		`(?s)@ApplicationScope\b[^{]*?(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+
 	sbRestControllerRE = regexp.MustCompile(
 		`(?s)@(?:Rest)?Controller\b[^{]*?(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
 	sbClassRequestMappingRE = regexp.MustCompile(
@@ -320,6 +338,111 @@ func ExtractSpringBoot(ctx PatternContext) PatternResult {
 				SourceRef: ownerRef, TargetRef: targetRef,
 				RelationshipType: "DEPENDS_ON",
 				Properties:       map[string]string{"injected_type": injectedType, "injection_kind": "constructor"},
+			})
+		}
+	}
+
+	// 5. Actuator: @Endpoint classes + @ReadOperation/@WriteOperation/@DeleteOperation methods
+	type actuatorEndpointInfo struct {
+		endpointID string
+		offset     int
+		ref        string
+	}
+	actuatorEndpoints := make(map[string]actuatorEndpointInfo)
+	for _, m := range sbActuatorEndpointRE.FindAllStringSubmatchIndex(source, -1) {
+		endpointID := source[m[2]:m[3]]
+		className := source[m[4]:m[5]]
+		ref := "scope:component:spring_actuator_endpoint:" + fp + ":" + className
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Component", SourceFile: fp,
+			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_SPRING_ACTUATOR", Ref: ref,
+			Properties: map[string]any{
+				"endpoint_id": endpointID, "framework": "spring_actuator",
+			},
+		}) {
+			actuatorEndpoints[className] = actuatorEndpointInfo{endpointID, m[0], ref}
+		}
+	}
+
+	findOwningActuator := func(offset int) (string, string) {
+		var bestName, bestRef string
+		for name, info := range actuatorEndpoints {
+			if info.offset <= offset {
+				if bestName == "" || actuatorEndpoints[bestName].offset < info.offset {
+					bestName = name
+					bestRef = info.ref
+				}
+			}
+		}
+		return bestName, bestRef
+	}
+
+	for _, m := range sbActuatorOperationRE.FindAllStringSubmatchIndex(source, -1) {
+		annText := source[m[2]:m[3]]
+		methodName := source[m[4]:m[5]]
+		ownerName, ownerRef := findOwningActuator(m[0])
+		if ownerName == "" {
+			continue
+		}
+		opKind := "read"
+		switch annText {
+		case "@WriteOperation":
+			opKind = "write"
+		case "@DeleteOperation":
+			opKind = "delete"
+		}
+		opRef := "scope:operation:spring_actuator_op:" + fp + ":" + ownerName + "." + methodName
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: ownerName + "." + methodName, Kind: "SCOPE.Operation",
+			Subtype: "function", SourceFile: fp,
+			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_SPRING_ACTUATOR", Ref: opRef,
+			Properties: map[string]any{
+				"operation_kind": opKind, "endpoint_class": ownerName,
+				"framework": "spring_actuator",
+			},
+		}) {
+			addRel(&result, seenRels, Relationship{
+				SourceRef: ownerRef, TargetRef: opRef,
+				RelationshipType: "OWNS",
+			})
+		}
+	}
+
+	// 6. DI scope resolution: Spring @Scope / @RequestScope / @SessionScope / @ApplicationScope
+	for _, m := range sbScopeAnnotationRE.FindAllStringSubmatchIndex(source, -1) {
+		scopeName := ""
+		if m[2] >= 0 {
+			scopeName = source[m[2]:m[3]] // ConfigurableBeanFactory.SCOPE_<X>
+		} else if m[4] >= 0 {
+			scopeName = source[m[4]:m[5]] // string literal
+		}
+		className := source[m[6]:m[7]]
+		ref := "scope:component:spring_scoped_bean:" + fp + ":" + className
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Component", SourceFile: fp,
+			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_SPRING_DI_SCOPE", Ref: ref,
+			Properties: map[string]any{"spring_scope": scopeName, "framework": "spring_boot"},
+		})
+	}
+	for _, pair := range []struct {
+		re    *regexp.Regexp
+		scope string
+	}{
+		{sbRequestScopeRE, "request"},
+		{sbSessionScopeRE, "session"},
+		{sbApplicationScopeRE, "application"},
+	} {
+		for _, m := range pair.re.FindAllStringSubmatchIndex(source, -1) {
+			className := source[m[2]:m[3]]
+			ref := "scope:component:spring_scoped_bean:" + fp + ":" + className
+			addEntity(&result, seenRefs, SecondaryEntity{
+				Name: className, Kind: "SCOPE.Component", SourceFile: fp,
+				LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+				Provenance: "INFERRED_FROM_SPRING_DI_SCOPE", Ref: ref,
+				Properties: map[string]any{"spring_scope": pair.scope, "framework": "spring_boot"},
 			})
 		}
 	}

--- a/internal/custom/java/spring_ecosystem.go
+++ b/internal/custom/java/spring_ecosystem.go
@@ -65,6 +65,22 @@ var (
 	seQueryMethodRE = regexp.MustCompile(
 		`(?s)@Query\s*\(\s*(?:value\s*=\s*)?"([^"]+)"\s*\)\s*(?:\w+(?:\s*<[^>]*>)?\s+)(\w+)\s*\(`)
 
+	// AutoConfiguration
+	// Matches @EnableAutoConfiguration, @SpringBootApplication, @AutoConfiguration on a class.
+	seAutoConfigClassRE = regexp.MustCompile(
+		`(?s)(@(?:EnableAutoConfiguration|SpringBootApplication|AutoConfiguration))\b[^{]*?` +
+			`(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+	// Matches @ConditionalOn* followed by a class declaration.
+	seConditionalOnClassRE = regexp.MustCompile(
+		`(?s)(@ConditionalOn\w+)(?:\([^)]*\))?\s*(?:@\w+(?:\([^)]*\))?\s*)*` +
+			`(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+
+	// Profile detection: @Profile("expr") on a class.
+	seProfileAnnotationRE = regexp.MustCompile(
+		`(?s)@Profile\s*\(\s*(?:\{[^}]*\}|"([^"]+)")\s*\)\s*` +
+			`(?:@\w+(?:\([^)]*\))?\s*)*` +
+			`(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+
 	// Integration
 	seServiceActivatorRE = regexp.MustCompile(
 		`(?s)@ServiceActivator\s*\([^)]*inputChannel\s*=\s*"([^"]+)"[^)]*\)\s*` +
@@ -299,6 +315,49 @@ func ExtractSpringEcosystem(ctx PatternContext) PatternResult {
 			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
 			Provenance: "INFERRED_FROM_SPRING_DATA", Ref: ref,
 			Properties: map[string]any{"query": query, "framework": "spring_data"},
+		})
+	}
+
+	// AutoConfiguration: @EnableAutoConfiguration / @SpringBootApplication / @AutoConfiguration / @ConditionalOn*
+	for _, m := range seAutoConfigClassRE.FindAllStringSubmatchIndex(source, -1) {
+		annName := source[m[2]:m[3]]
+		className := source[m[4]:m[5]]
+		ref := "scope:pattern:spring_autoconfig_class:" + fp + ":" + className
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Pattern", SourceFile: fp,
+			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_SPRING_AUTOCONFIG", Ref: ref,
+			Properties: map[string]any{"autoconfig_annotation": annName, "framework": "spring_boot"},
+		})
+	}
+	for _, m := range seConditionalOnClassRE.FindAllStringSubmatchIndex(source, -1) {
+		annText := source[m[2]:m[3]]
+		className := source[m[4]:m[5]]
+		ref := "scope:pattern:spring_conditional:" + fp + ":" + className
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Pattern", SourceFile: fp,
+			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_SPRING_AUTOCONFIG", Ref: ref,
+			Properties: map[string]any{"conditional_annotation": annText, "framework": "spring_boot"},
+		})
+	}
+
+	// Profile detection: @Profile("name") on classes
+	for _, m := range seProfileAnnotationRE.FindAllStringSubmatchIndex(source, -1) {
+		profileExpr := ""
+		if m[2] >= 0 {
+			profileExpr = source[m[2]:m[3]]
+		}
+		if m[4] < 0 {
+			continue // no class name captured
+		}
+		targetName := source[m[4]:m[5]]
+		ref := "scope:pattern:spring_profile:" + fp + ":" + targetName
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: targetName, Kind: "SCOPE.Pattern", SourceFile: fp,
+			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_SPRING_PROFILE", Ref: ref,
+			Properties: map[string]any{"profile": profileExpr, "framework": "spring_boot"},
 		})
 	}
 


### PR DESCRIPTION
Implements 4 missing cells for lang.java.framework.spring-boot:

- actuator_detection (partial): @Endpoint class + @ReadOperation/@WriteOperation/@DeleteOperation
  method extraction in spring_boot.go; OWNS edge from endpoint class to each operation.
- autoconfiguration_detection (partial): @EnableAutoConfiguration/@SpringBootApplication/
  @AutoConfiguration class detection + @ConditionalOn* class extraction in spring_ecosystem.go.
- profile_detection (partial): @Profile("name") class extraction with profile value captured
  in spring_ecosystem.go.
- di_scope_resolution (partial): @Scope("value")/@RequestScope/@SessionScope/@ApplicationScope
  class extraction with spring_scope property in spring_boot.go.

All 4 cells flipped missing→partial in registry.json (framework_specific + DI group).
Four proving tests added (TestSpringBoot_ActuatorDetection_Issue3081 et al.).

Closes #3081

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
