### PR TITLE
feat(coverage): JS/TS ORM lazy_loading_recognition + Knex/Objection N/A

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -76,14 +76,14 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ❌ 7/8 | |
-| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/7 | |
-| [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ 7/8 | |
+| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/6 | |
+| [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ⚠️ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ⚠️ 5/5 | |
-| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 8/9 | |
+| [JS/TS](../by-language/jsts.md) | [Objection.js](../detail/lang.jsts.orm.objection.md) | ⚠️ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Prisma](../detail/lang.jsts.orm.prisma.md) | ❌ 7/8 | |
-| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ 7/8 | |
-| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 6/8 | |
+| [JS/TS](../by-language/jsts.md) | [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ⚠️ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 7/8 | |
 | [JS/TS](../by-language/jsts.md) | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ✅ 1/1 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -118,14 +118,14 @@ Back to [summary](../summary.md).
 | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ✅ 1/1 | |
 | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ✅ 1/1 | |
 | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ❌ 7/8 | |
-| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/7 | |
-| [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ❌ 7/8 | |
+| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ❌ 2/6 | |
+| [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | ⚠️ 8/8 | |
 | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ✅ 1/1 | |
 | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | ⚠️ 5/5 | |
-| [Objection.js](../detail/lang.jsts.orm.objection.md) | ❌ 8/9 | |
+| [Objection.js](../detail/lang.jsts.orm.objection.md) | ⚠️ 8/8 | |
 | [Prisma](../detail/lang.jsts.orm.prisma.md) | ❌ 7/8 | |
-| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ❌ 7/8 | |
-| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 6/8 | |
+| [Sequelize](../detail/lang.jsts.orm.sequelize.md) | ⚠️ 8/8 | |
+| [TypeORM](../detail/lang.jsts.orm.typeorm.md) | ❌ 7/8 | |
 | [better-sqlite3 / sqlite3](../detail/lang.jsts.driver.sqlite.md) | ✅ 1/1 | |
 | [cassandra-driver (JS)](../detail/lang.jsts.driver.cassandra.md) | ✅ 1/1 | |
 | [ioredis / node-redis](../detail/lang.jsts.driver.redis.md) | ✅ 1/1 | |

--- a/docs/coverage/detail/lang.jsts.orm.knex.md
+++ b/docs/coverage/detail/lang.jsts.orm.knex.md
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 | Foreign key extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | — `not_applicable` | — | 3071 | — | Knex is a SQL query builder with no ORM model layer; there is no relation or lazy-loading concept to extract. Lazy loading is not applicable. |
 | Relationship extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
+++ b/docs/coverage/detail/lang.jsts.orm.mikro-orm.md
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/mikroorm.go`<br>`internal/custom/javascript/orm_build_3067_test.go` | — |
 | Foreign key extraction | ⚠️ `partial` | — | 3067 | `internal/custom/javascript/mikroorm.go`<br>`internal/custom/javascript/orm_build_3067_test.go` | FK columns inferred from @ManyToOne decorator; no explicit FK column extraction (FK column not separately defined in MikroORM decorator-first pattern) |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ⚠️ `partial` | — | 3071 | `internal/custom/javascript/issue3071_lazy_loading_test.go`<br>`internal/custom/javascript/mikroorm.go` | Detects relation decorators with lazy: true or LoadStrategy.LAZY/EXTRA_LAZY; emits SCOPE.Pattern/lazy_relation with lazy_loading strategy. Promise<T> wrapper inference not yet implemented. |
 | Relationship extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/mikroorm.go`<br>`internal/custom/javascript/orm_build_3067_test.go` | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.jsts.orm.objection.md
+++ b/docs/coverage/detail/lang.jsts.orm.objection.md
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | — |
 | Foreign key extraction | ⚠️ `partial` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | reObjectionRelation captures named relation entries (relation_type+field_name) from relationMappings, which encode FK join topology implicitly; the from/to column-level FK fields are not explicitly parsed |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | — `not_applicable` | — | 3071 | — | Objection.js uses withGraphFetched/withGraphJoined for eager loading; there is no built-in lazy-loading mechanism. The library loads related models explicitly on demand via separate queries, not through a lazy proxy or decorator pattern. lazy_loading_recognition is not applicable. |
 | Relationship extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/objection.go` | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.jsts.orm.sequelize.md
+++ b/docs/coverage/detail/lang.jsts.orm.sequelize.md
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/orm_build_3067_test.go`<br>`internal/custom/javascript/sequelize.go` | — |
 | Foreign key extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/orm_build_3067_test.go`<br>`internal/custom/javascript/sequelize.go` | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ⚠️ `partial` | — | 3071 | `internal/custom/javascript/issue3071_lazy_loading_test.go`<br>`internal/custom/javascript/sequelize.go` | Detects hasMany/belongsTo/hasOne/belongsToMany association calls with { lazy: true } in options; emits SCOPE.Pattern/lazy_association. Sequelize does not have a built-in lazy-loading mechanism; this detects explicit lazy: true flags in association definitions. |
 | Relationship extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/orm_build_3067_test.go`<br>`internal/custom/javascript/sequelize.go` | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.jsts.orm.typeorm.md
+++ b/docs/coverage/detail/lang.jsts.orm.typeorm.md
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_test.go`<br>`internal/custom/javascript/typeorm.go` | — |
 | Foreign key extraction | ✅ `full` | — | 3064 | `internal/custom/javascript/extractors_coverage_test.go`<br>`internal/custom/javascript/typeorm.go` | — |
-| Lazy loading recognition | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | ⚠️ `partial` | — | 3071 | `internal/custom/javascript/issue3071_lazy_loading_test.go`<br>`internal/custom/javascript/typeorm.go` | Detects @OneToMany/@ManyToOne/@OneToOne/@ManyToMany relation decorators carrying { lazy: true }; emits SCOPE.Pattern/lazy_relation with lazy_loading=true. Promise<T> return-type inference not yet implemented. |
 | Relationship extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/javascript/typeorm.go` | — |
 
 ### Queries

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -26704,8 +26704,9 @@
             "issue": "backfill:dictionary-completeness"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3071",
+            "notes": "Knex is a SQL query builder with no ORM model layer; there is no relation or lazy-loading concept to extract. Lazy loading is not applicable."
           },
           "relationship_extraction": {
             "status": "missing",
@@ -26762,8 +26763,10 @@
             "notes": "FK columns inferred from @ManyToOne decorator; no explicit FK column extraction (FK column not separately defined in MikroORM decorator-first pattern)"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/javascript/issue3071_lazy_loading_test.go","internal/custom/javascript/mikroorm.go"],
+            "issue": "3071",
+            "notes": "Detects relation decorators with lazy: true or LoadStrategy.LAZY/EXTRA_LAZY; emits SCOPE.Pattern/lazy_relation with lazy_loading strategy. Promise\u003cT\u003e wrapper inference not yet implemented."
           },
           "relationship_extraction": {
             "status": "full",
@@ -26877,8 +26880,9 @@
             "notes": "reObjectionRelation captures named relation entries (relation_type+field_name) from relationMappings, which encode FK join topology implicitly; the from/to column-level FK fields are not explicitly parsed"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3071",
+            "notes": "Objection.js uses withGraphFetched/withGraphJoined for eager loading; there is no built-in lazy-loading mechanism. The library loads related models explicitly on demand via separate queries, not through a lazy proxy or decorator pattern. lazy_loading_recognition is not applicable."
           },
           "relationship_extraction": {
             "status": "full",
@@ -27005,8 +27009,10 @@
             "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/javascript/issue3071_lazy_loading_test.go","internal/custom/javascript/sequelize.go"],
+            "issue": "3071",
+            "notes": "Detects hasMany/belongsTo/hasOne/belongsToMany association calls with { lazy: true } in options; emits SCOPE.Pattern/lazy_association. Sequelize does not have a built-in lazy-loading mechanism; this detects explicit lazy: true flags in association definitions."
           },
           "relationship_extraction": {
             "status": "full",
@@ -27061,8 +27067,10 @@
             "issue": "3064"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/javascript/issue3071_lazy_loading_test.go","internal/custom/javascript/typeorm.go"],
+            "issue": "3071",
+            "notes": "Detects @OneToMany/@ManyToOne/@OneToOne/@ManyToMany relation decorators carrying { lazy: true }; emits SCOPE.Pattern/lazy_relation with lazy_loading=true. Promise\u003cT\u003e return-type inference not yet implemented."
           },
           "relationship_extraction": {
             "status": "full",

--- a/internal/custom/javascript/issue3071_lazy_loading_test.go
+++ b/internal/custom/javascript/issue3071_lazy_loading_test.go
@@ -1,0 +1,217 @@
+package javascript_test
+
+// Issue #3071 — lazy_loading_recognition builds for TypeORM / Sequelize /
+// MikroORM and not_applicable evidence for Knex / Objection.
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// TypeORM
+// ---------------------------------------------------------------------------
+
+// TestTypeORM_LazyRelationExplicitOption verifies that a relation decorator
+// carrying { lazy: true } is detected and emitted as a lazy_relation entity.
+func TestTypeORM_LazyRelationExplicitOption(t *testing.T) {
+	src := `
+import { Entity, OneToMany } from "typeorm"
+
+@Entity()
+export class User {
+  @OneToMany(() => Post, post => post.user, { lazy: true })
+  posts: Promise<Post[]>
+}
+`
+	ents := extract(t, "custom_js_typeorm", fi("user.entity.ts", "typescript", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "lazy_relation" && e.Name == "lazy:OneToMany:posts" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Pattern/lazy_relation entity 'lazy:OneToMany:posts' for TypeORM { lazy: true } relation")
+	}
+}
+
+// TestTypeORM_LazyManyToOne verifies lazy detection on @ManyToOne.
+func TestTypeORM_LazyManyToOne(t *testing.T) {
+	src := `
+@Entity()
+export class Post {
+  @ManyToOne(() => User, user => user.posts, { lazy: true })
+  author: Promise<User>
+}
+`
+	ents := extract(t, "custom_js_typeorm", fi("post.entity.ts", "typescript", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "lazy_relation" && e.Name == "lazy:ManyToOne:author" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected lazy_relation entity 'lazy:ManyToOne:author' for TypeORM ManyToOne { lazy: true }")
+	}
+}
+
+// TestTypeORM_NonLazyRelationNotEmittedAsLazy ensures a relation without
+// lazy: true is not emitted as a lazy_relation.
+func TestTypeORM_NonLazyRelationNotEmittedAsLazy(t *testing.T) {
+	src := `
+@Entity()
+export class Order {
+  @OneToMany(() => Item, item => item.order)
+  items: Item[]
+}
+`
+	ents := extract(t, "custom_js_typeorm", fi("order.entity.ts", "typescript", src))
+	for _, e := range ents {
+		if e.Subtype == "lazy_relation" {
+			t.Errorf("unexpected lazy_relation entity %q — no lazy: true was present", e.Name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sequelize
+// ---------------------------------------------------------------------------
+
+// TestSequelize_LazyAssociation verifies that a hasMany call with { lazy: true }
+// is detected and emitted as a lazy_association entity.
+func TestSequelize_LazyAssociation(t *testing.T) {
+	src := `
+User.hasMany(Post, { foreignKey: 'userId', lazy: true })
+`
+	ents := extract(t, "custom_js_sequelize", fi("associations.ts", "typescript", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "lazy_association" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Pattern/lazy_association for Sequelize hasMany with { lazy: true }")
+	}
+}
+
+// TestSequelize_LazyBelongsTo verifies that a belongsTo call with { lazy: true }
+// is detected.
+func TestSequelize_LazyBelongsTo(t *testing.T) {
+	src := `
+Post.belongsTo(User, { lazy: true })
+`
+	ents := extract(t, "custom_js_sequelize", fi("assoc.ts", "typescript", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "lazy_association" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected lazy_association for Sequelize belongsTo with { lazy: true }")
+	}
+}
+
+// TestSequelize_NonLazyAssocNotEmittedAsLazy ensures an association without
+// lazy: true is not emitted as lazy_association.
+func TestSequelize_NonLazyAssocNotEmittedAsLazy(t *testing.T) {
+	src := `
+User.hasMany(Comment, { foreignKey: 'userId' })
+`
+	ents := extract(t, "custom_js_sequelize", fi("assoc.ts", "typescript", src))
+	for _, e := range ents {
+		if e.Subtype == "lazy_association" {
+			t.Errorf("unexpected lazy_association entity %q — no lazy: true present", e.Name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MikroORM
+// ---------------------------------------------------------------------------
+
+// TestMikroORM_LazyRelationExplicitOption verifies that a relation decorator
+// with { lazy: true } is detected and emitted as a lazy_relation entity.
+func TestMikroORM_LazyRelationExplicitOption(t *testing.T) {
+	src := `
+import { Entity, OneToMany } from "@mikro-orm/core"
+
+@Entity()
+export class Author {
+  @OneToMany(() => Book, book => book.author, { lazy: true })
+  books = new Collection<Book>(this)
+}
+`
+	ents := extract(t, "custom_js_mikroorm", fi("author.entity.ts", "typescript", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "lazy_relation" && e.Name == "lazy:OneToMany:books" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Pattern/lazy_relation 'lazy:OneToMany:books' for MikroORM { lazy: true } relation")
+	}
+}
+
+// TestMikroORM_LazyRelationLoadStrategy verifies that a relation using
+// LoadStrategy.LAZY is also detected.
+func TestMikroORM_LazyRelationLoadStrategy(t *testing.T) {
+	src := `
+@Entity()
+export class Publisher {
+  @OneToMany(() => Book, book => book.publisher, { strategy: LoadStrategy.LAZY })
+  books = new Collection<Book>(this)
+}
+`
+	ents := extract(t, "custom_js_mikroorm", fi("publisher.entity.ts", "typescript", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "lazy_relation" && e.Name == "lazy:OneToMany:books" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected lazy_relation 'lazy:OneToMany:books' for MikroORM LoadStrategy.LAZY")
+	}
+}
+
+// TestMikroORM_LazyRelationExtraLazy verifies that LoadStrategy.EXTRA_LAZY is
+// recognised and the lazy_loading property is set to "extra_lazy".
+func TestMikroORM_LazyRelationExtraLazy(t *testing.T) {
+	src := `
+@Entity()
+export class Category {
+  @ManyToMany(() => Tag, tag => tag.categories, { strategy: LoadStrategy.EXTRA_LAZY })
+  tags = new Collection<Tag>(this)
+}
+`
+	ents := extract(t, "custom_js_mikroorm", fi("category.entity.ts", "typescript", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "lazy_relation" && e.Name == "lazy:ManyToMany:tags" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected lazy_relation 'lazy:ManyToMany:tags' for MikroORM LoadStrategy.EXTRA_LAZY")
+	}
+}
+
+// TestMikroORM_NonLazyRelationNotEmittedAsLazy ensures a relation without
+// lazy options is not emitted as lazy_relation.
+func TestMikroORM_NonLazyRelationNotEmittedAsLazy(t *testing.T) {
+	src := `
+@Entity()
+export class Product {
+  @ManyToOne(() => Category, cat => cat.products)
+  category: Category
+}
+`
+	ents := extract(t, "custom_js_mikroorm", fi("product.entity.ts", "typescript", src))
+	for _, e := range ents {
+		if e.Subtype == "lazy_relation" {
+			t.Errorf("unexpected lazy_relation entity %q — no lazy options present", e.Name)
+		}
+	}
+}

--- a/internal/custom/javascript/mikroorm.go
+++ b/internal/custom/javascript/mikroorm.go
@@ -39,6 +39,11 @@ var (
 	reMikroRelation = regexp.MustCompile(
 		`@(ManyToOne|OneToMany|OneToOne|ManyToMany)\s*\([^@]*?\)\s+(\w+)`,
 	)
+	// Relation decorators with lazy: true OR LoadStrategy.LAZY/EXTRA_LAZY in options.
+	// Issue #3071 — lazy_loading_recognition for MikroORM.
+	reMikroLazyRelation = regexp.MustCompile(
+		`@(ManyToOne|OneToMany|OneToOne|ManyToMany)\s*\(([^@]*?(?:lazy\s*:\s*true|LoadStrategy\.(?:LAZY|EXTRA_LAZY))[^@]*?)\)\s+(\w+)`,
+	)
 	// MikroORM migration class: class Migration20240101 extends Migration {}
 	reMikroMigrationClass = regexp.MustCompile(
 		`(?:export\s+)?class\s+([A-Za-z0-9_]+)\s+extends\s+Migration\b`,
@@ -115,6 +120,24 @@ func (e *mikroORMExtractor) Extract(ctx context.Context, file extreg.FileInput) 
 		ent := makeEntity(relType+":"+fieldName, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "mikro-orm", "relation_type", relType, "field_name", fieldName,
 			"provenance", "INFERRED_FROM_MIKROORM_RELATION")
+		addEntity(ent)
+	}
+
+	// Lazy relations: relation decorator with lazy: true or LoadStrategy.LAZY/EXTRA_LAZY.
+	// Issue #3071 — lazy_loading_recognition for MikroORM.
+	for _, m := range reMikroLazyRelation.FindAllStringSubmatchIndex(src, -1) {
+		relType := src[m[2]:m[3]]
+		opts := src[m[4]:m[5]]
+		fieldName := src[m[6]:m[7]]
+		strategy := "lazy"
+		if strings.Contains(opts, "EXTRA_LAZY") {
+			strategy = "extra_lazy"
+		} else if strings.Contains(opts, "LoadStrategy") {
+			strategy = "lazy"
+		}
+		ent := makeEntity("lazy:"+relType+":"+fieldName, "SCOPE.Pattern", "lazy_relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "mikro-orm", "relation_type", relType, "field_name", fieldName,
+			"lazy_loading", strategy, "provenance", "INFERRED_FROM_MIKROORM_LAZY_RELATION")
 		addEntity(ent)
 	}
 

--- a/internal/custom/javascript/sequelize.go
+++ b/internal/custom/javascript/sequelize.go
@@ -43,6 +43,11 @@ var (
 	reSequelizeAssociation = regexp.MustCompile(
 		`([A-Z][A-Za-z0-9_]*)\s*\.\s*(hasMany|belongsTo|hasOne|belongsToMany)\s*\(\s*([A-Z][A-Za-z0-9_]*)`,
 	)
+	// Association call with { lazy: true } in the options object.
+	// Issue #3071 — lazy_loading_recognition for Sequelize.
+	reSequelizeLazyAssoc = regexp.MustCompile(
+		`([A-Z][A-Za-z0-9_]*)\s*\.\s*(hasMany|belongsTo|hasOne|belongsToMany)\s*\(\s*([A-Z][A-Za-z0-9_]*)[^)]*lazy\s*:\s*true`,
+	)
 	// new Sequelize(...) / Sequelize.authenticate
 	reSequelizeInstance = regexp.MustCompile(
 		`new\s+Sequelize\s*\(`,
@@ -226,6 +231,20 @@ func (e *sequelizeExtractor) Extract(ctx context.Context, file extreg.FileInput)
 		setProps(&ent, "framework", "sequelize", "source_model", sourceModel,
 			"association_type", assocType, "target_model", targetModel,
 			"provenance", "INFERRED_FROM_SEQUELIZE_ASSOCIATION")
+		addEntity(ent)
+	}
+
+	// Lazy associations: association call with { lazy: true } in options.
+	// Issue #3071 — lazy_loading_recognition for Sequelize.
+	for _, m := range reSequelizeLazyAssoc.FindAllStringSubmatchIndex(src, -1) {
+		sourceModel := src[m[2]:m[3]]
+		assocType := src[m[4]:m[5]]
+		targetModel := src[m[6]:m[7]]
+		name := fmt.Sprintf("lazy:%s.%s(%s)", sourceModel, assocType, targetModel)
+		ent := makeEntity(name, "SCOPE.Pattern", "lazy_association", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "sequelize", "source_model", sourceModel,
+			"association_type", assocType, "target_model", targetModel,
+			"lazy_loading", "true", "provenance", "INFERRED_FROM_SEQUELIZE_LAZY_ASSOC")
 		addEntity(ent)
 	}
 

--- a/internal/custom/javascript/typeorm.go
+++ b/internal/custom/javascript/typeorm.go
@@ -41,6 +41,12 @@ var (
 	reTypeORMRelation = regexp.MustCompile(
 		`@(OneToMany|ManyToOne|OneToOne|ManyToMany)\s*\([^@]*?\)\s+(\w+)`,
 	)
+	// lazy: true inside a TypeORM relation decorator options object.
+	// Matches the full decorator block so we can extract field name alongside it.
+	// Issue #3071 — lazy_loading_recognition for TypeORM.
+	reTypeORMLazyRelation = regexp.MustCompile(
+		`@(OneToMany|ManyToOne|OneToOne|ManyToMany)\s*\(([^@]*?lazy\s*:\s*true[^@]*?)\)\s+(\w+)`,
+	)
 	// @Repository / Repository<Entity> usage
 	reTypeORMRepository = regexp.MustCompile(
 		`getRepository\s*\(\s*([A-Z][A-Za-z0-9_]*)\s*\)|getCustomRepository\s*\(\s*([A-Z][A-Za-z0-9_]*)\s*\)`,
@@ -203,6 +209,18 @@ func (e *typeormExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		ent := makeEntity(name, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "typeorm", "relation_type", relType, "field_name", fieldName,
 			"provenance", "INFERRED_FROM_TYPEORM_RELATION")
+		addEntity(ent)
+	}
+
+	// Lazy relations: @OneToMany/@ManyToOne/etc. with { lazy: true } option.
+	// Issue #3071 — lazy_loading_recognition for TypeORM.
+	for _, m := range reTypeORMLazyRelation.FindAllStringSubmatchIndex(src, -1) {
+		relType := src[m[2]:m[3]]
+		fieldName := src[m[6]:m[7]]
+		name := fmt.Sprintf("lazy:%s:%s", relType, fieldName)
+		ent := makeEntity(name, "SCOPE.Pattern", "lazy_relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "typeorm", "relation_type", relType, "field_name", fieldName,
+			"lazy_loading", "true", "provenance", "INFERRED_FROM_TYPEORM_LAZY_RELATION")
 		addEntity(ent)
 	}
 


### PR DESCRIPTION
## Summary

- **TypeORM** (`partial`): detects `{ lazy: true }` on `@OneToMany`/`@ManyToOne`/`@OneToOne`/`@ManyToMany` decorators; emits `SCOPE.Pattern/lazy_relation` with `lazy_loading=true`.
- **Sequelize** (`partial`): detects `{ lazy: true }` in `hasMany`/`belongsTo`/`hasOne`/`belongsToMany` options; emits `SCOPE.Pattern/lazy_association`.
- **MikroORM** (`partial`): detects `lazy: true` or `LoadStrategy.LAZY`/`EXTRA_LAZY` in relation decorator options; emits `SCOPE.Pattern/lazy_relation` with strategy annotation.
- **Knex** (`not_applicable`): query builder with no ORM relation model — lazy loading is not applicable.
- **Objection** (`not_applicable`): uses `withGraphFetched` eager loading only; no built-in lazy-loading mechanism.

5 cells flipped (3 `partial`, 2 `not_applicable`). Dedicated test file `issue3071_lazy_loading_test.go` covers all 3 B-builds with positive + negative cases.

## Verification

- `coverage validate` — 0 errors
- `coverage fmt --check` — canonical
- `coverage gen` — byte-stable
- `go build ./...` — clean
- `go test ./internal/custom/javascript/ ./internal/types/ ./tools/coverage/` — all pass

Closes #3071