### PR TITLE
feat(coverage): dramatiq + django-signals recording-win

### DIFF
--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -29,6 +29,6 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [WebSocket](../detail/msg.websocket.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
 | [multi](../by-language/multi.md) | [Webhooks](../detail/msg.webhook.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
 | [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | ✅ | |
-| [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | ⚠️ | ⚠️ | |
-| [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ❌ | ❌ | — | ❌ | |
+| [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | ✅ | ✅ | |
+| [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | ✅ | |
 | [ruby](../by-language/ruby.md) | [Sidekiq (Ruby task queue)](../detail/msg.sidekiq.md) | ❌ | ❌ | — | ❌ | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -100,8 +100,8 @@ Back to [summary](../summary.md).
 | Name | Category | Status | Notes |
 |---|---|---|---|
 | [Celery (Python task queue)](../detail/msg.celery.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
-| [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | [message_broker](../by-category/message_broker.md) | ⚠️ | |
-| [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | [message_broker](../by-category/message_broker.md) | ❌ | |
+| [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
+| [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | [message_broker](../by-category/message_broker.md) | ✅ | |
 
 ### Validation
 

--- a/docs/coverage/detail/msg.django-signals.md
+++ b/docs/coverage/detail/msg.django-signals.md
@@ -13,7 +13,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Consumer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/django_signal_pubsub_edges.go` | — |
 | Producer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/django_signal_pubsub_edges.go` | — |
-| Topic attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/django_signal_pubsub_edges.go` | — |
+| Topic attribution | ✅ `full` | `2026-05-29` | 3058 | `internal/engine/django_signal_pubsub_edges.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/msg.dramatiq.md
+++ b/docs/coverage/detail/msg.dramatiq.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Consumer extraction | ❌ `missing` | — | — | — | — |
-| Producer extraction | ❌ `missing` | — | — | — | — |
+| Consumer extraction | ✅ `full` | `2026-05-29` | 3058 | `internal/custom/python/dramatiq.go` | — |
+| Producer extraction | ✅ `full` | `2026-05-29` | 3058 | `internal/custom/python/dramatiq.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -45934,9 +45934,10 @@
           "verified_at": "2026-05-28"
         },
         "topic_attribution": {
-          "status": "partial",
+          "status": "full",
           "cites": ["internal/engine/django_signal_pubsub_edges.go"],
-          "verified_at": "2026-05-28"
+          "issue": "3058",
+          "verified_at": "2026-05-29"
         }
       }
     },
@@ -45947,10 +45948,16 @@
       "label": "Dramatiq (Python task queue)",
       "capabilities": {
         "consumer_extraction": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/python/dramatiq.go"],
+          "issue": "3058",
+          "verified_at": "2026-05-29"
         },
         "producer_extraction": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/custom/python/dramatiq.go"],
+          "issue": "3058",
+          "verified_at": "2026-05-29"
         }
       }
     },


### PR DESCRIPTION
## Summary

- `msg.dramatiq` `consumer_extraction` + `producer_extraction`: missing → full (dramatiqExtractor in `internal/custom/python/dramatiq.go` emits `@dramatiq.actor` actors as consumers and `.send()`/`.send_with_options()` call sites as producers; `TestDramatiq_*` suite confirms all patterns fire)
- `msg.django-signals` `topic_attribution`: partial → full (`ApplyDjangoSignalPubSub` in `internal/engine/django_signal_pubsub_edges.go` emits `SCOPE.MessageTopic` per custom `Signal()`, `SUBSCRIBES_TO` from `@receiver` handlers and `PUBLISHES_TO` from `.send()` sites; `TestApplyDjangoSignalPubSub_*` confirms cross-file topology)
- Class A recording-win — no Go code changes

## Verification

- `coverage validate` 0 errors
- `coverage fmt --check` canonical
- `coverage gen` byte-stable
- `go build ./...` clean
- `go test ./internal/custom/python/ ./tools/coverage/` all pass

Closes #3058