### PR TITLE
feat(coverage): CDI interceptor/AOP extractor for jakarta-ee/jaxrs/quarkus

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -127,11 +127,11 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 3/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 | [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
 | [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ⚠️ 13/13 | |
-| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 9/16 | |
-| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 15/16 | |
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
-| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 15/16 | |
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 14/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -19,11 +19,11 @@ Back to [summary](../summary.md).
 | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 3/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
 | [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ⚠️ 13/13 | |
-| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 9/16 | |
-| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 15/16 | |
 | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
-| [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 15/16 | |
 | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 14/16 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |

--- a/docs/coverage/detail/lang.java.framework.jakarta-ee.md
+++ b/docs/coverage/detail/lang.java.framework.jakarta-ee.md
@@ -73,9 +73,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
+| Aspect extraction | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
+| Pointcut resolution | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.java.framework.jaxrs.md
+++ b/docs/coverage/detail/lang.java.framework.jaxrs.md
@@ -73,9 +73,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
+| Aspect extraction | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
+| Pointcut resolution | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.java.framework.quarkus.md
+++ b/docs/coverage/detail/lang.java.framework.quarkus.md
@@ -73,9 +73,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
+| Aspect extraction | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
+| Pointcut resolution | ⚠️ `partial` | — | 3082 | `internal/custom/java/cdi_interceptors.go` | — |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15312,16 +15312,19 @@
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           }
         },
         "Observability": {
@@ -15839,16 +15842,19 @@
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           }
         },
         "Observability": {
@@ -16860,16 +16866,19 @@
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "3082"
           }
         },
         "Observability": {

--- a/internal/custom/java/cdi_interceptors.go
+++ b/internal/custom/java/cdi_interceptors.go
@@ -1,0 +1,248 @@
+package java
+
+import "regexp"
+
+// CDI interceptor / AOP extractor for jakarta-ee, jaxrs, and quarkus
+// (#3082, epic #2847).
+//
+// CDI uses a different interception model than Spring AOP:
+//   - @Interceptor annotates the interceptor implementation class
+//     (aspect_extraction analogue).
+//   - @AroundInvoke / @AroundConstruct methods inside the interceptor class
+//     carry the cross-cutting advice (advice_attribution analogue).
+//   - @InterceptorBinding marks a custom qualifier annotation that binds an
+//     interceptor to target beans (pointcut_resolution analogue).
+//
+// Entity mapping (reuses SCOPE.Pattern kind, matching spring_aop.go):
+//   - @Interceptor class  → SCOPE.Pattern subtype=aspect   kind=interceptor
+//   - @AroundInvoke       → SCOPE.Pattern subtype=advice   kind=around_invoke
+//   - @AroundConstruct    → SCOPE.Pattern subtype=advice   kind=around_construct
+//   - @InterceptorBinding → SCOPE.Pattern subtype=pointcut kind=interceptor_binding
+//
+// Covers:
+//   advice_attribution    (missing → partial) for jakarta-ee, jaxrs, quarkus
+//   aspect_extraction     (missing → partial) for jakarta-ee, jaxrs, quarkus
+//   pointcut_resolution   (missing → partial) for jakarta-ee, jaxrs, quarkus
+
+// cdiFrameworks gates the frameworks for which CDI interceptor extraction runs.
+var cdiFrameworks = map[string]bool{
+	"jakarta_ee": true, "jakarta-ee": true, "jakartaee": true,
+	"java_ee": true, "javaee": true,
+	"jaxrs": true, "jax-rs": true,
+	"quarkus": true,
+}
+
+var (
+	// cdiInterceptorClassRE matches an @Interceptor-annotated class declaration,
+	// capturing the class name (group 1). The (?s) flag lets the annotation and
+	// the class keyword span intervening lines.
+	cdiInterceptorClassRE = regexp.MustCompile(
+		`(?s)@Interceptor\b[^{]*?\bclass\s+(\w+)`)
+
+	// cdiAroundInvokeRE matches an @AroundInvoke method, capturing the method
+	// name that follows (group 1 via a separate scan window).
+	cdiAroundInvokeRE = regexp.MustCompile(`@AroundInvoke\b`)
+
+	// cdiAroundConstructRE matches an @AroundConstruct method.
+	cdiAroundConstructRE = regexp.MustCompile(`@AroundConstruct\b`)
+
+	// cdiInterceptorBindingRE matches an @InterceptorBinding annotation
+	// declaration, capturing the annotation type name (group 1). Uses [^;]*?
+	// (stop at statement boundary) rather than [^{]*? so it crosses
+	// @Target({...}) without being blocked by the inner { character.
+	cdiInterceptorBindingRE = regexp.MustCompile(
+		`(?s)@InterceptorBinding\b[^;]*?@interface\s+(\w+)`)
+
+	// cdiAdviceMethodNameRE resolves the declared method name immediately after
+	// an advice annotation (same window-scan approach as spring_aop.go).
+	cdiAdviceMethodNameRE = regexp.MustCompile(
+		`(?s)^[^{(]*?` +
+			`(?:(?:public|protected|private|final|static|synchronized)\s+)*` +
+			`(?:<[^>]*>\s*)?` +
+			`(?:[\w.]+(?:\s*<[^>]*>)?(?:\[\])?\s+)` +
+			`(\w+)\s*\(`)
+)
+
+// canonicalCDIFramework normalises a CDI framework alias to its canonical name.
+func canonicalCDIFramework(framework string) string {
+	switch framework {
+	case "jakarta_ee", "jakarta-ee", "jakartaee", "java_ee", "javaee":
+		return "jakarta_ee"
+	case "jaxrs", "jax-rs":
+		return "jaxrs"
+	case "quarkus":
+		return "quarkus"
+	default:
+		return framework
+	}
+}
+
+// cdiAdviceMethodName extracts the declared method name from source starting
+// at offset from (just past the matched annotation end). Mirrors
+// aopAdviceMethodName in spring_aop.go.
+func cdiAdviceMethodName(source string, from int) string {
+	end := from + 400
+	if end > len(source) {
+		end = len(source)
+	}
+	window := source[from:end]
+	m := cdiAdviceMethodNameRE.FindStringSubmatch(window)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// cdiInterceptorInfo is bookkeeping for a detected @Interceptor class.
+type cdiInterceptorInfo struct {
+	offset int
+	ref    string
+}
+
+// findEnclosingInterceptor returns the @Interceptor class that most closely
+// precedes offset in source.
+func findEnclosingInterceptor(source string, offset int, interceptors map[string]cdiInterceptorInfo) string {
+	best := ""
+	bestOff := -1
+	for name, ii := range interceptors {
+		if ii.offset <= offset && ii.offset > bestOff {
+			best = name
+			bestOff = ii.offset
+		}
+	}
+	return best
+}
+
+// ExtractCDIInterceptors runs the CDI interceptor / AOP extractor for
+// jakarta-ee, jaxrs, and quarkus.
+func ExtractCDIInterceptors(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !cdiFrameworks[ctx.Framework] {
+		return result
+	}
+
+	source := ctx.Source
+	fp := ctx.FilePath
+	framework := canonicalCDIFramework(ctx.Framework)
+	seenRefs := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// 1. aspect_extraction: @Interceptor classes.
+	interceptors := make(map[string]cdiInterceptorInfo)
+	for _, m := range cdiInterceptorClassRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		ref := "scope:pattern:aspect:" + fp + ":" + className
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Pattern", Subtype: "aspect",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_CDI_INTERCEPTOR", Ref: ref,
+			Properties: map[string]any{
+				"kind":        "interceptor",
+				"interceptor": className,
+				"framework":   framework,
+			},
+		}) {
+			interceptors[className] = cdiInterceptorInfo{offset: m[0], ref: ref}
+		}
+	}
+
+	// 2. pointcut_resolution: @InterceptorBinding annotation-type declarations.
+	//    These act as binding qualifiers (CDI's pointcut equivalent).
+	for _, m := range cdiInterceptorBindingRE.FindAllStringSubmatchIndex(source, -1) {
+		annotName := source[m[2]:m[3]]
+		ref := "scope:pattern:pointcut:" + fp + ":" + annotName
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: annotName, Kind: "SCOPE.Pattern", Subtype: "pointcut",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_CDI_INTERCEPTOR_BINDING", Ref: ref,
+			Properties: map[string]any{
+				"kind":      "interceptor_binding",
+				"binding":   annotName,
+				"framework": framework,
+			},
+		})
+	}
+
+	// Only emit advice entities for files that actually declare an interceptor
+	// (same guard as spring_aop.go for @Aspect).
+	if len(interceptors) == 0 {
+		return result
+	}
+
+	// 3. advice_attribution: @AroundInvoke methods.
+	for _, m := range cdiAroundInvokeRE.FindAllStringIndex(source, -1) {
+		owner := findEnclosingInterceptor(source, m[0], interceptors)
+		if owner == "" {
+			continue
+		}
+		methodName := cdiAdviceMethodName(source, m[1])
+		name := owner + ".@AroundInvoke"
+		if methodName != "" {
+			name = owner + "." + methodName
+		}
+		props := map[string]any{
+			"kind":        "advice",
+			"advice_type": "around_invoke",
+			"interceptor": owner,
+			"framework":   framework,
+		}
+		if methodName != "" {
+			props["method"] = methodName
+		}
+		ref := "scope:pattern:advice:" + fp + ":" + name
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "advice",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_CDI_AROUND_INVOKE", Ref: ref,
+			Properties: props,
+		}) {
+			// OWNS edge: interceptor owns its advice.
+			if ii, ok := interceptors[owner]; ok {
+				addRel(&result, seenRels, Relationship{
+					SourceRef: ii.ref, TargetRef: ref, RelationshipType: "OWNS",
+				})
+			}
+		}
+	}
+
+	// 4. advice_attribution: @AroundConstruct methods.
+	for _, m := range cdiAroundConstructRE.FindAllStringIndex(source, -1) {
+		owner := findEnclosingInterceptor(source, m[0], interceptors)
+		if owner == "" {
+			continue
+		}
+		methodName := cdiAdviceMethodName(source, m[1])
+		name := owner + ".@AroundConstruct"
+		if methodName != "" {
+			name = owner + "." + methodName
+		}
+		props := map[string]any{
+			"kind":        "advice",
+			"advice_type": "around_construct",
+			"interceptor": owner,
+			"framework":   framework,
+		}
+		if methodName != "" {
+			props["method"] = methodName
+		}
+		ref := "scope:pattern:advice:" + fp + ":" + name
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "advice",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_CDI_AROUND_CONSTRUCT", Ref: ref,
+			Properties: props,
+		}) {
+			if ii, ok := interceptors[owner]; ok {
+				addRel(&result, seenRels, Relationship{
+					SourceRef: ii.ref, TargetRef: ref, RelationshipType: "OWNS",
+				})
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -4493,3 +4493,366 @@ public class ApplicationScopedBean {
 >>>>>>> c810d1fe5 (feat(java/spring-boot): add actuator, autoconfig, profile, di_scope extractors (#3081))
 	}
 }
+
+// ============================================================================
+// CDI interceptor / AOP tests (#3082)
+// ============================================================================
+
+// cdiEntityBySubtypeName returns the first SCOPE.Pattern entity whose Subtype
+// matches subtype and whose Name ends with name (or equals name).
+func cdiEntityBySubtypeName(r PatternResult, subtype, name string) (SecondaryEntity, bool) {
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == subtype && e.Name == name {
+			return e, true
+		}
+	}
+	return SecondaryEntity{}, false
+}
+
+// cdiHasRel returns true if result contains a relationship (src, tgt, kind).
+func cdiHasRel(r PatternResult, src, tgt, kind string) bool {
+	for _, rel := range r.Relationships {
+		if rel.SourceRef == src && rel.TargetRef == tgt && rel.RelationshipType == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCDIInterceptors_AspectExtraction_Issue3082 is the proving fixture for
+// aspect_extraction: @Interceptor class detection for jakarta-ee.
+// Registry target: lang.java.framework.jakarta-ee aspect_extraction = partial.
+func TestCDIInterceptors_AspectExtraction_Issue3082(t *testing.T) {
+	source := `
+package com.example;
+
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+@Logging
+@Interceptor
+public class LoggingInterceptor {
+
+    @AroundInvoke
+    public Object logCall(InvocationContext ctx) throws Exception {
+        System.out.println("before");
+        Object result = ctx.proceed();
+        System.out.println("after");
+        return result;
+    }
+}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "jakarta-ee",
+		FilePath:  "LoggingInterceptor.java",
+	})
+
+	// aspect_extraction.
+	asp, ok := cdiEntityBySubtypeName(r, "aspect", "LoggingInterceptor")
+	if !ok {
+		t.Fatalf("[#3082 aspect] expected aspect entity LoggingInterceptor; got %v", entityNames(r.Entities))
+	}
+	if asp.Kind != "SCOPE.Pattern" {
+		t.Errorf("[#3082 aspect] Kind = %q, want SCOPE.Pattern", asp.Kind)
+	}
+	if asp.Properties["kind"] != "interceptor" {
+		t.Errorf("[#3082 aspect] kind property = %v, want interceptor", asp.Properties["kind"])
+	}
+	if asp.Properties["framework"] != "jakarta_ee" {
+		t.Errorf("[#3082 aspect] framework = %v, want jakarta_ee", asp.Properties["framework"])
+	}
+
+	// advice_attribution: @AroundInvoke.
+	adv, ok := cdiEntityBySubtypeName(r, "advice", "LoggingInterceptor.logCall")
+	if !ok {
+		t.Fatalf("[#3082 advice] expected advice LoggingInterceptor.logCall; got %v", entityNames(r.Entities))
+	}
+	if adv.Properties["advice_type"] != "around_invoke" {
+		t.Errorf("[#3082 advice] logCall advice_type = %v, want around_invoke", adv.Properties["advice_type"])
+	}
+	if adv.Properties["interceptor"] != "LoggingInterceptor" {
+		t.Errorf("[#3082 advice] logCall interceptor = %v, want LoggingInterceptor", adv.Properties["interceptor"])
+	}
+
+	// OWNS edge: interceptor owns its advice.
+	if !cdiHasRel(r, asp.Ref, adv.Ref, "OWNS") {
+		t.Errorf("[#3082] expected OWNS edge interceptor -> advice")
+	}
+}
+
+// TestCDIInterceptors_PointcutResolution_Issue3082 is the proving fixture for
+// pointcut_resolution: @InterceptorBinding annotation detection for jakarta-ee.
+// Registry target: lang.java.framework.jakarta-ee pointcut_resolution = partial.
+func TestCDIInterceptors_PointcutResolution_Issue3082(t *testing.T) {
+	source := `
+package com.example;
+
+import jakarta.interceptor.InterceptorBinding;
+import java.lang.annotation.*;
+
+@Inherited
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Logging {}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "jakarta_ee",
+		FilePath:  "Logging.java",
+	})
+
+	pc, ok := cdiEntityBySubtypeName(r, "pointcut", "Logging")
+	if !ok {
+		t.Fatalf("[#3082 pointcut] expected pointcut entity Logging; got %v", entityNames(r.Entities))
+	}
+	if pc.Properties["kind"] != "interceptor_binding" {
+		t.Errorf("[#3082 pointcut] kind = %v, want interceptor_binding", pc.Properties["kind"])
+	}
+	if pc.Properties["framework"] != "jakarta_ee" {
+		t.Errorf("[#3082 pointcut] framework = %v, want jakarta_ee", pc.Properties["framework"])
+	}
+}
+
+// TestCDIInterceptors_AroundConstruct_Issue3082 proves @AroundConstruct is
+// detected and emitted as advice with kind=around_construct.
+func TestCDIInterceptors_AroundConstruct_Issue3082(t *testing.T) {
+	source := `
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.AroundConstruct;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+public class AuditInterceptor {
+
+    @AroundConstruct
+    public void auditConstruct(InvocationContext ctx) throws Exception {
+        ctx.proceed();
+    }
+}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "jakarta_ee",
+		FilePath:  "AuditInterceptor.java",
+	})
+
+	asp, ok := cdiEntityBySubtypeName(r, "aspect", "AuditInterceptor")
+	if !ok {
+		t.Fatalf("[#3082 aspect] expected AuditInterceptor aspect entity")
+	}
+
+	adv, ok := cdiEntityBySubtypeName(r, "advice", "AuditInterceptor.auditConstruct")
+	if !ok {
+		t.Fatalf("[#3082 advice] expected advice AuditInterceptor.auditConstruct; got %v", entityNames(r.Entities))
+	}
+	if adv.Properties["advice_type"] != "around_construct" {
+		t.Errorf("[#3082 advice] auditConstruct advice_type = %v, want around_construct", adv.Properties["advice_type"])
+	}
+	if !cdiHasRel(r, asp.Ref, adv.Ref, "OWNS") {
+		t.Errorf("[#3082] expected OWNS edge interceptor -> around_construct advice")
+	}
+}
+
+// TestCDIInterceptors_QuarkusFramework_Issue3082 proves the extractor runs for
+// the quarkus framework (advice_attribution, aspect_extraction for quarkus).
+// Registry target: lang.java.framework.quarkus advice_attribution/aspect_extraction = partial.
+func TestCDIInterceptors_QuarkusFramework_Issue3082(t *testing.T) {
+	source := `
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+@Transactional
+@Interceptor
+public class TransactionInterceptor {
+
+    @AroundInvoke
+    public Object manageTransaction(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "quarkus",
+		FilePath:  "TransactionInterceptor.java",
+	})
+
+	asp, ok := cdiEntityBySubtypeName(r, "aspect", "TransactionInterceptor")
+	if !ok {
+		t.Fatalf("[#3082 quarkus] expected aspect entity TransactionInterceptor")
+	}
+	if asp.Properties["framework"] != "quarkus" {
+		t.Errorf("[#3082 quarkus] framework = %v, want quarkus", asp.Properties["framework"])
+	}
+
+	adv, ok := cdiEntityBySubtypeName(r, "advice", "TransactionInterceptor.manageTransaction")
+	if !ok {
+		t.Fatalf("[#3082 quarkus] expected advice TransactionInterceptor.manageTransaction; got %v", entityNames(r.Entities))
+	}
+	if adv.Properties["advice_type"] != "around_invoke" {
+		t.Errorf("[#3082 quarkus] manageTransaction advice_type = %v, want around_invoke", adv.Properties["advice_type"])
+	}
+}
+
+// TestCDIInterceptors_JAXRSFramework_Issue3082 proves the extractor runs for
+// the jaxrs framework.
+// Registry target: lang.java.framework.jaxrs advice_attribution/aspect_extraction = partial.
+func TestCDIInterceptors_JAXRSFramework_Issue3082(t *testing.T) {
+	source := `
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+@Metered
+@Interceptor
+public class MetricsInterceptor {
+
+    @AroundInvoke
+    public Object recordMetrics(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "jaxrs",
+		FilePath:  "MetricsInterceptor.java",
+	})
+
+	asp, ok := cdiEntityBySubtypeName(r, "aspect", "MetricsInterceptor")
+	if !ok {
+		t.Fatalf("[#3082 jaxrs] expected aspect entity MetricsInterceptor")
+	}
+	if asp.Properties["framework"] != "jaxrs" {
+		t.Errorf("[#3082 jaxrs] framework = %v, want jaxrs", asp.Properties["framework"])
+	}
+	_, ok = cdiEntityBySubtypeName(r, "advice", "MetricsInterceptor.recordMetrics")
+	if !ok {
+		t.Fatalf("[#3082 jaxrs] expected advice MetricsInterceptor.recordMetrics")
+	}
+}
+
+// TestCDIInterceptors_QuarkusInterceptorBinding_Issue3082 proves
+// pointcut_resolution fires for quarkus with @InterceptorBinding.
+// Registry target: lang.java.framework.quarkus pointcut_resolution = partial.
+func TestCDIInterceptors_QuarkusInterceptorBinding_Issue3082(t *testing.T) {
+	source := `
+import jakarta.interceptor.InterceptorBinding;
+import java.lang.annotation.*;
+
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Transactional {}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "quarkus",
+		FilePath:  "Transactional.java",
+	})
+
+	pc, ok := cdiEntityBySubtypeName(r, "pointcut", "Transactional")
+	if !ok {
+		t.Fatalf("[#3082 quarkus pointcut] expected pointcut Transactional; got %v", entityNames(r.Entities))
+	}
+	if pc.Properties["kind"] != "interceptor_binding" {
+		t.Errorf("[#3082 quarkus pointcut] kind = %v, want interceptor_binding", pc.Properties["kind"])
+	}
+}
+
+// TestCDIInterceptors_JAXRSInterceptorBinding_Issue3082 proves
+// pointcut_resolution fires for jaxrs.
+// Registry target: lang.java.framework.jaxrs pointcut_resolution = partial.
+func TestCDIInterceptors_JAXRSInterceptorBinding_Issue3082(t *testing.T) {
+	source := `
+import jakarta.interceptor.InterceptorBinding;
+import java.lang.annotation.*;
+
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Metered {}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "jax-rs",
+		FilePath:  "Metered.java",
+	})
+
+	pc, ok := cdiEntityBySubtypeName(r, "pointcut", "Metered")
+	if !ok {
+		t.Fatalf("[#3082 jaxrs pointcut] expected pointcut Metered; got %v", entityNames(r.Entities))
+	}
+	if pc.Properties["framework"] != "jaxrs" {
+		t.Errorf("[#3082 jaxrs pointcut] framework = %v, want jaxrs", pc.Properties["framework"])
+	}
+}
+
+// TestCDIInterceptors_FrameworkGating_Issue3082 proves the extractor no-ops for
+// non-CDI frameworks (Spring, Micronaut) and non-java languages.
+func TestCDIInterceptors_FrameworkGating_Issue3082(t *testing.T) {
+	source := `
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.AroundInvoke;
+
+@Interceptor
+public class X {
+    @AroundInvoke
+    public Object go(InvocationContext c) throws Exception { return c.proceed(); }
+}
+`
+	for _, fw := range []string{"jakarta_ee", "jakarta-ee", "jakartaee", "jaxrs", "jax-rs", "quarkus"} {
+		r := ExtractCDIInterceptors(PatternContext{Source: source, Language: "java", Framework: fw, FilePath: "X.java"})
+		if len(r.Entities) == 0 {
+			t.Errorf("[#3082 gating] framework %q expected CDI entities, got none", fw)
+		}
+	}
+	for _, fw := range []string{"spring_boot", "spring-boot", "spring_webflux", "micronaut", "django"} {
+		r := ExtractCDIInterceptors(PatternContext{Source: source, Language: "java", Framework: fw, FilePath: "X.java"})
+		if len(r.Entities) != 0 {
+			t.Errorf("[#3082 gating] framework %q should no-op, got %d entities", fw, len(r.Entities))
+		}
+	}
+	r := ExtractCDIInterceptors(PatternContext{Source: source, Language: "python", Framework: "jakarta_ee", FilePath: "X.py"})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3082 gating] non-java should no-op, got %d entities", len(r.Entities))
+	}
+}
+
+// TestCDIInterceptors_NoAdviceOutsideInterceptor_Issue3082 proves @AroundInvoke
+// outside an @Interceptor class emits no advice entity.
+func TestCDIInterceptors_NoAdviceOutsideInterceptor_Issue3082(t *testing.T) {
+	source := `
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+public class PlainBean {
+    @AroundInvoke
+    public Object notReallyAdvice(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "jakarta_ee",
+		FilePath:  "PlainBean.java",
+	})
+	for _, e := range r.Entities {
+		if e.Subtype == "advice" {
+			t.Errorf("[#3082] no advice should be emitted outside @Interceptor class; got %s", e.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/custom/java/cdi_interceptors.go` implementing `ExtractCDIInterceptors` — detects `@Interceptor` classes (aspect_extraction), `@AroundInvoke`/`@AroundConstruct` methods (advice_attribution), and `@InterceptorBinding` annotation-type declarations (pointcut_resolution).
- Gated on jakarta_ee / jaxrs / quarkus frameworks; no-ops for Spring and all other frameworks.
- Emits `SCOPE.Pattern` entities (subtype: aspect/advice/pointcut) with OWNS edges wiring interceptor classes to their advice methods — mirrors `spring_aop.go` design.
- 9 registry cells flipped `missing → partial`: `advice_attribution`, `aspect_extraction`, `pointcut_resolution` × `jakarta-ee`, `jaxrs`, `quarkus`.
- 9 proving tests added (one per cell category + gating + guard tests).

Closes #3082

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>