### PR TITLE
feat(coverage): Micronaut AOP + HttpServerFilter middleware

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -130,7 +130,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
 | [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 15/16 | |
 | [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
-| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ⚠️ 16/16 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 15/16 | |
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 14/16 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -22,7 +22,7 @@ Back to [summary](../summary.md).
 | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
 | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 15/16 | |
 | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 19/20 | ❌ 4/16 | |
-| [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 12/16 | |
+| [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ⚠️ 16/16 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 15/16 | |
 | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ❌ 19/20 | ❌ 14/16 | |

--- a/docs/coverage/detail/lang.java.framework.micronaut.md
+++ b/docs/coverage/detail/lang.java.framework.micronaut.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3084) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go`<br>`testdata/fixtures/sources/java/micronaut/AuthFilter.java` | — |
 
 ### Testing
 
@@ -73,9 +73,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3084) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go`<br>`testdata/fixtures/sources/java/micronaut/LoggingInterceptor.java` | — |
+| Aspect extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3084) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go`<br>`testdata/fixtures/sources/java/micronaut/LoggingInterceptor.java` | — |
+| Pointcut resolution | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3084) | `internal/custom/java/extractors_test.go`<br>`internal/custom/java/micronaut_aop.go`<br>`testdata/fixtures/sources/java/micronaut/LoggingInterceptor.java` | — |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -16080,7 +16080,10 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/micronaut_aop.go","testdata/fixtures/sources/java/micronaut/AuthFilter.java"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3084",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -16157,16 +16160,22 @@
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/micronaut_aop.go","testdata/fixtures/sources/java/micronaut/LoggingInterceptor.java"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3084",
+            "verified_at": "2026-05-29"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/micronaut_aop.go","testdata/fixtures/sources/java/micronaut/LoggingInterceptor.java"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3084",
+            "verified_at": "2026-05-29"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/extractors_test.go","internal/custom/java/micronaut_aop.go","testdata/fixtures/sources/java/micronaut/LoggingInterceptor.java"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3084",
+            "verified_at": "2026-05-29"
           }
         },
         "Observability": {

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -2641,6 +2641,283 @@ public class UserControllerTest {
 	}
 }
 
+// ---- Micronaut AOP + HttpServerFilter (#3084) --------------------------------
+
+// TestMicronautAOP_AspectExtraction_Issue3084 proves that ExtractMicronautAOP
+// emits SCOPE.Pattern(subtype=aspect) entities for @Around-annotated @interface
+// and MethodInterceptor-implementing classes.
+// Cite: internal/custom/java/micronaut_aop.go
+func TestMicronautAOP_AspectExtraction_Issue3084(t *testing.T) {
+	source := `
+package com.example.aop;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Around
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Logged {}
+
+@Singleton
+@InterceptorBean(Logged.class)
+public class LoggingInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        return context.proceed();
+    }
+}
+`
+	r := ExtractMicronautAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "micronaut",
+		FilePath:  "LoggingInterceptor.java",
+	})
+
+	var aspects []SecondaryEntity
+	for _, e := range r.Entities {
+		if e.Subtype == "aspect" {
+			aspects = append(aspects, e)
+		}
+	}
+	if len(aspects) < 2 {
+		t.Errorf("[#3084 micronaut aspect_extraction] expected >=2 aspect entities (binding annotation + interceptor class), got %d: %v",
+			len(aspects), entityNames(r.Entities))
+	}
+	// Verify both the binding annotation and the interceptor class are present.
+	aspectNames := make(map[string]bool)
+	for _, e := range aspects {
+		aspectNames[e.Name] = true
+	}
+	for _, want := range []string{"Logged", "LoggingInterceptor"} {
+		if !aspectNames[want] {
+			t.Errorf("[#3084 micronaut aspect_extraction] expected aspect entity %q, got: %v", want, entityNames(r.Entities))
+		}
+	}
+}
+
+// TestMicronautAOP_AdviceAttribution_Issue3084 proves that ExtractMicronautAOP
+// emits SCOPE.Pattern(subtype=advice) entities for interceptor methods, and
+// emits OWNS + REFERENCES relationships.
+// Cite: internal/custom/java/micronaut_aop.go
+func TestMicronautAOP_AdviceAttribution_Issue3084(t *testing.T) {
+	source := `
+package com.example.aop;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Around
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Timed {}
+
+@Singleton
+@InterceptorBean(Timed.class)
+public class TimingInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        long start = System.nanoTime();
+        try { return context.proceed(); }
+        finally { System.out.println("elapsed: " + (System.nanoTime() - start)); }
+    }
+}
+`
+	r := ExtractMicronautAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "micronaut",
+		FilePath:  "TimingInterceptor.java",
+	})
+
+	var adviceEntities []SecondaryEntity
+	for _, e := range r.Entities {
+		if e.Subtype == "advice" {
+			adviceEntities = append(adviceEntities, e)
+		}
+	}
+	if len(adviceEntities) < 1 {
+		t.Errorf("[#3084 micronaut advice_attribution] expected >=1 advice entity, got 0: %v", entityNames(r.Entities))
+	}
+	// Verify advice_type = "around".
+	for _, e := range adviceEntities {
+		if v, ok := e.Properties["advice_type"].(string); !ok || v != "around" {
+			t.Errorf("[#3084 micronaut advice_attribution] expected advice_type=around, got %v", e.Properties["advice_type"])
+		}
+	}
+	// Verify at least one OWNS relationship from interceptor → advice.
+	var ownsRels []Relationship
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "OWNS" {
+			ownsRels = append(ownsRels, rel)
+		}
+	}
+	if len(ownsRels) < 1 {
+		t.Errorf("[#3084 micronaut advice_attribution] expected >=1 OWNS relationship, got 0")
+	}
+}
+
+// TestMicronautAOP_PointcutResolution_Issue3084 proves that ExtractMicronautAOP
+// emits SCOPE.Pattern(subtype=pointcut) entities for @Around binding annotations
+// and REFERENCES edges from advice to pointcut.
+// Cite: internal/custom/java/micronaut_aop.go
+func TestMicronautAOP_PointcutResolution_Issue3084(t *testing.T) {
+	source := `
+package com.example.aop;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+@Around
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Audited {}
+
+@Singleton
+@InterceptorBean(Audited.class)
+public class AuditInterceptor implements MethodInterceptor<Object, Object> {
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        System.out.println("audit: " + context.getMethodName());
+        return context.proceed();
+    }
+}
+`
+	r := ExtractMicronautAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "micronaut",
+		FilePath:  "AuditInterceptor.java",
+	})
+
+	var pointcuts []SecondaryEntity
+	for _, e := range r.Entities {
+		if e.Subtype == "pointcut" {
+			pointcuts = append(pointcuts, e)
+		}
+	}
+	if len(pointcuts) < 1 {
+		t.Errorf("[#3084 micronaut pointcut_resolution] expected >=1 pointcut entity, got 0: %v", entityNames(r.Entities))
+	}
+	pointcutNames := make(map[string]bool)
+	for _, e := range pointcuts {
+		pointcutNames[e.Name] = true
+	}
+	if !pointcutNames["Audited"] {
+		t.Errorf("[#3084 micronaut pointcut_resolution] expected pointcut entity 'Audited', got: %v", entityNames(r.Entities))
+	}
+	// Verify REFERENCES edge from advice → pointcut.
+	var refsRels []Relationship
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "REFERENCES" {
+			refsRels = append(refsRels, rel)
+		}
+	}
+	if len(refsRels) < 1 {
+		t.Errorf("[#3084 micronaut pointcut_resolution] expected >=1 REFERENCES relationship (advice → pointcut), got 0")
+	}
+}
+
+// TestMicronautAOP_MiddlewareCoverage_Issue3084 proves that ExtractMicronautAOP
+// emits SCOPE.Component entities for @Filter-annotated HttpServerFilter classes.
+// Cite: internal/custom/java/micronaut_aop.go
+func TestMicronautAOP_MiddlewareCoverage_Issue3084(t *testing.T) {
+	source := `
+package com.example.filter;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import org.reactivestreams.Publisher;
+
+@Filter("/**")
+public class AuthFilter implements HttpServerFilter {
+    @Override
+    public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+        return chain.proceed(request);
+    }
+}
+
+public class RateLimitFilter implements HttpServerFilter {
+    @Override
+    public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+        return chain.proceed(request);
+    }
+}
+`
+	r := ExtractMicronautAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "micronaut",
+		FilePath:  "Filters.java",
+	})
+
+	var filters []SecondaryEntity
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Component" {
+			if mw, ok := e.Properties["middleware"].(string); ok && mw == "http_server_filter" {
+				filters = append(filters, e)
+			}
+		}
+	}
+	if len(filters) < 2 {
+		t.Errorf("[#3084 micronaut middleware_coverage] expected >=2 HttpServerFilter entities, got %d: %v",
+			len(filters), entityNames(r.Entities))
+	}
+	// Verify url_pattern is captured for @Filter("/**").
+	var hasPattern bool
+	for _, f := range filters {
+		if f.Name == "AuthFilter" {
+			if pat, ok := f.Properties["url_pattern"].(string); ok && pat == "/**" {
+				hasPattern = true
+			}
+		}
+	}
+	if !hasPattern {
+		t.Errorf("[#3084 micronaut middleware_coverage] expected url_pattern='/**' on AuthFilter")
+	}
+}
+
+// TestMicronautAOP_NoFalsePositive_Issue3084 proves that ExtractMicronautAOP
+// does NOT emit entities for non-Micronaut frameworks.
+// Cite: internal/custom/java/micronaut_aop.go
+func TestMicronautAOP_NoFalsePositive_Issue3084(t *testing.T) {
+	source := `
+@Around
+public @interface Logged {}
+@InterceptorBean(Logged.class)
+public class LoggingInterceptor implements MethodInterceptor<Object, Object> {
+    public Object intercept(MethodInvocationContext<Object, Object> ctx) { return ctx.proceed(); }
+}
+`
+	// spring_boot framework should NOT trigger Micronaut AOP extractor.
+	r := ExtractMicronautAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_boot",
+		FilePath:  "LoggingInterceptor.java",
+	})
+	if len(r.Entities) > 0 {
+		t.Errorf("[#3084 micronaut no_false_positive] expected 0 entities for spring_boot framework, got %d: %v",
+			len(r.Entities), entityNames(r.Entities))
+	}
+}
+
 // ---- JAX-RS (standalone / Jakarta EE) --------------------------------------
 
 // TestJAXRS_RouteExtraction_Issue2995 proves route_extraction for JAX-RS via

--- a/internal/custom/java/micronaut_aop.go
+++ b/internal/custom/java/micronaut_aop.go
@@ -1,0 +1,302 @@
+package java
+
+import "regexp"
+
+// Micronaut AOP interceptor + HttpServerFilter middleware extractor.
+//
+// Covers four cells for lang.java.framework.micronaut (#3084):
+//
+//	AOP.advice_attribution      (missing → partial)
+//	AOP.aspect_extraction       (missing → partial)
+//	AOP.pointcut_resolution     (missing → partial)
+//	Middleware.middleware_coverage (missing → partial)
+//
+// Micronaut AOP uses a different model than Spring AOP:
+//   - An interceptor class implements MethodInterceptor<T, R> (or its reactive
+//     variant) and is bound to targets via @InterceptorBean(SomeAnnotation.class).
+//   - The interceptor class itself is annotated with @Singleton (or @Prototype),
+//     which makes it a bean, plus optionally @Around to mark it as an around-advice.
+//   - The binding annotation (custom @interface annotated with @Around) acts as
+//     the pointcut designator.
+//
+// Micronaut HTTP middleware uses:
+//   - HttpServerFilter: interface implemented by filter beans; @Filter("/**") marks
+//     the URL pattern.
+//   - @ServerFilter (Micronaut 4.x alias for @Filter on the server side).
+//
+// No new entity Kinds are needed: SCOPE.Pattern (aspect/advice/pointcut) and
+// SCOPE.Component (middleware) are already registered.
+
+var (
+	// mnAroundAnnotationRE matches a custom annotation type decorated with @Around,
+	// capturing the annotation name (group 1). This is the pointcut designator.
+	// Uses .{0,300}? to tolerate intervening annotations like @Retention/@Target
+	// (which may contain `@` and `{`) while bounding the match window.
+	mnAroundAnnotationRE = regexp.MustCompile(
+		`(?s)@Around\b.{0,300}?(?:public\s+)?@interface\s+(\w+)`)
+
+	// mnInterceptorBeanRE matches an @InterceptorBean(...) binding on a class,
+	// capturing the bound annotation name (group 1) and the class name (group 2).
+	mnInterceptorBeanRE = regexp.MustCompile(
+		`(?s)@InterceptorBean\s*\(\s*(?:value\s*=\s*)?(\w+)\.class\s*\)` +
+			`[^{]*?(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+
+	// mnMethodInterceptorClassRE matches a class that implements MethodInterceptor,
+	// capturing the class name (group 1). Handles both the generic and raw forms.
+	mnMethodInterceptorClassRE = regexp.MustCompile(
+		`(?s)(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)` +
+			`[^{]*?implements\s+[^{]*?MethodInterceptor\b`)
+
+	// mnAroundAdviceMethodRE matches the intercept() method inside an interceptor
+	// class (the canonical entry point for Micronaut MethodInterceptor), capturing
+	// the method name (group 1).
+	mnAroundAdviceMethodRE = regexp.MustCompile(
+		`(?m)(?:public|protected)\s+(?:<[^>]*>\s*)?` +
+			`(?:\w+(?:\s*<[^>]*>)?(?:\[\])?\s+)` +
+			`(intercept)\s*\(`)
+
+	// mnFilterClassRE matches a class that implements HttpServerFilter (or the
+	// @Filter/@ServerFilter annotated variant), capturing the class name (group 1).
+	// Form 1: @Filter("...") on the class declaration.
+	mnFilterAnnotationRE = regexp.MustCompile(
+		`(?s)@(?:Filter|ServerFilter)\s*` +
+			`(?:\(\s*(?:value\s*=\s*)?\"([^\"]*)\"\s*\)\s*)?` +
+			`[^{@]*?(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+
+	// mnHttpServerFilterImplRE matches "implements HttpServerFilter" on a class,
+	// capturing the class name (group 1).
+	mnHttpServerFilterImplRE = regexp.MustCompile(
+		`(?s)(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)` +
+			`[^{]*?implements\s+[^{]*?HttpServerFilter\b`)
+)
+
+// ExtractMicronautAOP detects Micronaut AOP interceptors and HttpServerFilter
+// middleware, emitting SCOPE.Pattern and SCOPE.Component entities.
+func ExtractMicronautAOP(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !micronautFrameworks[ctx.Framework] {
+		return result
+	}
+
+	source := ctx.Source
+	fp := ctx.FilePath
+	seenRefs := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// ── 1. aspect_extraction / pointcut_resolution ───────────────────────────
+	// An @Around-annotated custom @interface is the Micronaut pointcut designator
+	// (the binding annotation). Emit as aspect (contains the pointcut) and as
+	// pointcut.
+
+	pointcutRefByBinding := make(map[string]string) // bindingAnnotation -> ref
+
+	for _, m := range mnAroundAnnotationRE.FindAllStringSubmatchIndex(source, -1) {
+		annName := source[m[2]:m[3]]
+
+		// Emit SCOPE.Pattern(subtype=aspect) for the binding annotation — it
+		// plays the role of both the aspect designator and the pointcut in
+		// Micronaut's model.
+		aspectRef := "scope:pattern:aspect:" + fp + ":" + annName
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: annName, Kind: "SCOPE.Pattern", Subtype: "aspect",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_MICRONAUT_AROUND",
+			Ref:        aspectRef,
+			Properties: map[string]any{
+				"kind":      "aspect",
+				"aspect":    annName,
+				"framework": "micronaut",
+			},
+		})
+
+		// Emit SCOPE.Pattern(subtype=pointcut) for the binding annotation — the
+		// @Around annotation on the @interface is the pointcut declaration.
+		pcRef := "scope:pattern:pointcut:" + fp + ":" + annName
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: annName, Kind: "SCOPE.Pattern", Subtype: "pointcut",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_MICRONAUT_AROUND_POINTCUT",
+			Ref:        pcRef,
+			Properties: map[string]any{
+				"kind":      "pointcut",
+				"pointcut":  annName,
+				"framework": "micronaut",
+			},
+		}) {
+			pointcutRefByBinding[annName] = pcRef
+			// OWNS: aspect owns its pointcut.
+			addRel(&result, seenRels, Relationship{
+				SourceRef: aspectRef, TargetRef: pcRef, RelationshipType: "OWNS",
+			})
+		}
+	}
+
+	// ── 2. aspect_extraction: MethodInterceptor implementation ────────────────
+	// A class that implements MethodInterceptor is an interceptor (aspect).
+	// If it also has @InterceptorBean, record the binding.
+
+	interceptorRefs := make(map[string]string) // className -> ref
+
+	for _, m := range mnMethodInterceptorClassRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		ref := "scope:pattern:aspect:" + fp + ":" + className
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Pattern", Subtype: "aspect",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_MICRONAUT_METHOD_INTERCEPTOR",
+			Ref:        ref,
+			Properties: map[string]any{
+				"kind":      "aspect",
+				"aspect":    className,
+				"framework": "micronaut",
+			},
+		}) {
+			interceptorRefs[className] = ref
+		}
+	}
+
+	// ── 3. pointcut_resolution: @InterceptorBean binding ─────────────────────
+	// @InterceptorBean(SomeAnnotation.class) on an interceptor class links it
+	// to its binding annotation (the pointcut). Emit an OWNS edge from the
+	// interceptor aspect to the pointcut, and a REFERENCES edge from advice.
+
+	for _, m := range mnInterceptorBeanRE.FindAllStringSubmatchIndex(source, -1) {
+		bindingAnn := source[m[2]:m[3]]
+		className := source[m[4]:m[5]]
+
+		// Ensure the interceptor class entity exists (may have been found above
+		// or may only be declared via @InterceptorBean without explicit
+		// MethodInterceptor in scope).
+		interceptorRef := interceptorRefs[className]
+		if interceptorRef == "" {
+			interceptorRef = "scope:pattern:aspect:" + fp + ":" + className
+			addEntity(&result, seenRefs, SecondaryEntity{
+				Name: className, Kind: "SCOPE.Pattern", Subtype: "aspect",
+				SourceFile: fp,
+				LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+				Provenance: "INFERRED_FROM_MICRONAUT_INTERCEPTOR_BEAN",
+				Ref:        interceptorRef,
+				Properties: map[string]any{
+					"kind":      "aspect",
+					"aspect":    className,
+					"framework": "micronaut",
+				},
+			})
+			interceptorRefs[className] = interceptorRef
+		}
+
+		// ── 4. advice_attribution: the intercept() method is the around-advice ──
+		// Emit a SCOPE.Pattern(subtype=advice) for <ClassName>.intercept.
+		adviceName := className + ".intercept"
+		adviceRef := "scope:pattern:advice:" + fp + ":" + adviceName
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: adviceName, Kind: "SCOPE.Pattern", Subtype: "advice",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_MICRONAUT_INTERCEPTOR_BEAN",
+			Ref:        adviceRef,
+			Properties: map[string]any{
+				"kind":        "advice",
+				"advice_type": "around",
+				"aspect":      className,
+				"binding":     bindingAnn,
+				"framework":   "micronaut",
+			},
+		}) {
+			// OWNS: interceptor class owns the advice method.
+			addRel(&result, seenRels, Relationship{
+				SourceRef: interceptorRef, TargetRef: adviceRef, RelationshipType: "OWNS",
+			})
+			// REFERENCES: advice -> pointcut (the binding annotation).
+			if pcRef, ok := pointcutRefByBinding[bindingAnn]; ok {
+				addRel(&result, seenRels, Relationship{
+					SourceRef: adviceRef, TargetRef: pcRef, RelationshipType: "REFERENCES",
+				})
+			}
+		}
+	}
+
+	// ── 5. advice_attribution: intercept() bodies in MethodInterceptor classes ─
+	// When we detected a MethodInterceptor class but no @InterceptorBean, we
+	// still emit advice entities for intercept() methods found in the source
+	// so that advice_attribution has coverage even without explicit binding.
+	for _, m := range mnAroundAdviceMethodRE.FindAllStringSubmatchIndex(source, -1) {
+		methodName := source[m[2]:m[3]] // always "intercept"
+		ownerCls := findEnclosingClass(source, m[0])
+		if ownerCls == "" {
+			continue
+		}
+		interceptorRef := interceptorRefs[ownerCls]
+		if interceptorRef == "" {
+			// Not a known interceptor class; skip to avoid noise.
+			continue
+		}
+		adviceName := ownerCls + "." + methodName
+		adviceRef := "scope:pattern:advice:" + fp + ":" + adviceName
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: adviceName, Kind: "SCOPE.Pattern", Subtype: "advice",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_MICRONAUT_INTERCEPT_METHOD",
+			Ref:        adviceRef,
+			Properties: map[string]any{
+				"kind":        "advice",
+				"advice_type": "around",
+				"aspect":      ownerCls,
+				"framework":   "micronaut",
+			},
+		}) {
+			addRel(&result, seenRels, Relationship{
+				SourceRef: interceptorRef, TargetRef: adviceRef, RelationshipType: "OWNS",
+			})
+		}
+	}
+
+	// ── 6. middleware_coverage: HttpServerFilter / @Filter ────────────────────
+
+	// Form A: @Filter or @ServerFilter annotated class.
+	for _, m := range mnFilterAnnotationRE.FindAllStringSubmatchIndex(source, -1) {
+		urlPattern := ""
+		if m[2] >= 0 {
+			urlPattern = source[m[2]:m[3]]
+		}
+		className := source[m[4]:m[5]]
+		ref := "scope:component:micronaut_filter:" + fp + ":" + className
+		props := map[string]any{
+			"framework":  "micronaut",
+			"middleware": "http_server_filter",
+		}
+		if urlPattern != "" {
+			props["url_pattern"] = urlPattern
+		}
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Component", SourceFile: fp,
+			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_MICRONAUT_FILTER", Ref: ref,
+			Properties: props,
+		})
+	}
+
+	// Form B: class implements HttpServerFilter (may lack @Filter annotation).
+	for _, m := range mnHttpServerFilterImplRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		ref := "scope:component:micronaut_filter:" + fp + ":" + className
+		if seenRefs[ref] {
+			continue // already emitted by Form A
+		}
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Component", SourceFile: fp,
+			LineStart: lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_MICRONAUT_HTTP_SERVER_FILTER", Ref: ref,
+			Properties: map[string]any{
+				"framework":  "micronaut",
+				"middleware": "http_server_filter",
+			},
+		})
+	}
+
+	return result
+}

--- a/testdata/fixtures/sources/java/micronaut/AuthFilter.java
+++ b/testdata/fixtures/sources/java/micronaut/AuthFilter.java
@@ -1,0 +1,28 @@
+package com.example.filter;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import org.reactivestreams.Publisher;
+
+/**
+ * Micronaut HttpServerFilter middleware example.
+ *
+ * @Filter("/**") binds this filter to all incoming HTTP requests.
+ * Implements HttpServerFilter to participate in the filter chain.
+ */
+@Filter("/**")
+public class AuthFilter implements HttpServerFilter {
+
+    @Override
+    public Publisher<MutableHttpResponse<?>> doFilter(
+            HttpRequest<?> request, ServerFilterChain chain) {
+        String token = request.getHeaders().get("Authorization");
+        if (token == null || token.isBlank()) {
+            // In a real app: return unauthorized response
+        }
+        return chain.proceed(request);
+    }
+}

--- a/testdata/fixtures/sources/java/micronaut/LoggingInterceptor.java
+++ b/testdata/fixtures/sources/java/micronaut/LoggingInterceptor.java
@@ -1,0 +1,37 @@
+package com.example.aop;
+
+import io.micronaut.aop.Around;
+import io.micronaut.aop.InterceptorBean;
+import io.micronaut.aop.MethodInterceptor;
+import io.micronaut.aop.MethodInvocationContext;
+import jakarta.inject.Singleton;
+import java.lang.annotation.*;
+
+/**
+ * Micronaut AOP example: logging interceptor.
+ *
+ * @Logged is the binding annotation (acts as pointcut designator).
+ * LoggingInterceptor implements MethodInterceptor and is bound via @InterceptorBean.
+ */
+
+@Around
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Logged {
+    boolean includeArgs() default true;
+}
+
+@Singleton
+@InterceptorBean(Logged.class)
+public class LoggingInterceptor implements MethodInterceptor<Object, Object> {
+
+    @Override
+    public Object intercept(MethodInvocationContext<Object, Object> context) {
+        System.out.println("BEFORE " + context.getMethodName());
+        try {
+            return context.proceed();
+        } finally {
+            System.out.println("AFTER " + context.getMethodName());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `micronaut_aop.go`: detects `@Around`-annotated binding `@interface` declarations (aspect + pointcut), `MethodInterceptor` implementations (aspect), `@InterceptorBean` bindings (pointcut resolution + around-advice with OWNS/REFERENCES edges), and `@Filter`/`@ServerFilter`/`HttpServerFilter` class implementations (middleware).
- Resolve pre-existing merge conflict in `extractors_test.go` (Helidon #3088 ↔ Spring Boot #3081 sections — both kept).
- Add fixtures: `LoggingInterceptor.java`, `AuthFilter.java`.
- Add 5 proving tests covering all 4 cells + no-false-positive gate.
- Flip 4 cells: `lang.java.framework.micronaut` — `advice_attribution`, `aspect_extraction`, `pointcut_resolution`, `middleware_coverage` (missing → partial).

## Test plan

- [x] `go test ./internal/custom/java/ ./internal/types/ ./tools/coverage/` — all pass
- [x] `coverage validate` — 0 errors
- [x] `coverage fmt --check` — ok: canonical
- [x] `coverage gen` — byte-stable, 558 records
- [x] `go build ./...` — clean

Closes #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)