### PR TITLE
feat(coverage): Python ORM schema extraction (peewee/pony/beanie/mongoengine/tortoise)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -113,15 +113,15 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | ❌ 1/6 | |
 | [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | ❌ 1/6 | |
 | [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 1/6 | |
-| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 5/6 | |
+| [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ⚠️ 6/6 | |
 | [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |
-| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 5/6 | |
+| [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ⚠️ 6/6 | |
 | [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 1/2 | |
-| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 5/8 | |
-| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 5/8 | |
+| [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 6/8 | |
+| [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 6/8 | |
 | [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 8/8 | |
 | [python](../by-language/python.md) | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ⚠️ 8/8 | |
-| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 6/8 | |
+| [python](../by-language/python.md) | [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 7/8 | |
 | [python](../by-language/python.md) | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ⚠️ 1/1 | |
 | [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ⚠️ 1/1 | |
 | [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ⚠️ 1/1 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -77,15 +77,15 @@ Back to [summary](../summary.md).
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | ❌ 1/6 | |
-| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ❌ 5/6 | |
+| [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | ⚠️ 6/6 | |
 | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |
-| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ❌ 5/6 | |
+| [MongoEngine](../detail/lang.python.orm.mongoengine.md) | ⚠️ 6/6 | |
 | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | ❌ 1/2 | |
-| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 5/8 | |
-| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 5/8 | |
+| [Peewee](../detail/lang.python.orm.peewee.md) | ❌ 6/8 | |
+| [Pony ORM](../detail/lang.python.orm.pony.md) | ❌ 6/8 | |
 | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 8/8 | |
 | [SQLModel](../detail/lang.python.orm.sqlmodel.md) | ⚠️ 8/8 | |
-| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 6/8 | |
+| [Tortoise ORM](../detail/lang.python.orm.tortoise.md) | ❌ 7/8 | |
 | [boto3 DynamoDB](../detail/lang.python.driver.dynamodb.md) | ⚠️ 1/1 | |
 | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | ⚠️ 1/1 | |
 | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | ⚠️ 1/1 | |

--- a/docs/coverage/detail/lang.python.orm.beanie.md
+++ b/docs/coverage/detail/lang.python.orm.beanie.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/beanie.yaml` | — |
-| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Beanie Document field definitions (via Pydantic annotations) are not extracted at the ORM level; the schema_detector.go detects Pydantic usage generally but does not emit per-field ORM schema entities. |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | 3072 | `internal/custom/python/orm_schema.go` | Beanie Document field definitions (via Pydantic annotations) are not extracted at the ORM level; the schema_detector.go detects Pydantic usage generally but does not emit per-field ORM schema entities. |
 
 ### Relationships
 

--- a/docs/coverage/detail/lang.python.orm.mongoengine.md
+++ b/docs/coverage/detail/lang.python.orm.mongoengine.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/mongoengine.yaml` | — |
-| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | MongoEngine Document field definitions (StringField, IntField etc.) are not extracted at the ORM schema level; the MongoDB custom extractor handles aggregations/change streams but not model field schema. |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | 3072 | `internal/custom/python/orm_schema.go` | MongoEngine Document field definitions (StringField, IntField etc.) are not extracted at the ORM schema level; the MongoDB custom extractor handles aggregations/change streams but not model field schema. |
 
 ### Relationships
 

--- a/docs/coverage/detail/lang.python.orm.peewee.md
+++ b/docs/coverage/detail/lang.python.orm.peewee.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/peewee.yaml` | — |
-| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Peewee field definitions (CharField, IntegerField etc.) are not extracted; only model class detection and query attribution are handled. |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | 3072 | `internal/custom/python/orm_schema.go` | Peewee field definitions (CharField, IntegerField etc.) are not extracted; only model class detection and query attribution are handled. |
 
 ### Relationships
 

--- a/docs/coverage/detail/lang.python.orm.pony.md
+++ b/docs/coverage/detail/lang.python.orm.pony.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/python/orms/pony_orm.yaml` | — |
-| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Pony ORM entity field definitions (Required, Optional etc.) are not extracted; only model class detection and query attribution are handled. |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | 3072 | `internal/custom/python/orm_schema.go` | Pony ORM entity field definitions (Required, Optional etc.) are not extracted; only model class detection and query attribution are handled. |
 
 ### Relationships
 

--- a/docs/coverage/detail/lang.python.orm.tortoise.md
+++ b/docs/coverage/detail/lang.python.orm.tortoise.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/python/orms/tortoise_orm.yaml` | — |
-| Schema extraction | ❌ `missing` | `2026-05-29` | backfill:dictionary-completeness | — | Tortoise ORM field definitions (fields.CharField etc.) are not parsed by any Go extractor; only model class detection (model_extraction) is handled via YAML rules. |
+| Schema extraction | ⚠️ `partial` | `2026-05-29` | 3072 | `internal/custom/python/orm_schema.go` | Tortoise ORM field definitions (fields.CharField etc.) are not parsed by any Go extractor; only model class detection (model_extraction) is handled via YAML rules. |
 
 ### Relationships
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -37696,8 +37696,9 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness",
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_schema.go"],
+            "issue": "3072",
             "notes": "Beanie Document field definitions (via Pydantic annotations) are not extracted at the ORM level; the schema_detector.go detects Pydantic usage generally but does not emit per-field ORM schema entities.",
             "verified_at": "2026-05-29"
           }
@@ -37815,8 +37816,9 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness",
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_schema.go"],
+            "issue": "3072",
             "notes": "MongoEngine Document field definitions (StringField, IntField etc.) are not extracted at the ORM schema level; the MongoDB custom extractor handles aggregations/change streams but not model field schema.",
             "verified_at": "2026-05-29"
           }
@@ -37873,8 +37875,9 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness",
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_schema.go"],
+            "issue": "3072",
             "notes": "Peewee field definitions (CharField, IntegerField etc.) are not extracted; only model class detection and query attribution are handled.",
             "verified_at": "2026-05-29"
           }
@@ -37930,8 +37933,9 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness",
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_schema.go"],
+            "issue": "3072",
             "notes": "Pony ORM entity field definitions (Required, Optional etc.) are not extracted; only model class detection and query attribution are handled.",
             "verified_at": "2026-05-29"
           }
@@ -38114,8 +38118,9 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness",
+            "status": "partial",
+            "cites": ["internal/custom/python/orm_schema.go"],
+            "issue": "3072",
             "notes": "Tortoise ORM field definitions (fields.CharField etc.) are not parsed by any Go extractor; only model class detection (model_extraction) is handled via YAML rules.",
             "verified_at": "2026-05-29"
           }

--- a/internal/custom/python/orm_schema.go
+++ b/internal/custom/python/orm_schema.go
@@ -1,0 +1,421 @@
+package python
+
+// orm_schema.go — field-level (schema) extraction for Peewee, Pony ORM,
+// Beanie, MongoEngine, and Tortoise ORM.
+//
+// Issue #3072 — ORM schema extraction for peewee/pony/beanie/mongoengine/tortoise.
+// Pattern: mirrors the SQLAlchemy class-body scanner in sqlalchemy.go;
+// each extractor detects model class declarations then scans the class body
+// for field/attribute/column definitions and emits SCOPE.Schema entities.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_peewee_schema", &PeeweeSchemaExtractor{})
+	extractor.Register("python_pony_schema", &PonySchemaExtractor{})
+	extractor.Register("python_beanie_schema", &BeanieSchemaExtractor{})
+	extractor.Register("python_mongoengine_schema", &MongoEngineSchemaExtractor{})
+	extractor.Register("python_tortoise_schema", &TortoiseSchemaExtractor{})
+}
+
+// ============================================================================
+// Peewee — field-level extraction
+// ============================================================================
+
+// PeeweeSchemaExtractor emits SCOPE.Schema entities for field assignments
+// inside Peewee Model subclasses.
+// e.g.  name = CharField(max_length=100)
+type PeeweeSchemaExtractor struct{}
+
+func (e *PeeweeSchemaExtractor) Language() string { return "python_peewee_schema" }
+
+var (
+	// peeweeSchemaModelRe matches a Peewee model class declaration.
+	peeweeSchemaModelRe = regexp.MustCompile(
+		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// peeweeFieldRe matches field assignments in the class body:
+	//   name = CharField(...)
+	//   age  = IntegerField()
+	// Captures: (attr_name, FieldTypeName)
+	peeweeFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*([A-Za-z_][A-Za-z0-9_]*Field)\s*\(`)
+
+	// peeweeSchemaBaseIndicators are common Peewee base class names.
+	peeweeSchemaBaseIndicators = []string{"Model", "peewee.Model", "pw.Model"}
+)
+
+func isPeeweeSchemaModel(bases string) bool {
+	for _, ind := range peeweeSchemaBaseIndicators {
+		if strings.Contains(bases, ind) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *PeeweeSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_peewee_schema")
+	_, span := tracer.Start(ctx, "custom.python_peewee_schema")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+	if !strings.Contains(source, "peewee") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	for _, idx := range allMatchesIndex(peeweeSchemaModelRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isPeeweeSchemaModel(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		// Emit the model entity
+		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "peewee", "pattern_type": "model", "class_name": className}))
+
+		// Emit each field entity
+		for _, fIdx := range allMatchesIndex(peeweeFieldRe, body) {
+			attrName := body[fIdx[2]:fIdx[3]]
+			fieldType := body[fIdx[4]:fIdx[5]]
+			fieldLine := classLine + strings.Count(body[:fIdx[0]], "\n")
+			out = append(out, entity(className+"."+attrName, "SCOPE.Schema", "column", file.Path, fieldLine,
+				map[string]string{
+					"framework":    "peewee",
+					"pattern_type": "field",
+					"field_type":   fieldType,
+					"parent_class": className,
+				}))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// Pony ORM — attribute-level extraction
+// ============================================================================
+
+// PonySchemaExtractor emits SCOPE.Schema entities for attribute definitions
+// inside Pony db.Entity subclasses.
+// e.g.  name = Required(str)   or   age = Optional(int, default=0)
+type PonySchemaExtractor struct{}
+
+func (e *PonySchemaExtractor) Language() string { return "python_pony_schema" }
+
+var (
+	// ponySchemaEntityRe matches a Pony entity class declaration.
+	ponySchemaEntityRe = regexp.MustCompile(
+		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// ponyAttrRe matches scalar attribute assignments in the class body:
+	//   name     = Required(str)
+	//   age      = Optional(int, default=0)
+	//   created  = Optional(datetime)
+	// Captures: (attr_name, Pony_descriptor)
+	ponyAttrRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*(Required|Optional|PrimaryKey|Set|Discriminator)\s*\(`)
+)
+
+// isPonyEntity is defined in orm_relationships.go (shared with the relationship extractor).
+
+func (e *PonySchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_pony_schema")
+	_, span := tracer.Start(ctx, "custom.python_pony_schema")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+	if !strings.Contains(source, "pony") && !strings.Contains(source, "ponyorm") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	for _, idx := range allMatchesIndex(ponySchemaEntityRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isPonyEntity(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		// Emit the entity model
+		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "pony", "pattern_type": "entity", "class_name": className}))
+
+		// Emit each attribute entity
+		for _, aIdx := range allMatchesIndex(ponyAttrRe, body) {
+			attrName := body[aIdx[2]:aIdx[3]]
+			descriptor := body[aIdx[4]:aIdx[5]]
+			attrLine := classLine + strings.Count(body[:aIdx[0]], "\n")
+			out = append(out, entity(className+"."+attrName, "SCOPE.Schema", "column", file.Path, attrLine,
+				map[string]string{
+					"framework":    "pony",
+					"pattern_type": "attribute",
+					"descriptor":   descriptor,
+					"parent_class": className,
+				}))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// Beanie — document field extraction
+// ============================================================================
+
+// BeanieSchemaExtractor emits SCOPE.Schema entities for annotated field
+// definitions inside Beanie Document subclasses.
+// Beanie uses Pydantic-style annotations:  name: str   or   age: Optional[int]
+type BeanieSchemaExtractor struct{}
+
+func (e *BeanieSchemaExtractor) Language() string { return "python_beanie_schema" }
+
+var (
+	// beanieDocumentRe matches a Beanie Document class declaration.
+	beanieDocumentRe = regexp.MustCompile(
+		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// beanieFieldRe matches Pydantic-style annotated field declarations:
+	//   name: str
+	//   age: Optional[int] = None
+	//   tags: List[str] = []
+	// Captures: (attr_name, type_annotation_prefix)
+	beanieFieldRe = regexp.MustCompile(
+		`(?m)^\s{4}(\w+)\s*:\s*([A-Za-z_][A-Za-z0-9_\[\], |]*)`)
+)
+
+// isBeanieDocument is defined in orm_relationships.go (shared with the relationship extractor).
+
+func (e *BeanieSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_beanie_schema")
+	_, span := tracer.Start(ctx, "custom.python_beanie_schema")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+	if !strings.Contains(source, "beanie") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	for _, idx := range allMatchesIndex(beanieDocumentRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isBeanieDocument(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		// Emit the document model entity
+		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "beanie", "pattern_type": "document", "class_name": className}))
+
+		// Emit each field entity (annotated attributes, skip dunder / class vars)
+		for _, fIdx := range allMatchesIndex(beanieFieldRe, body) {
+			attrName := body[fIdx[2]:fIdx[3]]
+			// Skip dunder attributes and common Pydantic internals
+			if strings.HasPrefix(attrName, "_") || attrName == "model_config" || attrName == "Settings" {
+				continue
+			}
+			typeAnnotation := strings.TrimSpace(body[fIdx[4]:fIdx[5]])
+			fieldLine := classLine + strings.Count(body[:fIdx[0]], "\n")
+			out = append(out, entity(className+"."+attrName, "SCOPE.Schema", "column", file.Path, fieldLine,
+				map[string]string{
+					"framework":       "beanie",
+					"pattern_type":    "field",
+					"type_annotation": typeAnnotation,
+					"parent_class":    className,
+				}))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// MongoEngine — document field extraction
+// ============================================================================
+
+// MongoEngineSchemaExtractor emits SCOPE.Schema entities for field assignments
+// inside MongoEngine Document/EmbeddedDocument subclasses.
+// e.g.  name = StringField(required=True)
+type MongoEngineSchemaExtractor struct{}
+
+func (e *MongoEngineSchemaExtractor) Language() string { return "python_mongoengine_schema" }
+
+var (
+	// mongoengineDocumentRe matches a MongoEngine Document class declaration.
+	mongoengineDocumentRe = regexp.MustCompile(
+		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// mongoengineFieldRe matches MongoEngine field assignments:
+	//   name = StringField(required=True)
+	//   age  = IntField(default=0)
+	// Captures: (attr_name, FieldTypeName)
+	mongoengineFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*([A-Za-z_][A-Za-z0-9_]*Field)\s*\(`)
+)
+
+// isMongoEngineDoc is defined in orm_relationships.go (shared with the relationship extractor).
+
+func (e *MongoEngineSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_mongoengine_schema")
+	_, span := tracer.Start(ctx, "custom.python_mongoengine_schema")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+	if !strings.Contains(source, "mongoengine") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	for _, idx := range allMatchesIndex(mongoengineDocumentRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isMongoEngineDoc(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		// Emit the document entity
+		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "mongoengine", "pattern_type": "document", "class_name": className}))
+
+		// Emit each field entity
+		for _, fIdx := range allMatchesIndex(mongoengineFieldRe, body) {
+			attrName := body[fIdx[2]:fIdx[3]]
+			fieldType := body[fIdx[4]:fIdx[5]]
+			fieldLine := classLine + strings.Count(body[:fIdx[0]], "\n")
+			out = append(out, entity(className+"."+attrName, "SCOPE.Schema", "column", file.Path, fieldLine,
+				map[string]string{
+					"framework":    "mongoengine",
+					"pattern_type": "field",
+					"field_type":   fieldType,
+					"parent_class": className,
+				}))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// Tortoise ORM — column-level extraction
+// ============================================================================
+
+// TortoiseSchemaExtractor emits SCOPE.Schema entities for field assignments
+// inside Tortoise Model subclasses.
+// e.g.  name = fields.CharField(max_length=255)
+type TortoiseSchemaExtractor struct{}
+
+func (e *TortoiseSchemaExtractor) Language() string { return "python_tortoise_schema" }
+
+var (
+	// tortoiseSchemaModelRe matches a Tortoise model class declaration.
+	tortoiseSchemaModelRe = regexp.MustCompile(
+		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s*:`)
+
+	// tortoiseFieldRe matches Tortoise field assignments:
+	//   name    = fields.CharField(max_length=255)
+	//   age     = fields.IntField()
+	//   created = fields.DatetimeField(auto_now_add=True)
+	// Captures: (attr_name, field_type_path)  e.g. "fields.CharField"
+	tortoiseFieldRe = regexp.MustCompile(
+		`(?m)^\s+(\w+)\s*=\s*((?:fields|tortoise\.fields)\.[A-Za-z_][A-Za-z0-9_]*(?:Field|field))\s*\(`)
+)
+
+// isTortoiseModel is defined in orm_relationships.go (shared with the relationship extractor).
+
+func (e *TortoiseSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_tortoise_schema")
+	_, span := tracer.Start(ctx, "custom.python_tortoise_schema")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+	if !strings.Contains(source, "tortoise") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	for _, idx := range allMatchesIndex(tortoiseSchemaModelRe, source) {
+		className := source[idx[2]:idx[3]]
+		bases := source[idx[4]:idx[5]]
+		if !isTortoiseModel(bases) {
+			continue
+		}
+
+		classLine := lineOf(source, idx[0])
+		body := extractClassBody(source, idx[0])
+
+		// Emit the model entity
+		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, classLine,
+			map[string]string{"framework": "tortoise", "pattern_type": "model", "class_name": className}))
+
+		// Emit each column entity
+		for _, fIdx := range allMatchesIndex(tortoiseFieldRe, body) {
+			attrName := body[fIdx[2]:fIdx[3]]
+			fieldType := body[fIdx[4]:fIdx[5]]
+			fieldLine := classLine + strings.Count(body[:fIdx[0]], "\n")
+			out = append(out, entity(className+"."+attrName, "SCOPE.Schema", "column", file.Path, fieldLine,
+				map[string]string{
+					"framework":    "tortoise",
+					"pattern_type": "column",
+					"field_type":   fieldType,
+					"parent_class": className,
+				}))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/python/orm_schema_test.go
+++ b/internal/custom/python/orm_schema_test.go
@@ -1,0 +1,518 @@
+package python_test
+
+// orm_schema_test.go — field-level (schema) extraction tests for
+// Peewee, Pony ORM, Beanie, MongoEngine, and Tortoise ORM.
+//
+// Issue #3072 — ORM schema extraction for peewee/pony/beanie/mongoengine/tortoise.
+
+import (
+	"os"
+	"testing"
+)
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// fixtureSchema loads a testdata file and returns its content.
+func fixtureSchema(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("fixtureSchema: %v", err)
+	}
+	return string(b)
+}
+
+// hasSchemaEntity returns true if any entity in result matches name+kind+props.
+func hasSchemaEntity(result []extractResult, name, kind string, props map[string]string) bool {
+	for _, e := range result {
+		if e.Name != name || e.Kind != kind {
+			continue
+		}
+		match := true
+		for k, v := range props {
+			if e.Props[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// countSchemaEntities returns the count of entities matching kind+props.
+func countSchemaEntities(result []extractResult, kind string, props map[string]string) int {
+	n := 0
+	for _, e := range result {
+		if e.Kind != kind {
+			continue
+		}
+		match := true
+		for k, v := range props {
+			if e.Props[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			n++
+		}
+	}
+	return n
+}
+
+// ============================================================================
+// Peewee schema extraction tests
+// ============================================================================
+
+func TestPeeweeSchema_ModelEmitted(t *testing.T) {
+	src := fixtureSchema(t, "peewee_schema.py")
+	ents := extract(t, "python_peewee_schema", src)
+
+	if !hasSchemaEntity(ents, "User", "SCOPE.Schema", map[string]string{
+		"framework":    "peewee",
+		"pattern_type": "model",
+		"class_name":   "User",
+	}) {
+		t.Fatal("expected User model entity")
+	}
+	if !hasSchemaEntity(ents, "Post", "SCOPE.Schema", map[string]string{
+		"framework":    "peewee",
+		"pattern_type": "model",
+		"class_name":   "Post",
+	}) {
+		t.Fatal("expected Post model entity")
+	}
+}
+
+func TestPeeweeSchema_FieldsEmitted(t *testing.T) {
+	src := fixtureSchema(t, "peewee_schema.py")
+	ents := extract(t, "python_peewee_schema", src)
+
+	expected := []struct {
+		name      string
+		fieldType string
+	}{
+		{"User.username", "CharField"},
+		{"User.email", "CharField"},
+		{"User.age", "IntegerField"},
+		{"User.active", "BooleanField"},
+		{"User.created_at", "DateTimeField"},
+		{"Post.title", "CharField"},
+		{"Post.body", "TextField"},
+		{"Post.score", "FloatField"},
+		{"Post.published", "BooleanField"},
+	}
+
+	for _, tc := range expected {
+		if !hasSchemaEntity(ents, tc.name, "SCOPE.Schema", map[string]string{
+			"framework":    "peewee",
+			"pattern_type": "field",
+			"field_type":   tc.fieldType,
+		}) {
+			t.Errorf("expected field entity %q with type %q", tc.name, tc.fieldType)
+		}
+	}
+}
+
+func TestPeeweeSchema_FieldSubtype(t *testing.T) {
+	src := fixtureSchema(t, "peewee_schema.py")
+	ents := extract(t, "python_peewee_schema", src)
+
+	for _, e := range ents {
+		if e.Props["pattern_type"] == "field" && e.Subtype != "column" {
+			t.Errorf("field entity %q: expected subtype 'column', got %q", e.Name, e.Subtype)
+		}
+	}
+}
+
+func TestPeeweeSchema_NoFalsePositiveWithoutPeewee(t *testing.T) {
+	src := `
+class MyClass(object):
+    name = CharField(max_length=100)
+`
+	ents := extract(t, "python_peewee_schema", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities for non-peewee file, got %d", len(ents))
+	}
+}
+
+func TestPeeweeSchema_InlineSource(t *testing.T) {
+	src := `import peewee
+from peewee import Model, CharField, IntegerField
+
+class Article(Model):
+    title = CharField(max_length=200)
+    views = IntegerField(default=0)
+`
+	ents := extract(t, "python_peewee_schema", src)
+
+	if !hasSchemaEntity(ents, "Article", "SCOPE.Schema", map[string]string{"framework": "peewee", "pattern_type": "model"}) {
+		t.Fatal("expected Article model entity")
+	}
+	if !hasSchemaEntity(ents, "Article.title", "SCOPE.Schema", map[string]string{"framework": "peewee", "pattern_type": "field", "field_type": "CharField"}) {
+		t.Fatal("expected Article.title field entity")
+	}
+	if !hasSchemaEntity(ents, "Article.views", "SCOPE.Schema", map[string]string{"framework": "peewee", "pattern_type": "field", "field_type": "IntegerField"}) {
+		t.Fatal("expected Article.views field entity")
+	}
+}
+
+// ============================================================================
+// Pony ORM schema extraction tests
+// ============================================================================
+
+func TestPonySchema_EntityEmitted(t *testing.T) {
+	src := fixtureSchema(t, "pony_schema.py")
+	ents := extract(t, "python_pony_schema", src)
+
+	if !hasSchemaEntity(ents, "Author", "SCOPE.Schema", map[string]string{
+		"framework":    "pony",
+		"pattern_type": "entity",
+		"class_name":   "Author",
+	}) {
+		t.Fatal("expected Author entity")
+	}
+	if !hasSchemaEntity(ents, "Book", "SCOPE.Schema", map[string]string{
+		"framework":    "pony",
+		"pattern_type": "entity",
+		"class_name":   "Book",
+	}) {
+		t.Fatal("expected Book entity")
+	}
+}
+
+func TestPonySchema_AttributesEmitted(t *testing.T) {
+	src := fixtureSchema(t, "pony_schema.py")
+	ents := extract(t, "python_pony_schema", src)
+
+	expected := []struct {
+		name       string
+		descriptor string
+	}{
+		{"Author.name", "Required"},
+		{"Author.email", "Optional"},
+		{"Book.title", "Required"},
+		{"Book.isbn", "PrimaryKey"},
+		{"Book.year", "Optional"},
+		{"Book.price", "Optional"},
+		{"Book.author", "Required"},
+	}
+
+	for _, tc := range expected {
+		if !hasSchemaEntity(ents, tc.name, "SCOPE.Schema", map[string]string{
+			"framework":    "pony",
+			"pattern_type": "attribute",
+			"descriptor":   tc.descriptor,
+		}) {
+			t.Errorf("expected attribute entity %q with descriptor %q", tc.name, tc.descriptor)
+		}
+	}
+}
+
+func TestPonySchema_SetRelationNotField(t *testing.T) {
+	// Set() is also captured since it is a valid Pony descriptor
+	src := `from pony.orm import Database, Required, Set
+db = Database()
+class Author(db.Entity):
+    name = Required(str)
+    books = Set("Book")
+`
+	ents := extract(t, "python_pony_schema", src)
+	if !hasSchemaEntity(ents, "Author.books", "SCOPE.Schema", map[string]string{"descriptor": "Set"}) {
+		t.Fatal("expected Author.books Set attribute entity")
+	}
+}
+
+func TestPonySchema_NoFalsePositiveWithoutPony(t *testing.T) {
+	src := `
+class Author(object):
+    name = Required(str)
+`
+	ents := extract(t, "python_pony_schema", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities for non-pony file, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// Beanie schema extraction tests
+// ============================================================================
+
+func TestBeanieSchema_DocumentEmitted(t *testing.T) {
+	src := fixtureSchema(t, "beanie_schema.py")
+	ents := extract(t, "python_beanie_schema", src)
+
+	if !hasSchemaEntity(ents, "Category", "SCOPE.Schema", map[string]string{
+		"framework":    "beanie",
+		"pattern_type": "document",
+		"class_name":   "Category",
+	}) {
+		t.Fatal("expected Category document entity")
+	}
+	if !hasSchemaEntity(ents, "Product", "SCOPE.Schema", map[string]string{
+		"framework":    "beanie",
+		"pattern_type": "document",
+		"class_name":   "Product",
+	}) {
+		t.Fatal("expected Product document entity")
+	}
+}
+
+func TestBeanieSchema_FieldsEmitted(t *testing.T) {
+	src := fixtureSchema(t, "beanie_schema.py")
+	ents := extract(t, "python_beanie_schema", src)
+
+	expectedFields := []string{
+		"Category.name",
+		"Category.description",
+		"Product.title",
+		"Product.price",
+		"Product.stock",
+		"Product.tags",
+		"Product.category",
+	}
+
+	for _, name := range expectedFields {
+		if !hasSchemaEntity(ents, name, "SCOPE.Schema", map[string]string{
+			"framework":    "beanie",
+			"pattern_type": "field",
+		}) {
+			t.Errorf("expected field entity %q", name)
+		}
+	}
+}
+
+func TestBeanieSchema_FieldSubtype(t *testing.T) {
+	src := fixtureSchema(t, "beanie_schema.py")
+	ents := extract(t, "python_beanie_schema", src)
+
+	for _, e := range ents {
+		if e.Props["pattern_type"] == "field" && e.Subtype != "column" {
+			t.Errorf("field entity %q: expected subtype 'column', got %q", e.Name, e.Subtype)
+		}
+	}
+}
+
+func TestBeanieSchema_InlineSource(t *testing.T) {
+	src := `from beanie import Document
+from typing import Optional
+
+class Item(Document):
+    name: str
+    price: float
+    description: Optional[str] = None
+`
+	ents := extract(t, "python_beanie_schema", src)
+
+	if !hasSchemaEntity(ents, "Item", "SCOPE.Schema", map[string]string{"framework": "beanie", "pattern_type": "document"}) {
+		t.Fatal("expected Item document entity")
+	}
+	if !hasSchemaEntity(ents, "Item.name", "SCOPE.Schema", map[string]string{"framework": "beanie", "pattern_type": "field"}) {
+		t.Fatal("expected Item.name field entity")
+	}
+	if !hasSchemaEntity(ents, "Item.price", "SCOPE.Schema", map[string]string{"framework": "beanie", "pattern_type": "field"}) {
+		t.Fatal("expected Item.price field entity")
+	}
+}
+
+func TestBeanieSchema_NoFalsePositiveWithoutBeanie(t *testing.T) {
+	src := `from pydantic import BaseModel
+
+class Item(BaseModel):
+    name: str
+    price: float
+`
+	ents := extract(t, "python_beanie_schema", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities for non-beanie file, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// MongoEngine schema extraction tests
+// ============================================================================
+
+func TestMongoEngineSchema_DocumentEmitted(t *testing.T) {
+	src := fixtureSchema(t, "mongoengine_schema.py")
+	ents := extract(t, "python_mongoengine_schema", src)
+
+	if !hasSchemaEntity(ents, "Customer", "SCOPE.Schema", map[string]string{
+		"framework":    "mongoengine",
+		"pattern_type": "document",
+		"class_name":   "Customer",
+	}) {
+		t.Fatal("expected Customer document entity")
+	}
+	if !hasSchemaEntity(ents, "Address", "SCOPE.Schema", map[string]string{
+		"framework":    "mongoengine",
+		"pattern_type": "document",
+		"class_name":   "Address",
+	}) {
+		t.Fatal("expected Address embedded document entity")
+	}
+}
+
+func TestMongoEngineSchema_FieldsEmitted(t *testing.T) {
+	src := fixtureSchema(t, "mongoengine_schema.py")
+	ents := extract(t, "python_mongoengine_schema", src)
+
+	expected := []struct {
+		name      string
+		fieldType string
+	}{
+		{"Address.street", "StringField"},
+		{"Address.city", "StringField"},
+		{"Address.zipcode", "StringField"},
+		{"Customer.name", "StringField"},
+		{"Customer.email", "StringField"},
+		{"Customer.age", "IntField"},
+		{"Customer.balance", "FloatField"},
+		{"Customer.active", "BooleanField"},
+		{"Customer.address", "EmbeddedDocumentField"},
+		{"Customer.tags", "ListField"},
+	}
+
+	for _, tc := range expected {
+		if !hasSchemaEntity(ents, tc.name, "SCOPE.Schema", map[string]string{
+			"framework":    "mongoengine",
+			"pattern_type": "field",
+			"field_type":   tc.fieldType,
+		}) {
+			t.Errorf("expected field entity %q with type %q", tc.name, tc.fieldType)
+		}
+	}
+}
+
+func TestMongoEngineSchema_NoFalsePositiveWithoutMongoEngine(t *testing.T) {
+	src := `
+class Customer(object):
+    name = StringField(required=True)
+`
+	ents := extract(t, "python_mongoengine_schema", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities for non-mongoengine file, got %d", len(ents))
+	}
+}
+
+func TestMongoEngineSchema_InlineSource(t *testing.T) {
+	src := `import mongoengine
+from mongoengine import Document, StringField, IntField
+
+class BlogPost(Document):
+    title = StringField(required=True, max_length=200)
+    views = IntField(default=0)
+`
+	ents := extract(t, "python_mongoengine_schema", src)
+
+	if !hasSchemaEntity(ents, "BlogPost", "SCOPE.Schema", map[string]string{"framework": "mongoengine", "pattern_type": "document"}) {
+		t.Fatal("expected BlogPost document entity")
+	}
+	if !hasSchemaEntity(ents, "BlogPost.title", "SCOPE.Schema", map[string]string{"framework": "mongoengine", "pattern_type": "field", "field_type": "StringField"}) {
+		t.Fatal("expected BlogPost.title field entity")
+	}
+	if !hasSchemaEntity(ents, "BlogPost.views", "SCOPE.Schema", map[string]string{"framework": "mongoengine", "pattern_type": "field", "field_type": "IntField"}) {
+		t.Fatal("expected BlogPost.views field entity")
+	}
+}
+
+// ============================================================================
+// Tortoise ORM schema extraction tests
+// ============================================================================
+
+func TestTortoiseSchema_ModelEmitted(t *testing.T) {
+	src := fixtureSchema(t, "tortoise_schema.py")
+	ents := extract(t, "python_tortoise_schema", src)
+
+	if !hasSchemaEntity(ents, "Tournament", "SCOPE.Schema", map[string]string{
+		"framework":    "tortoise",
+		"pattern_type": "model",
+		"class_name":   "Tournament",
+	}) {
+		t.Fatal("expected Tournament model entity")
+	}
+	if !hasSchemaEntity(ents, "Event", "SCOPE.Schema", map[string]string{
+		"framework":    "tortoise",
+		"pattern_type": "model",
+		"class_name":   "Event",
+	}) {
+		t.Fatal("expected Event model entity")
+	}
+}
+
+func TestTortoiseSchema_ColumnsEmitted(t *testing.T) {
+	src := fixtureSchema(t, "tortoise_schema.py")
+	ents := extract(t, "python_tortoise_schema", src)
+
+	expected := []struct {
+		name      string
+		fieldType string
+	}{
+		{"Tournament.id", "fields.IntField"},
+		{"Tournament.name", "fields.CharField"},
+		{"Tournament.created_at", "fields.DatetimeField"},
+		{"Tournament.active", "fields.BooleanField"},
+		{"Event.id", "fields.IntField"},
+		{"Event.name", "fields.CharField"},
+		{"Event.prize", "fields.DecimalField"},
+		{"Event.description", "fields.TextField"},
+	}
+
+	for _, tc := range expected {
+		if !hasSchemaEntity(ents, tc.name, "SCOPE.Schema", map[string]string{
+			"framework":    "tortoise",
+			"pattern_type": "column",
+			"field_type":   tc.fieldType,
+		}) {
+			t.Errorf("expected column entity %q with type %q", tc.name, tc.fieldType)
+		}
+	}
+}
+
+func TestTortoiseSchema_ColumnSubtype(t *testing.T) {
+	src := fixtureSchema(t, "tortoise_schema.py")
+	ents := extract(t, "python_tortoise_schema", src)
+
+	for _, e := range ents {
+		if e.Props["pattern_type"] == "column" && e.Subtype != "column" {
+			t.Errorf("column entity %q: expected subtype 'column', got %q", e.Name, e.Subtype)
+		}
+	}
+}
+
+func TestTortoiseSchema_NoFalsePositiveWithoutTortoise(t *testing.T) {
+	src := `
+class Event(Model):
+    name = CharField(max_length=255)
+`
+	ents := extract(t, "python_tortoise_schema", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities for non-tortoise file, got %d", len(ents))
+	}
+}
+
+func TestTortoiseSchema_InlineSource(t *testing.T) {
+	src := `from tortoise import fields
+from tortoise.models import Model
+
+class User(Model):
+    id = fields.IntField(pk=True)
+    username = fields.CharField(max_length=50)
+    email = fields.CharField(max_length=255)
+`
+	ents := extract(t, "python_tortoise_schema", src)
+
+	if !hasSchemaEntity(ents, "User", "SCOPE.Schema", map[string]string{"framework": "tortoise", "pattern_type": "model"}) {
+		t.Fatal("expected User model entity")
+	}
+	if !hasSchemaEntity(ents, "User.id", "SCOPE.Schema", map[string]string{"framework": "tortoise", "pattern_type": "column", "field_type": "fields.IntField"}) {
+		t.Fatal("expected User.id column entity")
+	}
+	if !hasSchemaEntity(ents, "User.username", "SCOPE.Schema", map[string]string{"framework": "tortoise", "pattern_type": "column", "field_type": "fields.CharField"}) {
+		t.Fatal("expected User.username column entity")
+	}
+}

--- a/internal/custom/python/testdata/beanie_schema.py
+++ b/internal/custom/python/testdata/beanie_schema.py
@@ -1,0 +1,23 @@
+"""Beanie ODM field-level fixture — schema extraction test."""
+from typing import Optional, List
+from beanie import Document, Link
+from pydantic import Field
+
+
+class Category(Document):
+    name: str
+    description: Optional[str] = None
+
+    class Settings:
+        name = "categories"
+
+
+class Product(Document):
+    title: str
+    price: float
+    stock: int = 0
+    tags: List[str] = []
+    category: Optional[str] = None
+
+    class Settings:
+        name = "products"

--- a/internal/custom/python/testdata/mongoengine_schema.py
+++ b/internal/custom/python/testdata/mongoengine_schema.py
@@ -1,0 +1,24 @@
+"""MongoEngine ODM field-level fixture — schema extraction test."""
+import mongoengine
+from mongoengine import Document, EmbeddedDocument, StringField, IntField, FloatField, BooleanField, ListField, EmbeddedDocumentField
+
+
+mongoengine.connect("mydb")
+
+
+class Address(EmbeddedDocument):
+    street = StringField(required=True)
+    city = StringField(max_length=100)
+    zipcode = StringField(max_length=20)
+
+
+class Customer(Document):
+    name = StringField(required=True, max_length=200)
+    email = StringField(required=True)
+    age = IntField(min_value=0)
+    balance = FloatField(default=0.0)
+    active = BooleanField(default=True)
+    address = EmbeddedDocumentField(Address)
+    tags = ListField(StringField())
+
+    meta = {"collection": "customers"}

--- a/internal/custom/python/testdata/peewee_schema.py
+++ b/internal/custom/python/testdata/peewee_schema.py
@@ -1,0 +1,26 @@
+"""Peewee ORM field-level fixture — schema extraction test."""
+import peewee
+from peewee import Model, CharField, IntegerField, FloatField, BooleanField, DateTimeField, TextField
+
+
+database = peewee.SqliteDatabase("app.db")
+
+
+class BaseModel(Model):
+    class Meta:
+        database = database
+
+
+class User(BaseModel):
+    username = CharField(max_length=100, unique=True)
+    email = CharField(max_length=255)
+    age = IntegerField(null=True)
+    active = BooleanField(default=True)
+    created_at = DateTimeField()
+
+
+class Post(BaseModel):
+    title = CharField(max_length=200)
+    body = TextField()
+    score = FloatField(default=0.0)
+    published = BooleanField(default=False)

--- a/internal/custom/python/testdata/pony_schema.py
+++ b/internal/custom/python/testdata/pony_schema.py
@@ -1,0 +1,18 @@
+"""Pony ORM attribute-level fixture — schema extraction test."""
+from pony.orm import Database, Required, Optional, PrimaryKey, Set
+
+db = Database()
+
+
+class Author(db.Entity):
+    name = Required(str)
+    email = Optional(str)
+    books = Set("Book")
+
+
+class Book(db.Entity):
+    title = Required(str)
+    isbn = PrimaryKey(str)
+    year = Optional(int)
+    price = Optional(float)
+    author = Required(Author)

--- a/internal/custom/python/testdata/tortoise_schema.py
+++ b/internal/custom/python/testdata/tortoise_schema.py
@@ -1,0 +1,23 @@
+"""Tortoise ORM column-level fixture — schema extraction test."""
+from tortoise import fields
+from tortoise.models import Model
+
+
+class Tournament(Model):
+    id = fields.IntField(pk=True)
+    name = fields.CharField(max_length=255)
+    created_at = fields.DatetimeField(auto_now_add=True)
+    active = fields.BooleanField(default=True)
+
+    class Meta:
+        table = "tournament"
+
+
+class Event(Model):
+    id = fields.IntField(pk=True)
+    name = fields.CharField(max_length=255)
+    prize = fields.DecimalField(max_digits=10, decimal_places=2)
+    description = fields.TextField()
+
+    class Meta:
+        table = "event"


### PR DESCRIPTION
## Summary

- Add `orm_schema.go`: regex-based field-level extraction for 5 Python ORMs (Peewee, Pony ORM, Beanie, MongoEngine, Tortoise), mirroring the SQLAlchemy class-body scanner in `sqlalchemy.go`
- Each extractor: import-guard gate, model/entity/document class detection, class-body scan emitting `SCOPE.Schema` entities with subtype `column` and properties `framework`/`pattern_type`/`field_type`/`parent_class`
- 5 dedicated fixture files + 23 tests in `orm_schema_test.go` (all pass, including no-false-positive guards per ORM)
- Flip 5 cells `missing → partial`: `schema_extraction` for peewee / pony / beanie / mongoengine / tortoise

## Test plan

- [ ] `go test ./internal/custom/python/ ./internal/types/ ./tools/coverage/` — all pass
- [ ] `coverage validate` — 0 errors
- [ ] `coverage fmt --check` — canonical
- [ ] `coverage gen` — byte-stable docs update

Closes #3072

🤖 Generated with [Claude Code](https://claude.com/claude-code)