### PR TITLE
feat(coverage): Javalin route/handler/middleware extractor + C-flips

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -129,7 +129,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 13/13 | |
 | [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 16/16 | |
 | [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 15/16 | |
-| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ⚠️ 20/20 | ❌ 4/16 | |
+| [java](../by-language/java.md) | [Javalin](../detail/lang.java.framework.javalin.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 7/7 | |
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 16/16 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 15/16 | |
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -21,7 +21,7 @@ Back to [summary](../summary.md).
 | [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 13/13 | |
 | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 16/16 | |
 | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 15/16 | |
-| [Javalin](../detail/lang.java.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ⚠️ 20/20 | ❌ 4/16 | |
+| [Javalin](../detail/lang.java.framework.javalin.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 7/7 | |
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 16/16 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 15/16 | |
 | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |

--- a/docs/coverage/detail/lang.java.framework.javalin.md
+++ b/docs/coverage/detail/lang.java.framework.javalin.md
@@ -15,34 +15,34 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ❌ `missing` | — | — | — | — |
-| Handler attribution | ❌ `missing` | — | — | — | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ⚠️ `partial` | — | 3085 | `internal/custom/java/javalin_routes.go`<br>`internal/engine/http_endpoint_synthesis.go` | — |
+| Handler attribution | ⚠️ `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
+| Route extraction | ⚠️ `partial` | — | 3085 | `internal/custom/java/javalin_routes.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`testdata/fixtures/sources/java/javalin/App.java` | — |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | ❌ `missing` | — | — | — | — |
+| Auth coverage | ⚠️ `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ⚠️ `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
+| Request validation | ⚠️ `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | — | 3085 | `internal/custom/java/javalin_routes.go` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | — | 3085 | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/junit5.go` | — |
 
 ### Type System
 
@@ -57,25 +57,25 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | 3085 | — | Javalin is a micro-framework with no built-in DI container; dependency injection is not part of the framework and must be provided externally (e.g. Guice, Koin). DI binding is therefore not_applicable for lang.java.framework.javalin. |
+| DI injection point | — `not_applicable` | — | 3085 | — | Javalin has no built-in DI container; @Inject is not a Javalin concept. DI injection points are not_applicable. |
+| DI scope resolution | — `not_applicable` | — | 3085 | — | Javalin has no DI scopes (@Singleton, @RequestScoped, etc.); scope resolution is not_applicable. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | 3085 | — | Javalin is a micro HTTP framework with no built-in transaction management. @Transactional is a Spring/JTA concept; transaction boundary extraction is not_applicable for Javalin. |
+| Transaction propagation | — `not_applicable` | — | 3085 | — | Javalin has no transaction propagation model; not_applicable. |
+| Transaction rollback rules | — `not_applicable` | — | 3085 | — | Javalin has no transaction rollback rules; not_applicable. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | 3085 | — | Javalin has no AOP support; @Aspect / @Before / @Around are Spring/AspectJ concepts not present in Javalin. Advice attribution is not_applicable. |
+| Aspect extraction | — `not_applicable` | — | 3085 | — | Javalin has no AOP aspect system; aspect extraction is not_applicable. |
+| Pointcut resolution | — `not_applicable` | — | 3085 | — | Javalin has no AOP pointcut system; pointcut resolution is not_applicable. |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15535,40 +15535,52 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "3085"
           },
           "handler_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go"],
+            "issue": "3085"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go","internal/engine/http_endpoint_synthesis.go","testdata/fixtures/sources/java/javalin/App.java"],
+            "issue": "3085"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go"],
+            "issue": "3085"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go"],
+            "issue": "3085"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go"],
+            "issue": "3085"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go"],
+            "issue": "3085"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go","internal/custom/java/junit5.go"],
+            "issue": "3085"
           }
         },
         "Type System": {
@@ -15594,44 +15606,53 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin is a micro-framework with no built-in DI container; dependency injection is not part of the framework and must be provided externally (e.g. Guice, Koin). DI binding is therefore not_applicable for lang.java.framework.javalin."
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin has no built-in DI container; @Inject is not a Javalin concept. DI injection points are not_applicable."
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin has no DI scopes (@Singleton, @RequestScoped, etc.); scope resolution is not_applicable."
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin is a micro HTTP framework with no built-in transaction management. @Transactional is a Spring/JTA concept; transaction boundary extraction is not_applicable for Javalin."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin has no transaction propagation model; not_applicable."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin has no transaction rollback rules; not_applicable."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin has no AOP support; @Aspect / @Before / @Around are Spring/AspectJ concepts not present in Javalin. Advice attribution is not_applicable."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin has no AOP aspect system; aspect extraction is not_applicable."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "3085",
+            "notes": "Javalin has no AOP pointcut system; pointcut resolution is not_applicable."
           }
         },
         "Observability": {

--- a/internal/custom/java/javalin_routes.go
+++ b/internal/custom/java/javalin_routes.go
@@ -1,0 +1,346 @@
+package java
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Javalin custom extractor — route extraction, handler attribution, middleware,
+// DTO, auth, and tests.
+//
+// Javalin is a lightweight Java/Kotlin web framework that uses a lambda DSL for
+// routing: `app.get("/path", ctx -> { ... })` — there are no annotations or
+// resource classes. The framework has no built-in DI, AOP, or transaction
+// management (DI/AOP/tx cells are not_applicable for Javalin).
+//
+// Coverage cells delivered (#3085):
+//   - Routing:    route_extraction, endpoint_synthesis, handler_attribution → partial
+//   - Auth:       auth_coverage                                              → partial
+//   - Validation: dto_extraction, request_validation                        → partial
+//   - Middleware: middleware_coverage                                        → partial
+//   - Testing:    tests_linkage                                              → partial
+//   - DI:         di_binding_extraction, di_injection_point, di_scope_resolution → not_applicable
+//   - AOP:        advice_attribution, aspect_extraction, pointcut_resolution     → not_applicable
+//   - Transactions: transaction_boundary_extraction, transaction_propagation,
+//                   transaction_rollback_rules                                   → not_applicable
+
+// javalinFrameworks is the set of framework identifiers that activate the
+// Javalin extractor.
+var javalinFrameworks = map[string]bool{
+	"javalin": true,
+}
+
+var (
+	// Route registration: app.get("/path", handler) — captures verb and path.
+	// Also matches app.get("/path", ctx -> ...) inline lambda and
+	// app.get("/path", new HandlerClass()) reference forms.
+	javalinRouteRE = regexp.MustCompile(
+		`(?m)\bapp\s*\.\s*(get|post|put|delete|patch|head|options|before|after)\s*\(\s*"([^"]+)"`)
+
+	// Handler attribution: captures the lambda parameter or method reference
+	// after the path. Matches three forms:
+	//   1. Lambda:    ctx ->
+	//   2. Method ref: ClassName::method or this::method
+	//   3. new Handler(): new ClassName()
+	javalinHandlerRE = regexp.MustCompile(
+		`(?m)\bapp\s*\.\s*(?:get|post|put|delete|patch|head|options)\s*\(\s*"[^"]+"\s*,\s*` +
+			`(?:` +
+			`(\w+)\s*->` + // lambda param
+			`|(\w+)::(\w+)` + // method reference
+			`|new\s+(\w+)\s*\(` + // new Handler()
+			`)`)
+
+	// Middleware: app.before() and app.after() with no path (global middleware)
+	// and app.before("/path", handler) (path-scoped middleware).
+	javalinBeforeAfterRE = regexp.MustCompile(
+		`(?m)\bapp\s*\.\s*(before|after)\s*\(`)
+
+	// DTO extraction: ctx.bodyAsClass(MyDto.class) — captures the DTO class name.
+	javalinBodyAsClassRE = regexp.MustCompile(
+		`\bctx\s*\.\s*bodyAsClass\s*\(\s*(\w+)\s*\.class\s*\)`)
+
+	// Request validation: ctx.bodyValidator(MyDto.class) form.
+	javalinBodyValidatorRE = regexp.MustCompile(
+		`\bctx\s*\.\s*bodyValidator\s*\(\s*(\w+)\s*\.class\s*\)`)
+
+	// Auth: common Javalin auth guard patterns:
+	//   1. JavalinJWT.getTokenPayload / decodeToken usage
+	//   2. ctx.attribute("user") checks in before handlers
+	//   3. accessManager callback (app.accessManager / AccessManager implementation)
+	//   4. ctx.basicAuthCredentials() / ctx.cookieStore()
+	javalinAuthGuardRE = regexp.MustCompile(
+		`(?:JavalinJWT\s*\.|` +
+			`ctx\s*\.\s*attribute\s*\(\s*"(?:user|principal|token|auth|jwt|session)"\s*\)|` +
+			`ctx\s*\.\s*(?:basicAuthCredentials|header\s*\(\s*"Authorization")` +
+			`)`)
+
+	// Access manager: app.accessManager(...) or config.accessManager(...)
+	// Javalin v4 uses app.accessManager; v5 uses config.accessManager inside create().
+	javalinAccessManagerRE = regexp.MustCompile(
+		`(?m)\b(?:app|config)\s*\.\s*accessManager\s*\(`)
+
+	// Tests: JavalinTest.create / JavalinTest.test / TestUtil.test —
+	// Javalin's test utility setup detection. Both create (v4) and test (v5) forms.
+	javalinTestRE = regexp.MustCompile(
+		`\bJavalinTest\s*\.\s*(?:create|test)\b|\bTestUtil\s*\.\s*test\b`)
+
+	// Tests: @Test methods in Javalin test classes (reuse junit5 if available,
+	// but we also match directly for tests_linkage evidence).
+	javalinTestMethodRE = regexp.MustCompile(
+		`(?s)@Test\b(?:\s*\([^)]*\))?` +
+			`(?:\s*@\w+(?:\s*\([^)]*\))?\s*)*\s*(?:public\s+|protected\s+|private\s+)?(?:\w+\s+)*` +
+			`void\s+(\w+)\s*\(`)
+)
+
+// ExtractJavalin runs the Javalin extractor for route, middleware, DTO, auth,
+// and test-linkage patterns.
+func ExtractJavalin(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !javalinFrameworks[ctx.Framework] {
+		return result
+	}
+
+	// Quick-exit: no Javalin signals in this file.
+	if !strings.Contains(ctx.Source, "javalin") && !strings.Contains(ctx.Source, "Javalin") {
+		return result
+	}
+
+	seen := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// ---------------------------------------------------------------------------
+	// Route extraction + handler attribution
+	// ---------------------------------------------------------------------------
+	for _, idx := range javalinRouteRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 6 {
+			continue
+		}
+		rawVerb := ctx.Source[idx[2]:idx[3]]
+		rawPath := ctx.Source[idx[4]:idx[5]]
+
+		// before/after are middleware — handled separately below.
+		if rawVerb == "before" || rawVerb == "after" {
+			continue
+		}
+
+		verb := strings.ToUpper(rawVerb)
+		ref := fmt.Sprintf("javalin:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
+
+		e := SecondaryEntity{
+			Name:       rawPath,
+			Kind:       "Route",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_JAVALIN_ROUTE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"http_verb":  verb,
+				"path":       rawPath,
+				"framework":  "javalin",
+				"route_type": "lambda_dsl",
+			},
+		}
+		addEntity(&result, seen, e)
+
+		// Handler attribution: look for the handler expression after the path.
+		// Scan the line containing this route for a handler pattern.
+		lineStart := idx[0]
+		lineEnd := strings.Index(ctx.Source[lineStart:], "\n")
+		if lineEnd < 0 {
+			lineEnd = len(ctx.Source) - lineStart
+		}
+		lineContent := ctx.Source[lineStart : lineStart+lineEnd]
+
+		var handlerName string
+		if m := javalinHandlerRE.FindStringSubmatch(lineContent); len(m) >= 2 {
+			switch {
+			case m[1] != "": // lambda param
+				handlerName = m[1]
+			case m[2] != "" && m[3] != "": // method ref
+				handlerName = m[2] + "::" + m[3]
+			case m[4] != "": // new Handler()
+				handlerName = m[4]
+			}
+		}
+
+		if handlerName != "" {
+			handlerRef := fmt.Sprintf("javalin:handler:%s:%s", handlerName, ctx.FilePath)
+			handler := SecondaryEntity{
+				Name:       handlerName,
+				Kind:       "Handler",
+				SourceFile: ctx.FilePath,
+				LineStart:  lineOf(ctx.Source, idx[0]),
+				Provenance: "INFERRED_FROM_JAVALIN_HANDLER",
+				Ref:        handlerRef,
+				Properties: map[string]any{
+					"framework":    "javalin",
+					"handler_type": "lambda",
+					"http_verb":    verb,
+					"path":         rawPath,
+				},
+			}
+			addEntity(&result, seen, handler)
+			addRel(&result, seenRels, Relationship{
+				SourceRef:        ref,
+				TargetRef:        handlerRef,
+				RelationshipType: "HANDLED_BY",
+				Properties:       map[string]string{"framework": "javalin"},
+			})
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Middleware: app.before() and app.after() handlers
+	// ---------------------------------------------------------------------------
+	for _, idx := range javalinBeforeAfterRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		handlerType := ctx.Source[idx[2]:idx[3]] // "before" or "after"
+		ref := fmt.Sprintf("javalin:middleware:%s:%d:%s", handlerType, lineOf(ctx.Source, idx[0]), ctx.FilePath)
+
+		e := SecondaryEntity{
+			Name:       handlerType + "_handler",
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_JAVALIN_MIDDLEWARE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "javalin",
+				"middleware_type": handlerType,
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Auth: access manager + auth guard patterns in before handlers
+	// ---------------------------------------------------------------------------
+	if javalinAccessManagerRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("javalin:auth:access_manager:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "accessManager",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, javalinAccessManagerRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_JAVALIN_ACCESS_MANAGER",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":   "javalin",
+				"auth_type":   "access_manager",
+				"auth_hook":   "app.accessManager",
+				"description": "Javalin AccessManager interface — centralized role-based auth hook",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if javalinAuthGuardRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("javalin:auth:guard:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "auth_guard",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, javalinAuthGuardRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_JAVALIN_AUTH_GUARD",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "javalin",
+				"auth_type": "inline_guard",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// DTO extraction: ctx.bodyAsClass(MyDto.class)
+	// ---------------------------------------------------------------------------
+	for _, m := range javalinBodyAsClassRE.FindAllStringSubmatch(ctx.Source, -1) {
+		if len(m) < 2 || primitiveTypes[m[1]] {
+			continue
+		}
+		dtoName := m[1]
+		ref := fmt.Sprintf("javalin:dto:%s:%s", dtoName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       dtoName,
+			Kind:       "Schema",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strings.Index(ctx.Source, m[0])),
+			Provenance: "INFERRED_FROM_JAVALIN_DTO",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "javalin",
+				"dto_source": "ctx.bodyAsClass",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// Request validation: ctx.bodyValidator(MyDto.class)
+	for _, m := range javalinBodyValidatorRE.FindAllStringSubmatch(ctx.Source, -1) {
+		if len(m) < 2 || primitiveTypes[m[1]] {
+			continue
+		}
+		dtoName := m[1]
+		ref := fmt.Sprintf("javalin:validation:%s:%s", dtoName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       dtoName,
+			Kind:       "Schema",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strings.Index(ctx.Source, m[0])),
+			Provenance: "INFERRED_FROM_JAVALIN_VALIDATION",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":        "javalin",
+				"dto_source":       "ctx.bodyValidator",
+				"request_validated": true,
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests: JavalinTest.create / TestUtil.test + @Test methods
+	// ---------------------------------------------------------------------------
+	if javalinTestRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("javalin:test_setup:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "JavalinTest",
+			Kind:       "TestSetup",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, javalinTestRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_JAVALIN_TEST_SETUP",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "javalin",
+				"test_setup": "JavalinTest.create",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	for _, idx := range javalinTestMethodRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		methodName := ctx.Source[idx[2]:idx[3]]
+		ref := fmt.Sprintf("javalin:test:%s:%s", methodName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       methodName,
+			Kind:       "TestCase",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_JAVALIN_TEST_METHOD",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "javalin",
+				"test_annotation": "Test",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	return result
+}

--- a/internal/custom/java/javalin_routes_test.go
+++ b/internal/custom/java/javalin_routes_test.go
@@ -1,0 +1,908 @@
+package java
+
+import (
+	"strings"
+	"testing"
+)
+
+// ============================================================================
+// Issue #3085: Javalin route/handler/middleware/DTO extractor
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Routing: route_extraction + endpoint_synthesis + handler_attribution
+// ----------------------------------------------------------------------------
+
+// TestJavalin_RouteExtraction_Issue3085 proves that basic app.get/post/put/
+// delete routes are extracted from a Javalin lambda DSL app.
+// Registry target: lang.java.framework.javalin Routing/route_extraction → partial.
+// Cite: internal/custom/java/javalin_routes.go
+func TestJavalin_RouteExtraction_Issue3085(t *testing.T) {
+	source := `
+package com.example;
+
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+
+        app.get("/users", ctx -> {
+            ctx.json(userService.findAll());
+        });
+
+        app.post("/users", ctx -> {
+            var user = ctx.bodyAsClass(UserRequest.class);
+            userService.create(user);
+            ctx.status(201);
+        });
+
+        app.get("/users/{id}", ctx -> {
+            var id = ctx.pathParam("id");
+            ctx.json(userService.findById(id));
+        });
+
+        app.put("/users/{id}", ctx -> {
+            var user = ctx.bodyAsClass(UserRequest.class);
+            userService.update(ctx.pathParam("id"), user);
+        });
+
+        app.delete("/users/{id}", ctx -> {
+            userService.delete(ctx.pathParam("id"));
+            ctx.status(204);
+        });
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_ROUTE" {
+			key := e.Properties["http_verb"].(string) + ":" + e.Properties["path"].(string)
+			routes[key] = true
+		}
+	}
+
+	for _, want := range []string{
+		"GET:/users",
+		"POST:/users",
+		"GET:/users/{id}",
+		"PUT:/users/{id}",
+		"DELETE:/users/{id}",
+	} {
+		if !routes[want] {
+			t.Errorf("[#3085 route_extraction] expected route %q, got %v", want, routes)
+		}
+	}
+}
+
+// TestJavalin_HandlerAttribution_LambdaParam_Issue3085 proves that the lambda
+// parameter name is captured as the handler for route attribution.
+// Registry target: lang.java.framework.javalin Routing/handler_attribution → partial.
+// Cite: internal/custom/java/javalin_routes.go
+func TestJavalin_HandlerAttribution_LambdaParam_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.get("/orders", ctx -> ctx.json(orders));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_HANDLER" {
+			found = true
+			if e.Properties["framework"] != "javalin" {
+				t.Errorf("[#3085 handler_attribution] expected framework=javalin, got %v", e.Properties["framework"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3085 handler_attribution] expected INFERRED_FROM_JAVALIN_HANDLER entity")
+	}
+}
+
+// TestJavalin_HandlerAttribution_MethodRef_Issue3085 proves that method
+// references (ClassName::method) are extracted as handler attributions.
+func TestJavalin_HandlerAttribution_MethodRef_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.get("/users", UserController::getAll);
+        app.post("/users", UserController::create);
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	handlerNames := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_HANDLER" {
+			handlerNames[e.Name] = true
+		}
+	}
+	if !handlerNames["UserController::getAll"] {
+		t.Errorf("[#3085 handler_attribution] expected UserController::getAll handler, got %v", handlerNames)
+	}
+	if !handlerNames["UserController::create"] {
+		t.Errorf("[#3085 handler_attribution] expected UserController::create handler, got %v", handlerNames)
+	}
+}
+
+// TestJavalin_RouteExtraction_Gating_Issue3085 confirms the extractor does not
+// fire for non-javalin frameworks.
+func TestJavalin_RouteExtraction_Gating_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.get("/users", ctx -> ctx.json(users));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot",
+		FilePath: "App.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3085 gating] expected 0 entities for framework=spring_boot, got %d", len(r.Entities))
+	}
+}
+
+// TestJavalin_RouteExtraction_NoSignalGating_Issue3085 confirms the extractor
+// no-ops on Java files with no Javalin signal.
+func TestJavalin_RouteExtraction_NoSignalGating_Issue3085(t *testing.T) {
+	source := `
+public class OrderService {
+    public Order findById(long id) { return null; }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source: source, Language: "java", Framework: "javalin",
+		FilePath: "OrderService.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3085 no-signal-gating] expected 0 entities for file without Javalin signal, got %d", len(r.Entities))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Middleware: middleware_coverage — before/after handlers
+// ----------------------------------------------------------------------------
+
+// TestJavalin_Middleware_Before_Issue3085 proves that app.before() global
+// middleware handlers are extracted.
+// Registry target: lang.java.framework.javalin Middleware/middleware_coverage → partial.
+// Cite: internal/custom/java/javalin_routes.go
+func TestJavalin_Middleware_Before_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+
+        // Global before handler — runs before every request
+        app.before(ctx -> {
+            ctx.header("X-Request-Id", java.util.UUID.randomUUID().toString());
+        });
+
+        // Path-scoped before handler
+        app.before("/api/*", ctx -> {
+            String token = ctx.header("Authorization");
+            if (token == null) ctx.status(401).result("Unauthorized");
+        });
+
+        app.get("/users", ctx -> ctx.json(users));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	beforeCount := 0
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_MIDDLEWARE" {
+			middlewareType, _ := e.Properties["middleware_type"].(string)
+			if middlewareType == "before" {
+				beforeCount++
+			}
+		}
+	}
+	if beforeCount < 2 {
+		t.Errorf("[#3085 middleware_coverage] expected >= 2 'before' middleware entities, got %d", beforeCount)
+	}
+}
+
+// TestJavalin_Middleware_After_Issue3085 proves that app.after() middleware
+// handlers are extracted.
+func TestJavalin_Middleware_After_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.after(ctx -> {
+            // log response
+        });
+        app.get("/ping", ctx -> ctx.result("pong"));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_MIDDLEWARE" {
+			if t2, _ := e.Properties["middleware_type"].(string); t2 == "after" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3085 middleware_coverage] expected INFERRED_FROM_JAVALIN_MIDDLEWARE entity with middleware_type=after")
+	}
+}
+
+// TestJavalin_Middleware_FrameworkProperty_Issue3085 confirms that middleware
+// entities carry framework=javalin.
+func TestJavalin_Middleware_FrameworkProperty_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.before(ctx -> { /* noop */ });
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_MIDDLEWARE" {
+			if e.Properties["framework"] != "javalin" {
+				t.Errorf("[#3085 middleware] expected framework=javalin, got %v", e.Properties["framework"])
+			}
+			return
+		}
+	}
+	t.Errorf("[#3085 middleware] expected at least one INFERRED_FROM_JAVALIN_MIDDLEWARE entity")
+}
+
+// ----------------------------------------------------------------------------
+// Auth: auth_coverage — AccessManager + inline auth guard
+// ----------------------------------------------------------------------------
+
+// TestJavalin_Auth_AccessManager_Issue3085 proves that app.accessManager(...)
+// is extracted as auth_coverage evidence.
+// Registry target: lang.java.framework.javalin Auth/auth_coverage → partial.
+// Cite: internal/custom/java/javalin_routes.go
+func TestJavalin_Auth_AccessManager_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+import io.javalin.security.AccessManager;
+import io.javalin.security.RouteRole;
+
+public class App {
+
+    enum Role implements RouteRole { ADMIN, USER, ANYONE }
+
+    public static void main(String[] args) {
+        var app = Javalin.create(config -> {
+            config.accessManager((handler, ctx, permittedRoles) -> {
+                var userRole = getUserRole(ctx);
+                if (permittedRoles.contains(userRole)) {
+                    handler.handle(ctx);
+                } else {
+                    ctx.status(401).result("Unauthorized");
+                }
+            });
+        }).start(7070);
+
+        app.get("/admin", ctx -> ctx.result("admin"), Role.ADMIN);
+        app.get("/profile", ctx -> ctx.result("profile"), Role.USER);
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_ACCESS_MANAGER" {
+			found = true
+			if e.Properties["auth_type"] != "access_manager" {
+				t.Errorf("[#3085 auth_coverage] expected auth_type=access_manager, got %v", e.Properties["auth_type"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3085 auth_coverage] expected INFERRED_FROM_JAVALIN_ACCESS_MANAGER entity")
+	}
+}
+
+// TestJavalin_Auth_InlineGuard_Issue3085 proves that inline auth guard patterns
+// (Authorization header checks in before handlers) are captured.
+func TestJavalin_Auth_InlineGuard_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.before("/api/*", ctx -> {
+            String token = ctx.header("Authorization");
+            if (token == null || !isValid(token)) {
+                ctx.status(401).result("Unauthorized");
+            }
+        });
+        app.get("/api/users", ctx -> ctx.json(users));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_AUTH_GUARD" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("[#3085 auth_coverage] expected INFERRED_FROM_JAVALIN_AUTH_GUARD entity for Authorization header check")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Validation: dto_extraction + request_validation
+// ----------------------------------------------------------------------------
+
+// TestJavalin_DTO_BodyAsClass_Issue3085 proves that ctx.bodyAsClass(MyDto.class)
+// is extracted as DTO evidence.
+// Registry target: lang.java.framework.javalin Validation/dto_extraction → partial.
+// Cite: internal/custom/java/javalin_routes.go
+func TestJavalin_DTO_BodyAsClass_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+import com.example.dto.CreateUserRequest;
+import com.example.dto.UpdateOrderRequest;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+
+        app.post("/users", ctx -> {
+            var body = ctx.bodyAsClass(CreateUserRequest.class);
+            userService.create(body);
+            ctx.status(201);
+        });
+
+        app.put("/orders/{id}", ctx -> {
+            var req = ctx.bodyAsClass(UpdateOrderRequest.class);
+            orderService.update(ctx.pathParam("id"), req);
+        });
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	dtoNames := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_DTO" {
+			dtoNames[e.Name] = true
+		}
+	}
+	if !dtoNames["CreateUserRequest"] {
+		t.Errorf("[#3085 dto_extraction] expected CreateUserRequest DTO entity, got %v", dtoNames)
+	}
+	if !dtoNames["UpdateOrderRequest"] {
+		t.Errorf("[#3085 dto_extraction] expected UpdateOrderRequest DTO entity, got %v", dtoNames)
+	}
+}
+
+// TestJavalin_RequestValidation_BodyValidator_Issue3085 proves that
+// ctx.bodyValidator(MyDto.class) is extracted as request_validation evidence.
+// Registry target: lang.java.framework.javalin Validation/request_validation → partial.
+// Cite: internal/custom/java/javalin_routes.go
+func TestJavalin_RequestValidation_BodyValidator_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+import com.example.dto.CreateProductRequest;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+
+        app.post("/products", ctx -> {
+            CreateProductRequest req = ctx.bodyValidator(CreateProductRequest.class)
+                .check(it -> it.getName() != null, "Name is required")
+                .check(it -> it.getPrice() > 0, "Price must be positive")
+                .get();
+            productService.create(req);
+            ctx.status(201);
+        });
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_VALIDATION" && e.Name == "CreateProductRequest" {
+			found = true
+			if e.Properties["request_validated"] != true {
+				t.Errorf("[#3085 request_validation] expected request_validated=true, got %v", e.Properties["request_validated"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3085 request_validation] expected INFERRED_FROM_JAVALIN_VALIDATION entity for CreateProductRequest")
+	}
+}
+
+// TestJavalin_DTO_PrimitiveSkip_Issue3085 confirms that primitive/framework
+// types are not extracted as DTOs.
+func TestJavalin_DTO_PrimitiveSkip_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.post("/echo", ctx -> {
+            String body = ctx.bodyAsClass(String.class);
+            ctx.result(body);
+        });
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_DTO" && e.Name == "String" {
+			t.Errorf("[#3085 dto_extraction] String is a primitive type and should not be extracted as DTO")
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests: tests_linkage — JavalinTest.create + @Test methods
+// ----------------------------------------------------------------------------
+
+// TestJavalin_TestsLinkage_JavalinTest_Issue3085 proves that JavalinTest.create
+// is detected as test-infrastructure evidence.
+// Registry target: lang.java.framework.javalin Testing/tests_linkage → partial.
+// Cite: internal/custom/java/javalin_routes.go
+func TestJavalin_TestsLinkage_JavalinTest_Issue3085(t *testing.T) {
+	source := `
+package com.example;
+
+import io.javalin.Javalin;
+import io.javalin.testtools.JavalinTest;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserControllerTest {
+
+    Javalin app = App.createApp();
+
+    @Test
+    void getUsers_returns200() {
+        JavalinTest.test(app, (server, client) -> {
+            assertThat(client.get("/users").code()).isEqualTo(200);
+        });
+    }
+
+    @Test
+    void createUser_returns201() {
+        JavalinTest.test(app, (server, client) -> {
+            assertThat(client.post("/users").code()).isEqualTo(201);
+        });
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "UserControllerTest.java",
+	})
+
+	foundSetup := false
+	testCount := 0
+	for _, e := range r.Entities {
+		switch e.Provenance {
+		case "INFERRED_FROM_JAVALIN_TEST_SETUP":
+			foundSetup = true
+		case "INFERRED_FROM_JAVALIN_TEST_METHOD":
+			testCount++
+		}
+	}
+	if !foundSetup {
+		t.Errorf("[#3085 tests_linkage] expected INFERRED_FROM_JAVALIN_TEST_SETUP entity")
+	}
+	if testCount < 2 {
+		t.Errorf("[#3085 tests_linkage] expected >= 2 @Test method entities, got %d", testCount)
+	}
+}
+
+// TestJavalin_TestsLinkage_JUnit5_Issue3085 proves that ExtractJUnit5 runs
+// for the "javalin" framework (javalin is in junit5Frameworks).
+// Registry target: lang.java.framework.javalin Testing/tests_linkage → partial.
+// Cite: internal/custom/java/junit5.go
+func TestJavalin_TestsLinkage_JUnit5_Issue3085(t *testing.T) {
+	source := `
+import org.junit.jupiter.api.Test;
+import io.javalin.Javalin;
+
+class AppTest {
+    @Test
+    void ping() {}
+
+    @Test
+    void healthCheck() {}
+}
+`
+	r := ExtractJUnit5(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "AppTest.java",
+	})
+	if len(r.Entities) == 0 {
+		t.Errorf("[#3085 tests_linkage] expected JUnit5 entities for framework=javalin, got none")
+	}
+	testCount := 0
+	for _, e := range r.Entities {
+		if e.Properties["test_annotation"] == "Test" {
+			testCount++
+		}
+	}
+	if testCount < 2 {
+		t.Errorf("[#3085 tests_linkage] expected >= 2 @Test entities for javalin, got %d", testCount)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Comprehensive: full Javalin app
+// ----------------------------------------------------------------------------
+
+// TestJavalin_FullApp_Issue3085 verifies a realistic Javalin app with routes,
+// middleware, auth, and DTOs all extracted correctly.
+// This is the comprehensive proving test that justifies partial status for all
+// 8 B cells.
+func TestJavalin_FullApp_Issue3085(t *testing.T) {
+	source := `
+package com.example;
+
+import io.javalin.Javalin;
+import io.javalin.security.AccessManager;
+import io.javalin.security.RouteRole;
+import com.example.dto.CreateUserRequest;
+import com.example.dto.UserResponse;
+
+public class App {
+
+    enum Role implements RouteRole { ADMIN, USER, ANYONE }
+
+    public static Javalin createApp() {
+        return Javalin.create(config -> {
+            config.accessManager((handler, ctx, permittedRoles) -> {
+                if (permittedRoles.contains(Role.ANYONE)) {
+                    handler.handle(ctx);
+                } else {
+                    var user = ctx.attribute("user");
+                    if (user == null) ctx.status(401).result("Unauthorized");
+                    else handler.handle(ctx);
+                }
+            });
+        });
+    }
+
+    public static void main(String[] args) {
+        var app = createApp().start(7070);
+
+        // Global request logger
+        app.before(ctx -> {
+            System.out.println(ctx.method() + " " + ctx.path());
+        });
+
+        // Response time header
+        app.after(ctx -> {
+            ctx.header("X-Response-Time", "...");
+        });
+
+        // Public routes
+        app.get("/health", ctx -> ctx.result("UP"), Role.ANYONE);
+
+        // Auth-required routes
+        app.get("/users", ctx -> {
+            ctx.json(userService.findAll());
+        }, Role.USER);
+
+        app.post("/users", ctx -> {
+            var req = ctx.bodyAsClass(CreateUserRequest.class);
+            var created = userService.create(req);
+            ctx.status(201).json(created);
+        }, Role.USER);
+
+        app.get("/users/{id}", ctx -> {
+            ctx.json(userService.findById(ctx.pathParam("id")));
+        }, Role.USER);
+
+        app.put("/users/{id}", ctx -> {
+            var req = ctx.bodyValidator(CreateUserRequest.class)
+                .check(it -> it.getName() != null, "Name required")
+                .get();
+            userService.update(ctx.pathParam("id"), req);
+        }, Role.USER);
+
+        app.delete("/users/{id}", ctx -> {
+            userService.delete(ctx.pathParam("id"));
+            ctx.status(204);
+        }, Role.ADMIN);
+
+        // 404 handler
+        app.error(404, ctx -> ctx.result("Not found"));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	// Validate routes
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_ROUTE" {
+			key := e.Properties["http_verb"].(string) + ":" + e.Properties["path"].(string)
+			routes[key] = true
+		}
+	}
+	for _, want := range []string{
+		"GET:/health",
+		"GET:/users",
+		"POST:/users",
+		"GET:/users/{id}",
+		"PUT:/users/{id}",
+		"DELETE:/users/{id}",
+	} {
+		if !routes[want] {
+			t.Errorf("[#3085 full-app] expected route %q, got %v", want, routes)
+		}
+	}
+
+	// Validate middleware
+	middlewareCount := 0
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_MIDDLEWARE" {
+			middlewareCount++
+		}
+	}
+	if middlewareCount < 2 {
+		t.Errorf("[#3085 full-app] expected >= 2 middleware entities (before+after), got %d", middlewareCount)
+	}
+
+	// Validate auth
+	foundAuth := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_ACCESS_MANAGER" {
+			foundAuth = true
+		}
+	}
+	if !foundAuth {
+		t.Errorf("[#3085 full-app] expected INFERRED_FROM_JAVALIN_ACCESS_MANAGER entity")
+	}
+
+	// Validate DTOs
+	dtoNames := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_DTO" || e.Provenance == "INFERRED_FROM_JAVALIN_VALIDATION" {
+			dtoNames[e.Name] = true
+		}
+	}
+	if !dtoNames["CreateUserRequest"] {
+		t.Errorf("[#3085 full-app] expected CreateUserRequest DTO, got %v", dtoNames)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// AOP: not_applicable — Javalin has no AOP support
+// ----------------------------------------------------------------------------
+
+// TestJavalin_AOP_NotApplicable_Issue3085 confirms that Javalin does not have
+// AOP (advice_attribution, aspect_extraction, pointcut_resolution are
+// not_applicable). This test documents the negative assertion: the Spring AOP
+// extractor must NOT fire for framework=javalin.
+// Registry target: AOP/advice_attribution, AOP/aspect_extraction,
+//
+//	AOP/pointcut_resolution → not_applicable.
+func TestJavalin_AOP_NotApplicable_Issue3085(t *testing.T) {
+	source := `
+package com.example;
+
+import io.javalin.Javalin;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+// Note: @Aspect is NOT a Javalin concept — this is here to test that
+// Spring AOP extractor does not fire for javalin framework.
+@Aspect
+public class LoggingAspect {
+    @Before("execution(* com.example.*.*(..))")
+    public void logBefore() {}
+}
+`
+	// Spring AOP extractor should not fire for javalin framework.
+	r := ExtractSpringAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "LoggingAspect.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3085 aop-not-applicable] Spring AOP extractor should not fire for framework=javalin, got %d entities", len(r.Entities))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// HANDLED_BY relationship emission
+// ----------------------------------------------------------------------------
+
+// TestJavalin_HandlerRelationship_Issue3085 proves that Route→Handler
+// HANDLED_BY relationships are emitted when a handler is identifiable.
+func TestJavalin_HandlerRelationship_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.get("/products", ProductController::listAll);
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "HANDLED_BY" {
+			found = true
+			if rel.Properties["framework"] != "javalin" {
+				t.Errorf("[#3085 handler_attribution] expected framework=javalin on HANDLED_BY edge, got %v", rel.Properties["framework"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3085 handler_attribution] expected HANDLED_BY relationship for method reference handler")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Synthesis integration: synthesizeJavalin in http_endpoint_synthesis.go
+// ----------------------------------------------------------------------------
+
+// TestJavalin_RouteProperties_Issue3085 confirms that route entities carry the
+// expected properties that the synthesis pass consumes.
+func TestJavalin_RouteProperties_Issue3085(t *testing.T) {
+	source := `
+import io.javalin.Javalin;
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.get("/api/v1/items/{itemId}", ctx -> ctx.json(items));
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "javalin",
+		FilePath:  "App.java",
+	})
+
+	for _, e := range r.Entities {
+		if e.Provenance != "INFERRED_FROM_JAVALIN_ROUTE" {
+			continue
+		}
+		if e.Properties["framework"] != "javalin" {
+			t.Errorf("[#3085] expected framework=javalin, got %v", e.Properties["framework"])
+		}
+		if e.Properties["http_verb"] != "GET" {
+			t.Errorf("[#3085] expected http_verb=GET, got %v", e.Properties["http_verb"])
+		}
+		if e.Properties["path"] != "/api/v1/items/{itemId}" {
+			t.Errorf("[#3085] expected path=/api/v1/items/{itemId}, got %v", e.Properties["path"])
+		}
+		if e.Properties["route_type"] != "lambda_dsl" {
+			t.Errorf("[#3085] expected route_type=lambda_dsl, got %v", e.Properties["route_type"])
+		}
+		return
+	}
+	t.Errorf("[#3085] expected at least one INFERRED_FROM_JAVALIN_ROUTE entity")
+}
+
+// ----------------------------------------------------------------------------
+// Helper to check for strings in entity properties (used in verbose checks)
+// ----------------------------------------------------------------------------
+
+func containsStr(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/custom/java/junit5.go
+++ b/internal/custom/java/junit5.go
@@ -25,6 +25,8 @@ var junit5Frameworks = map[string]bool{
 	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
 	// Dropwizard uses JUnit 5 with DropwizardExtensionsSupport for tests_linkage (#3087).
 	"dropwizard": true,
+	// Javalin uses JUnit 5 with JavalinTest.create / TestUtil.test for tests_linkage (#3085).
+	"javalin": true,
 }
 
 var (

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -330,6 +330,8 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeSpringFromComposed(entities, path, emit)
 		// JAX-RS: scan the file directly.
 		synthesizeJAXRS(string(content), emit)
+		// Javalin (#3085): lambda DSL `app.get("/path", handler)` routing.
+		synthesizeJavalin(string(content), emit)
 		// Consumer side (#721): HttpClient / RestTemplate /
 		// WebClient / OkHttp / Apache HttpClient / Retrofit.
 		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
@@ -795,6 +797,40 @@ func synthesizeJAXRS(content string, emit emitFn) {
 		full := joinPathFragments(classPrefix, methodPath)
 		canonical := httproutes.Canonicalize(httproutes.FrameworkJAXRS, full)
 		emit(verb, canonical, "jaxrs", "Controller", methodName)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Javalin (Java) — lambda DSL routing (#3085)
+// ---------------------------------------------------------------------------
+
+// javalinRouteRe captures Javalin lambda-DSL route registrations of the form:
+//
+//	app.get("/path", handler)
+//	app.post("/path", ctx -> { ... })
+//
+// The receiver is always `app` (or any variable name Javalin is assigned to);
+// we match against the well-known verb names and capture verb + path.
+var javalinRouteRe = regexp.MustCompile(
+	`\bapp\s*\.\s*(get|post|put|delete|patch|head|options)\s*\(\s*"([^"]+)"`)
+
+// synthesizeJavalin scans a Java file for Javalin lambda-DSL route
+// registrations and emits one http_endpoint_definition per (verb, path) pair.
+// Javalin uses `{param}` curly-brace path parameters (JAX-RS style), so
+// FrameworkJavalin is passed to Canonicalize.
+func synthesizeJavalin(content string, emit emitFn) {
+	// File-signal gate: require a Javalin-specific import or API reference.
+	if !strings.Contains(content, "javalin") && !strings.Contains(content, "Javalin") {
+		return
+	}
+	for _, m := range javalinRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		rawPath := m[2]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkJavalin, rawPath)
+		emit(verb, canonical, "javalin", "Route", "")
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis_javalin_3085_test.go
+++ b/internal/engine/http_endpoint_synthesis_javalin_3085_test.go
@@ -1,0 +1,125 @@
+package engine
+
+// Javalin endpoint synthesis tests for issue #3085.
+// These tests verify that synthesizeJavalin in http_endpoint_synthesis.go
+// correctly emits http_endpoint_definition entities for Javalin lambda-DSL routes.
+
+import (
+	"testing"
+)
+
+// TestSynth_Javalin_BasicRoutes_Issue3085 verifies that Javalin lambda-DSL
+// route registrations are synthesised into http_endpoint_definition entities
+// with correct (verb, canonical-path) IDs.
+// Registry target: lang.java.framework.javalin Routing/endpoint_synthesis → partial.
+// Cite: internal/engine/http_endpoint_synthesis.go (synthesizeJavalin)
+func TestSynth_Javalin_BasicRoutes_Issue3085(t *testing.T) {
+	src := `package com.example;
+
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+
+        app.get("/users", ctx -> ctx.json(userService.findAll()));
+        app.post("/users", ctx -> {
+            ctx.status(201);
+        });
+        app.get("/users/{id}", ctx -> ctx.json(userService.findById(ctx.pathParam("id"))));
+        app.put("/users/{id}", ctx -> userService.update(ctx.pathParam("id"), ctx.body()));
+        app.delete("/users/{id}", ctx -> {
+            userService.delete(ctx.pathParam("id"));
+            ctx.status(204);
+        });
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/App.java", src)
+	want := []string{
+		"http:GET:/users",
+		"http:POST:/users",
+		"http:GET:/users/{id}",
+		"http:PUT:/users/{id}",
+		"http:DELETE:/users/{id}",
+	}
+	requireContains(t, got, want, "Javalin basic routes")
+}
+
+// TestSynth_Javalin_PathParams_Issue3085 verifies that Javalin {param}
+// curly-brace path parameters are canonicalised correctly.
+func TestSynth_Javalin_PathParams_Issue3085(t *testing.T) {
+	src := `package com.example;
+
+import io.javalin.Javalin;
+
+public class App {
+    public static void main(String[] args) {
+        var app = Javalin.create().start(7070);
+        app.get("/orgs/{orgId}/projects/{projectId}", ctx -> ctx.json("ok"));
+        app.patch("/items/{itemId}/status", ctx -> ctx.status(200));
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/App.java", src)
+	want := []string{
+		"http:GET:/orgs/{orgId}/projects/{projectId}",
+		"http:PATCH:/items/{itemId}/status",
+	}
+	requireContains(t, got, want, "Javalin path params")
+}
+
+// TestSynth_Javalin_NoSignalNoOp_Issue3085 verifies that the synthesizer
+// no-ops on Java files without any Javalin signal.
+func TestSynth_Javalin_NoSignalNoOp_Issue3085(t *testing.T) {
+	src := `package com.example;
+
+public class OrderService {
+    public Order findById(long id) { return null; }
+    public void save(Order o) {}
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/OrderService.java", src)
+	for _, id := range got {
+		// We expect zero Javalin synthetics
+		if len(id) > 5 && id[:5] == "http:" {
+			// Any http: ID here would have to come from JAX-RS or Spring, not Javalin.
+			// This file has neither, so any http: entity is a failure.
+			t.Errorf("[#3085 no-signal-noop] unexpected http entity %q in non-Javalin file", id)
+		}
+	}
+}
+
+// TestSynth_Javalin_CoexistsWithJAXRS_Issue3085 verifies that Javalin and
+// JAX-RS synthetics can coexist in the same file without cross-contamination.
+// (Unusual in practice, but tests dedup isolation.)
+func TestSynth_Javalin_CoexistsWithJAXRS_Issue3085(t *testing.T) {
+	src := `package com.example;
+
+import io.javalin.Javalin;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+// Hypothetical file that has both Javalin routes and JAX-RS annotations.
+// In practice these would not coexist, but we verify the synthesisers
+// produce distinct IDs without interfering.
+
+@Path("/jaxrs-users")
+public class HybridResource {
+    @GET
+    public String getUsers() { return "[]"; }
+}
+
+class JavalinApp {
+    static void register(Javalin app) {
+        app.get("/javalin-items", ctx -> ctx.result("[]"));
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/HybridResource.java", src)
+	want := []string{
+		"http:GET:/jaxrs-users",
+		"http:GET:/javalin-items",
+	}
+	requireContains(t, got, want, "Javalin+JAX-RS coexistence")
+}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -120,6 +120,10 @@ const (
 	// `@app.route('/path')` / `@app.get('/path')` with Flask-style `<converter:name>`
 	// angle-bracket path parameters. Canonicalisation reuses the angle-bracket walker.
 	FrameworkQuart = "quart"
+	// FrameworkJavalin (#3085) — Javalin `app.get("/users/{id}", handler)` uses
+	// `{name}` curly-brace path parameters identical to JAX-RS / Spring.
+	// Canonicalisation reuses canonicalizeCurlyBraces.
+	FrameworkJavalin = "javalin"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -157,7 +161,8 @@ func Canonicalize(framework, raw string) string {
 		out = canonicalizeAngleBrackets(out)
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum,
 		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore, FrameworkHapi,
-		FrameworkLitestar, FrameworkAiohttp, FrameworkFalcon, FrameworkHug:
+		FrameworkLitestar, FrameworkAiohttp, FrameworkFalcon, FrameworkHug,
+		FrameworkJavalin:
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkTornado:
 		// Tornado paths arrive already pre-processed by the synthesizer

--- a/testdata/fixtures/sources/java/javalin/App.java
+++ b/testdata/fixtures/sources/java/javalin/App.java
@@ -1,0 +1,160 @@
+package com.example.javalin;
+
+import io.javalin.Javalin;
+import io.javalin.security.AccessManager;
+import io.javalin.security.RouteRole;
+import com.example.javalin.dto.CreateUserRequest;
+import com.example.javalin.dto.UserResponse;
+import com.example.javalin.dto.CreateOrderRequest;
+import com.example.javalin.controller.UserController;
+
+/**
+ * Javalin sample application — fixture for #3085.
+ *
+ * Demonstrates:
+ *   - Lambda DSL route registration (route_extraction, endpoint_synthesis)
+ *   - Handler attribution via lambda param and method reference
+ *   - Before/after middleware (middleware_coverage)
+ *   - AccessManager for role-based auth (auth_coverage)
+ *   - ctx.bodyAsClass and ctx.bodyValidator for DTO extraction
+ *   - Path parameters in {param} curly-brace style
+ */
+public class App {
+
+    enum Role implements RouteRole { ADMIN, USER, ANYONE }
+
+    public static Javalin createApp() {
+        return Javalin.create(config -> {
+            // AccessManager: centralised role-based auth hook
+            config.accessManager((handler, ctx, permittedRoles) -> {
+                if (permittedRoles.contains(Role.ANYONE)) {
+                    handler.handle(ctx);
+                } else {
+                    User user = ctx.attribute("user");
+                    if (user == null) {
+                        ctx.status(401).result("Unauthorized");
+                    } else if (permittedRoles.contains(user.getRole())) {
+                        handler.handle(ctx);
+                    } else {
+                        ctx.status(403).result("Forbidden");
+                    }
+                }
+            });
+        });
+    }
+
+    public static void main(String[] args) {
+        var app = createApp().start(7070);
+
+        // ---------------------------------------------------------------------------
+        // Middleware: before/after handlers (middleware_coverage)
+        // ---------------------------------------------------------------------------
+
+        // Global before handler — request logging
+        app.before(ctx -> {
+            System.out.println("[REQ] " + ctx.method() + " " + ctx.path());
+        });
+
+        // Path-scoped before handler — API key validation
+        app.before("/api/*", ctx -> {
+            String apiKey = ctx.header("X-Api-Key");
+            if (apiKey == null || !isValidApiKey(apiKey)) {
+                ctx.status(401).result("Invalid API key");
+            }
+        });
+
+        // Global after handler — response time header
+        app.after(ctx -> {
+            ctx.header("X-Powered-By", "Javalin");
+        });
+
+        // ---------------------------------------------------------------------------
+        // Public routes (no auth)
+        // ---------------------------------------------------------------------------
+
+        app.get("/health", ctx -> ctx.json("{\"status\":\"UP\"}"), Role.ANYONE);
+
+        app.get("/version", ctx -> ctx.result("1.0.0"), Role.ANYONE);
+
+        // ---------------------------------------------------------------------------
+        // User routes — lambda DSL (route_extraction + endpoint_synthesis)
+        // ---------------------------------------------------------------------------
+
+        app.get("/users", ctx -> {
+            ctx.json(userService.findAll());
+        }, Role.USER);
+
+        app.post("/users", ctx -> {
+            // DTO extraction: ctx.bodyAsClass (dto_extraction)
+            var req = ctx.bodyAsClass(CreateUserRequest.class);
+            var created = userService.create(req);
+            ctx.status(201).json(created);
+        }, Role.USER);
+
+        app.get("/users/{id}", ctx -> {
+            String id = ctx.pathParam("id");
+            ctx.json(userService.findById(id));
+        }, Role.USER);
+
+        app.put("/users/{id}", ctx -> {
+            // Request validation: ctx.bodyValidator (request_validation)
+            var req = ctx.bodyValidator(CreateUserRequest.class)
+                .check(it -> it.getName() != null && !it.getName().isEmpty(), "Name is required")
+                .check(it -> it.getEmail() != null, "Email is required")
+                .get();
+            userService.update(ctx.pathParam("id"), req);
+            ctx.status(200);
+        }, Role.USER);
+
+        app.delete("/users/{id}", ctx -> {
+            userService.delete(ctx.pathParam("id"));
+            ctx.status(204);
+        }, Role.ADMIN);
+
+        // ---------------------------------------------------------------------------
+        // Handler attribution via method reference (handler_attribution)
+        // ---------------------------------------------------------------------------
+
+        app.get("/orders", UserController::listOrders);
+        app.post("/orders", UserController::createOrder);
+        app.get("/orders/{orderId}", UserController::getOrder);
+
+        // ---------------------------------------------------------------------------
+        // Order management (DTO extraction)
+        // ---------------------------------------------------------------------------
+
+        app.put("/orders/{orderId}", ctx -> {
+            var req = ctx.bodyAsClass(CreateOrderRequest.class);
+            orderService.update(ctx.pathParam("orderId"), req);
+        }, Role.USER);
+
+        app.delete("/orders/{orderId}", ctx -> {
+            orderService.cancel(ctx.pathParam("orderId"));
+            ctx.status(204);
+        }, Role.USER);
+
+        // ---------------------------------------------------------------------------
+        // Admin routes (ADMIN role required)
+        // ---------------------------------------------------------------------------
+
+        app.get("/admin/stats", ctx -> {
+            ctx.json(statsService.getAll());
+        }, Role.ADMIN);
+
+        app.delete("/admin/cache", ctx -> {
+            cacheService.evictAll();
+            ctx.status(200).result("Cache cleared");
+        }, Role.ADMIN);
+
+        // ---------------------------------------------------------------------------
+        // Error handlers
+        // ---------------------------------------------------------------------------
+
+        app.error(404, ctx -> ctx.result("Resource not found"));
+        app.error(500, ctx -> ctx.result("Internal server error"));
+    }
+
+    private static boolean isValidApiKey(String key) {
+        return key != null && key.startsWith("ak_");
+    }
+}


### PR DESCRIPTION
## Summary

- Build `internal/custom/java/javalin_routes.go`: regex-based extractor for Javalin lambda-DSL routes (`app.get("/path", handler)`), before/after middleware, `AccessManager` auth hook, `ctx.bodyAsClass`/`bodyValidator` DTO extraction, `JavalinTest.create` test setup, and `@Test` method detection
- Wire `synthesizeJavalin` into `http_endpoint_synthesis.go` (Java case), emitting `http_endpoint_definition` entities with `FrameworkJavalin` curly-brace canonicalization
- Add `FrameworkJavalin = "javalin"` to `internal/engine/httproutes/canonicalize.go` (maps to `canonicalizeCurlyBraces` — same as JAX-RS/Spring)
- Gate `ExtractJUnit5` on `"javalin"` in `internal/custom/java/junit5.go`
- Flip 8 B cells → `partial`: `route_extraction`, `endpoint_synthesis`, `handler_attribution`, `auth_coverage`, `dto_extraction`, `request_validation`, `middleware_coverage`, `tests_linkage`
- Flip 9 C cells → `not_applicable`: DI (`di_binding_extraction`, `di_injection_point`, `di_scope_resolution`), AOP (`advice_attribution`, `aspect_extraction`, `pointcut_resolution`), Transactions (`transaction_boundary_extraction`, `transaction_propagation`, `transaction_rollback_rules`) — Javalin is a micro-framework with no built-in DI container, AOP, or transaction management

## Test plan

- [x] 19 unit tests in `internal/custom/java/javalin_routes_test.go` — all pass
- [x] 4 engine synthesis tests in `internal/engine/http_endpoint_synthesis_javalin_3085_test.go` — all pass
- [x] `go build ./...` — clean
- [x] `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` — all pass
- [x] `coverage validate` — 0 errors
- [x] `coverage fmt --check` — canonical
- [x] `coverage gen` — byte-stable (only expected docs/coverage/ changes)

Closes #3085

🤖 Generated with [Claude Code](https://claude.com/claude-code)