### PR TITLE
feat(coverage): Vert.x route/middleware extractor + C-flips

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -134,7 +134,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 15/16 | |
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 14/16 | |
-| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ⚠️ 20/20 | ❌ 4/16 | |
+| [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | ⚠️ 1/1 | — | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/3 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | ❌ 0/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ❌ 2/3 | ❌ 0/1 | ❌ 0/4 | ❌ 0/1 | ❌ 17/21 | ❌ 0/15 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -26,7 +26,7 @@ Back to [summary](../summary.md).
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 15/16 | |
 | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | ⚠️ 3/3 | ✅ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 21/21 | ⚠️ 18/18 | |
 | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | ❌ 2/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 14/16 | |
-| [Vert.x](../detail/lang.java.framework.vertx.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ⚠️ 20/20 | ❌ 4/16 | |
+| [Vert.x](../detail/lang.java.framework.vertx.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 7/7 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.java.framework.vertx.md
+++ b/docs/coverage/detail/lang.java.framework.vertx.md
@@ -17,32 +17,32 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/vert_x.yaml` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go`<br>`internal/engine/http_endpoint_synthesis.go` | — |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | ❌ `missing` | — | — | — | — |
+| Auth coverage | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go` | — |
+| Request validation | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/vertx_routes.go` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3086) | `internal/custom/java/junit5.go`<br>`internal/custom/java/vertx_routes.go` | — |
 
 ### Type System
 
@@ -57,25 +57,25 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in DI container. Applications use external DI (Guice, CDI, Spring) or manual wiring. |
+| DI injection point | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in DI container. Applications use external DI (Guice, CDI, Spring) or manual wiring. |
+| DI scope resolution | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in DI container. Applications use external DI (Guice, CDI, Spring) or manual wiring. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in transaction management. Applications use manual async callbacks or Vert.x SQL client directly. |
+| Transaction propagation | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in transaction management. Applications use manual async callbacks or Vert.x SQL client directly. |
+| Transaction rollback rules | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in transaction management. Applications use manual async callbacks or Vert.x SQL client directly. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in AOP support. Applications use external AOP (AspectJ, Spring AOP) if needed. |
+| Aspect extraction | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in AOP support. Applications use external AOP (AspectJ, Spring AOP) if needed. |
+| Pointcut resolution | — `not_applicable` | — | [link](https://github.com/cajasmota/archigraph/issues/3086) | — | Vert.x has no built-in AOP support. Applications use external AOP (AspectJ, Spring AOP) if needed. |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -18164,34 +18164,48 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/vertx_routes.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/vertx_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/vertx_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/vertx_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/vertx_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/junit5.go","internal/custom/java/vertx_routes.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -18217,44 +18231,53 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in DI container. Applications use external DI (Guice, CDI, Spring) or manual wiring."
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in DI container. Applications use external DI (Guice, CDI, Spring) or manual wiring."
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in DI container. Applications use external DI (Guice, CDI, Spring) or manual wiring."
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in transaction management. Applications use manual async callbacks or Vert.x SQL client directly."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in transaction management. Applications use manual async callbacks or Vert.x SQL client directly."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in transaction management. Applications use manual async callbacks or Vert.x SQL client directly."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in AOP support. Applications use external AOP (AspectJ, Spring AOP) if needed."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in AOP support. Applications use external AOP (AspectJ, Spring AOP) if needed."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "issue": "https://github.com/cajasmota/archigraph/issues/3086",
+            "notes": "Vert.x has no built-in AOP support. Applications use external AOP (AspectJ, Spring AOP) if needed."
           }
         },
         "Observability": {

--- a/internal/custom/java/junit5.go
+++ b/internal/custom/java/junit5.go
@@ -27,6 +27,8 @@ var junit5Frameworks = map[string]bool{
 	"dropwizard": true,
 	// Javalin uses JUnit 5 with JavalinTest.create / TestUtil.test for tests_linkage (#3085).
 	"javalin": true,
+	// Vert.x uses JUnit 5 with VertxExtension / VertxTestContext for tests_linkage (#3086).
+	"vertx": true, "vert.x": true, "vert_x": true, "vertx_web": true, "vertx-web": true,
 }
 
 var (

--- a/internal/custom/java/vertx_routes.go
+++ b/internal/custom/java/vertx_routes.go
@@ -1,0 +1,513 @@
+package java
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Vert.x custom extractor — route extraction, handler attribution, middleware,
+// DTO, auth, and tests.
+//
+// Vert.x Web uses a lambda/callback DSL for routing:
+//
+//	router.get("/path").handler(ctx -> ...)
+//	router.route("/path").handler(routingContext -> ...)
+//
+// The router.route().handler() chain is also used for global middleware when
+// no path is specified. Auth is handled via BasicAuthHandler.create(),
+// JWTAuthHandler.create(), or manual header checks in route handlers.
+//
+// Vert.x has NO built-in DI, AOP, or transaction management:
+//   - DI: di_binding_extraction, di_injection_point, di_scope_resolution → not_applicable
+//   - AOP: advice_attribution, aspect_extraction, pointcut_resolution → not_applicable
+//   - Transactions: transaction_boundary_extraction, transaction_propagation,
+//     transaction_rollback_rules → not_applicable
+//
+// Coverage cells delivered (#3086):
+//   - Routing:    route_extraction                   → partial
+//   - Auth:       auth_coverage                      → partial
+//   - Validation: dto_extraction, request_validation → partial
+//   - Middleware: middleware_coverage                 → partial
+//   - Testing:    tests_linkage                       → partial
+//   - DI:         di_binding_extraction, di_injection_point, di_scope_resolution → not_applicable
+//   - AOP:        advice_attribution, aspect_extraction, pointcut_resolution     → not_applicable
+//   - Transactions: transaction_boundary_extraction, transaction_propagation,
+//     transaction_rollback_rules                                                 → not_applicable
+
+// vertxFrameworks is the set of framework identifiers that activate the Vert.x extractor.
+var vertxFrameworks = map[string]bool{
+	"vertx":      true,
+	"vert.x":     true,
+	"vert_x":     true,
+	"vertx_web":  true,
+	"vertx-web":  true,
+}
+
+var (
+	// Route extraction: router.get("/path") or router.route("/path") DSL chains.
+	// Captures verb and path. Supports all common HTTP verbs plus route() for
+	// path-scoped handler chains.
+	vertxRouteRE = regexp.MustCompile(
+		`(?m)\brouter\s*\.\s*(get|post|put|delete|patch|head|options|route)\s*\(\s*"([^"]+)"`)
+
+	// Global middleware: router.route().handler(...) with no path argument.
+	// This form appears as router.route().handler(... without a path parameter.
+	vertxGlobalRouteRE = regexp.MustCompile(
+		`(?m)\brouter\s*\.\s*route\s*\(\s*\)\s*\.`)
+
+	// Handler attribution: captures the lambda parameter or method reference
+	// in .handler(ctx -> ...) or .handler(ClassName::method).
+	// Three forms:
+	//   1. Lambda: ctx ->
+	//   2. Method ref: ClassName::method
+	//   3. new Handler(): new ClassName()
+	vertxHandlerRE = regexp.MustCompile(
+		`\.handler\s*\(\s*` +
+			`(?:` +
+			`(\w+)\s*->` + // lambda param
+			`|(\w+)::(\w+)` + // method reference
+			`|new\s+(\w+)\s*\(` + // new Handler()
+			`)`)
+
+	// Auth: BasicAuthHandler.create(...) detection
+	vertxBasicAuthRE = regexp.MustCompile(
+		`\bBasicAuthHandler\s*\.\s*create\s*\(`)
+
+	// Auth: JWTAuthHandler.create(...) detection
+	vertxJWTAuthRE = regexp.MustCompile(
+		`\bJWTAuthHandler\s*\.\s*create\s*\(`)
+
+	// Auth: OAuth2AuthHandler or generic auth handler patterns
+	vertxOAuth2RE = regexp.MustCompile(
+		`\b(?:OAuth2AuthHandler|AuthorizationHandler|RedirectAuthHandler)\s*\.\s*create\s*\(`)
+
+	// Auth: manual Authorization header check in handler
+	vertxAuthGuardRE = regexp.MustCompile(
+		`ctx\s*\.\s*request\s*\(\s*\)\s*\.\s*getHeader\s*\(\s*"Authorization"\s*\)|` +
+			`ctx\s*\.\s*user\s*\(\s*\)|` +
+			`ctx\s*\.\s*fail\s*\(\s*401`)
+
+	// DTO extraction: body().as(Foo.class) or body().asPojo(Foo.class)
+	vertxBodyAsRE = regexp.MustCompile(
+		`\bbody\s*\(\s*\)\s*\.\s*as(?:Pojo)?\s*\(\s*(\w+)\s*\.class\s*\)`)
+
+	// DTO extraction: request().bodyHandler(...) with JSON body
+	vertxBodyHandlerRE = regexp.MustCompile(
+		`\bbodyHandler\s*\(\s*(?:\w+)\s*->\s*\{[^}]*\.mapTo\s*\(\s*(\w+)\s*\.class\s*\)`)
+
+	// Request validation: validator pattern (vertx-web-validation)
+	// RequestParameterProcessor / body validation using `BodyProcessorFactory.create(Foo.class)`
+	vertxValidatorRE = regexp.MustCompile(
+		`(?:RequestPredicate\s*\.\s*|BodyProcessorFactory\s*\.\s*create\s*\(\s*)(\w+)\s*\.class`)
+
+	// Tests: VertxTestContext + JUnit5 integration
+	vertxTestContextRE = regexp.MustCompile(
+		`\bVertxTestContext\b`)
+
+	// Tests: @RunWith(VertxUnitRunner.class) - Vert.x Unit runner (JUnit 4 style)
+	vertxUnitRunnerRE = regexp.MustCompile(
+		`@RunWith\s*\(\s*VertxUnitRunner\s*\.class\s*\)`)
+
+	// Tests: @ExtendWith(VertxExtension.class) - Vert.x JUnit 5 extension
+	vertxExtensionRE = regexp.MustCompile(
+		`@ExtendWith\s*\(\s*VertxExtension\s*\.class\s*\)`)
+
+	// Tests: @Test methods in Vert.x test classes
+	vertxTestMethodRE = regexp.MustCompile(
+		`(?s)@Test\b(?:\s*\([^)]*\))?` +
+			`(?:\s*@\w+(?:\s*\([^)]*\))?\s*)*\s*(?:public\s+|protected\s+|private\s+)?(?:\w+\s+)*` +
+			`void\s+(\w+)\s*\(`)
+)
+
+// ExtractVertx runs the Vert.x extractor for route, middleware, DTO, auth,
+// and test-linkage patterns.
+func ExtractVertx(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !vertxFrameworks[ctx.Framework] {
+		return result
+	}
+
+	// Quick-exit: no Vert.x signals in this file.
+	if !strings.Contains(ctx.Source, "vertx") && !strings.Contains(ctx.Source, "Vertx") &&
+		!strings.Contains(ctx.Source, "vert.x") && !strings.Contains(ctx.Source, "AbstractVerticle") &&
+		!strings.Contains(ctx.Source, "Router") {
+		return result
+	}
+
+	seen := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// ---------------------------------------------------------------------------
+	// Route extraction + handler attribution
+	// ---------------------------------------------------------------------------
+	for _, idx := range vertxRouteRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 6 {
+			continue
+		}
+		rawVerb := ctx.Source[idx[2]:idx[3]]
+		rawPath := ctx.Source[idx[4]:idx[5]]
+
+		// Normalize: route() without a verb is treated as a middleware chain
+		// unless it has a .handler() that's actually a route. We still emit
+		// it as route_type=path_chain to indicate partial coverage.
+		verb := strings.ToUpper(rawVerb)
+		if rawVerb == "route" {
+			verb = "ANY"
+		}
+
+		ref := fmt.Sprintf("vertx:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
+
+		e := SecondaryEntity{
+			Name:       rawPath,
+			Kind:       "Route",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_VERTX_ROUTE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"http_verb":  verb,
+				"path":       rawPath,
+				"framework":  "vertx",
+				"route_type": "lambda_dsl",
+			},
+		}
+		addEntity(&result, seen, e)
+
+		// Handler attribution: scan the line/block after the route for .handler(...)
+		lineStart := idx[0]
+		// Look ahead up to 2 lines for .handler() call
+		lineEnd := lineStart
+		newlinesFound := 0
+		for lineEnd < len(ctx.Source) && newlinesFound < 3 {
+			if ctx.Source[lineEnd] == '\n' {
+				newlinesFound++
+			}
+			lineEnd++
+		}
+		if lineEnd > len(ctx.Source) {
+			lineEnd = len(ctx.Source)
+		}
+		snippet := ctx.Source[lineStart:lineEnd]
+
+		if m := vertxHandlerRE.FindStringSubmatch(snippet); len(m) >= 2 {
+			var handlerName string
+			switch {
+			case len(m) > 1 && m[1] != "": // lambda param
+				handlerName = m[1]
+			case len(m) > 3 && m[2] != "" && m[3] != "": // method ref
+				handlerName = m[2] + "::" + m[3]
+			case len(m) > 4 && m[4] != "": // new Handler()
+				handlerName = m[4]
+			}
+
+			if handlerName != "" {
+				handlerRef := fmt.Sprintf("vertx:handler:%s:%s", handlerName, ctx.FilePath)
+				handler := SecondaryEntity{
+					Name:       handlerName,
+					Kind:       "Handler",
+					SourceFile: ctx.FilePath,
+					LineStart:  lineOf(ctx.Source, idx[0]),
+					Provenance: "INFERRED_FROM_VERTX_HANDLER",
+					Ref:        handlerRef,
+					Properties: map[string]any{
+						"framework":    "vertx",
+						"handler_type": "lambda",
+						"http_verb":    verb,
+						"path":         rawPath,
+					},
+				}
+				addEntity(&result, seen, handler)
+				addRel(&result, seenRels, Relationship{
+					SourceRef:        ref,
+					TargetRef:        handlerRef,
+					RelationshipType: "HANDLED_BY",
+					Properties:       map[string]string{"framework": "vertx"},
+				})
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Middleware: router.route().handler(...) — global middleware (no path)
+	// ---------------------------------------------------------------------------
+	for _, idx := range vertxGlobalRouteRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 2 {
+			continue
+		}
+		lineStart := idx[0]
+		// Look ahead for .handler() attribution
+		lineEnd := lineStart
+		newlinesFound := 0
+		for lineEnd < len(ctx.Source) && newlinesFound < 3 {
+			if ctx.Source[lineEnd] == '\n' {
+				newlinesFound++
+			}
+			lineEnd++
+		}
+		if lineEnd > len(ctx.Source) {
+			lineEnd = len(ctx.Source)
+		}
+		snippet := ctx.Source[lineStart:lineEnd]
+
+		// Determine middleware type from the chained method names
+		middlewareType := "request_handler"
+		if strings.Contains(snippet, "BodyHandler") {
+			middlewareType = "body_handler"
+		} else if strings.Contains(snippet, "CorsHandler") {
+			middlewareType = "cors_handler"
+		} else if strings.Contains(snippet, "LoggerHandler") {
+			middlewareType = "logger_handler"
+		} else if strings.Contains(snippet, "SessionHandler") {
+			middlewareType = "session_handler"
+		} else if strings.Contains(snippet, "TimeoutHandler") {
+			middlewareType = "timeout_handler"
+		} else if strings.Contains(snippet, "StaticHandler") {
+			middlewareType = "static_handler"
+		} else if strings.Contains(snippet, "AuthenticationHandler") ||
+			strings.Contains(snippet, "JWTAuthHandler") ||
+			strings.Contains(snippet, "BasicAuthHandler") {
+			middlewareType = "auth_handler"
+		}
+
+		ref := fmt.Sprintf("vertx:middleware:%s:%d:%s", middlewareType, lineOf(ctx.Source, idx[0]), ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       middlewareType,
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_VERTX_MIDDLEWARE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "vertx",
+				"middleware_type": middlewareType,
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Auth: BasicAuthHandler, JWTAuthHandler, OAuth2AuthHandler, inline guards
+	// ---------------------------------------------------------------------------
+	if vertxBasicAuthRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("vertx:auth:basic_auth:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "BasicAuthHandler",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, vertxBasicAuthRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_VERTX_AUTH",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "vertx",
+				"auth_type": "basic_auth",
+				"auth_hook": "BasicAuthHandler.create",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if vertxJWTAuthRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("vertx:auth:jwt_auth:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "JWTAuthHandler",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, vertxJWTAuthRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_VERTX_AUTH",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "vertx",
+				"auth_type": "jwt_auth",
+				"auth_hook": "JWTAuthHandler.create",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if vertxOAuth2RE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("vertx:auth:oauth2:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "OAuth2AuthHandler",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, vertxOAuth2RE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_VERTX_AUTH",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "vertx",
+				"auth_type": "oauth2",
+				"auth_hook": "OAuth2AuthHandler.create",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if vertxAuthGuardRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("vertx:auth:guard:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "auth_guard",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, vertxAuthGuardRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_VERTX_AUTH_GUARD",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "vertx",
+				"auth_type": "inline_guard",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// DTO extraction: body().as(Foo.class) and mapTo(Foo.class)
+	// ---------------------------------------------------------------------------
+	for _, m := range vertxBodyAsRE.FindAllStringSubmatch(ctx.Source, -1) {
+		if len(m) < 2 || primitiveTypes[m[1]] {
+			continue
+		}
+		dtoName := m[1]
+		ref := fmt.Sprintf("vertx:dto:%s:%s", dtoName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       dtoName,
+			Kind:       "Schema",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strings.Index(ctx.Source, m[0])),
+			Provenance: "INFERRED_FROM_VERTX_DTO",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "vertx",
+				"dto_source": "body().as",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	for _, m := range vertxBodyHandlerRE.FindAllStringSubmatch(ctx.Source, -1) {
+		if len(m) < 2 || primitiveTypes[m[1]] {
+			continue
+		}
+		dtoName := m[1]
+		ref := fmt.Sprintf("vertx:dto:body_handler:%s:%s", dtoName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       dtoName,
+			Kind:       "Schema",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strings.Index(ctx.Source, m[0])),
+			Provenance: "INFERRED_FROM_VERTX_DTO",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "vertx",
+				"dto_source": "bodyHandler.mapTo",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// Request validation: vertx-web-validation RequestPredicate / BodyProcessorFactory
+	for _, m := range vertxValidatorRE.FindAllStringSubmatch(ctx.Source, -1) {
+		if len(m) < 2 || primitiveTypes[m[1]] {
+			continue
+		}
+		dtoName := m[1]
+		ref := fmt.Sprintf("vertx:validation:%s:%s", dtoName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       dtoName,
+			Kind:       "Schema",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strings.Index(ctx.Source, m[0])),
+			Provenance: "INFERRED_FROM_VERTX_VALIDATION",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":         "vertx",
+				"dto_source":        "RequestPredicate/BodyProcessorFactory",
+				"request_validated": true,
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests: VertxTestContext / VertxExtension / VertxUnitRunner + @Test methods
+	// ---------------------------------------------------------------------------
+	testSetupDetected := false
+	if vertxTestContextRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("vertx:test_setup:test_context:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "VertxTestContext",
+			Kind:       "TestSetup",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, vertxTestContextRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_VERTX_TEST_SETUP",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "vertx",
+				"test_setup": "VertxTestContext",
+			},
+		}
+		addEntity(&result, seen, e)
+		testSetupDetected = true
+	}
+
+	if vertxExtensionRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("vertx:test_setup:extension:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "VertxExtension",
+			Kind:       "TestSetup",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, vertxExtensionRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_VERTX_TEST_SETUP",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "vertx",
+				"test_setup": "VertxExtension",
+			},
+		}
+		addEntity(&result, seen, e)
+		testSetupDetected = true
+	}
+
+	if vertxUnitRunnerRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("vertx:test_setup:unit_runner:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "VertxUnitRunner",
+			Kind:       "TestSetup",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, vertxUnitRunnerRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_VERTX_TEST_SETUP",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "vertx",
+				"test_setup": "VertxUnitRunner",
+			},
+		}
+		addEntity(&result, seen, e)
+		testSetupDetected = true
+	}
+
+	_ = testSetupDetected // used for documentation clarity
+
+	for _, idx := range vertxTestMethodRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		methodName := ctx.Source[idx[2]:idx[3]]
+		ref := fmt.Sprintf("vertx:test:%s:%s", methodName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       methodName,
+			Kind:       "TestCase",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_VERTX_TEST_METHOD",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "vertx",
+				"test_annotation": "Test",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	return result
+}

--- a/internal/custom/java/vertx_routes_test.go
+++ b/internal/custom/java/vertx_routes_test.go
@@ -1,0 +1,876 @@
+package java
+
+import (
+	"testing"
+)
+
+// ============================================================================
+// Issue #3086: Vert.x route/middleware/DTO/auth/tests extractor
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Routing: route_extraction + handler_attribution
+// ----------------------------------------------------------------------------
+
+// TestVertx_RouteExtraction_Issue3086 proves that basic router.get/post/put/
+// delete routes are extracted from a Vert.x Web application.
+// Registry target: lang.java.framework.vertx Routing/route_extraction → partial.
+// Cite: internal/custom/java/vertx_routes.go
+func TestVertx_RouteExtraction_Issue3086(t *testing.T) {
+	source := `
+package com.example;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class MainVerticle extends AbstractVerticle {
+    @Override
+    public void start() {
+        Router router = Router.router(vertx);
+
+        router.get("/users").handler(this::getAllUsers);
+        router.post("/users").handler(this::createUser);
+        router.get("/users/:id").handler(this::getUser);
+        router.put("/users/:id").handler(this::updateUser);
+        router.delete("/users/:id").handler(this::deleteUser);
+
+        vertx.createHttpServer().requestHandler(router).listen(8080);
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "MainVerticle.java",
+	})
+
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_ROUTE" {
+			key := e.Properties["http_verb"].(string) + ":" + e.Properties["path"].(string)
+			routes[key] = true
+		}
+	}
+
+	for _, want := range []string{
+		"GET:/users",
+		"POST:/users",
+		"GET:/users/:id",
+		"PUT:/users/:id",
+		"DELETE:/users/:id",
+	} {
+		if !routes[want] {
+			t.Errorf("[#3086 route_extraction] expected route %q, got %v", want, routes)
+		}
+	}
+}
+
+// TestVertx_RouteExtraction_CurlyBrace_Issue3086 proves that Vert.x {param}
+// style path parameters are also extracted (router accepts both styles).
+func TestVertx_RouteExtraction_CurlyBrace_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+
+public class App {
+    void setup(Router router) {
+        router.get("/orders/{orderId}").handler(ctx -> {
+            ctx.response().end(orderId);
+        });
+        router.delete("/orders/{orderId}/items/{itemId}").handler(ctx -> {});
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_ROUTE" {
+			key := e.Properties["http_verb"].(string) + ":" + e.Properties["path"].(string)
+			routes[key] = true
+		}
+	}
+
+	if !routes["GET:/orders/{orderId}"] {
+		t.Errorf("[#3086 route_extraction] expected GET:/orders/{orderId}, got %v", routes)
+	}
+	if !routes["DELETE:/orders/{orderId}/items/{itemId}"] {
+		t.Errorf("[#3086 route_extraction] expected DELETE:/orders/{orderId}/items/{itemId}, got %v", routes)
+	}
+}
+
+// TestVertx_HandlerAttribution_LambdaParam_Issue3086 proves that the lambda
+// parameter name is captured as the handler for route attribution.
+// Registry target: lang.java.framework.vertx Routing/handler_attribution → partial.
+// Cite: internal/custom/java/vertx_routes.go
+func TestVertx_HandlerAttribution_LambdaParam_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+
+public class App {
+    void setup(Router router) {
+        router.get("/items").handler(ctx -> {
+            ctx.response().end("[]");
+        });
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_HANDLER" {
+			found = true
+			if e.Properties["framework"] != "vertx" {
+				t.Errorf("[#3086 handler_attribution] expected framework=vertx, got %v", e.Properties["framework"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3086 handler_attribution] expected INFERRED_FROM_VERTX_HANDLER entity")
+	}
+}
+
+// TestVertx_HandlerAttribution_MethodRef_Issue3086 proves that method
+// references (ClassName::method or this::method) are extracted as handler attributions.
+func TestVertx_HandlerAttribution_MethodRef_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+
+public class MainVerticle {
+    void setup(Router router) {
+        router.get("/users").handler(UserController::getAll);
+        router.post("/users").handler(UserController::create);
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "MainVerticle.java",
+	})
+
+	handlerNames := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_HANDLER" {
+			handlerNames[e.Name] = true
+		}
+	}
+	if !handlerNames["UserController::getAll"] {
+		t.Errorf("[#3086 handler_attribution] expected UserController::getAll handler, got %v", handlerNames)
+	}
+	if !handlerNames["UserController::create"] {
+		t.Errorf("[#3086 handler_attribution] expected UserController::create handler, got %v", handlerNames)
+	}
+}
+
+// TestVertx_RouteExtraction_Gating_Issue3086 confirms the extractor does not
+// fire for non-vertx frameworks.
+func TestVertx_RouteExtraction_Gating_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+public class App {
+    void setup(Router router) {
+        router.get("/users").handler(ctx -> ctx.response().end("[]"));
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot",
+		FilePath: "App.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3086 gating] expected 0 entities for framework=spring_boot, got %d", len(r.Entities))
+	}
+}
+
+// TestVertx_RouteExtraction_NoSignalGating_Issue3086 confirms the extractor
+// no-ops on Java files with no Vert.x signal.
+func TestVertx_RouteExtraction_NoSignalGating_Issue3086(t *testing.T) {
+	source := `
+public class OrderService {
+    public Order findById(long id) { return null; }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source: source, Language: "java", Framework: "vertx",
+		FilePath: "OrderService.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3086 no-signal-gating] expected 0 entities for file without Vert.x signal, got %d", len(r.Entities))
+	}
+}
+
+// TestVertx_Route_RouteTypeProperty_Issue3086 confirms that route entities
+// carry route_type=lambda_dsl and framework=vertx.
+func TestVertx_Route_RouteTypeProperty_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+
+public class App {
+    void setup(Router router) {
+        router.get("/api/v1/items/{itemId}").handler(ctx -> {
+            ctx.response().end("item");
+        });
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	for _, e := range r.Entities {
+		if e.Provenance != "INFERRED_FROM_VERTX_ROUTE" {
+			continue
+		}
+		if e.Properties["framework"] != "vertx" {
+			t.Errorf("[#3086] expected framework=vertx, got %v", e.Properties["framework"])
+		}
+		if e.Properties["http_verb"] != "GET" {
+			t.Errorf("[#3086] expected http_verb=GET, got %v", e.Properties["http_verb"])
+		}
+		if e.Properties["route_type"] != "lambda_dsl" {
+			t.Errorf("[#3086] expected route_type=lambda_dsl, got %v", e.Properties["route_type"])
+		}
+		return
+	}
+	t.Errorf("[#3086] expected at least one INFERRED_FROM_VERTX_ROUTE entity")
+}
+
+// ----------------------------------------------------------------------------
+// Middleware: middleware_coverage — router.route().handler(...) global handlers
+// ----------------------------------------------------------------------------
+
+// TestVertx_Middleware_GlobalHandler_Issue3086 proves that router.route().handler(...)
+// global middleware handlers are extracted.
+// Registry target: lang.java.framework.vertx Middleware/middleware_coverage → partial.
+// Cite: internal/custom/java/vertx_routes.go
+func TestVertx_Middleware_GlobalHandler_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.LoggerHandler;
+import io.vertx.ext.web.handler.CorsHandler;
+
+public class App {
+    void setup(Router router) {
+        // Global body parser
+        router.route().handler(BodyHandler.create());
+        // Global CORS
+        router.route().handler(CorsHandler.create("*"));
+        // Global request logger
+        router.route().handler(LoggerHandler.create());
+
+        router.get("/health").handler(ctx -> ctx.response().end("UP"));
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	middlewareTypes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_MIDDLEWARE" {
+			mt, _ := e.Properties["middleware_type"].(string)
+			middlewareTypes[mt] = true
+		}
+	}
+	if len(middlewareTypes) < 2 {
+		t.Errorf("[#3086 middleware_coverage] expected >= 2 middleware entities, got %d types: %v", len(middlewareTypes), middlewareTypes)
+	}
+	if !middlewareTypes["body_handler"] {
+		t.Errorf("[#3086 middleware_coverage] expected body_handler middleware, got %v", middlewareTypes)
+	}
+}
+
+// TestVertx_Middleware_FrameworkProperty_Issue3086 confirms that middleware
+// entities carry framework=vertx.
+func TestVertx_Middleware_FrameworkProperty_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+
+public class App {
+    void setup(Router router) {
+        router.route().handler(BodyHandler.create());
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_MIDDLEWARE" {
+			if e.Properties["framework"] != "vertx" {
+				t.Errorf("[#3086 middleware] expected framework=vertx, got %v", e.Properties["framework"])
+			}
+			return
+		}
+	}
+	t.Errorf("[#3086 middleware] expected at least one INFERRED_FROM_VERTX_MIDDLEWARE entity")
+}
+
+// ----------------------------------------------------------------------------
+// Auth: auth_coverage — BasicAuthHandler, JWTAuthHandler, inline guards
+// ----------------------------------------------------------------------------
+
+// TestVertx_Auth_JWTAuthHandler_Issue3086 proves that JWTAuthHandler.create(...)
+// is extracted as auth_coverage evidence.
+// Registry target: lang.java.framework.vertx Auth/auth_coverage → partial.
+// Cite: internal/custom/java/vertx_routes.go
+func TestVertx_Auth_JWTAuthHandler_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.JWTAuthHandler;
+import io.vertx.ext.auth.jwt.JWTAuth;
+
+public class App {
+    void setup(Router router, JWTAuth jwtProvider) {
+        router.route("/api/*").handler(JWTAuthHandler.create(jwtProvider));
+        router.get("/api/users").handler(ctx -> {
+            ctx.response().end("[]");
+        });
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_AUTH" && e.Name == "JWTAuthHandler" {
+			found = true
+			if e.Properties["auth_type"] != "jwt_auth" {
+				t.Errorf("[#3086 auth_coverage] expected auth_type=jwt_auth, got %v", e.Properties["auth_type"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3086 auth_coverage] expected INFERRED_FROM_VERTX_AUTH entity for JWTAuthHandler")
+	}
+}
+
+// TestVertx_Auth_BasicAuthHandler_Issue3086 proves that BasicAuthHandler.create(...)
+// is extracted as auth_coverage evidence.
+func TestVertx_Auth_BasicAuthHandler_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BasicAuthHandler;
+
+public class App {
+    void setup(Router router) {
+        router.route().handler(BasicAuthHandler.create(authProvider));
+        router.get("/protected").handler(ctx -> ctx.response().end("secret"));
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_AUTH" && e.Name == "BasicAuthHandler" {
+			found = true
+			if e.Properties["auth_type"] != "basic_auth" {
+				t.Errorf("[#3086 auth_coverage] expected auth_type=basic_auth, got %v", e.Properties["auth_type"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3086 auth_coverage] expected INFERRED_FROM_VERTX_AUTH entity for BasicAuthHandler")
+	}
+}
+
+// TestVertx_Auth_InlineGuard_Issue3086 proves that inline auth guard patterns
+// (user() checks in handlers) are captured.
+func TestVertx_Auth_InlineGuard_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+
+public class App {
+    void setup(Router router) {
+        router.route("/api/*").handler(ctx -> {
+            if (ctx.user() == null) {
+                ctx.fail(401);
+            } else {
+                ctx.next();
+            }
+        });
+        router.get("/api/data").handler(ctx -> ctx.response().end("data"));
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_AUTH_GUARD" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("[#3086 auth_coverage] expected INFERRED_FROM_VERTX_AUTH_GUARD entity for ctx.user() check")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Validation: dto_extraction + request_validation
+// ----------------------------------------------------------------------------
+
+// TestVertx_DTO_BodyAs_Issue3086 proves that body().as(Foo.class) is extracted
+// as DTO evidence.
+// Registry target: lang.java.framework.vertx Validation/dto_extraction → partial.
+// Cite: internal/custom/java/vertx_routes.go
+func TestVertx_DTO_BodyAs_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+
+public class App {
+    void setup(Router router) {
+        router.route().handler(BodyHandler.create());
+
+        router.post("/users").handler(ctx -> {
+            CreateUserRequest req = ctx.body().as(CreateUserRequest.class);
+            userService.create(req);
+            ctx.response().setStatusCode(201).end();
+        });
+
+        router.put("/orders/:id").handler(ctx -> {
+            UpdateOrderRequest req = ctx.body().as(UpdateOrderRequest.class);
+            orderService.update(ctx.pathParam("id"), req);
+        });
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	dtoNames := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_DTO" {
+			dtoNames[e.Name] = true
+		}
+	}
+	if !dtoNames["CreateUserRequest"] {
+		t.Errorf("[#3086 dto_extraction] expected CreateUserRequest DTO entity, got %v", dtoNames)
+	}
+	if !dtoNames["UpdateOrderRequest"] {
+		t.Errorf("[#3086 dto_extraction] expected UpdateOrderRequest DTO entity, got %v", dtoNames)
+	}
+}
+
+// TestVertx_DTO_PrimitiveSkip_Issue3086 confirms that primitive/framework
+// types are not extracted as DTOs.
+func TestVertx_DTO_PrimitiveSkip_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+
+public class App {
+    void setup(Router router) {
+        router.post("/echo").handler(ctx -> {
+            String body = ctx.body().as(String.class);
+            ctx.response().end(body);
+        });
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_DTO" && e.Name == "String" {
+			t.Errorf("[#3086 dto_extraction] String is a primitive type and should not be extracted as DTO")
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests: tests_linkage — VertxTestContext / VertxExtension + @Test methods
+// ----------------------------------------------------------------------------
+
+// TestVertx_TestsLinkage_VertxTestContext_Issue3086 proves that VertxTestContext
+// is detected as test-infrastructure evidence.
+// Registry target: lang.java.framework.vertx Testing/tests_linkage → partial.
+// Cite: internal/custom/java/vertx_routes.go
+func TestVertx_TestsLinkage_VertxTestContext_Issue3086(t *testing.T) {
+	source := `
+package com.example;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(VertxExtension.class)
+class MainVerticleTest {
+
+    @Test
+    void verticleDeployed(Vertx vertx, VertxTestContext testContext) {
+        vertx.deployVerticle(new MainVerticle(), testContext.succeedingThenComplete());
+    }
+
+    @Test
+    void getUsers_returns200(Vertx vertx, VertxTestContext testContext) throws InterruptedException {
+        // test logic
+        testContext.completeNow();
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "MainVerticleTest.java",
+	})
+
+	foundSetup := false
+	testCount := 0
+	for _, e := range r.Entities {
+		switch e.Provenance {
+		case "INFERRED_FROM_VERTX_TEST_SETUP":
+			foundSetup = true
+		case "INFERRED_FROM_VERTX_TEST_METHOD":
+			testCount++
+		}
+	}
+	if !foundSetup {
+		t.Errorf("[#3086 tests_linkage] expected INFERRED_FROM_VERTX_TEST_SETUP entity")
+	}
+	if testCount < 2 {
+		t.Errorf("[#3086 tests_linkage] expected >= 2 @Test method entities, got %d", testCount)
+	}
+}
+
+// TestVertx_TestsLinkage_JUnit5_Issue3086 proves that ExtractJUnit5 runs
+// for the "vertx" framework (vertx is in junit5Frameworks).
+// Registry target: lang.java.framework.vertx Testing/tests_linkage → partial.
+// Cite: internal/custom/java/junit5.go
+func TestVertx_TestsLinkage_JUnit5_Issue3086(t *testing.T) {
+	source := `
+import org.junit.jupiter.api.Test;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxTestContext;
+
+class AppTest {
+    @Test
+    void ping(Vertx vertx, VertxTestContext ctx) {}
+
+    @Test
+    void healthCheck(Vertx vertx, VertxTestContext ctx) {}
+}
+`
+	r := ExtractJUnit5(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "AppTest.java",
+	})
+	if len(r.Entities) == 0 {
+		t.Errorf("[#3086 tests_linkage] expected JUnit5 entities for framework=vertx, got none")
+	}
+	testCount := 0
+	for _, e := range r.Entities {
+		if e.Properties["test_annotation"] == "Test" {
+			testCount++
+		}
+	}
+	if testCount < 2 {
+		t.Errorf("[#3086 tests_linkage] expected >= 2 @Test entities for vertx, got %d", testCount)
+	}
+}
+
+// TestVertx_TestsLinkage_VertxExtension_Issue3086 proves that @ExtendWith(VertxExtension.class)
+// is detected as test setup evidence.
+func TestVertx_TestsLinkage_VertxExtension_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Test;
+
+@ExtendWith(VertxExtension.class)
+class MyTest {
+    @Test
+    void someTest() {}
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "MyTest.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_TEST_SETUP" && e.Name == "VertxExtension" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("[#3086 tests_linkage] expected INFERRED_FROM_VERTX_TEST_SETUP with VertxExtension")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// HANDLED_BY relationship emission
+// ----------------------------------------------------------------------------
+
+// TestVertx_HandlerRelationship_Issue3086 proves that Route→Handler
+// HANDLED_BY relationships are emitted when a handler is identifiable.
+func TestVertx_HandlerRelationship_Issue3086(t *testing.T) {
+	source := `
+import io.vertx.ext.web.Router;
+
+public class App {
+    void setup(Router router) {
+        router.get("/products").handler(ProductController::listAll);
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "App.java",
+	})
+
+	found := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "HANDLED_BY" {
+			found = true
+			if rel.Properties["framework"] != "vertx" {
+				t.Errorf("[#3086 handler_attribution] expected framework=vertx on HANDLED_BY edge, got %v", rel.Properties["framework"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3086 handler_attribution] expected HANDLED_BY relationship for method reference handler")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// AOP: not_applicable — Vert.x has no built-in AOP support
+// ----------------------------------------------------------------------------
+
+// TestVertx_AOP_NotApplicable_Issue3086 confirms that Vert.x does not have
+// AOP (advice_attribution, aspect_extraction, pointcut_resolution are
+// not_applicable). The Spring AOP extractor must NOT fire for framework=vertx.
+// Registry target: AOP/advice_attribution, AOP/aspect_extraction,
+//
+//	AOP/pointcut_resolution → not_applicable.
+func TestVertx_AOP_NotApplicable_Issue3086(t *testing.T) {
+	source := `
+package com.example;
+
+import io.vertx.core.AbstractVerticle;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+// Note: @Aspect is NOT a Vert.x concept — this is here to confirm that
+// Spring AOP extractor does not fire for vertx framework.
+@Aspect
+public class LoggingAspect {
+    @Before("execution(* com.example.*.*(..))")
+    public void logBefore() {}
+}
+`
+	// Spring AOP extractor should not fire for vertx framework.
+	r := ExtractSpringAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "LoggingAspect.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3086 aop-not-applicable] Spring AOP extractor should not fire for framework=vertx, got %d entities", len(r.Entities))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Comprehensive: full Vert.x application
+// ----------------------------------------------------------------------------
+
+// TestVertx_FullApp_Issue3086 verifies a realistic Vert.x Web application with
+// routes, middleware, auth (JWT), DTOs all extracted correctly.
+// This is the comprehensive proving test that justifies partial status for all
+// 6 B cells (route_extraction, auth_coverage, middleware_coverage, dto_extraction,
+// request_validation, tests_linkage).
+func TestVertx_FullApp_Issue3086(t *testing.T) {
+	source := `
+package com.example;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.JWTAuthHandler;
+import io.vertx.ext.web.handler.CorsHandler;
+import io.vertx.ext.auth.jwt.JWTAuth;
+import com.example.dto.CreateUserRequest;
+import com.example.dto.UpdateUserRequest;
+
+public class MainVerticle extends AbstractVerticle {
+    private JWTAuth jwtProvider;
+
+    @Override
+    public void start() throws Exception {
+        Router router = Router.router(vertx);
+
+        // Global middleware
+        router.route().handler(BodyHandler.create());
+        router.route().handler(CorsHandler.create("*"));
+
+        // JWT auth for /api/* routes
+        router.route("/api/*").handler(JWTAuthHandler.create(jwtProvider));
+
+        // Public routes
+        router.get("/health").handler(ctx -> {
+            ctx.response().setStatusCode(200).end("UP");
+        });
+
+        // CRUD routes
+        router.get("/api/users").handler(UserHandler::listAll);
+        router.post("/api/users").handler(ctx -> {
+            CreateUserRequest req = ctx.body().as(CreateUserRequest.class);
+            userService.create(req);
+            ctx.response().setStatusCode(201).end();
+        });
+        router.get("/api/users/:id").handler(UserHandler::getById);
+        router.put("/api/users/:id").handler(ctx -> {
+            UpdateUserRequest req = ctx.body().as(UpdateUserRequest.class);
+            userService.update(ctx.pathParam("id"), req);
+        });
+        router.delete("/api/users/:id").handler(UserHandler::delete);
+
+        vertx.createHttpServer()
+            .requestHandler(router)
+            .listen(8080, result -> {
+                if (result.succeeded()) {
+                    System.out.println("Server started on port 8080");
+                }
+            });
+    }
+}
+`
+	r := ExtractVertx(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "vertx",
+		FilePath:  "MainVerticle.java",
+	})
+
+	// Validate routes
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_ROUTE" {
+			key := e.Properties["http_verb"].(string) + ":" + e.Properties["path"].(string)
+			routes[key] = true
+		}
+	}
+	for _, want := range []string{
+		"GET:/health",
+		"GET:/api/users",
+		"POST:/api/users",
+		"GET:/api/users/:id",
+		"PUT:/api/users/:id",
+		"DELETE:/api/users/:id",
+	} {
+		if !routes[want] {
+			t.Errorf("[#3086 full-app] expected route %q, got %v", want, routes)
+		}
+	}
+
+	// Validate middleware
+	middlewareCount := 0
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_MIDDLEWARE" {
+			middlewareCount++
+		}
+	}
+	if middlewareCount < 2 {
+		t.Errorf("[#3086 full-app] expected >= 2 middleware entities (BodyHandler+CorsHandler), got %d", middlewareCount)
+	}
+
+	// Validate auth
+	foundJWT := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_AUTH" && e.Properties["auth_type"] == "jwt_auth" {
+			foundJWT = true
+		}
+	}
+	if !foundJWT {
+		t.Errorf("[#3086 full-app] expected INFERRED_FROM_VERTX_AUTH entity with auth_type=jwt_auth")
+	}
+
+	// Validate DTOs
+	dtoNames := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_VERTX_DTO" {
+			dtoNames[e.Name] = true
+		}
+	}
+	if !dtoNames["CreateUserRequest"] {
+		t.Errorf("[#3086 full-app] expected CreateUserRequest DTO, got %v", dtoNames)
+	}
+	if !dtoNames["UpdateUserRequest"] {
+		t.Errorf("[#3086 full-app] expected UpdateUserRequest DTO, got %v", dtoNames)
+	}
+
+	// Validate handler attributions via HANDLED_BY relationship
+	foundHandledBy := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "HANDLED_BY" && rel.Properties["framework"] == "vertx" {
+			foundHandledBy = true
+			break
+		}
+	}
+	if !foundHandledBy {
+		t.Errorf("[#3086 full-app] expected at least one HANDLED_BY relationship")
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -332,6 +332,8 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeJAXRS(string(content), emit)
 		// Javalin (#3085): lambda DSL `app.get("/path", handler)` routing.
 		synthesizeJavalin(string(content), emit)
+		// Vert.x (#3086): lambda DSL `router.get("/path").handler(...)` routing.
+		synthesizeVertx(string(content), emit)
 		// Consumer side (#721): HttpClient / RestTemplate /
 		// WebClient / OkHttp / Apache HttpClient / Retrofit.
 		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
@@ -831,6 +833,45 @@ func synthesizeJavalin(content string, emit emitFn) {
 		rawPath := m[2]
 		canonical := httproutes.Canonicalize(httproutes.FrameworkJavalin, rawPath)
 		emit(verb, canonical, "javalin", "Route", "")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Vert.x (Java) — lambda DSL routing (#3086)
+// ---------------------------------------------------------------------------
+
+// vertxRouteRe captures Vert.x Web router lambda-DSL route registrations of the form:
+//
+//	router.get("/path").handler(handler)
+//	router.post("/path").handler(ctx -> { ... })
+//	router.route("/path").handler(...)  — path-scoped handler chain
+//
+// The verb list excludes "route" which is matched separately.
+var vertxRouteRe = regexp.MustCompile(
+	`\brouter\s*\.\s*(get|post|put|delete|patch|head|options)\s*\(\s*"([^"]+)"`)
+
+// synthesizeVertx scans a Java file for Vert.x Web router lambda-DSL route
+// registrations and emits one http_endpoint_definition per (verb, path) pair.
+// Vert.x Web uses `{param}` curly-brace path parameters (JAX-RS style), so
+// FrameworkVertx is passed to Canonicalize.
+func synthesizeVertx(content string, emit emitFn) {
+	// File-signal gate: require a Vert.x-specific import or API reference.
+	if !strings.Contains(content, "vertx") && !strings.Contains(content, "Vertx") &&
+		!strings.Contains(content, "AbstractVerticle") && !strings.Contains(content, "Router") {
+		return
+	}
+	// Secondary gate: require router.get/post/... pattern.
+	if !strings.Contains(content, "router.") && !strings.Contains(content, "router ") {
+		return
+	}
+	for _, m := range vertxRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		rawPath := m[2]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkVertx, rawPath)
+		emit(verb, canonical, "vertx", "Route", "")
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis_vertx_3086_test.go
+++ b/internal/engine/http_endpoint_synthesis_vertx_3086_test.go
@@ -1,0 +1,121 @@
+package engine
+
+// Vert.x endpoint synthesis tests for issue #3086.
+// These tests verify that synthesizeVertx in http_endpoint_synthesis.go
+// correctly emits http_endpoint_definition entities for Vert.x Web router routes.
+
+import (
+	"testing"
+)
+
+// TestSynth_Vertx_BasicRoutes_Issue3086 verifies that Vert.x Web router
+// route registrations are synthesised into http_endpoint_definition entities
+// with correct (verb, canonical-path) IDs.
+// Registry target: lang.java.framework.vertx Routing/endpoint_synthesis → partial.
+// Cite: internal/engine/http_endpoint_synthesis.go (synthesizeVertx)
+func TestSynth_Vertx_BasicRoutes_Issue3086(t *testing.T) {
+	src := `package com.example;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.ext.web.Router;
+
+public class MainVerticle extends AbstractVerticle {
+    @Override
+    public void start() {
+        Router router = Router.router(vertx);
+
+        router.get("/users").handler(ctx -> ctx.response().end("[]"));
+        router.post("/users").handler(ctx -> {
+            ctx.response().setStatusCode(201).end();
+        });
+        router.get("/users/:id").handler(ctx -> ctx.response().end("user"));
+        router.put("/users/:id").handler(ctx -> ctx.response().end());
+        router.delete("/users/:id").handler(ctx -> ctx.response().setStatusCode(204).end());
+
+        vertx.createHttpServer().requestHandler(router).listen(8080);
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/MainVerticle.java", src)
+	want := []string{
+		"http:GET:/users",
+		"http:POST:/users",
+		"http:GET:/users/:id",
+		"http:PUT:/users/:id",
+		"http:DELETE:/users/:id",
+	}
+	requireContains(t, got, want, "Vert.x basic routes")
+}
+
+// TestSynth_Vertx_PathParams_Issue3086 verifies that Vert.x {param}
+// curly-brace path parameters are canonicalised correctly.
+func TestSynth_Vertx_PathParams_Issue3086(t *testing.T) {
+	src := `package com.example;
+
+import io.vertx.ext.web.Router;
+
+public class App {
+    void setup(Router router) {
+        router.get("/orgs/{orgId}/projects/{projectId}").handler(ctx -> ctx.response().end("ok"));
+        router.patch("/items/{itemId}/status").handler(ctx -> ctx.response().setStatusCode(200).end());
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/App.java", src)
+	want := []string{
+		"http:GET:/orgs/{orgId}/projects/{projectId}",
+		"http:PATCH:/items/{itemId}/status",
+	}
+	requireContains(t, got, want, "Vert.x path params")
+}
+
+// TestSynth_Vertx_NoSignalNoOp_Issue3086 verifies that the synthesizer
+// no-ops on Java files without any Vert.x signal.
+func TestSynth_Vertx_NoSignalNoOp_Issue3086(t *testing.T) {
+	src := `package com.example;
+
+public class OrderService {
+    public Order findById(long id) { return null; }
+    public void save(Order o) {}
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/OrderService.java", src)
+	for _, id := range got {
+		// We expect zero Vert.x synthetics. Any http: ID here would come from
+		// JAX-RS or Spring, but this file has neither.
+		if len(id) > 5 && id[:5] == "http:" {
+			t.Errorf("[#3086 no-signal-noop] unexpected http entity %q in non-Vert.x file", id)
+		}
+	}
+}
+
+// TestSynth_Vertx_CoexistsWithJavalin_Issue3086 verifies that Vert.x and
+// Javalin synthetics can coexist in the same Java case without contaminating
+// each other (dedup isolation).
+func TestSynth_Vertx_CoexistsWithJavalin_Issue3086(t *testing.T) {
+	src := `package com.example;
+
+import io.vertx.ext.web.Router;
+import io.javalin.Javalin;
+
+// Hypothetical file with both Vert.x router and Javalin routes.
+// In practice these would not coexist, but tests dedup isolation.
+class VertxApp {
+    void setup(Router router) {
+        router.get("/vertx-items").handler(ctx -> ctx.response().end("[]"));
+    }
+}
+
+class JavalinApp {
+    static void register(Javalin app) {
+        app.get("/javalin-items", ctx -> ctx.result("[]"));
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/App.java", src)
+	want := []string{
+		"http:GET:/vertx-items",
+		"http:GET:/javalin-items",
+	}
+	requireContains(t, got, want, "Vert.x+Javalin coexistence")
+}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -124,6 +124,10 @@ const (
 	// `{name}` curly-brace path parameters identical to JAX-RS / Spring.
 	// Canonicalisation reuses canonicalizeCurlyBraces.
 	FrameworkJavalin = "javalin"
+	// FrameworkVertx (#3086) — Vert.x Web `router.get("/users/:id", ...)` uses
+	// `{name}` curly-brace path parameters identical to JAX-RS / Spring.
+	// Canonicalisation reuses canonicalizeCurlyBraces.
+	FrameworkVertx = "vertx"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -162,7 +166,7 @@ func Canonicalize(framework, raw string) string {
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum,
 		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore, FrameworkHapi,
 		FrameworkLitestar, FrameworkAiohttp, FrameworkFalcon, FrameworkHug,
-		FrameworkJavalin:
+		FrameworkJavalin, FrameworkVertx:
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkTornado:
 		// Tornado paths arrive already pre-processed by the synthesizer

--- a/internal/engine/testdata/fixtures/sources/java/vertx/MainVerticle.java
+++ b/internal/engine/testdata/fixtures/sources/java/vertx/MainVerticle.java
@@ -1,0 +1,116 @@
+package com.example;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.CorsHandler;
+import io.vertx.ext.web.handler.JWTAuthHandler;
+import io.vertx.ext.web.handler.LoggerHandler;
+import io.vertx.ext.auth.jwt.JWTAuth;
+import com.example.dto.CreateUserRequest;
+import com.example.dto.UpdateUserRequest;
+
+/**
+ * Main Vert.x Web verticle — used as a fixture for the Vert.x route extractor
+ * test suite (internal/custom/java/vertx_routes.go, issue #3086).
+ *
+ * Demonstrates:
+ *  - Router lambda DSL: router.get("/path").handler(ctx -> ...)
+ *  - Method-reference handlers: router.get("/path").handler(Handler::method)
+ *  - Global middleware: router.route().handler(BodyHandler.create())
+ *  - JWT auth: router.route("/api/*").handler(JWTAuthHandler.create(jwt))
+ *  - DTO body mapping: ctx.body().as(CreateUserRequest.class)
+ *  - Path parameters: /users/:id (colon style, Vert.x default)
+ */
+public class MainVerticle extends AbstractVerticle {
+
+    private JWTAuth jwtProvider;
+    private UserService userService;
+
+    @Override
+    public void start(Promise<Void> startPromise) {
+        jwtProvider = createJwtProvider();
+        userService = new UserService();
+
+        Router router = Router.router(vertx);
+
+        // ----------------------------------------------------------------
+        // Global middleware
+        // ----------------------------------------------------------------
+        router.route().handler(BodyHandler.create());
+        router.route().handler(LoggerHandler.create());
+        router.route().handler(CorsHandler.create("*")
+            .allowedMethod(io.vertx.core.http.HttpMethod.GET)
+            .allowedMethod(io.vertx.core.http.HttpMethod.POST));
+
+        // ----------------------------------------------------------------
+        // JWT authentication for /api/* routes
+        // ----------------------------------------------------------------
+        router.route("/api/*").handler(JWTAuthHandler.create(jwtProvider));
+
+        // ----------------------------------------------------------------
+        // Public routes
+        // ----------------------------------------------------------------
+        router.get("/health").handler(ctx ->
+            ctx.response().setStatusCode(200).end("UP"));
+
+        router.get("/version").handler(ctx ->
+            ctx.response().end("{\"version\":\"1.0.0\"}"));
+
+        // ----------------------------------------------------------------
+        // User CRUD routes (authenticated)
+        // ----------------------------------------------------------------
+        router.get("/api/users").handler(UserHandler::listAll);
+
+        router.post("/api/users").handler(ctx -> {
+            CreateUserRequest req = ctx.body().as(CreateUserRequest.class);
+            userService.create(req)
+                .onSuccess(user -> ctx.response().setStatusCode(201).end(user.toJson().encode()))
+                .onFailure(err -> ctx.fail(500, err));
+        });
+
+        router.get("/api/users/:id").handler(UserHandler::getById);
+
+        router.put("/api/users/:id").handler(ctx -> {
+            String id = ctx.pathParam("id");
+            UpdateUserRequest req = ctx.body().as(UpdateUserRequest.class);
+            userService.update(id, req)
+                .onSuccess(updated -> ctx.response().end(updated.toJson().encode()))
+                .onFailure(err -> ctx.fail(404, err));
+        });
+
+        router.delete("/api/users/:id").handler(UserHandler::delete);
+
+        // ----------------------------------------------------------------
+        // Nested resource routes
+        // ----------------------------------------------------------------
+        router.get("/api/users/:userId/posts").handler(ctx -> {
+            String userId = ctx.pathParam("userId");
+            postService.findByUser(userId)
+                .onSuccess(posts -> ctx.response().end(posts.encode()));
+        });
+
+        router.get("/api/users/:userId/posts/:postId").handler(ctx -> {
+            ctx.response().end("post");
+        });
+
+        // ----------------------------------------------------------------
+        // Start HTTP server
+        // ----------------------------------------------------------------
+        vertx.createHttpServer()
+            .requestHandler(router)
+            .listen(8080, http -> {
+                if (http.succeeded()) {
+                    startPromise.complete();
+                } else {
+                    startPromise.fail(http.cause());
+                }
+            });
+    }
+
+    private JWTAuth createJwtProvider() {
+        // JWT provider configuration (simplified)
+        return JWTAuth.create(vertx, new io.vertx.ext.auth.jwt.JWTAuthOptions());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `internal/custom/java/vertx_routes.go`: Vert.x Web route extractor using the `router.get("/path").handler(...)` lambda DSL. Covers route extraction (get/post/put/delete/patch), middleware detection (`router.route().handler(...)`), auth via `BasicAuthHandler`/`JWTAuthHandler`/`OAuth2AuthHandler.create()` and inline `ctx.user()`/`ctx.fail(401)` guards, DTO mapping via `ctx.body().as(Foo.class)`, and test linkage via `VertxTestContext`/`VertxExtension`/`@ExtendWith(VertxExtension.class)`.
- Adds `synthesizeVertx()` to `internal/engine/http_endpoint_synthesis.go`: emits `http_endpoint_definition` per (verb, canonical-path) pair, registered in the `java` synthesis case alongside Javalin.
- Adds `FrameworkVertx` constant to `httproutes/canonicalize.go` (uses `canonicalizeCurlyBraces` — Vert.x supports both `:colon` and `{curly}` path param styles).
- Registers `vertx`/`vert.x`/`vert_x`/`vertx_web` in `junit5Frameworks` for `tests_linkage` coverage.
- Fixture: `testdata/fixtures/sources/java/vertx/MainVerticle.java`.
- 6 B-cells → partial: `route_extraction`, `auth_coverage`, `middleware_coverage`, `dto_extraction`, `request_validation`, `tests_linkage`.
- 9 C-cells → not_applicable: `di_binding_extraction`, `di_injection_point`, `di_scope_resolution` (Vert.x has no built-in DI); `advice_attribution`, `aspect_extraction`, `pointcut_resolution` (no AOP); `transaction_boundary_extraction`, `transaction_propagation`, `transaction_rollback_rules` (no built-in tx management).
- 24 dedicated tests (20 in `vertx_routes_test.go`, 4 in `http_endpoint_synthesis_vertx_3086_test.go`).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/engine/ ./internal/custom/java/ ./internal/types/ ./tools/coverage/` all pass
- [x] `coverage validate` 0 errors
- [x] `coverage fmt --check` clean
- [x] `coverage gen` byte-stable

Closes #3086

🤖 Generated with [Claude Code](https://claude.com/claude-code)