### PR TITLE
feat(coverage): Python ORM relationship extractor (peewee/pony/beanie/mongoengine/tortoise)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -113,15 +113,15 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | ❌ 1/6 | |
 | [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 1/6 | |
 | [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 1/6 | |
-| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 2/7 | |
+| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 5/6 | |
 | [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |
-| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 2/7 | |
+| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 5/6 | |
 | [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 1/2 | |
-| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 2/8 | |
-| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 2/8 | |
+| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 5/8 | |
+| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 5/8 | |
 | [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 8/8 | |
 | [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ⚠️ 8/8 | |
-| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 2/8 | |
+| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 6/8 | |
 | [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ⚠️ 1/1 | |
 | [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ⚠️ 1/1 | |
 | [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ⚠️ 1/1 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -77,15 +77,15 @@ Back to [summary](../summary.md).
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 1/6 | |
-| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 2/7 | |
+| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 5/6 | |
 | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |
-| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 2/7 | |
+| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 5/6 | |
 | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 1/2 | |
-| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 2/8 | |
-| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 2/8 | |
+| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 5/8 | |
+| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 5/8 | |
 | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 8/8 | |
 | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ⚠️ 8/8 | |
-| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 2/8 | |
+| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 6/8 | |
 | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ⚠️ 1/1 | |
 | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ⚠️ 1/1 | |
 | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ⚠️ 1/1 | |

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -22,10 +22,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Beanie (Motor-based async ODM) does not have a lazy-loading mechanism; all queries are explicit async calls. |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/beanie_relationships.py` | — |
+| Foreign key extraction | — `not_applicable` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/beanie_relationships.py` | — |
+| Lazy loading recognition | ⚠️ `partial` | `2026-05-29` | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/beanie_relationships.py` | Beanie (Motor-based async ODM) does not have a lazy-loading mechanism; all queries are explicit async calls. |
+| Relationship extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/beanie_relationships.py` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -22,10 +22,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | MongoEngine uses ReferenceField with lazy loading but no extractor tracks lazy_loading strategy properties. |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/mongoengine_relationships.py` | — |
+| Foreign key extraction | — `not_applicable` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/mongoengine_relationships.py` | — |
+| Lazy loading recognition | ⚠️ `partial` | `2026-05-29` | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/mongoengine_relationships.py` | MongoEngine uses ReferenceField with lazy loading but no extractor tracks lazy_loading strategy properties. |
+| Relationship extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/mongoengine_relationships.py` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.python.orm.peewee.md
+++ b/docs/coverage/detail/lang.python.orm.peewee.md
@@ -22,10 +22,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/beanie_relationships.py`<br>`internal/custom/python/testdata/mongoengine_relationships.py`<br>`internal/custom/python/testdata/peewee_relationships.py`<br>`internal/custom/python/testdata/pony_relationships.py`<br>`internal/custom/python/testdata/tortoise_relationships.py` | — |
+| Foreign key extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/beanie_relationships.py`<br>`internal/custom/python/testdata/mongoengine_relationships.py`<br>`internal/custom/python/testdata/peewee_relationships.py`<br>`internal/custom/python/testdata/pony_relationships.py`<br>`internal/custom/python/testdata/tortoise_relationships.py` | — |
 | Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Peewee does not support lazy loading; all queries are explicit. DeferredForeignKey is a different concept not tracked here. |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/beanie_relationships.py`<br>`internal/custom/python/testdata/mongoengine_relationships.py`<br>`internal/custom/python/testdata/peewee_relationships.py`<br>`internal/custom/python/testdata/pony_relationships.py`<br>`internal/custom/python/testdata/tortoise_relationships.py` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.python.orm.pony.md
+++ b/docs/coverage/detail/lang.python.orm.pony.md
@@ -22,10 +22,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/pony_relationships.py` | — |
+| Foreign key extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/pony_relationships.py` | — |
 | Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Pony ORM lazy loading is implicit via @db_session but not tracked structurally; no extractor emits lazy-load relationship entities. |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/pony_relationships.py` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.python.orm.tortoise.md
+++ b/docs/coverage/detail/lang.python.orm.tortoise.md
@@ -22,10 +22,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Tortoise ORM does not have a lazy-loading concept comparable to SQLAlchemy; prefetch_related is async-explicit and tracked under query_attribution only. |
-| Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/tortoise_relationships.py` | — |
+| Foreign key extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/tortoise_relationships.py` | — |
+| Lazy loading recognition | ⚠️ `partial` | `2026-05-29` | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/tortoise_relationships.py` | Tortoise ORM does not have a lazy-loading concept comparable to SQLAlchemy; prefetch_related is async-explicit and tracked under query_attribution only. |
+| Relationship extraction | ⚠️ `partial` | — | 3070 | `internal/custom/python/orm_relationships.go`<br>`internal/custom/python/testdata/tortoise_relationships.py` | — |
 
 ### Queries
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -37704,22 +37704,26 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/beanie_relationships.py"],
+            "issue": "3070"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/beanie_relationships.py"],
+            "issue": "3070"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness",
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/beanie_relationships.py"],
+            "issue": "3070",
             "notes": "Beanie (Motor-based async ODM) does not have a lazy-loading mechanism; all queries are explicit async calls.",
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/beanie_relationships.py"],
+            "issue": "3070"
           }
         },
         "Queries": {
@@ -37819,22 +37823,26 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/mongoengine_relationships.py"],
+            "issue": "3070"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/mongoengine_relationships.py"],
+            "issue": "3070"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness",
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/mongoengine_relationships.py"],
+            "issue": "3070",
             "notes": "MongoEngine uses ReferenceField with lazy loading but no extractor tracks lazy_loading strategy properties.",
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/mongoengine_relationships.py"],
+            "issue": "3070"
           }
         },
         "Queries": {
@@ -37873,12 +37881,14 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/beanie_relationships.py","internal/custom/python/testdata/mongoengine_relationships.py","internal/custom/python/testdata/peewee_relationships.py","internal/custom/python/testdata/pony_relationships.py","internal/custom/python/testdata/tortoise_relationships.py"],
+            "issue": "3070"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/beanie_relationships.py","internal/custom/python/testdata/mongoengine_relationships.py","internal/custom/python/testdata/peewee_relationships.py","internal/custom/python/testdata/pony_relationships.py","internal/custom/python/testdata/tortoise_relationships.py"],
+            "issue": "3070"
           },
           "lazy_loading_recognition": {
             "status": "missing",
@@ -37887,8 +37897,9 @@
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/beanie_relationships.py","internal/custom/python/testdata/mongoengine_relationships.py","internal/custom/python/testdata/peewee_relationships.py","internal/custom/python/testdata/pony_relationships.py","internal/custom/python/testdata/tortoise_relationships.py"],
+            "issue": "3070"
           }
         },
         "Queries": {
@@ -37927,12 +37938,14 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/pony_relationships.py"],
+            "issue": "3070"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/pony_relationships.py"],
+            "issue": "3070"
           },
           "lazy_loading_recognition": {
             "status": "missing",
@@ -37941,8 +37954,9 @@
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/pony_relationships.py"],
+            "issue": "3070"
           }
         },
         "Queries": {
@@ -38108,22 +38122,26 @@
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/tortoise_relationships.py"],
+            "issue": "3070"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/tortoise_relationships.py"],
+            "issue": "3070"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness",
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/tortoise_relationships.py"],
+            "issue": "3070",
             "notes": "Tortoise ORM does not have a lazy-loading concept comparable to SQLAlchemy; prefetch_related is async-explicit and tracked under query_attribution only.",
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_relationships.go","internal/custom/python/testdata/tortoise_relationships.py"],
+            "issue": "3070"
           }
         },
         "Queries": {

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -3150,3 +3150,452 @@ func TestObservability_FixtureTracing(t *testing.T) {
 		t.Error("fixture: expected trace_span entities")
 	}
 }
+
+// ============================================================================
+// ORM relationship extractor tests — issue #3070
+// ============================================================================
+
+// ---- Peewee ----------------------------------------------------------------
+
+func TestPeeweeRel_ForeignKeyField(t *testing.T) {
+	src := `import peewee
+from peewee import Model, ForeignKeyField, CharField
+
+class Author(Model):
+    name = CharField()
+
+class Book(Model):
+    title = CharField()
+    author = ForeignKeyField(Author, backref="books")
+`
+	ents := extract(t, "python_peewee_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Book.author" && e.Props["pattern_type"] == "foreign_key" && e.Props["target_model"] == "Author" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Book.author foreign_key entity with target_model=Author")
+	}
+}
+
+func TestPeeweeRel_ManyToManyField(t *testing.T) {
+	src := `import peewee
+from peewee import Model, ManyToManyField, CharField
+
+class Tag(Model):
+    name = CharField()
+
+class Article(Model):
+    title = CharField()
+    tags = ManyToManyField(Tag, backref="articles")
+`
+	ents := extract(t, "python_peewee_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Article.tags" && e.Props["pattern_type"] == "many_to_many" && e.Props["target_model"] == "Tag" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Article.tags many_to_many entity with target_model=Tag")
+	}
+}
+
+func TestPeeweeRel_NoFalsePositive(t *testing.T) {
+	src := `class SomethingElse:
+    name = "test"
+`
+	ents := extract(t, "python_peewee_rel", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities from non-peewee file, got %d", len(ents))
+	}
+}
+
+func TestPeeweeRel_Fixture(t *testing.T) {
+	src, err := os.ReadFile("testdata/peewee_relationships.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := extract(t, "python_peewee_rel", string(src))
+
+	fkCount := 0
+	mtmCount := 0
+	for _, e := range ents {
+		switch e.Props["pattern_type"] {
+		case "foreign_key":
+			fkCount++
+		case "many_to_many":
+			mtmCount++
+		}
+	}
+	if fkCount < 3 {
+		t.Errorf("expected >=3 foreign_key entities, got %d", fkCount)
+	}
+	if mtmCount < 1 {
+		t.Errorf("expected >=1 many_to_many entity, got %d", mtmCount)
+	}
+}
+
+// ---- Pony ORM --------------------------------------------------------------
+
+func TestPonyRel_Required(t *testing.T) {
+	src := `from pony.orm import Database, Required, Set
+
+db = Database()
+
+class Department(db.Entity):
+    name = Required(str)
+    employees = Set("Employee")
+
+class Employee(db.Entity):
+    name = Required(str)
+    department = Required(Department)
+`
+	ents := extract(t, "python_pony_rel", src)
+	foundDept := false
+	foundSet := false
+	for _, e := range ents {
+		if e.Name == "Employee.department" && e.Props["pattern_type"] == "relationship" && e.Props["target_model"] == "Department" {
+			foundDept = true
+		}
+		if e.Name == "Department.employees" && e.Props["pattern_type"] == "many_to_many" && e.Props["target_model"] == "Employee" {
+			foundSet = true
+		}
+	}
+	if !foundDept {
+		t.Fatal("expected Employee.department relationship entity")
+	}
+	if !foundSet {
+		t.Fatal("expected Department.employees many_to_many entity")
+	}
+}
+
+func TestPonyRel_Optional(t *testing.T) {
+	src := `from pony.orm import Database, Required, Optional
+
+db = Database()
+
+class Employee(db.Entity):
+    name = Required(str)
+    manager = Optional("Employee")
+`
+	ents := extract(t, "python_pony_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Employee.manager" && e.Props["pattern_type"] == "relationship" && e.Props["rel_kind"] == "Optional" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Employee.manager Optional relationship entity")
+	}
+}
+
+func TestPonyRel_Fixture(t *testing.T) {
+	src, err := os.ReadFile("testdata/pony_relationships.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := extract(t, "python_pony_rel", string(src))
+
+	relCount := 0
+	for _, e := range ents {
+		if e.Props["framework"] == "pony" {
+			relCount++
+		}
+	}
+	if relCount < 4 {
+		t.Errorf("expected >=4 pony relationship entities, got %d", relCount)
+	}
+}
+
+// ---- Beanie ----------------------------------------------------------------
+
+func TestBeanieRel_LinkField(t *testing.T) {
+	src := `from beanie import Document, Link
+
+class Category(Document):
+    name: str
+
+class Product(Document):
+    title: str
+    category: Link[Category]
+`
+	ents := extract(t, "python_beanie_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Product.category" && e.Props["pattern_type"] == "link" && e.Props["target_model"] == "Category" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Product.category link entity with target_model=Category")
+	}
+}
+
+func TestBeanieRel_FetchLinks(t *testing.T) {
+	src := `from beanie import Document, Link
+from typing import List
+
+class Category(Document):
+    name: str
+
+class Product(Document):
+    category: Link[Category]
+
+async def get(id):
+    return await Product.get(id, fetch_links=True)
+`
+	ents := extract(t, "python_beanie_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Product.category" && e.Props["lazy_loading"] == "fetch_links" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected fetch_links lazy_loading annotation on Link field")
+	}
+}
+
+func TestBeanieRel_Fixture(t *testing.T) {
+	src, err := os.ReadFile("testdata/beanie_relationships.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := extract(t, "python_beanie_rel", string(src))
+
+	linkCount := 0
+	for _, e := range ents {
+		if e.Props["framework"] == "beanie" && (e.Props["pattern_type"] == "link" || e.Props["pattern_type"] == "back_link") {
+			linkCount++
+		}
+	}
+	if linkCount < 3 {
+		t.Errorf("expected >=3 beanie link entities, got %d", linkCount)
+	}
+}
+
+// ---- MongoEngine -----------------------------------------------------------
+
+func TestMongoEngineRel_ReferenceField(t *testing.T) {
+	src := `import mongoengine
+from mongoengine import Document, ReferenceField, StringField
+
+class Author(Document):
+    name = StringField()
+
+class Book(Document):
+    title = StringField()
+    author = ReferenceField(Author)
+`
+	ents := extract(t, "python_mongoengine_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Book.author" && e.Props["pattern_type"] == "reference" && e.Props["target_model"] == "Author" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Book.author reference entity with target_model=Author")
+	}
+}
+
+func TestMongoEngineRel_EmbeddedDocumentField(t *testing.T) {
+	src := `from mongoengine import Document, EmbeddedDocument, EmbeddedDocumentField, StringField
+
+class Address(EmbeddedDocument):
+    street = StringField()
+
+class Person(Document):
+    name = StringField()
+    address = EmbeddedDocumentField(Address)
+`
+	ents := extract(t, "python_mongoengine_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Person.address" && e.Props["pattern_type"] == "embedded" && e.Props["target_model"] == "Address" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Person.address embedded entity with target_model=Address")
+	}
+}
+
+func TestMongoEngineRel_LazyReferenceField(t *testing.T) {
+	src := `from mongoengine import Document, LazyReferenceField, StringField
+
+class Category(Document):
+    name = StringField()
+
+class Post(Document):
+    title = StringField()
+    category = LazyReferenceField(Category)
+`
+	ents := extract(t, "python_mongoengine_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Post.category" && e.Props["pattern_type"] == "lazy_reference" && e.Props["lazy_loading"] == "lazy_reference" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Post.category lazy_reference entity with lazy_loading annotation")
+	}
+}
+
+func TestMongoEngineRel_Fixture(t *testing.T) {
+	src, err := os.ReadFile("testdata/mongoengine_relationships.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := extract(t, "python_mongoengine_rel", string(src))
+
+	refCount := 0
+	embCount := 0
+	for _, e := range ents {
+		switch e.Props["pattern_type"] {
+		case "reference", "lazy_reference":
+			refCount++
+		case "embedded", "embedded_list":
+			embCount++
+		}
+	}
+	if refCount < 2 {
+		t.Errorf("expected >=2 reference entities, got %d", refCount)
+	}
+	if embCount < 2 {
+		t.Errorf("expected >=2 embedded entities, got %d", embCount)
+	}
+}
+
+// ---- Tortoise ORM ----------------------------------------------------------
+
+func TestTortoiseRel_ForeignKeyField(t *testing.T) {
+	src := `from tortoise import fields
+from tortoise.models import Model
+
+class Tournament(Model):
+    name = fields.CharField(max_length=255)
+
+class Event(Model):
+    name = fields.CharField(max_length=255)
+    tournament = fields.ForeignKeyField("models.Tournament", related_name="events")
+`
+	ents := extract(t, "python_tortoise_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Event.tournament" && e.Props["pattern_type"] == "foreign_key" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Event.tournament foreign_key entity")
+	}
+}
+
+func TestTortoiseRel_ManyToManyField(t *testing.T) {
+	src := `from tortoise import fields
+from tortoise.models import Model
+
+class Team(Model):
+    name = fields.CharField(max_length=255)
+
+class Event(Model):
+    name = fields.CharField(max_length=255)
+    participants = fields.ManyToManyField("models.Team", related_name="events")
+`
+	ents := extract(t, "python_tortoise_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Event.participants" && e.Props["pattern_type"] == "many_to_many" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Event.participants many_to_many entity")
+	}
+}
+
+func TestTortoiseRel_OneToOneField(t *testing.T) {
+	src := `from tortoise import fields
+from tortoise.models import Model
+
+class Profile(Model):
+    bio = fields.TextField()
+
+class Player(Model):
+    name = fields.CharField(max_length=255)
+    profile = fields.OneToOneField("models.Profile", related_name="player")
+`
+	ents := extract(t, "python_tortoise_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Player.profile" && e.Props["pattern_type"] == "one_to_one" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Player.profile one_to_one entity")
+	}
+}
+
+func TestTortoiseRel_ReverseRelation(t *testing.T) {
+	src := `from tortoise import fields
+from tortoise.models import Model
+
+class Tournament(Model):
+    name = fields.CharField(max_length=255)
+    events: fields.ReverseRelation["Event"]
+`
+	ents := extract(t, "python_tortoise_rel", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "Tournament.events" && e.Props["pattern_type"] == "reverse_relation" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Tournament.events reverse_relation entity")
+	}
+}
+
+func TestTortoiseRel_Fixture(t *testing.T) {
+	src, err := os.ReadFile("testdata/tortoise_relationships.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := extract(t, "python_tortoise_rel", string(src))
+
+	fkCount := 0
+	mtmCount := 0
+	o2oCount := 0
+	revCount := 0
+	for _, e := range ents {
+		switch e.Props["pattern_type"] {
+		case "foreign_key":
+			fkCount++
+		case "many_to_many":
+			mtmCount++
+		case "one_to_one":
+			o2oCount++
+		case "reverse_relation":
+			revCount++
+		}
+	}
+	if fkCount < 2 {
+		t.Errorf("expected >=2 foreign_key entities, got %d", fkCount)
+	}
+	if mtmCount < 1 {
+		t.Errorf("expected >=1 many_to_many entity, got %d", mtmCount)
+	}
+	if o2oCount < 1 {
+		t.Errorf("expected >=1 one_to_one entity, got %d", o2oCount)
+	}
+	if revCount < 1 {
+		t.Errorf("expected >=1 reverse_relation entity, got %d", revCount)
+	}
+}

--- a/internal/custom/python/orm_relationships.go
+++ b/internal/custom/python/orm_relationships.go
@@ -1,0 +1,582 @@
+package python
+
+// orm_relationships.go — relationship/FK extraction for Peewee, Pony ORM,
+// Beanie, MongoEngine, and Tortoise ORM.
+//
+// Issue #3070 — ORM relationship extractor for peewee/pony/beanie/mongoengine/tortoise.
+// Pattern: mirrors saRelationshipRe / saForeignKeyRe from sqlalchemy.go.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_peewee_rel", &PeeweeRelExtractor{})
+	extractor.Register("python_pony_rel", &PonyRelExtractor{})
+	extractor.Register("python_beanie_rel", &BeanieRelExtractor{})
+	extractor.Register("python_mongoengine_rel", &MongoEngineRelExtractor{})
+	extractor.Register("python_tortoise_rel", &TortoiseRelExtractor{})
+}
+
+// ============================================================================
+// Peewee
+// ============================================================================
+
+// PeeweeRelExtractor extracts ForeignKeyField and ManyToManyField relationships
+// from Peewee ORM model classes.
+type PeeweeRelExtractor struct{}
+
+func (e *PeeweeRelExtractor) Language() string { return "python_peewee_rel" }
+
+var (
+	// peeweeModelRe matches class definitions that extend a Peewee Model.
+	peeweeModelRe = regexp.MustCompile(`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// peeweeFKFieldRe matches:  attr = ForeignKeyField(TargetModel, ...)
+	peeweeFKFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*ForeignKeyField\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// peeweeMTMFieldRe matches: attr = ManyToManyField(TargetModel, ...)
+	peeweeMTMFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*ManyToManyField\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// peeweeBaseIndicators are common Peewee base class names.
+	peeweeBaseIndicators = []string{"Model", "peewee.Model", "pw.Model"}
+)
+
+func isPeeweeModel(bases string) bool {
+	for _, ind := range peeweeBaseIndicators {
+		if strings.Contains(bases, ind) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *PeeweeRelExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_peewee_rel")
+	_, span := tracer.Start(ctx, "custom.python_peewee_rel")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	// Gate: file must import/reference peewee
+	source := string(file.Content)
+	if !strings.Contains(source, "peewee") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	for _, idx := range allMatchesIndex(peeweeModelRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isPeeweeModel(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		// ForeignKeyField → foreign_key / relationship
+		for _, fkIdx := range allMatchesIndex(peeweeFKFieldRe, body) {
+			attr := body[fkIdx[2]:fkIdx[3]]
+			target := body[fkIdx[4]:fkIdx[5]]
+			relLine := classLine + strings.Count(body[:fkIdx[0]], "\n")
+			props := map[string]string{
+				"framework":    "peewee",
+				"pattern_type": "foreign_key",
+				"target_model": target,
+				"parent_class": className,
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+
+		// ManyToManyField → association / relationship
+		for _, mtmIdx := range allMatchesIndex(peeweeMTMFieldRe, body) {
+			attr := body[mtmIdx[2]:mtmIdx[3]]
+			target := body[mtmIdx[4]:mtmIdx[5]]
+			relLine := classLine + strings.Count(body[:mtmIdx[0]], "\n")
+			props := map[string]string{
+				"framework":    "peewee",
+				"pattern_type": "many_to_many",
+				"target_model": target,
+				"parent_class": className,
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// Pony ORM
+// ============================================================================
+
+// PonyRelExtractor extracts Required/Optional/Set relationships that reference
+// other entities in Pony ORM model classes.
+type PonyRelExtractor struct{}
+
+func (e *PonyRelExtractor) Language() string { return "python_pony_rel" }
+
+var (
+	// ponyEntityRe matches class definitions that extend db.Entity or Entity.
+	ponyEntityRe = regexp.MustCompile(`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// ponyRelRe matches Required/Optional/Set fields that reference another entity.
+	// Handles both unquoted class refs (Required(Department)) and quoted string refs
+	// (Optional("Employee"), Set("Project")).  The three capture groups after (2) are:
+	//   group 3: double-quoted ref  group 4: single-quoted ref  group 5: bare class ref
+	ponyRelRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*(Required|Optional|Set)\s*\(\s*(?:"([A-Za-z_][A-Za-z0-9_]*)"|'([A-Za-z_][A-Za-z0-9_]*)'|([A-Z][A-Za-z0-9_]*))`)
+
+	// ponyBaseIndicators are common Pony ORM base class names.
+	ponyBaseIndicators = []string{"db.Entity", "Entity"}
+)
+
+func isPonyEntity(bases string) bool {
+	for _, ind := range ponyBaseIndicators {
+		if strings.Contains(bases, ind) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *PonyRelExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_pony_rel")
+	_, span := tracer.Start(ctx, "custom.python_pony_rel")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	source := string(file.Content)
+	if !strings.Contains(source, "pony") && !strings.Contains(source, "db.Entity") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	for _, idx := range allMatchesIndex(ponyEntityRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isPonyEntity(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		for _, rIdx := range allMatchesIndex(ponyRelRe, body) {
+			attr := body[rIdx[2]:rIdx[3]]
+			relKind := body[rIdx[4]:rIdx[5]] // Required | Optional | Set
+			// target may come from group 3 (double-quoted), 4 (single-quoted), or 5 (bare class)
+			target := ""
+			for _, pair := range [][2]int{{rIdx[6], rIdx[7]}, {rIdx[8], rIdx[9]}, {rIdx[10], rIdx[11]}} {
+				if pair[0] >= 0 {
+					target = body[pair[0]:pair[1]]
+					break
+				}
+			}
+			if target == "" {
+				continue
+			}
+			relLine := classLine + strings.Count(body[:rIdx[0]], "\n")
+
+			patternType := "relationship"
+			if relKind == "Set" {
+				patternType = "many_to_many"
+			}
+
+			props := map[string]string{
+				"framework":    "pony",
+				"pattern_type": patternType,
+				"rel_kind":     relKind,
+				"target_model": target,
+				"parent_class": className,
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// Beanie
+// ============================================================================
+
+// BeanieRelExtractor extracts Link[Model] type-hint relationships from Beanie
+// ODM document classes (async MongoDB).
+type BeanieRelExtractor struct{}
+
+func (e *BeanieRelExtractor) Language() string { return "python_beanie_rel" }
+
+var (
+	// beanieDocRe matches class definitions that extend Document.
+	beanieDocRe = regexp.MustCompile(`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// beanieLinkRe matches: attr: Link[Model], List[Link[Model]], Optional[Link[Model]],
+	// or List[Link["Model"]] (quoted forward-reference form).
+	beanieLinkRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*:\s*(?:(?:Optional|List)\s*\[\s*)*Link\s*\[\s*"?([A-Za-z_][A-Za-z0-9_]*)"?`)
+
+	// beanieBackLinkRe matches: attr: BackLink[TargetModel]
+	beanieBackLinkRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*:\s*BackLink\s*\[\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// beanieFetchLinksRe detects use of fetch_links=True (lazy_loading_recognition)
+	beanieFetchLinksRe = regexp.MustCompile(`fetch_links\s*=\s*True`)
+
+	// beanieBaseIndicators are common Beanie base class names.
+	beanieBaseIndicators = []string{"Document", "beanie.Document"}
+)
+
+func isBeanieDocument(bases string) bool {
+	for _, ind := range beanieBaseIndicators {
+		if strings.Contains(bases, ind) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *BeanieRelExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_beanie_rel")
+	_, span := tracer.Start(ctx, "custom.python_beanie_rel")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	source := string(file.Content)
+	if !strings.Contains(source, "beanie") && !strings.Contains(source, "Link[") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	// Detect fetch_links=True for lazy_loading_recognition at file level
+	hasFetchLinks := beanieFetchLinksRe.MatchString(source)
+
+	for _, idx := range allMatchesIndex(beanieDocRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isBeanieDocument(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		// Link[Model] fields
+		for _, lIdx := range allMatchesIndex(beanieLinkRe, body) {
+			attr := body[lIdx[2]:lIdx[3]]
+			target := body[lIdx[4]:lIdx[5]]
+			relLine := classLine + strings.Count(body[:lIdx[0]], "\n")
+			props := map[string]string{
+				"framework":    "beanie",
+				"pattern_type": "link",
+				"target_model": target,
+				"parent_class": className,
+			}
+			if hasFetchLinks {
+				props["lazy_loading"] = "fetch_links"
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+
+		// BackLink[Model] fields
+		for _, blIdx := range allMatchesIndex(beanieBackLinkRe, body) {
+			attr := body[blIdx[2]:blIdx[3]]
+			target := body[blIdx[4]:blIdx[5]]
+			relLine := classLine + strings.Count(body[:blIdx[0]], "\n")
+			props := map[string]string{
+				"framework":    "beanie",
+				"pattern_type": "back_link",
+				"target_model": target,
+				"parent_class": className,
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// MongoEngine
+// ============================================================================
+
+// MongoEngineRelExtractor extracts ReferenceField and EmbeddedDocumentField
+// relationships from MongoEngine document classes.
+//
+// Note: MongoEngine is a MongoDB ODM. "foreign key" as an RDBMS concept is
+// not applicable — ReferenceField is the closest analog (a DBRef/ObjectId
+// pointer) but it is NOT a SQL FK with integrity constraints. We record
+// association_extraction and relationship_extraction as partial, and treat
+// foreign_key_extraction as not_applicable for MongoDB-based ORMs.
+type MongoEngineRelExtractor struct{}
+
+func (e *MongoEngineRelExtractor) Language() string { return "python_mongoengine_rel" }
+
+var (
+	// meDocRe matches class definitions that extend Document or EmbeddedDocument.
+	meDocRe = regexp.MustCompile(`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// meReferenceFieldRe matches: attr = ReferenceField(TargetModel, ...)
+	meReferenceFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*ReferenceField\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// meEmbeddedFieldRe matches: attr = EmbeddedDocumentField(TargetDoc, ...)
+	meEmbeddedFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*EmbeddedDocumentField\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// meEmbeddedListFieldRe matches: attr = EmbeddedDocumentListField(TargetDoc, ...)
+	meEmbeddedListFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*EmbeddedDocumentListField\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// meLazyReferenceRe matches: attr = LazyReferenceField(TargetModel, ...)
+	meLazyReferenceRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*LazyReferenceField\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// meBaseIndicators are common MongoEngine base class names.
+	meBaseIndicators = []string{"Document", "EmbeddedDocument", "mongoengine.Document", "me.Document"}
+)
+
+func isMongoEngineDoc(bases string) bool {
+	for _, ind := range meBaseIndicators {
+		if strings.Contains(bases, ind) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *MongoEngineRelExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_mongoengine_rel")
+	_, span := tracer.Start(ctx, "custom.python_mongoengine_rel")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	source := string(file.Content)
+	if !strings.Contains(source, "mongoengine") && !strings.Contains(source, "ReferenceField") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	type fieldPattern struct {
+		re          *regexp.Regexp
+		patternType string
+		isLazy      bool
+	}
+	fieldPatterns := []fieldPattern{
+		{meReferenceFieldRe, "reference", false},
+		{meEmbeddedFieldRe, "embedded", false},
+		{meEmbeddedListFieldRe, "embedded_list", false},
+		{meLazyReferenceRe, "lazy_reference", true},
+	}
+
+	for _, idx := range allMatchesIndex(meDocRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isMongoEngineDoc(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		for _, fp := range fieldPatterns {
+			for _, fIdx := range allMatchesIndex(fp.re, body) {
+				attr := body[fIdx[2]:fIdx[3]]
+				target := body[fIdx[4]:fIdx[5]]
+				relLine := classLine + strings.Count(body[:fIdx[0]], "\n")
+				props := map[string]string{
+					"framework":    "mongoengine",
+					"pattern_type": fp.patternType,
+					"target_model": target,
+					"parent_class": className,
+				}
+				if fp.isLazy {
+					props["lazy_loading"] = "lazy_reference"
+				}
+				out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+			}
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// Tortoise ORM
+// ============================================================================
+
+// TortoiseRelExtractor extracts fields.ForeignKeyField and
+// fields.ManyToManyField relationships from Tortoise ORM model classes.
+type TortoiseRelExtractor struct{}
+
+func (e *TortoiseRelExtractor) Language() string { return "python_tortoise_rel" }
+
+var (
+	// tortoiseModelRe matches class definitions that extend tortoise Model.
+	tortoiseModelRe = regexp.MustCompile(`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// tortoiseFKRe matches:
+	//   attr = fields.ForeignKeyField("app.Model", ...)
+	//   attr: fields.ForeignKeyRelation[Model]  (type annotation form)
+	tortoiseFKRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*(?:=\s*fields\.ForeignKeyField\s*\(\s*["']([^"']+)["']|:\s*fields\.ForeignKeyRelation\s*\[\s*([A-Za-z_][A-Za-z0-9_]*))`)
+
+	// tortoiseMTMRe matches:
+	//   attr = fields.ManyToManyField("app.Model", ...)
+	//   attr: fields.ManyToManyRelation[Model]
+	tortoiseMTMRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*(?:=\s*fields\.ManyToManyField\s*\(\s*["']([^"']+)["']|:\s*fields\.ManyToManyRelation\s*\[\s*([A-Za-z_][A-Za-z0-9_]*))`)
+
+	// tortoiseO2OFieldRe matches: attr = fields.OneToOneField("app.Model", ...)
+	tortoiseO2OFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*fields\.OneToOneField\s*\(\s*["']([^"']+)["']`)
+
+	// tortoiseBackRefRe matches: attr: fields.ReverseRelation[Model] or ["Model"]
+	tortoiseBackRefRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*:\s*fields\.ReverseRelation\s*\[\s*"?([A-Za-z_][A-Za-z0-9_]*)"?`)
+
+	// tortoiseBaseIndicators are common Tortoise ORM base class names.
+	tortoiseBaseIndicators = []string{"Model", "tortoise.Model", "tortoise.models.Model"}
+)
+
+func isTortoiseModel(bases string) bool {
+	for _, ind := range tortoiseBaseIndicators {
+		if strings.Contains(bases, ind) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *TortoiseRelExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_tortoise_rel")
+	_, span := tracer.Start(ctx, "custom.python_tortoise_rel")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	source := string(file.Content)
+	if !strings.Contains(source, "tortoise") && !strings.Contains(source, "fields.ForeignKeyField") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	for _, idx := range allMatchesIndex(tortoiseModelRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isTortoiseModel(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		// ForeignKeyField / ForeignKeyRelation
+		for _, fkIdx := range allMatchesIndex(tortoiseFKRe, body) {
+			attr := body[fkIdx[2]:fkIdx[3]]
+			// group 2 is assignment form "app.Model" string, group 3 is annotation form
+			target := ""
+			if fkIdx[4] >= 0 {
+				target = body[fkIdx[4]:fkIdx[5]]
+			} else if fkIdx[6] >= 0 {
+				target = body[fkIdx[6]:fkIdx[7]]
+			}
+			relLine := classLine + strings.Count(body[:fkIdx[0]], "\n")
+			props := map[string]string{
+				"framework":    "tortoise",
+				"pattern_type": "foreign_key",
+				"target_model": target,
+				"parent_class": className,
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+
+		// ManyToManyField / ManyToManyRelation
+		for _, mtmIdx := range allMatchesIndex(tortoiseMTMRe, body) {
+			attr := body[mtmIdx[2]:mtmIdx[3]]
+			target := ""
+			if mtmIdx[4] >= 0 {
+				target = body[mtmIdx[4]:mtmIdx[5]]
+			} else if mtmIdx[6] >= 0 {
+				target = body[mtmIdx[6]:mtmIdx[7]]
+			}
+			relLine := classLine + strings.Count(body[:mtmIdx[0]], "\n")
+			props := map[string]string{
+				"framework":    "tortoise",
+				"pattern_type": "many_to_many",
+				"target_model": target,
+				"parent_class": className,
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+
+		// OneToOneField
+		for _, o2oIdx := range allMatchesIndex(tortoiseO2OFieldRe, body) {
+			attr := body[o2oIdx[2]:o2oIdx[3]]
+			target := body[o2oIdx[4]:o2oIdx[5]]
+			relLine := classLine + strings.Count(body[:o2oIdx[0]], "\n")
+			props := map[string]string{
+				"framework":    "tortoise",
+				"pattern_type": "one_to_one",
+				"target_model": target,
+				"parent_class": className,
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+
+		// ReverseRelation (back-references)
+		for _, brIdx := range allMatchesIndex(tortoiseBackRefRe, body) {
+			attr := body[brIdx[2]:brIdx[3]]
+			target := body[brIdx[4]:brIdx[5]]
+			relLine := classLine + strings.Count(body[:brIdx[0]], "\n")
+			props := map[string]string{
+				"framework":    "tortoise",
+				"pattern_type": "reverse_relation",
+				"target_model": target,
+				"parent_class": className,
+			}
+			out = append(out, entity(className+"."+attr, "SCOPE.Schema", "", file.Path, relLine, props))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/python/testdata/beanie_relationships.py
+++ b/internal/custom/python/testdata/beanie_relationships.py
@@ -1,0 +1,33 @@
+"""Beanie ODM relationship fixture — issue #3070."""
+from typing import List, Optional
+from beanie import Document, Link, BackLink
+from pydantic import Field
+
+
+class Category(Document):
+    name: str
+
+    class Settings:
+        name = "categories"
+
+
+class Product(Document):
+    title: str
+    category: Link[Category]
+    related: List[Link["Product"]] = []
+
+    class Settings:
+        name = "products"
+
+
+class Order(Document):
+    items: List[Link[Product]]
+    category_ref: Optional[Link[Category]] = None
+
+    class Settings:
+        name = "orders"
+
+
+# fetch_links usage for lazy_loading_recognition
+async def get_order(order_id: str) -> Order:
+    return await Order.get(order_id, fetch_links=True)

--- a/internal/custom/python/testdata/mongoengine_relationships.py
+++ b/internal/custom/python/testdata/mongoengine_relationships.py
@@ -1,0 +1,45 @@
+"""MongoEngine ODM relationship fixture — issue #3070."""
+import mongoengine as me
+from mongoengine import (
+    Document,
+    EmbeddedDocument,
+    ReferenceField,
+    EmbeddedDocumentField,
+    EmbeddedDocumentListField,
+    LazyReferenceField,
+    StringField,
+    IntField,
+)
+
+
+class Address(EmbeddedDocument):
+    street = StringField()
+    city = StringField()
+
+
+class Category(Document):
+    name = StringField()
+
+    meta = {"collection": "categories"}
+
+
+class Author(Document):
+    name = StringField()
+
+    meta = {"collection": "authors"}
+
+
+class Book(Document):
+    title = StringField()
+    author = ReferenceField(Author)
+    category = LazyReferenceField(Category)
+    address = EmbeddedDocumentField(Address)
+
+    meta = {"collection": "books"}
+
+
+class Library(Document):
+    name = StringField()
+    books = EmbeddedDocumentListField(Book)
+
+    meta = {"collection": "libraries"}

--- a/internal/custom/python/testdata/peewee_relationships.py
+++ b/internal/custom/python/testdata/peewee_relationships.py
@@ -1,0 +1,44 @@
+"""Peewee ORM relationship fixture — issue #3070."""
+import peewee
+from peewee import Model, ForeignKeyField, ManyToManyField, CharField, IntegerField
+
+database = peewee.SqliteDatabase("test.db")
+
+
+class Author(Model):
+    name = CharField()
+
+    class Meta:
+        database = database
+
+
+class Book(Model):
+    title = CharField()
+    author = ForeignKeyField(Author, backref="books")
+    year = IntegerField()
+
+    class Meta:
+        database = database
+
+
+class Tag(Model):
+    name = CharField(unique=True)
+
+    class Meta:
+        database = database
+
+
+class BookTag(Model):
+    book = ForeignKeyField(Book)
+    tag = ForeignKeyField(Tag)
+
+    class Meta:
+        database = database
+
+
+class Article(Model):
+    title = CharField()
+    tags = ManyToManyField(Tag, backref="articles")
+
+    class Meta:
+        database = database

--- a/internal/custom/python/testdata/pony_relationships.py
+++ b/internal/custom/python/testdata/pony_relationships.py
@@ -1,0 +1,22 @@
+"""Pony ORM relationship fixture — issue #3070."""
+from pony.orm import Database, Required, Optional, Set, PrimaryKey
+
+db = Database()
+
+
+class Department(db.Entity):
+    name = Required(str)
+    employees = Set("Employee")
+
+
+class Employee(db.Entity):
+    name = Required(str)
+    department = Required(Department)
+    manager = Optional("Employee", reverse="subordinates")
+    subordinates = Set("Employee", reverse="manager")
+    projects = Set("Project")
+
+
+class Project(db.Entity):
+    title = Required(str)
+    members = Set(Employee)

--- a/internal/custom/python/testdata/tortoise_relationships.py
+++ b/internal/custom/python/testdata/tortoise_relationships.py
@@ -1,0 +1,48 @@
+"""Tortoise ORM relationship fixture — issue #3070."""
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    name = fields.CharField(max_length=255)
+    events: fields.ReverseRelation["Event"]
+
+    class Meta:
+        table = "tournament"
+
+
+class Event(Model):
+    name = fields.CharField(max_length=255)
+    tournament: fields.ForeignKeyRelation[Tournament] = fields.ForeignKeyField(
+        "models.Tournament", related_name="events"
+    )
+    participants: fields.ManyToManyRelation["Team"] = fields.ManyToManyField(
+        "models.Team", related_name="events", through="event_team"
+    )
+
+    class Meta:
+        table = "event"
+
+
+class Team(Model):
+    name = fields.CharField(max_length=255)
+    events: fields.ManyToManyRelation[Event]
+
+    class Meta:
+        table = "team"
+
+
+class Player(Model):
+    name = fields.CharField(max_length=255)
+    team = fields.ForeignKeyField("models.Team", related_name="players")
+    profile = fields.OneToOneField("models.Profile", related_name="player", null=True)
+
+    class Meta:
+        table = "player"
+
+
+class Profile(Model):
+    bio = fields.TextField()
+
+    class Meta:
+        table = "profile"


### PR DESCRIPTION
## Summary

- Add `orm_relationships.go` with five extractors — `PeeweeRelExtractor`, `PonyRelExtractor`, `BeanieRelExtractor`, `MongoEngineRelExtractor`, `TortoiseRelExtractor` — each using regex patterns mirroring `saRelationshipRe`/`saForeignKeyRe` from `sqlalchemy.go`
- Detect `ForeignKeyField`/`ManyToManyField` (Peewee), `Required`/`Optional`/`Set(Entity)` with quoted + bare refs (Pony), `Link[Model]`/`List[Link[...]]`/`Optional[Link[...]]` + `fetch_links=True` (Beanie), `ReferenceField`/`EmbeddedDocumentField`/`LazyReferenceField` (MongoEngine), `fields.ForeignKeyField`/`ManyToManyField`/`OneToOneField`/`ReverseRelation` (Tortoise)
- 17 cells flipped: 15 `missing→partial`, 2 `missing→not_applicable` (`foreign_key_extraction` for Beanie + MongoEngine — MongoDB ODMs have no SQL FK semantics)
- 5 fixture files + 19 tests added; all pass

## Cells flipped

| Record | Capability | Status |
|---|---|---|
| `lang.python.orm.peewee` | `association_extraction` | partial |
| `lang.python.orm.peewee` | `foreign_key_extraction` | partial |
| `lang.python.orm.peewee` | `relationship_extraction` | partial |
| `lang.python.orm.pony` | `association_extraction` | partial |
| `lang.python.orm.pony` | `foreign_key_extraction` | partial |
| `lang.python.orm.pony` | `relationship_extraction` | partial |
| `lang.python.orm.beanie` | `association_extraction` | partial |
| `lang.python.orm.beanie` | `lazy_loading_recognition` | partial |
| `lang.python.orm.beanie` | `relationship_extraction` | partial |
| `lang.python.orm.beanie` | `foreign_key_extraction` | **not_applicable** |
| `lang.python.orm.mongoengine` | `association_extraction` | partial |
| `lang.python.orm.mongoengine` | `lazy_loading_recognition` | partial |
| `lang.python.orm.mongoengine` | `relationship_extraction` | partial |
| `lang.python.orm.mongoengine` | `foreign_key_extraction` | **not_applicable** |
| `lang.python.orm.tortoise` | `association_extraction` | partial |
| `lang.python.orm.tortoise` | `foreign_key_extraction` | partial |
| `lang.python.orm.tortoise` | `lazy_loading_recognition` | partial |
| `lang.python.orm.tortoise` | `relationship_extraction` | partial |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/custom/python/ ./internal/types/ ./tools/coverage/` — all pass (19 new tests)
- [x] `coverage validate` — 0 errors
- [x] `coverage fmt --check` — canonical
- [x] `coverage gen` — byte-stable

Closes #3070