### PR TITLE
feat(coverage): Pipfile + pyproject lockfile parsing

### DIFF
--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -20,8 +20,8 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [java](../by-language/java.md) | [pom.xml](../detail/pkg.pom.md) | — | — | ✅ | — | |
 | [JS/TS](../by-language/jsts.md) | [package.json (npm/yarn/pnpm)](../detail/pkg.npm.md) | — | ✅ | ✅ | — | |
 | [php](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | ❌ | ❌ | — | |
-| [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | ❌ | ❌ | — | |
-| [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | ❌ | ✅ | — | |
+| [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | ⚠️ | ⚠️ | — | |
+| [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | ⚠️ | ✅ | — | |
 | [python](../by-language/python.md) | [requirements.txt](../detail/pkg.requirements.md) | — | — | ✅ | — | |
 | [ruby](../by-language/ruby.md) | [Gemfile](../detail/pkg.gemfile.md) | — | ❌ | ✅ | — | |
 | [rust](../by-language/rust.md) | [Cargo.toml](../detail/pkg.cargo.md) | — | ❌ | ✅ | — | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -57,12 +57,12 @@ Back to [summary](../summary.md).
 | [Hatch](../detail/build.hatch.md) | ⚠️ | — | — | ⚠️ | |
 | [Hypothesis (property tests)](../detail/test.hypothesis.md) | ❌ | — | — | ❌ | |
 | [Pipenv](../detail/build.pipenv.md) | ⚠️ | — | — | ⚠️ | |
-| [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | ❌ | ❌ | — | |
+| [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | ⚠️ | ⚠️ | — | |
 | [Poetry](../detail/build.poetry.md) | ✅ | — | — | ✅ | |
 | [doctest (stdlib)](../detail/test.doctest.md) | ❌ | — | — | ❌ | |
 | [nose2](../detail/test.nose2.md) | ❌ | — | — | ❌ | |
 | [pip (requirements.txt)](../detail/build.pip.md) | ✅ | — | — | ✅ | |
-| [pyproject.toml](../detail/pkg.pyproject.md) | — | ❌ | ✅ | — | |
+| [pyproject.toml](../detail/pkg.pyproject.md) | — | ⚠️ | ✅ | — | |
 | [pytest](../detail/test.pytest.md) | ✅ | — | — | ✅ | |
 | [requirements.txt](../detail/pkg.requirements.md) | — | — | ✅ | — | |
 | [setuptools / setup.py](../detail/build.setuptools.md) | ⚠️ | — | — | ⚠️ | |

--- a/docs/coverage/detail/pkg.pipfile.md
+++ b/docs/coverage/detail/pkg.pipfile.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | ❌ `missing` | — | — | — | — |
-| Manifest parsing | ❌ `missing` | — | — | — | — |
+| Lockfile parsing | ⚠️ `partial` | `2026-05-29` | 3075 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/pylock_test.go` | — |
+| Manifest parsing | ⚠️ `partial` | `2026-05-29` | 3075 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/pylock_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/pkg.pyproject.md
+++ b/docs/coverage/detail/pkg.pyproject.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | ❌ `missing` | — | — | — | — |
+| Lockfile parsing | ⚠️ `partial` | `2026-05-29` | 3075 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/pylock_test.go` | — |
 | Manifest parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/cross/manifest/extractor.go` | — |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -46301,10 +46301,16 @@
       "label": "Pipfile / Pipfile.lock",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go","internal/extractors/cross/manifest/pylock_test.go"],
+          "issue": "3075",
+          "verified_at": "2026-05-29"
         },
         "manifest_parsing": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go","internal/extractors/cross/manifest/pylock_test.go"],
+          "issue": "3075",
+          "verified_at": "2026-05-29"
         }
       }
     },
@@ -46344,7 +46350,10 @@
       "label": "pyproject.toml",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go","internal/extractors/cross/manifest/pylock_test.go"],
+          "issue": "3075",
+          "verified_at": "2026-05-29"
         },
         "manifest_parsing": {
           "status": "full",

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -8,6 +8,11 @@
 //   - go.mod               (go_modules)
 //   - Cargo.toml           (cargo)
 //   - pyproject.toml       (pip/poetry)
+//   - uv.lock              (uv lockfile)
+//   - pdm.lock             (pdm lockfile)
+//   - poetry.lock          (poetry lockfile)
+//   - Pipfile              (pipenv manifest)
+//   - Pipfile.lock         (pipenv lockfile)
 //   - pom.xml              (maven)
 //   - requirements.txt     (pip)
 //   - pubspec.yaml         (pub/dart)
@@ -95,6 +100,11 @@ var exactManifestNames = map[string]bool{
 	"go.mod":              true,
 	"Cargo.toml":          true,
 	"pyproject.toml":      true,
+	"uv.lock":             true,
+	"pdm.lock":            true,
+	"poetry.lock":         true,
+	"Pipfile":             true,
+	"Pipfile.lock":        true,
 	"pom.xml":             true,
 	"requirements.txt":    true,
 	"pubspec.yaml":        true,
@@ -118,6 +128,11 @@ func detectPackageManager(filePath string) string {
 		"go.mod":              "go_modules",
 		"Cargo.toml":          "cargo",
 		"pyproject.toml":      "pip",
+		"uv.lock":             "uv",
+		"pdm.lock":            "pdm",
+		"poetry.lock":         "poetry",
+		"Pipfile":             "pipenv",
+		"Pipfile.lock":        "pipenv",
 		"pom.xml":             "maven",
 		"requirements.txt":    "pip",
 		"pubspec.yaml":        "pub",
@@ -747,6 +762,229 @@ func parseGemfile(source string) []dep {
 }
 
 // ---------------------------------------------------------------------------
+// Parser: Pipfile (Pipenv manifest)
+// ---------------------------------------------------------------------------
+
+// pipfileDepLineRE matches a pipenv dependency line in [packages] or
+// [dev-packages] sections.  Both forms are supported:
+//
+//	requests = "*"
+//	Django = ">=3.2,<4"
+//	flask = {version = "^2.0", extras = ["async"]}
+var pipfileDepLineRE = regexp.MustCompile(
+	`(?m)^\s*([A-Za-z0-9](?:[A-Za-z0-9._-]*)?)\s*=\s*(?:"([^"]*)"|\{[^}]*version\s*=\s*"([^"]*)"[^}]*\}|'([^']*)')`,
+)
+
+func parsePipfile(source string) []dep {
+	// Build a minimal section index (same pattern as parseCargoToml).
+	type sectionEntry struct {
+		start int
+		name  string
+	}
+	sectionMatches := tomlSectionRE.FindAllStringSubmatchIndex(source, -1)
+	sections := make([]sectionEntry, 0, len(sectionMatches))
+	for _, m := range sectionMatches {
+		sections = append(sections, sectionEntry{
+			start: m[0],
+			name:  strings.TrimSpace(source[m[2]:m[3]]),
+		})
+	}
+	sections = append(sections, sectionEntry{start: len(source), name: "__end__"})
+
+	bodyFor := func(name string) string {
+		for i, s := range sections[:len(sections)-1] {
+			if s.name == name {
+				return source[s.start:sections[i+1].start]
+			}
+		}
+		return ""
+	}
+
+	extractDeps := func(body string, isDev bool, depKind string) []dep {
+		var out []dep
+		for _, m := range pipfileDepLineRE.FindAllStringSubmatch(body, -1) {
+			name := m[1]
+			if name == "python_version" || name == "python_full_version" {
+				continue
+			}
+			// version is in group 2 (plain string), 3 (table version=), or 4 (single-quoted string)
+			version := m[2]
+			if version == "" {
+				version = m[3]
+			}
+			if version == "" {
+				version = m[4]
+			}
+			if version == "*" {
+				version = ""
+			}
+			out = append(out, dep{name: name, version: version, isDev: isDev, kind: depKind})
+		}
+		return out
+	}
+
+	var out []dep
+	seen := map[string]bool{}
+	addDeps := func(deps []dep) {
+		for _, d := range deps {
+			if !seen[d.name] {
+				seen[d.name] = true
+				out = append(out, d)
+			}
+		}
+	}
+	addDeps(extractDeps(bodyFor("packages"), false, "runtime"))
+	addDeps(extractDeps(bodyFor("dev-packages"), true, "dev"))
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parser: Pipfile.lock (Pipenv lockfile)
+// ---------------------------------------------------------------------------
+
+// parsePipfileLock parses a Pipfile.lock JSON document.
+//
+// Structure:
+//
+//	{
+//	  "default": { "<name>": { "version": "==1.2.3" }, ... },
+//	  "develop": { "<name>": { "version": "==1.2.3" }, ... }
+//	}
+//
+// Versions are stored as PEP 440 constraints (e.g. "==1.2.3"); we strip
+// the leading "==" for a cleaner display.
+func parsePipfileLock(source string) []dep {
+	var data struct {
+		Default map[string]struct {
+			Version string `json:"version"`
+		} `json:"default"`
+		Develop map[string]struct {
+			Version string `json:"version"`
+		} `json:"develop"`
+	}
+	if err := json.Unmarshal([]byte(source), &data); err != nil {
+		return nil
+	}
+
+	var out []dep
+	seen := map[string]bool{}
+	add := func(name, version string, isDev bool) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		// Strip leading "==" from locked version specifier.
+		version = strings.TrimPrefix(version, "==")
+		out = append(out, dep{name: name, version: version, isDev: isDev, kind: "locked"})
+	}
+	for name, pkg := range data.Default {
+		add(name, pkg.Version, false)
+	}
+	for name, pkg := range data.Develop {
+		add(name, pkg.Version, true)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parser: uv.lock (uv lockfile, TOML-based)
+// ---------------------------------------------------------------------------
+
+// uvLockPackageNameRE matches a [[package]] entry name line in uv.lock.
+//
+//	[[package]]
+//	name = "requests"
+//	version = "2.31.0"
+var uvLockNameRE = regexp.MustCompile(`(?m)^name\s*=\s*"([^"]+)"`)
+var uvLockVersionRE = regexp.MustCompile(`(?m)^version\s*=\s*"([^"]+)"`)
+
+// parseUvLock parses a uv.lock file (TOML format, [[package]] array).
+//
+// Each [[package]] block lists one resolved package with name + version.
+// We scan all blocks and emit them as kind=locked deps.
+func parseUvLock(source string) []dep {
+	// Split on [[package]] boundaries.
+	blocks := strings.Split(source, "[[package]]")
+	var out []dep
+	seen := map[string]bool{}
+
+	for _, block := range blocks[1:] { // skip preamble before first [[package]]
+		nm := uvLockNameRE.FindStringSubmatch(block)
+		if nm == nil {
+			continue
+		}
+		name := nm[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		version := ""
+		if vm := uvLockVersionRE.FindStringSubmatch(block); vm != nil {
+			version = vm[1]
+		}
+		out = append(out, dep{name: name, version: version, kind: "locked"})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parser: pdm.lock (PDM lockfile, TOML-based)
+// ---------------------------------------------------------------------------
+
+// parsePdmLock parses a pdm.lock file.
+//
+// pdm.lock uses the same [[package]] array structure as uv.lock, though
+// it also includes a [metadata] block at the top.  We reuse the same
+// name/version extraction approach.
+func parsePdmLock(source string) []dep {
+	return parseUvLock(source) // identical structure
+}
+
+// ---------------------------------------------------------------------------
+// Parser: poetry.lock (Poetry lockfile, TOML-based)
+// ---------------------------------------------------------------------------
+
+// poetryLockNameRE / poetryLockVersionRE match the name and version fields
+// inside a [[package]] block in poetry.lock.
+var poetryLockNameRE = regexp.MustCompile(`(?m)^name\s*=\s*"([^"]+)"`)
+var poetryLockVersionRE = regexp.MustCompile(`(?m)^version\s*=\s*"([^"]+)"`)
+
+// parsePoetryLock parses a poetry.lock file.
+//
+// poetry.lock is TOML-based with [[package]] blocks, each carrying name,
+// version, and optional category ("main" vs "dev").  We emit kind=locked
+// deps and flag dev when category == "dev".
+func parsePoetryLock(source string) []dep {
+	blocks := strings.Split(source, "[[package]]")
+	var out []dep
+	seen := map[string]bool{}
+
+	categoryRE := regexp.MustCompile(`(?m)^category\s*=\s*"([^"]+)"`)
+
+	for _, block := range blocks[1:] {
+		nm := poetryLockNameRE.FindStringSubmatch(block)
+		if nm == nil {
+			continue
+		}
+		name := nm[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		version := ""
+		if vm := poetryLockVersionRE.FindStringSubmatch(block); vm != nil {
+			version = vm[1]
+		}
+		isDev := false
+		if cm := categoryRE.FindStringSubmatch(block); cm != nil {
+			isDev = cm[1] == "dev"
+		}
+		out = append(out, dep{name: name, version: version, isDev: isDev, kind: "locked"})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
 // Dispatch table
 // ---------------------------------------------------------------------------
 
@@ -761,6 +999,11 @@ var parsers = map[string]parserFn{
 	"go.mod":              parseGoMod,
 	"Cargo.toml":          parseCargoToml,
 	"pyproject.toml":      parsePyprojectToml,
+	"uv.lock":             parseUvLock,
+	"pdm.lock":            parsePdmLock,
+	"poetry.lock":         parsePoetryLock,
+	"Pipfile":             parsePipfile,
+	"Pipfile.lock":        parsePipfileLock,
 	"pom.xml":             parsePomXML,
 	"requirements.txt":    parseRequirementsTxt,
 	"pubspec.yaml":        parsePubspecYaml,

--- a/internal/extractors/cross/manifest/pylock_test.go
+++ b/internal/extractors/cross/manifest/pylock_test.go
@@ -1,0 +1,478 @@
+package manifest
+
+// Tests for Pipfile / Pipfile.lock (pkg.pipfile) and Python lockfile parsers
+// (uv.lock / pdm.lock / poetry.lock) for pkg.pyproject.
+//
+// Issue: #3075 — lockfile parsing for Pipfile + pyproject (uv/pdm)
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+func findDep(deps []dep, name string) *dep {
+	for i := range deps {
+		if deps[i].name == name {
+			return &deps[i]
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Pipfile (manifest)
+// ---------------------------------------------------------------------------
+
+func TestParsePipfile_BasicDeps(t *testing.T) {
+	src := `
+[[source]]
+url = "https://pypi.org/simple"
+
+[packages]
+requests = "*"
+Django = ">=3.2,<4"
+flask = {version = "^2.0", extras = ["async"]}
+
+[dev-packages]
+pytest = ">=7"
+black = "*"
+
+[requires]
+python_version = "3.11"
+`
+	deps := parsePipfile(src)
+	if len(deps) != 5 {
+		t.Fatalf("expected 5 deps, got %d: %+v", len(deps), deps)
+	}
+
+	requests := findDep(deps, "requests")
+	if requests == nil {
+		t.Fatal("expected requests dep")
+	}
+	if requests.isDev {
+		t.Error("requests should not be dev")
+	}
+	if requests.kind != "runtime" {
+		t.Errorf("requests kind=%q want runtime", requests.kind)
+	}
+
+	django := findDep(deps, "Django")
+	if django == nil {
+		t.Fatal("expected Django dep")
+	}
+	if django.version != ">=3.2,<4" {
+		t.Errorf("Django version=%q want >=3.2,<4", django.version)
+	}
+
+	flask := findDep(deps, "flask")
+	if flask == nil {
+		t.Fatal("expected flask dep")
+	}
+	if flask.version != "^2.0" {
+		t.Errorf("flask version=%q want ^2.0", flask.version)
+	}
+
+	pytest := findDep(deps, "pytest")
+	if pytest == nil {
+		t.Fatal("expected pytest dep")
+	}
+	if !pytest.isDev {
+		t.Error("pytest should be isDev=true")
+	}
+	if pytest.kind != "dev" {
+		t.Errorf("pytest kind=%q want dev", pytest.kind)
+	}
+
+	black := findDep(deps, "black")
+	if black == nil {
+		t.Fatal("expected black dep")
+	}
+	if !black.isDev {
+		t.Error("black should be isDev=true")
+	}
+	// "*" version should be normalised to ""
+	if black.version != "" {
+		t.Errorf("black version=%q want empty string (wildcard normalised)", black.version)
+	}
+}
+
+func TestParsePipfile_EmptyFile(t *testing.T) {
+	deps := parsePipfile("")
+	if len(deps) != 0 {
+		t.Errorf("expected 0 deps for empty Pipfile, got %d", len(deps))
+	}
+}
+
+func TestParsePipfile_SkipsPythonVersion(t *testing.T) {
+	// python_version pseudo-key should not be emitted as a dependency.
+	src := `
+[packages]
+requests = "*"
+
+[requires]
+python_version = "3.11"
+python_full_version = "3.11.2"
+`
+	deps := parsePipfile(src)
+	for _, d := range deps {
+		if d.name == "python_version" || d.name == "python_full_version" {
+			t.Errorf("should not emit %q as a dependency", d.name)
+		}
+	}
+}
+
+func TestParsePipfile_ViaExtractor(t *testing.T) {
+	// End-to-end: extractor recognises "Pipfile" as a manifest.
+	src := `
+[packages]
+httpx = ">=0.23"
+
+[dev-packages]
+mypy = "*"
+`
+	records := runExtract(t, "project/Pipfile", src)
+	deps := depEntities(records)
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 dep entities, got %d", len(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "pipenv" {
+			t.Errorf("package_manager=%q want pipenv", d.Properties["package_manager"])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pipfile.lock
+// ---------------------------------------------------------------------------
+
+func TestParsePipfileLock_Basic(t *testing.T) {
+	src := `{
+  "_meta": {
+    "hash": {"sha256": "abc"},
+    "pipfile-spec": 6,
+    "requires": {"python_version": "3.11"},
+    "sources": [{"name": "pypi", "url": "https://pypi.org/simple", "verify_ssl": true}]
+  },
+  "default": {
+    "certifi": {"hashes": ["sha256:abc"], "version": "==2023.7.22"},
+    "requests": {"hashes": ["sha256:def"], "version": "==2.31.0"},
+    "urllib3": {"hashes": ["sha256:ghi"], "version": "==2.0.4"}
+  },
+  "develop": {
+    "pytest": {"hashes": ["sha256:jkl"], "version": "==7.4.0"},
+    "black": {"hashes": ["sha256:mno"], "version": "==23.7.0"}
+  }
+}`
+	deps := parsePipfileLock(src)
+	if len(deps) != 5 {
+		t.Fatalf("expected 5 locked deps, got %d: %+v", len(deps), deps)
+	}
+
+	requests := findDep(deps, "requests")
+	if requests == nil {
+		t.Fatal("expected requests dep")
+	}
+	if requests.version != "2.31.0" {
+		t.Errorf("requests version=%q want 2.31.0 (== prefix stripped)", requests.version)
+	}
+	if requests.isDev {
+		t.Error("requests should not be isDev")
+	}
+	if requests.kind != "locked" {
+		t.Errorf("requests kind=%q want locked", requests.kind)
+	}
+
+	pytest := findDep(deps, "pytest")
+	if pytest == nil {
+		t.Fatal("expected pytest dep")
+	}
+	if !pytest.isDev {
+		t.Error("pytest should be isDev=true")
+	}
+	if pytest.version != "7.4.0" {
+		t.Errorf("pytest version=%q want 7.4.0", pytest.version)
+	}
+}
+
+func TestParsePipfileLock_InvalidJSON(t *testing.T) {
+	deps := parsePipfileLock("{invalid}")
+	if deps != nil {
+		t.Errorf("expected nil for invalid JSON, got %v", deps)
+	}
+}
+
+func TestParsePipfileLock_ViaExtractor(t *testing.T) {
+	src := `{
+  "default": {
+    "httpx": {"version": "==0.24.1"}
+  },
+  "develop": {
+    "pytest": {"version": "==7.4.0"}
+  }
+}`
+	records := runExtract(t, "project/Pipfile.lock", src)
+	deps := depEntities(records)
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 dep entities, got %d", len(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "pipenv" {
+			t.Errorf("package_manager=%q want pipenv", d.Properties["package_manager"])
+		}
+		if d.Properties["dependency_kind"] != "locked" {
+			t.Errorf("dependency_kind=%q want locked", d.Properties["dependency_kind"])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// uv.lock
+// ---------------------------------------------------------------------------
+
+func TestParseUvLock_Basic(t *testing.T) {
+	src := `version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "certifi"
+version = "2023.7.22"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "httpx"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+  { name = "certifi" },
+]
+
+[[package]]
+name = "pytest"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+`
+	deps := parseUvLock(src)
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 locked deps, got %d: %+v", len(deps), deps)
+	}
+
+	httpx := findDep(deps, "httpx")
+	if httpx == nil {
+		t.Fatal("expected httpx dep")
+	}
+	if httpx.version != "0.24.1" {
+		t.Errorf("httpx version=%q want 0.24.1", httpx.version)
+	}
+	if httpx.kind != "locked" {
+		t.Errorf("httpx kind=%q want locked", httpx.kind)
+	}
+}
+
+func TestParseUvLock_EmptyFile(t *testing.T) {
+	deps := parseUvLock("")
+	if len(deps) != 0 {
+		t.Errorf("expected 0 deps, got %d", len(deps))
+	}
+}
+
+func TestParseUvLock_ViaExtractor(t *testing.T) {
+	src := `version = 1
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+`
+	records := runExtract(t, "project/uv.lock", src)
+	deps := depEntities(records)
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep entity, got %d", len(deps))
+	}
+	if deps[0].Properties["package_manager"] != "uv" {
+		t.Errorf("package_manager=%q want uv", deps[0].Properties["package_manager"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pdm.lock
+// ---------------------------------------------------------------------------
+
+func TestParsePdmLock_Basic(t *testing.T) {
+	src := `[metadata]
+groups = ["default", "dev"]
+strategy = ["cross_platform", "static_urls"]
+lock_version = "4.5"
+content_hash = "sha256:abc123"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+
+[[package]]
+name = "pytest"
+version = "7.4.0"
+`
+	deps := parsePdmLock(src)
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 locked deps, got %d: %+v", len(deps), deps)
+	}
+
+	requests := findDep(deps, "requests")
+	if requests == nil {
+		t.Fatal("expected requests dep")
+	}
+	if requests.version != "2.31.0" {
+		t.Errorf("requests version=%q want 2.31.0", requests.version)
+	}
+	if requests.kind != "locked" {
+		t.Errorf("requests kind=%q want locked", requests.kind)
+	}
+}
+
+func TestParsePdmLock_ViaExtractor(t *testing.T) {
+	src := `[[package]]
+name = "django"
+version = "4.2.0"
+`
+	records := runExtract(t, "project/pdm.lock", src)
+	deps := depEntities(records)
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dep entity, got %d", len(deps))
+	}
+	if deps[0].Properties["package_manager"] != "pdm" {
+		t.Errorf("package_manager=%q want pdm", deps[0].Properties["package_manager"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// poetry.lock
+// ---------------------------------------------------------------------------
+
+func TestParsePoetryLock_Basic(t *testing.T) {
+	src := `# This file is automatically @generated by Poetry 1.6.0 and should not be changed by hand.
+
+[[package]]
+name = "certifi"
+version = "2023.7.22"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "pytest"
+version = "7.4.0"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.11"
+content-hash = "abc123"
+`
+	deps := parsePoetryLock(src)
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 locked deps, got %d: %+v", len(deps), deps)
+	}
+
+	requests := findDep(deps, "requests")
+	if requests == nil {
+		t.Fatal("expected requests dep")
+	}
+	if requests.version != "2.31.0" {
+		t.Errorf("requests version=%q want 2.31.0", requests.version)
+	}
+	if requests.isDev {
+		t.Error("requests (main) should not be isDev")
+	}
+	if requests.kind != "locked" {
+		t.Errorf("requests kind=%q want locked", requests.kind)
+	}
+
+	pytest := findDep(deps, "pytest")
+	if pytest == nil {
+		t.Fatal("expected pytest dep")
+	}
+	if !pytest.isDev {
+		t.Error("pytest (dev) should be isDev=true")
+	}
+}
+
+func TestParsePoetryLock_ViaExtractor(t *testing.T) {
+	src := `[[package]]
+name = "flask"
+version = "2.3.0"
+category = "main"
+
+[[package]]
+name = "black"
+version = "23.7.0"
+category = "dev"
+`
+	records := runExtract(t, "project/poetry.lock", src)
+	deps := depEntities(records)
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 dep entities, got %d", len(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "poetry" {
+			t.Errorf("package_manager=%q want poetry", d.Properties["package_manager"])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsManifest / detectPackageManager integration
+// ---------------------------------------------------------------------------
+
+func TestIsManifest_PythonLockfiles(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"project/Pipfile", true},
+		{"project/Pipfile.lock", true},
+		{"project/uv.lock", true},
+		{"project/pdm.lock", true},
+		{"project/poetry.lock", true},
+		{"project/unknown.lock", false},
+	}
+	for _, tc := range cases {
+		got := IsManifest(tc.path)
+		if got != tc.want {
+			t.Errorf("IsManifest(%q)=%v want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestDetectPackageManager_PythonLockfiles(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"Pipfile", "pipenv"},
+		{"Pipfile.lock", "pipenv"},
+		{"uv.lock", "uv"},
+		{"pdm.lock", "pdm"},
+		{"poetry.lock", "poetry"},
+	}
+	for _, tc := range cases {
+		got := detectPackageManager(tc.path)
+		if got != tc.want {
+			t.Errorf("detectPackageManager(%q)=%q want %q", tc.path, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `parsePipfile` and `parsePipfileLock` to the cross-language manifest extractor (`internal/extractors/cross/manifest/extractor.go`), handling `Pipfile` manifest deps and `Pipfile.lock` JSON locked tree
- Add `parseUvLock`, `parsePdmLock`, and `parsePoetryLock` for TOML-based Python lockfiles (`uv.lock`, `pdm.lock`, `poetry.lock`), completing `pkg.pyproject` lockfile coverage
- Dedicated test file `pylock_test.go` with 16 tests covering all parsers individually and via the extractor interface

## Cells flipped (3)

| Record | Capability | Before | After |
|---|---|---|---|
| `pkg.pipfile` | `manifest_parsing` | missing | partial |
| `pkg.pipfile` | `lockfile_parsing` | missing | partial |
| `pkg.pyproject` | `lockfile_parsing` | missing | partial |

## Verification

- `coverage validate` → 0 errors
- `coverage fmt --check` → canonical
- `coverage gen` → byte-stable (docs regenerated)
- `go build ./...` → clean
- `go test ./internal/extractors/cross/manifest/ ./tools/coverage/ ./internal/types/` → all pass

Closes #3075