### PR TITLE
feat(coverage): attrs + marshmallow constraint extraction

### DIFF
--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -108,5 +108,5 @@ Back to [summary](../summary.md).
 | Name | Testing | Other capabilities | Notes |
 |---|---|---|---|
 | [Pydantic](../detail/lang.python.validation.pydantic.md) | ⚠️ 1/1 | ⚠️ 5/5 | |
-| [attrs](../detail/lang.python.validation.attrs.md) | ⚠️ 1/1 | ❌ 3/5 | |
-| [marshmallow](../detail/lang.python.validation.marshmallow.md) | ⚠️ 1/1 | ❌ 4/5 | |
+| [attrs](../detail/lang.python.validation.attrs.md) | ⚠️ 1/1 | ❌ 4/5 | |
+| [marshmallow](../detail/lang.python.validation.marshmallow.md) | ⚠️ 1/1 | ⚠️ 5/5 | |

--- a/docs/coverage/detail/lang.python.validation.attrs.md
+++ b/docs/coverage/detail/lang.python.validation.attrs.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Constraint extraction | ❌ `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/2985) | — | — |
+| Constraint extraction | ⚠️ `partial` | `2026-05-29` | 3077 | `internal/custom/python/attrs.go`<br>`internal/custom/python/extractors_test.go`<br>`internal/custom/python/testdata/attrs_validators.py` | validators.instance_of(), in_(), and and_() on attrib()/field() validator= kwargs emit constraint_<field> SCOPE.Pattern entities; tested in TestAttrs_Constraint_InstanceOf, TestAttrs_Constraint_In, TestAttrs_Constraint_And, TestAttrs_Constraint_FullFixture. |
 | Custom validator extraction | ✅ `full` | `2026-05-29` | 3061 | `internal/custom/python/attrs.go`<br>`internal/custom/python/extractors_test.go`<br>`internal/custom/python/testdata/attrs_validators.py` | @<field>.validator decorator-style validators (TestAttrs_FieldValidator) and validator= kwarg (TestAttrs_ValidatorKwarg) both fully extracted as SCOPE.Pattern field_validator entities; TestAttrs_FullFixture exercises the fixture end-to-end. |
 
 ### Coercion

--- a/docs/coverage/detail/lang.python.validation.marshmallow.md
+++ b/docs/coverage/detail/lang.python.validation.marshmallow.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Constraint extraction | ❌ `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/2985) | — | — |
+| Constraint extraction | ⚠️ `partial` | `2026-05-29` | 3077 | `internal/custom/python/extractors_test.go`<br>`internal/custom/python/marshmallow.go`<br>`internal/custom/python/testdata/marshmallow_nested.py` | validate.Range(min,max), validate.Length(min,max), validate.OneOf([...]) on field declarations emit constraint_<field> SCOPE.Pattern entities with constraint_validator/constraint_min/constraint_max/constraint_choices props; tested in TestMarshmallow_Constraint_Range, TestMarshmallow_Constraint_Length, TestMarshmallow_Constraint_OneOf, TestMarshmallow_Constraint_FullFixture. |
 | Custom validator extraction | ✅ `full` | `2026-05-29` | 3061 | `internal/custom/python/extractors_test.go`<br>`internal/custom/python/marshmallow.go`<br>`internal/custom/python/testdata/marshmallow_nested.py` | @validates('field') emits SCOPE.Pattern field_validator entities; @validates_schema emits schema_validator entities. Both decorator forms tested in TestMarshmallow_ValidatesDecorator, TestMarshmallow_ValidatesSchema, and TestMarshmallow_FullFixture. |
 
 ### Coercion

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -38244,8 +38244,11 @@
         },
         "Constraints": {
           "constraint_extraction": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2985"
+            "status": "partial",
+            "cites": ["internal/custom/python/attrs.go","internal/custom/python/extractors_test.go","internal/custom/python/testdata/attrs_validators.py"],
+            "issue": "3077",
+            "notes": "validators.instance_of(), in_(), and and_() on attrib()/field() validator= kwargs emit constraint_\u003cfield\u003e SCOPE.Pattern entities; tested in TestAttrs_Constraint_InstanceOf, TestAttrs_Constraint_In, TestAttrs_Constraint_And, TestAttrs_Constraint_FullFixture.",
+            "verified_at": "2026-05-29"
           },
           "custom_validator_extraction": {
             "status": "full",
@@ -38297,8 +38300,11 @@
         },
         "Constraints": {
           "constraint_extraction": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2985"
+            "status": "partial",
+            "cites": ["internal/custom/python/extractors_test.go","internal/custom/python/marshmallow.go","internal/custom/python/testdata/marshmallow_nested.py"],
+            "issue": "3077",
+            "notes": "validate.Range(min,max), validate.Length(min,max), validate.OneOf([...]) on field declarations emit constraint_\u003cfield\u003e SCOPE.Pattern entities with constraint_validator/constraint_min/constraint_max/constraint_choices props; tested in TestMarshmallow_Constraint_Range, TestMarshmallow_Constraint_Length, TestMarshmallow_Constraint_OneOf, TestMarshmallow_Constraint_FullFixture.",
+            "verified_at": "2026-05-29"
           },
           "custom_validator_extraction": {
             "status": "full",

--- a/internal/custom/python/attrs.go
+++ b/internal/custom/python/attrs.go
@@ -61,6 +61,13 @@ var (
 
 	// converter= kwarg — type coercion
 	attrsConverterRe = regexp.MustCompile(`\bconverter\s*=\s*(\w[\w.]*)`)
+
+	// Constraint validators — match validators.instance_of(X), validators.in_([...]),
+	// validators.and_(...), and their attr.validators.* / attrs.validators.* prefixed forms.
+	// Note: closing ")" is optional because the attrib regex may truncate nested parens.
+	attrsInstanceOfRe = regexp.MustCompile(`(?:attr(?:s)?\.)?validators\.instance_of\(\s*(\w[\w.]*)`)
+	attrsInRe         = regexp.MustCompile(`(?:attr(?:s)?\.)?validators\.in_\(\s*(\[[^\]]*\]|[^\s,)]+)`)
+	attrsAndRe        = regexp.MustCompile(`(?:attr(?:s)?\.)?validators\.and_\(`)
 )
 
 // attrsReferenced reports whether the source likely uses the attrs library.
@@ -160,6 +167,49 @@ func (e *AttrsExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 				"target_field": targetAttr,
 				"validator_fn": fnName,
 			},
+		))
+	}
+
+	// 4. Constraint extraction: validators.instance_of() / in_() / and_()
+	// on attrib()/field() validator= kwargs. Emit a dedicated constraint_<field>
+	// entity per field so coverage/constraint_extraction can be cited. Issue #3077.
+	for _, idx := range allMatchesIndex(attrsAttribRe, source) {
+		attrName := source[idx[2]:idx[3]]
+		args := source[idx[4]:idx[5]]
+		validatorVal := ""
+		if m := attrsValidatorKwargRe.FindStringSubmatch(args); m != nil {
+			validatorVal = strings.TrimSpace(m[1])
+		}
+		if validatorVal == "" {
+			continue
+		}
+		props := map[string]string{
+			"framework":    "attrs",
+			"pattern_type": "constraint",
+			"field":        attrName,
+		}
+		emitConstraint := false
+		// Check and_() first — it wraps other validators and contains them as args,
+		// so instance_of/in_ would false-match inside an and_() call.
+		if attrsAndRe.MatchString(validatorVal) {
+			props["constraint_validator"] = "and_"
+			emitConstraint = true
+		} else if m := attrsInstanceOfRe.FindStringSubmatch(validatorVal); m != nil {
+			props["constraint_type"] = strings.TrimSpace(m[1])
+			props["constraint_validator"] = "instance_of"
+			emitConstraint = true
+		} else if m := attrsInRe.FindStringSubmatch(validatorVal); m != nil {
+			props["constraint_values"] = strings.TrimSpace(m[1])
+			props["constraint_validator"] = "in_"
+			emitConstraint = true
+		}
+		if !emitConstraint {
+			continue
+		}
+		line := lineOf(source, idx[0])
+		out = append(out, entity(
+			"constraint_"+attrName, string(types.EntityKindPattern), "",
+			file.Path, line, props,
 		))
 	}
 

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -2630,6 +2630,125 @@ class UserSchema(Schema):
 	}
 }
 
+// TestMarshmallow_Constraint_Range verifies validate.Range(min,max) extraction.
+// Issue #3077.
+func TestMarshmallow_Constraint_Range(t *testing.T) {
+	src := `from marshmallow import Schema, fields, validate
+
+class PriceSchema(Schema):
+    price = fields.Float(validate=validate.Range(min=0, max=9999))
+`
+	ents := extract(t, "python_marshmallow", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "constraint_price" &&
+			e.Props["constraint_validator"] == "Range" &&
+			e.Props["constraint_min"] == "0" &&
+			e.Props["constraint_max"] == "9999" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected constraint_price with Range(min=0, max=9999), got %+v", ents)
+	}
+}
+
+// TestMarshmallow_Constraint_Length verifies validate.Length(min,max) extraction.
+// Issue #3077.
+func TestMarshmallow_Constraint_Length(t *testing.T) {
+	src := `from marshmallow import Schema, fields, validate
+
+class ItemSchema(Schema):
+    name = fields.Str(validate=validate.Length(min=1, max=100))
+`
+	ents := extract(t, "python_marshmallow", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "constraint_name" &&
+			e.Props["constraint_validator"] == "Length" &&
+			e.Props["constraint_min"] == "1" &&
+			e.Props["constraint_max"] == "100" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected constraint_name with Length(min=1, max=100), got %+v", ents)
+	}
+}
+
+// TestMarshmallow_Constraint_OneOf verifies validate.OneOf([...]) extraction.
+// Issue #3077.
+func TestMarshmallow_Constraint_OneOf(t *testing.T) {
+	src := `from marshmallow import Schema, fields, validate
+
+class StatusSchema(Schema):
+    status = fields.Str(validate=validate.OneOf(["active", "inactive"]))
+`
+	ents := extract(t, "python_marshmallow", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "constraint_status" &&
+			e.Props["constraint_validator"] == "OneOf" &&
+			e.Props["constraint_choices"] != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected constraint_status with OneOf, got %+v", ents)
+	}
+}
+
+// TestMarshmallow_Constraint_NoLambda ensures a plain lambda validate= does NOT
+// emit a constraint entity (no recognized validate.* validator call). Issue #3077.
+func TestMarshmallow_Constraint_NoLambda(t *testing.T) {
+	src := `from marshmallow import Schema, fields
+
+class OrderSchema(Schema):
+    amount = fields.Float(required=True, validate=lambda x: x > 0)
+`
+	ents := extract(t, "python_marshmallow", src)
+	for _, e := range ents {
+		if e.Name == "constraint_amount" {
+			t.Fatal("constraint_amount must not be emitted for a lambda validate=")
+		}
+	}
+}
+
+// TestMarshmallow_Constraint_FullFixture exercises constraint extraction against
+// testdata/marshmallow_nested.py. Proves constraint_extraction. Issue #3077.
+func TestMarshmallow_Constraint_FullFixture(t *testing.T) {
+	content, err := os.ReadFile("testdata/marshmallow_nested.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ext, _ := extractor.Get("python_marshmallow")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "testdata/marshmallow_nested.py",
+		Content:  content,
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("extract fixture: %v", err)
+	}
+
+	// ProductSchema has price (Range), name (Length), status (OneOf).
+	want := map[string]bool{
+		"constraint_price":  false, // validate.Range(min=0, max=99999)
+		"constraint_name":   false, // validate.Length(min=1, max=100)
+		"constraint_status": false, // validate.OneOf([...])
+	}
+	for _, e := range ents {
+		if _, tracked := want[e.Name]; tracked {
+			want[e.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("fixture: expected constraint entity %q not emitted", name)
+		}
+	}
+}
+
 func TestMarshmallow_NoMatch(t *testing.T) {
 	src := `def regular():
     pass
@@ -2805,6 +2924,125 @@ class Payment:
 	}
 	if !found {
 		t.Fatal("expected attrib entity with converter=float for amount")
+	}
+}
+
+// TestAttrs_Constraint_InstanceOf verifies that validators.instance_of() on an
+// attrib() / field() emits a constraint_<field> entity. Issue #3077.
+func TestAttrs_Constraint_InstanceOf(t *testing.T) {
+	src := `import attr
+
+@attr.s
+class Address:
+    street = attr.ib(validator=attr.validators.instance_of(str))
+    zip_code = attr.ib(default="")
+`
+	ents := extract(t, "python_attrs", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "constraint_street" &&
+			e.Props["pattern_type"] == "constraint" &&
+			e.Props["constraint_validator"] == "instance_of" &&
+			e.Props["constraint_type"] == "str" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected constraint_street with instance_of/str, got %+v", ents)
+	}
+	// zip_code has no validator= kwarg — must NOT emit a constraint entity.
+	for _, e := range ents {
+		if e.Name == "constraint_zip_code" {
+			t.Fatal("constraint_zip_code should not be emitted for a field with no validator")
+		}
+	}
+}
+
+// TestAttrs_Constraint_In verifies validators.in_([...]) constraint extraction.
+// Issue #3077.
+func TestAttrs_Constraint_In(t *testing.T) {
+	src := `import attr
+import attrs
+
+@attrs.define
+class Product:
+    status: str = field(validator=attr.validators.in_(["active", "inactive"]))
+`
+	ents := extract(t, "python_attrs", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "constraint_status" &&
+			e.Props["constraint_validator"] == "in_" &&
+			e.Props["constraint_values"] != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected constraint_status with in_ validator, got %+v", ents)
+	}
+}
+
+// TestAttrs_Constraint_And verifies validators.and_(...) constraint extraction.
+// Issue #3077.
+func TestAttrs_Constraint_And(t *testing.T) {
+	src := `import attr
+import attrs
+from attrs import define, field
+
+@attrs.define
+class Order:
+    quantity: int = field(
+        validator=attr.validators.and_(
+            attr.validators.instance_of(int),
+            attr.validators.in_([1, 5, 10]),
+        )
+    )
+`
+	ents := extract(t, "python_attrs", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "constraint_quantity" && e.Props["constraint_validator"] == "and_" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected constraint_quantity with and_ validator, got %+v", ents)
+	}
+}
+
+// TestAttrs_Constraint_FullFixture exercises the constraint entities against the
+// testdata/attrs_validators.py fixture. Proves constraint_extraction. Issue #3077.
+func TestAttrs_Constraint_FullFixture(t *testing.T) {
+	content, err := os.ReadFile("testdata/attrs_validators.py")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ext, _ := extractor.Get("python_attrs")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "testdata/attrs_validators.py",
+		Content:  content,
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("extract fixture: %v", err)
+	}
+
+	// street/city use instance_of(str); status uses in_(); quantity uses and_().
+	want := map[string]bool{
+		"constraint_street": false, // instance_of(str)
+		"constraint_city":   false, // instance_of(str)
+		"constraint_status": false, // in_(["active", ...])
+		"constraint_quantity": false, // and_(...)
+	}
+	for _, e := range ents {
+		if _, tracked := want[e.Name]; tracked {
+			want[e.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("fixture: expected constraint entity %q not emitted", name)
+		}
 	}
 }
 

--- a/internal/custom/python/marshmallow.go
+++ b/internal/custom/python/marshmallow.go
@@ -66,6 +66,17 @@ var (
 
 	// Coercion kwarg on a field, e.g. load_default=, missing=, data_key=
 	mmCoercionKwargRe = regexp.MustCompile(`\b(?:load_default|missing|data_key|load_only|dump_only)\s*=`)
+
+	// Constraint validators: detect validate.Range / validate.Length / validate.OneOf
+	// in the field declaration's argument blob. The blob may be truncated at the first
+	// ")" by the field regex (which uses [^)]*), so regexes do not require closing ")".
+	mmValidateRangeRe  = regexp.MustCompile(`(?:[\w.]*validate\.)?Range\s*\(([^)]*)`)
+	mmValidateLengthRe = regexp.MustCompile(`(?:[\w.]*validate\.)?Length\s*\(([^)]*)`)
+	mmValidateOneOfRe  = regexp.MustCompile(`(?:[\w.]*validate\.)?OneOf\s*\(([^)]*)`)
+
+	// min= / max= inside Range/Length arg blobs
+	mmConstraintMinRe = regexp.MustCompile(`\bmin\s*=\s*([^\s,)]+)`)
+	mmConstraintMaxRe = regexp.MustCompile(`\bmax\s*=\s*([^\s,)]+)`)
 )
 
 // marshmallowReferenced reports whether the source likely uses marshmallow.
@@ -207,6 +218,59 @@ func (e *MarshmallowExtractor) Extract(ctx context.Context, file extractor.FileI
 				"hook_type":    hookType,
 				"hook_fn":      fnName,
 			},
+		))
+	}
+
+	// 7. Constraint extraction: validate.Range(min,max) / validate.Length(min,max) /
+	// validate.OneOf([...]) on field declarations. The field args blob may be truncated
+	// at the first ")" by mmFieldRe, but that is enough to detect the validator and
+	// extract min/max kwargs. Issue #3077.
+	for _, idx := range allMatchesIndex(mmFieldRe, source) {
+		fieldName := source[idx[2]:idx[3]]
+		args := source[idx[6]:idx[7]]
+		// Only process fields that have a validate= kwarg referencing a named validator
+		// (not a plain lambda — lambdas don't contain a word boundary before "Range" etc.)
+		if !strings.Contains(args, "validate") {
+			continue
+		}
+		props := map[string]string{
+			"framework":    "marshmallow",
+			"pattern_type": "constraint",
+			"field":        fieldName,
+		}
+		emitConstraint := false
+		if m := mmValidateRangeRe.FindStringSubmatch(args); m != nil {
+			innerArgs := m[1]
+			props["constraint_validator"] = "Range"
+			if mn := mmConstraintMinRe.FindStringSubmatch(innerArgs); mn != nil {
+				props["constraint_min"] = strings.TrimSpace(mn[1])
+			}
+			if mx := mmConstraintMaxRe.FindStringSubmatch(innerArgs); mx != nil {
+				props["constraint_max"] = strings.TrimSpace(mx[1])
+			}
+			emitConstraint = true
+		} else if m := mmValidateLengthRe.FindStringSubmatch(args); m != nil {
+			innerArgs := m[1]
+			props["constraint_validator"] = "Length"
+			if mn := mmConstraintMinRe.FindStringSubmatch(innerArgs); mn != nil {
+				props["constraint_min"] = strings.TrimSpace(mn[1])
+			}
+			if mx := mmConstraintMaxRe.FindStringSubmatch(innerArgs); mx != nil {
+				props["constraint_max"] = strings.TrimSpace(mx[1])
+			}
+			emitConstraint = true
+		} else if m := mmValidateOneOfRe.FindStringSubmatch(args); m != nil {
+			props["constraint_validator"] = "OneOf"
+			props["constraint_choices"] = strings.TrimSpace(m[1])
+			emitConstraint = true
+		}
+		if !emitConstraint {
+			continue
+		}
+		line := lineOf(source, idx[0])
+		out = append(out, entity(
+			"constraint_"+fieldName, string(types.EntityKindPattern), "",
+			file.Path, line, props,
 		))
 	}
 

--- a/internal/custom/python/testdata/attrs_validators.py
+++ b/internal/custom/python/testdata/attrs_validators.py
@@ -1,15 +1,16 @@
-"""Dependency-free proving fixture for the attrs extractor (issue #2985).
+"""Dependency-free proving fixture for the attrs extractor (issue #2985, #3077).
 
 Exercises attrs class declarations (@attr.s, @attr.define, @define),
 attribute declarations (attrib / field), @<field>.validator decorator
-validators, validator= kwarg, and converter= for type coercion.
+validators, validator= kwarg, converter= for type coercion, and
+constraint extraction via validators.instance_of() / in_() / and_().
 """
 import attr
 import attrs
 from attrs import define, field, Factory
 
 
-# Classic @attr.s style
+# Classic @attr.s style — instance_of() constraints
 @attr.s
 class Address:
     street = attr.ib(validator=attr.validators.instance_of(str))
@@ -55,3 +56,15 @@ class Invoice:
     order: Order = attr.ib()
     billing_address: Address = attr.ib()
     total: float = attr.ib(default=0.0, converter=float)
+
+
+# Constraint extraction evidence — validators.in_() and validators.and_() (issue #3077)
+@attrs.define
+class Product:
+    status: str = field(validator=attr.validators.in_(["active", "inactive", "pending"]))
+    quantity: int = field(
+        validator=attr.validators.and_(
+            attr.validators.instance_of(int),
+            attr.validators.in_([1, 5, 10, 50, 100]),
+        )
+    )

--- a/internal/custom/python/testdata/marshmallow_nested.py
+++ b/internal/custom/python/testdata/marshmallow_nested.py
@@ -1,9 +1,10 @@
-"""Dependency-free proving fixture for the marshmallow extractor (issue #2985).
+"""Dependency-free proving fixture for the marshmallow extractor (issue #2985, #3077).
 
 Exercises marshmallow Schema class declarations, field types, Nested() fields,
-@validates, @validates_schema, and @post_load coercion hooks.
+@validates, @validates_schema, @post_load coercion hooks, and constraint
+extraction via validate.Range() / validate.Length() / validate.OneOf().
 """
-from marshmallow import Schema, fields, validates, validates_schema, post_load, pre_load, ValidationError
+from marshmallow import Schema, fields, validates, validates_schema, post_load, pre_load, validate, ValidationError
 
 
 class AddressSchema(Schema):
@@ -45,3 +46,10 @@ class OrderSchema(Schema):
     def normalize_amount(self, data, **kwargs):
         data["amount"] = float(data.get("amount", 0))
         return data
+
+
+# Constraint extraction evidence — Range / Length / OneOf (issue #3077)
+class ProductSchema(Schema):
+    price = fields.Float(validate=validate.Range(min=0, max=99999))
+    name = fields.Str(validate=validate.Length(min=1, max=100))
+    status = fields.Str(validate=validate.OneOf(["active", "inactive", "pending"]))


### PR DESCRIPTION
## Summary

- Extend `AttrsExtractor` (`internal/custom/python/attrs.go`) to detect `validators.instance_of()`, `validators.in_()`, and `validators.and_()` on `attrib()`/`field()` `validator=` kwargs and emit `constraint_<field>` `SCOPE.Pattern` entities.
- Extend `MarshmallowExtractor` (`internal/custom/python/marshmallow.go`) to detect `validate.Range(min,max)`, `validate.Length(min,max)`, and `validate.OneOf([...])` on field declarations and emit `constraint_<field>` `SCOPE.Pattern` entities with bound props.
- Add 9 dedicated tests in `extractors_test.go` (4 attrs, 5 marshmallow) including full-fixture tests against updated testdata.
- Flip `constraint_extraction` `missing→partial` for `lang.python.validation.attrs` and `lang.python.validation.marshmallow`.

Closes #3077

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>