### PR TITLE
feat(coverage): Struts route/middleware extractor + C-flips

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -123,7 +123,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
 | [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 7/20 | ❌ 3/16 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 7/20 | ❌ 3/16 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ❌ 0/1 | ❌ 7/20 | ❌ 4/7 | |
 | [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 13/13 | |
 | [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 13/16 | |
 | [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 13/13 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -15,7 +15,7 @@ Back to [summary](../summary.md).
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 7/20 | ❌ 3/16 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | ❌ 2/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ❌ 7/20 | ❌ 3/16 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ❌ 0/1 | ❌ 7/20 | ❌ 4/7 | |
 | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 13/13 | |
 | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 13/16 | |
 | [Helidon](../detail/lang.java.framework.helidon.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 13/13 | |

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -17,13 +17,13 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
 | Handler attribution | ⚠️ `partial` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/apache_struts.yaml` | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | ⚠️ `partial` | `2026-05-29` | 3089 | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Extracts @Action(value=...) annotations and struts.xml <action> elements; @Namespace prefix composition; HANDLED_BY relationships to action classes |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | ❌ `missing` | — | — | — | — |
+| Auth coverage | ⚠️ `partial` | `2026-05-29` | 3089 | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Detects JAAS (LoginContext/Subject) and Spring Security (SecurityContextHolder/@PreAuthorize/@Secured) integration markers; Struts has no built-in auth, so detection is heuristic based on common integration patterns |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | `2026-05-29` | 3089 | `internal/custom/java/struts_routes.go`<br>`internal/custom/java/struts_routes_test.go` | Detects Interceptor/AbstractInterceptor implementors and intercept(ActionInvocation) overrides; the Struts interceptor stack is the primary middleware mechanism |
 
 ### Testing
 
@@ -57,25 +57,25 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | Struts 2 has no intrinsic DI; Spring-plugin DI is optional and handled by the Spring DI extractor |
+| DI injection point | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | Struts 2 has no intrinsic DI injection points; Spring-plugin injection is optional |
+| DI scope resolution | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | Struts 2 has no intrinsic DI scope management |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | Struts has no transaction management; projects use Spring @Transactional or JTA outside the framework |
+| Transaction propagation | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | No transaction propagation in Struts core; deferred to Spring/JTA layer |
+| Transaction rollback rules | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | No rollback-rule declarations in Struts; deferred to Spring/JTA layer |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | Struts uses interceptor chain for cross-cutting concerns, not AspectJ AOP; Spring AOP extractor must not fire for framework=struts |
+| Aspect extraction | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | Struts uses interceptors not AspectJ @Aspect |
+| Pointcut resolution | — `not_applicable` | — | 3089 | `internal/custom/java/struts_routes.go` | Struts has no pointcut concept; interceptors cover this role |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -17768,13 +17768,20 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/struts_routes.go","internal/custom/java/struts_routes_test.go"],
+            "issue": "3089",
+            "notes": "Extracts @Action(value=...) annotations and struts.xml \u003caction\u003e elements; @Namespace prefix composition; HANDLED_BY relationships to action classes",
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/struts_routes.go","internal/custom/java/struts_routes_test.go"],
+            "issue": "3089",
+            "notes": "Detects JAAS (LoginContext/Subject) and Spring Security (SecurityContextHolder/@PreAuthorize/@Secured) integration markers; Struts has no built-in auth, so detection is heuristic based on common integration patterns",
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -17789,7 +17796,11 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/struts_routes.go","internal/custom/java/struts_routes_test.go"],
+            "issue": "3089",
+            "notes": "Detects Interceptor/AbstractInterceptor implementors and intercept(ActionInvocation) overrides; the Struts interceptor stack is the primary middleware mechanism",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -17821,44 +17832,62 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "Struts 2 has no intrinsic DI; Spring-plugin DI is optional and handled by the Spring DI extractor"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "Struts 2 has no intrinsic DI injection points; Spring-plugin injection is optional"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "Struts 2 has no intrinsic DI scope management"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "Struts has no transaction management; projects use Spring @Transactional or JTA outside the framework"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "No transaction propagation in Struts core; deferred to Spring/JTA layer"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "No rollback-rule declarations in Struts; deferred to Spring/JTA layer"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "Struts uses interceptor chain for cross-cutting concerns, not AspectJ AOP; Spring AOP extractor must not fire for framework=struts"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "Struts uses interceptors not AspectJ @Aspect"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/struts_routes.go"],
+            "issue": "3089",
+            "notes": "Struts has no pointcut concept; interceptors cover this role"
           }
         },
         "Observability": {

--- a/internal/custom/java/junit5.go
+++ b/internal/custom/java/junit5.go
@@ -29,6 +29,9 @@ var junit5Frameworks = map[string]bool{
 	"javalin": true,
 	// Vert.x uses JUnit 5 with VertxExtension / VertxTestContext for tests_linkage (#3086).
 	"vertx": true, "vert.x": true, "vert_x": true, "vertx_web": true, "vertx-web": true,
+	// Struts uses JUnit 5 (or JUnit 4 via Struts Test Plugin) for tests_linkage (#3089).
+	"struts": true, "struts2": true, "struts-2": true, "apache_struts": true, "apache-struts": true,
+	"struts_2": true,
 }
 
 var (

--- a/internal/custom/java/struts_routes.go
+++ b/internal/custom/java/struts_routes.go
@@ -1,0 +1,458 @@
+package java
+
+import (
+	"encoding/xml"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Struts custom extractor — route extraction, handler attribution, middleware
+// (interceptor chain).
+//
+// Apache Struts 2 defines routes in two ways:
+//  1. Annotation-based: @Action(value="/path") on action class methods, with
+//     optional @Result annotations for response mapping.
+//  2. XML-based: <action name="X" class="Y" method="Z"> elements inside
+//     <package> blocks in struts.xml.
+//
+// Middleware in Struts is the interceptor chain: classes that implement
+// com.opensymphony.xwork2.interceptor.Interceptor and override intercept().
+// Struts ships a large default interceptor stack (params, validation, workflow,
+// etc.) that applies to every action; custom interceptors are declared in
+// struts.xml and wired to actions.
+//
+// Auth: Struts has no built-in auth layer — projects integrate JAAS or Spring
+// Security externally. We detect JAAS (LoginContext / Subject) and Spring
+// Security (@PreAuthorize / SecurityContextHolder) markers and emit an
+// AuthGuard entity when present.
+//
+// DI is C (not_applicable for this extractor): Struts 2 supports Spring-plugin
+// DI as an optional add-on, not an intrinsic part of the framework. The Spring
+// DI extractor handles those bindings separately.
+//
+// AOP is C (not_applicable): Struts uses its interceptor chain rather than
+// AspectJ/Spring AOP. The Spring AOP extractor must NOT fire for
+// framework=struts.
+//
+// Transactions are C (not_applicable): Struts has no transaction management;
+// projects use Spring @Transactional or JTA outside the framework.
+//
+// Coverage cells delivered (#3089):
+//   - Routing:    route_extraction                → partial
+//   - Auth:       auth_coverage                   → partial
+//   - Middleware: middleware_coverage              → partial
+//   - DI:         di_binding_extraction, di_injection_point, di_scope_resolution → not_applicable
+//   - AOP:        advice_attribution, aspect_extraction, pointcut_resolution     → not_applicable
+//   - Transactions: transaction_boundary_extraction, transaction_propagation,
+//     transaction_rollback_rules                                                 → not_applicable
+
+// strutsFrameworks is the set of framework identifiers that activate the Struts
+// extractor.
+var strutsFrameworks = map[string]bool{
+	"struts":         true,
+	"struts2":        true,
+	"struts-2":       true,
+	"apache_struts":  true,
+	"apache-struts":  true,
+	"struts_2":       true,
+}
+
+var (
+	// @Action(value="/path") — annotation on a method or class.
+	// Also matches @Action("/path") shorthand (value is positional).
+	// Capture group 1: the path string.
+	strutsActionAnnotationRE = regexp.MustCompile(
+		`@Action\s*\(\s*(?:value\s*=\s*)?"([^"]+)"`)
+
+	// @Action with method attribute: @Action(value="/path", ...)
+	// We already capture the path above; no separate RE needed.
+
+	// @Result(name="...", location="...") — response mapping annotation.
+	// Capture group 1: result name, group 2: result location (JSP/redirect).
+	strutsResultAnnotationRE = regexp.MustCompile(
+		`@Result\s*\(\s*name\s*=\s*"([^"]+)"\s*,\s*(?:location|type)\s*=\s*"([^"]+)"`)
+
+	// Interceptor implementation: class Foo implements Interceptor
+	// or extends AbstractInterceptor (the most common extension point).
+	// Capture group 1: class name.
+	strutsInterceptorImplRE = regexp.MustCompile(
+		`(?:public\s+)?(?:abstract\s+)?class\s+(\w+)\s+(?:extends\s+\w+\s+)?implements\s+[^{]*\bInterceptor\b`)
+
+	// AbstractInterceptor subclass (alternative pattern).
+	strutsAbstractInterceptorRE = regexp.MustCompile(
+		`(?:public\s+)?class\s+(\w+)\s+extends\s+AbstractInterceptor\b`)
+
+	// intercept() method override — strongest signal for a custom interceptor.
+	strutsInterceptMethodRE = regexp.MustCompile(
+		`(?m)public\s+String\s+intercept\s*\(\s*ActionInvocation\b`)
+
+	// Auth: JAAS integration markers.
+	strutsJAASLoginContextRE = regexp.MustCompile(
+		`\bLoginContext\b|\bSubject\.doAs\b|\bLoginModule\b`)
+
+	// Auth: Spring Security markers (common in Struts+Spring stacks).
+	strutsSpringSecurityRE = regexp.MustCompile(
+		`@PreAuthorize\b|@Secured\b|\bSecurityContextHolder\b|\bAuthentication\b`)
+
+	// Auth: custom security interceptor names commonly used with Struts.
+	strutsSecurityInterceptorRE = regexp.MustCompile(
+		`(?i)(?:security|auth(?:entication|orization)?|login)\s*interceptor`)
+
+	// ActionSupport subclass — the canonical Struts 2 action base class.
+	strutsActionSupportRE = regexp.MustCompile(
+		`\bextends\s+ActionSupport\b`)
+
+	// @Namespace("/prefix") — package-level namespace annotation.
+	strutsNamespaceRE = regexp.MustCompile(
+		`@Namespace\s*\(\s*"([^"]+)"`)
+)
+
+// strutsXMLAction represents a parsed <action> element from struts.xml.
+type strutsXMLAction struct {
+	Name   string `xml:"name,attr"`
+	Class  string `xml:"class,attr"`
+	Method string `xml:"method,attr"`
+}
+
+// strutsXMLPackage represents a parsed <package> element from struts.xml.
+type strutsXMLPackage struct {
+	Name      string            `xml:"name,attr"`
+	Namespace string            `xml:"namespace,attr"`
+	Actions   []strutsXMLAction `xml:"action"`
+}
+
+// strutsXMLConfig represents a parsed struts.xml config.
+type strutsXMLConfig struct {
+	Packages []strutsXMLPackage `xml:"package"`
+}
+
+// parseStrutsXML parses a struts.xml document and returns the action mappings.
+// Returns nil on parse error (caller falls back to regex).
+func parseStrutsXML(content string) []strutsXMLPackage {
+	var cfg strutsXMLConfig
+	dec := xml.NewDecoder(strings.NewReader(content))
+	dec.Strict = false
+	// Struts XML uses a DOCTYPE declaration that the stdlib XML parser will
+	// reject if entity expansion is attempted. We simply ignore token errors
+	// (DOCTYPE/ProcInst) and collect what we can.
+	if err := dec.Decode(&cfg); err != nil {
+		// Partial parse may have populated some packages — use what we have.
+		_ = err
+	}
+	return cfg.Packages
+}
+
+// ExtractStruts runs the Struts extractor for route, interceptor (middleware),
+// and auth patterns.
+func ExtractStruts(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !strutsFrameworks[ctx.Framework] {
+		return result
+	}
+
+	// Quick-exit: no Struts signals in this file.
+	isXML := strings.HasSuffix(ctx.FilePath, ".xml")
+	if !isXML {
+		if !strings.Contains(ctx.Source, "struts2") &&
+			!strings.Contains(ctx.Source, "Struts") &&
+			!strings.Contains(ctx.Source, "ActionSupport") &&
+			!strings.Contains(ctx.Source, "opensymphony") &&
+			!strings.Contains(ctx.Source, "@Action") &&
+			!strings.Contains(ctx.Source, "Interceptor") {
+			return result
+		}
+	}
+
+	seen := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// -------------------------------------------------------------------------
+	// Namespace detection (annotation-level prefix)
+	// -------------------------------------------------------------------------
+	namespace := ""
+	if m := strutsNamespaceRE.FindStringSubmatch(ctx.Source); len(m) >= 2 {
+		namespace = m[1]
+		if namespace == "/" {
+			namespace = ""
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Route extraction: @Action annotation
+	// -------------------------------------------------------------------------
+	for _, idx := range strutsActionAnnotationRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		rawPath := ctx.Source[idx[2]:idx[3]]
+		fullPath := joinStrutsPath(namespace, rawPath)
+		ref := fmt.Sprintf("struts:route:GET:%s:%s", fullPath, ctx.FilePath)
+
+		e := SecondaryEntity{
+			Name:       fullPath,
+			Kind:       "Route",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_STRUTS_ACTION_ANNOTATION",
+			Ref:        ref,
+			Properties: map[string]any{
+				"http_verb":  "ANY",
+				"path":       fullPath,
+				"framework":  "struts",
+				"route_type": "annotation",
+			},
+		}
+		addEntity(&result, seen, e)
+
+		// Handler attribution: find the enclosing class name.
+		enclosingClass := findEnclosingClass(ctx.Source, idx[0])
+		if enclosingClass != "" {
+			handlerRef := fmt.Sprintf("struts:handler:%s:%s", enclosingClass, ctx.FilePath)
+			handler := SecondaryEntity{
+				Name:       enclosingClass,
+				Kind:       "Handler",
+				SourceFile: ctx.FilePath,
+				LineStart:  lineOf(ctx.Source, idx[0]),
+				Provenance: "INFERRED_FROM_STRUTS_ACTION_HANDLER",
+				Ref:        handlerRef,
+				Properties: map[string]any{
+					"framework":    "struts",
+					"handler_type": "action_class",
+					"path":         fullPath,
+				},
+			}
+			addEntity(&result, seen, handler)
+			addRel(&result, seenRels, Relationship{
+				SourceRef:        ref,
+				TargetRef:        handlerRef,
+				RelationshipType: "HANDLED_BY",
+				Properties:       map[string]string{"framework": "struts"},
+			})
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Route extraction: struts.xml <action> elements (XML-only path)
+	// -------------------------------------------------------------------------
+	if isXML {
+		pkgs := parseStrutsXML(ctx.Source)
+		for _, pkg := range pkgs {
+			ns := pkg.Namespace
+			if ns == "/" {
+				ns = ""
+			}
+			for _, action := range pkg.Actions {
+				rawPath := "/" + action.Name
+				fullPath := joinStrutsPath(ns, rawPath)
+				method := action.Method
+				if method == "" {
+					method = "execute"
+				}
+				ref := fmt.Sprintf("struts:route:xml:%s:%s", fullPath, ctx.FilePath)
+
+				e := SecondaryEntity{
+					Name:       fullPath,
+					Kind:       "Route",
+					SourceFile: ctx.FilePath,
+					LineStart:  1,
+					Provenance: "INFERRED_FROM_STRUTS_XML_ACTION",
+					Ref:        ref,
+					Properties: map[string]any{
+						"http_verb":      "ANY",
+						"path":           fullPath,
+						"framework":      "struts",
+						"route_type":     "xml_config",
+						"action_class":   action.Class,
+						"action_method":  method,
+						"package_name":   pkg.Name,
+						"namespace":      ns,
+					},
+				}
+				addEntity(&result, seen, e)
+
+				if action.Class != "" {
+					// Derive simple class name from fully qualified name.
+					className := action.Class
+					if dot := strings.LastIndex(className, "."); dot >= 0 {
+						className = className[dot+1:]
+					}
+					handlerRef := fmt.Sprintf("struts:handler:xml:%s:%s:%s", className, method, ctx.FilePath)
+					handler := SecondaryEntity{
+						Name:       className + "." + method,
+						Kind:       "Handler",
+						SourceFile: ctx.FilePath,
+						LineStart:  1,
+						Provenance: "INFERRED_FROM_STRUTS_XML_HANDLER",
+						Ref:        handlerRef,
+						Properties: map[string]any{
+							"framework":    "struts",
+							"handler_type": "action_method",
+							"path":         fullPath,
+							"class":        action.Class,
+							"method":       method,
+						},
+					}
+					addEntity(&result, seen, handler)
+					addRel(&result, seenRels, Relationship{
+						SourceRef:        ref,
+						TargetRef:        handlerRef,
+						RelationshipType: "HANDLED_BY",
+						Properties:       map[string]string{"framework": "struts"},
+					})
+				}
+			}
+		}
+
+		// XML files have no interceptor or auth content — return early.
+		return result
+	}
+
+	// -------------------------------------------------------------------------
+	// Middleware: Interceptor implementations
+	// -------------------------------------------------------------------------
+	// Pattern 1: implements Interceptor
+	for _, idx := range strutsInterceptorImplRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		className := ctx.Source[idx[2]:idx[3]]
+		ref := fmt.Sprintf("struts:interceptor:%s:%s", className, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       className,
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_STRUTS_INTERCEPTOR",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":        "struts",
+				"middleware_type":  "interceptor",
+				"interceptor_impl": "Interceptor",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// Pattern 2: extends AbstractInterceptor
+	for _, idx := range strutsAbstractInterceptorRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		className := ctx.Source[idx[2]:idx[3]]
+		ref := fmt.Sprintf("struts:interceptor:%s:%s", className, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       className,
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_STRUTS_INTERCEPTOR",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":        "struts",
+				"middleware_type":  "interceptor",
+				"interceptor_impl": "AbstractInterceptor",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// Pattern 3: intercept(ActionInvocation) method override alone
+	// (catches interceptor subclasses that extend a third-party base class).
+	if strutsInterceptMethodRE.MatchString(ctx.Source) {
+		// Only emit a generic interceptor entity if we didn't already emit one
+		// for the class above (dedup by ref).
+		className := findEnclosingClass(ctx.Source,
+			strutsInterceptMethodRE.FindStringIndex(ctx.Source)[0])
+		if className != "" {
+			ref := fmt.Sprintf("struts:interceptor:%s:%s", className, ctx.FilePath)
+			e := SecondaryEntity{
+				Name:       className,
+				Kind:       "Middleware",
+				SourceFile: ctx.FilePath,
+				LineStart:  lineOf(ctx.Source, strutsInterceptMethodRE.FindStringIndex(ctx.Source)[0]),
+				Provenance: "INFERRED_FROM_STRUTS_INTERCEPTOR",
+				Ref:        ref,
+				Properties: map[string]any{
+					"framework":        "struts",
+					"middleware_type":  "interceptor",
+					"interceptor_impl": "intercept_override",
+				},
+			}
+			addEntity(&result, seen, e)
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Auth: JAAS / Spring Security markers
+	// -------------------------------------------------------------------------
+	if strutsJAASLoginContextRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("struts:auth:jaas:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "jaas_auth",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strutsJAASLoginContextRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_STRUTS_AUTH_JAAS",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "struts",
+				"auth_type": "jaas",
+				"auth_hook": "LoginContext",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if strutsSpringSecurityRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("struts:auth:spring_security:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "spring_security_auth",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strutsSpringSecurityRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_STRUTS_AUTH_SPRING_SECURITY",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "struts",
+				"auth_type": "spring_security",
+				"auth_hook": "SecurityContextHolder/@PreAuthorize",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if strutsSecurityInterceptorRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("struts:auth:security_interceptor:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "security_interceptor",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strutsSecurityInterceptorRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_STRUTS_AUTH_INTERCEPTOR",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "struts",
+				"auth_type": "security_interceptor",
+				"auth_hook": "named_security_interceptor",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	return result
+}
+
+// joinStrutsPath joins a namespace prefix with an action path, ensuring
+// exactly one slash between them and a leading slash on the result.
+func joinStrutsPath(namespace, path string) string {
+	ns := strings.TrimRight(namespace, "/")
+	p := path
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	if ns == "" {
+		return p
+	}
+	return ns + p
+}

--- a/internal/custom/java/struts_routes_test.go
+++ b/internal/custom/java/struts_routes_test.go
@@ -1,0 +1,856 @@
+package java
+
+import (
+	"testing"
+)
+
+// ============================================================================
+// Issue #3089: Struts route/interceptor/auth extractor
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Routing: route_extraction — @Action annotation
+// ----------------------------------------------------------------------------
+
+// TestStruts_RouteExtraction_ActionAnnotation_Issue3089 proves that
+// @Action(value="/path") annotations are extracted as Route entities.
+// Registry target: lang.java.framework.struts Routing/route_extraction → partial.
+// Cite: internal/custom/java/struts_routes.go
+func TestStruts_RouteExtraction_ActionAnnotation_Issue3089(t *testing.T) {
+	source := `
+package com.example;
+
+import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.Result;
+import com.opensymphony.xwork2.ActionSupport;
+
+public class UserAction extends ActionSupport {
+
+    @Action(value="/users/list")
+    @Result(name="success", location="/WEB-INF/jsp/users.jsp")
+    public String list() {
+        return SUCCESS;
+    }
+
+    @Action(value="/users/create")
+    @Result(name="success", location="/WEB-INF/jsp/createUser.jsp")
+    public String create() {
+        return SUCCESS;
+    }
+
+    @Action(value="/users/{id}/edit")
+    public String edit() {
+        return SUCCESS;
+    }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "UserAction.java",
+	})
+
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_ACTION_ANNOTATION" {
+			routes[e.Properties["path"].(string)] = true
+		}
+	}
+
+	for _, want := range []string{
+		"/users/list",
+		"/users/create",
+		"/users/{id}/edit",
+	} {
+		if !routes[want] {
+			t.Errorf("[#3089 route_extraction] expected route %q, got %v", want, routes)
+		}
+	}
+}
+
+// TestStruts_RouteExtraction_ActionShorthand_Issue3089 proves that the
+// positional @Action("/path") shorthand (no explicit value=) is extracted.
+func TestStruts_RouteExtraction_ActionShorthand_Issue3089(t *testing.T) {
+	source := `
+import org.apache.struts2.convention.annotation.Action;
+import com.opensymphony.xwork2.ActionSupport;
+
+public class OrderAction extends ActionSupport {
+    @Action("/orders/new")
+    public String newOrder() { return SUCCESS; }
+
+    @Action("/orders/save")
+    public String save() { return SUCCESS; }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "OrderAction.java",
+	})
+
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_ACTION_ANNOTATION" {
+			routes[e.Properties["path"].(string)] = true
+		}
+	}
+
+	if !routes["/orders/new"] {
+		t.Errorf("[#3089 route_extraction] expected /orders/new, got %v", routes)
+	}
+	if !routes["/orders/save"] {
+		t.Errorf("[#3089 route_extraction] expected /orders/save, got %v", routes)
+	}
+}
+
+// TestStruts_RouteExtraction_Namespace_Issue3089 proves that @Namespace prefix
+// is prepended to @Action paths.
+func TestStruts_RouteExtraction_Namespace_Issue3089(t *testing.T) {
+	source := `
+import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.Namespace;
+import com.opensymphony.xwork2.ActionSupport;
+
+@Namespace("/api/v1")
+public class ProductAction extends ActionSupport {
+    @Action("/products")
+    public String list() { return SUCCESS; }
+
+    @Action("/products/{id}")
+    public String show() { return SUCCESS; }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "ProductAction.java",
+	})
+
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_ACTION_ANNOTATION" {
+			routes[e.Properties["path"].(string)] = true
+		}
+	}
+
+	if !routes["/api/v1/products"] {
+		t.Errorf("[#3089 route_extraction] expected /api/v1/products with namespace prefix, got %v", routes)
+	}
+	if !routes["/api/v1/products/{id}"] {
+		t.Errorf("[#3089 route_extraction] expected /api/v1/products/{id} with namespace prefix, got %v", routes)
+	}
+}
+
+// TestStruts_RouteExtraction_XMLConfig_Issue3089 proves that struts.xml
+// <action> elements are extracted from XML config files.
+// Registry target: lang.java.framework.struts Routing/route_extraction → partial.
+// Cite: internal/custom/java/struts_routes.go
+func TestStruts_RouteExtraction_XMLConfig_Issue3089(t *testing.T) {
+	source := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE struts PUBLIC "-//Apache Software Foundation//DTD Struts Configuration 2.5//EN"
+    "http://struts.apache.org/dtds/struts-2.5.dtd">
+<struts>
+    <package name="default" namespace="/app" extends="struts-default">
+        <action name="users" class="com.example.UserAction" method="list">
+            <result name="success">/WEB-INF/jsp/users.jsp</result>
+        </action>
+        <action name="createUser" class="com.example.UserAction" method="create">
+            <result name="success" type="redirectAction">users</result>
+        </action>
+        <action name="userDetail" class="com.example.UserAction" method="show">
+            <result>/WEB-INF/jsp/userDetail.jsp</result>
+        </action>
+    </package>
+    <package name="admin" namespace="/admin" extends="struts-default">
+        <action name="dashboard" class="com.example.AdminAction">
+            <result>/WEB-INF/jsp/admin.jsp</result>
+        </action>
+    </package>
+</struts>
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "struts.xml",
+	})
+
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_XML_ACTION" {
+			routes[e.Properties["path"].(string)] = true
+		}
+	}
+
+	for _, want := range []string{
+		"/app/users",
+		"/app/createUser",
+		"/app/userDetail",
+		"/admin/dashboard",
+	} {
+		if !routes[want] {
+			t.Errorf("[#3089 route_extraction] expected route %q, got %v", want, routes)
+		}
+	}
+}
+
+// TestStruts_RouteExtraction_XMLConfig_NoNamespace_Issue3089 proves that
+// <action> elements in packages without a namespace are extracted with a
+// leading slash.
+func TestStruts_RouteExtraction_XMLConfig_NoNamespace_Issue3089(t *testing.T) {
+	source := `<?xml version="1.0" encoding="UTF-8"?>
+<struts>
+    <package name="default" extends="struts-default">
+        <action name="login" class="com.example.LoginAction">
+            <result>/login.jsp</result>
+        </action>
+        <action name="logout" class="com.example.LoginAction" method="logout">
+            <result type="redirect">/login.action</result>
+        </action>
+    </package>
+</struts>
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "struts.xml",
+	})
+
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_XML_ACTION" {
+			routes[e.Properties["path"].(string)] = true
+		}
+	}
+
+	if !routes["/login"] {
+		t.Errorf("[#3089 route_extraction] expected /login, got %v", routes)
+	}
+	if !routes["/logout"] {
+		t.Errorf("[#3089 route_extraction] expected /logout, got %v", routes)
+	}
+}
+
+// TestStruts_HandlerAttribution_Annotation_Issue3089 proves that the
+// enclosing action class is attributed as the handler for @Action routes.
+// Registry target: Routing/handler_attribution is already partial via YAML rule.
+func TestStruts_HandlerAttribution_Annotation_Issue3089(t *testing.T) {
+	source := `
+import org.apache.struts2.convention.annotation.Action;
+import com.opensymphony.xwork2.ActionSupport;
+
+public class InvoiceAction extends ActionSupport {
+    @Action("/invoices/list")
+    public String list() { return SUCCESS; }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "InvoiceAction.java",
+	})
+
+	foundRoute := false
+	foundHandler := false
+	foundRel := false
+
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_ACTION_ANNOTATION" {
+			foundRoute = true
+		}
+		if e.Provenance == "INFERRED_FROM_STRUTS_ACTION_HANDLER" {
+			foundHandler = true
+			if e.Name != "InvoiceAction" {
+				t.Errorf("[#3089 handler_attribution] expected handler name=InvoiceAction, got %q", e.Name)
+			}
+		}
+	}
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "HANDLED_BY" && rel.Properties["framework"] == "struts" {
+			foundRel = true
+		}
+	}
+
+	if !foundRoute {
+		t.Errorf("[#3089 handler_attribution] expected INFERRED_FROM_STRUTS_ACTION_ANNOTATION entity")
+	}
+	if !foundHandler {
+		t.Errorf("[#3089 handler_attribution] expected INFERRED_FROM_STRUTS_ACTION_HANDLER entity")
+	}
+	if !foundRel {
+		t.Errorf("[#3089 handler_attribution] expected HANDLED_BY relationship")
+	}
+}
+
+// TestStruts_HandlerAttribution_XML_Issue3089 proves that the action class
+// and method from struts.xml are attributed as handlers.
+func TestStruts_HandlerAttribution_XML_Issue3089(t *testing.T) {
+	source := `<?xml version="1.0" encoding="UTF-8"?>
+<struts>
+    <package name="default" namespace="/" extends="struts-default">
+        <action name="search" class="com.example.SearchAction" method="execute">
+            <result>/search.jsp</result>
+        </action>
+    </package>
+</struts>
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "struts.xml",
+	})
+
+	foundHandler := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_XML_HANDLER" {
+			foundHandler = true
+			if e.Properties["class"] != "com.example.SearchAction" {
+				t.Errorf("[#3089 handler_attribution] expected class=com.example.SearchAction, got %v", e.Properties["class"])
+			}
+			if e.Properties["method"] != "execute" {
+				t.Errorf("[#3089 handler_attribution] expected method=execute, got %v", e.Properties["method"])
+			}
+		}
+	}
+	if !foundHandler {
+		t.Errorf("[#3089 handler_attribution] expected INFERRED_FROM_STRUTS_XML_HANDLER entity")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Middleware: middleware_coverage — interceptor chain
+// ----------------------------------------------------------------------------
+
+// TestStruts_Middleware_InterceptorImpl_Issue3089 proves that classes
+// implementing the Interceptor interface are extracted as Middleware entities.
+// Registry target: lang.java.framework.struts Middleware/middleware_coverage → partial.
+// Cite: internal/custom/java/struts_routes.go
+func TestStruts_Middleware_InterceptorImpl_Issue3089(t *testing.T) {
+	source := `
+package com.example;
+
+import com.opensymphony.xwork2.interceptor.Interceptor;
+import com.opensymphony.xwork2.ActionInvocation;
+
+public class LoggingInterceptor implements Interceptor {
+
+    @Override
+    public void init() {}
+
+    @Override
+    public void destroy() {}
+
+    @Override
+    public String intercept(ActionInvocation invocation) throws Exception {
+        System.out.println("Before action: " + invocation.getAction());
+        String result = invocation.invoke();
+        System.out.println("After action: " + result);
+        return result;
+    }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "LoggingInterceptor.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Kind == "Middleware" && e.Provenance == "INFERRED_FROM_STRUTS_INTERCEPTOR" {
+			found = true
+			if e.Name != "LoggingInterceptor" {
+				t.Errorf("[#3089 middleware_coverage] expected name=LoggingInterceptor, got %q", e.Name)
+			}
+			if e.Properties["middleware_type"] != "interceptor" {
+				t.Errorf("[#3089 middleware_coverage] expected middleware_type=interceptor, got %v", e.Properties["middleware_type"])
+			}
+			if e.Properties["framework"] != "struts" {
+				t.Errorf("[#3089 middleware_coverage] expected framework=struts, got %v", e.Properties["framework"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3089 middleware_coverage] expected Middleware entity from implements Interceptor")
+	}
+}
+
+// TestStruts_Middleware_AbstractInterceptor_Issue3089 proves that classes
+// extending AbstractInterceptor are extracted as Middleware entities.
+func TestStruts_Middleware_AbstractInterceptor_Issue3089(t *testing.T) {
+	source := `
+import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
+import com.opensymphony.xwork2.ActionInvocation;
+
+public class AuthInterceptor extends AbstractInterceptor {
+    @Override
+    public String intercept(ActionInvocation invocation) throws Exception {
+        String user = (String) invocation.getInvocationContext().getSession().get("user");
+        if (user == null) {
+            return "login";
+        }
+        return invocation.invoke();
+    }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "AuthInterceptor.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Kind == "Middleware" && e.Provenance == "INFERRED_FROM_STRUTS_INTERCEPTOR" {
+			found = true
+			if e.Name != "AuthInterceptor" {
+				t.Errorf("[#3089 middleware_coverage] expected name=AuthInterceptor, got %q", e.Name)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3089 middleware_coverage] expected Middleware entity from extends AbstractInterceptor")
+	}
+}
+
+// TestStruts_Middleware_InterceptMethod_Issue3089 proves that a class with
+// an intercept(ActionInvocation) override is detected even without an
+// explicit implements/extends declaration in the same file.
+func TestStruts_Middleware_InterceptMethod_Issue3089(t *testing.T) {
+	source := `
+import com.opensymphony.xwork2.ActionInvocation;
+
+public class TimingInterceptor extends BaseFrameworkInterceptor {
+    @Override
+    public String intercept(ActionInvocation invocation) throws Exception {
+        long start = System.currentTimeMillis();
+        String result = invocation.invoke();
+        long elapsed = System.currentTimeMillis() - start;
+        System.out.println("Elapsed: " + elapsed + "ms");
+        return result;
+    }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "TimingInterceptor.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Kind == "Middleware" && e.Provenance == "INFERRED_FROM_STRUTS_INTERCEPTOR" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("[#3089 middleware_coverage] expected Middleware entity from intercept(ActionInvocation) override")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Auth: auth_coverage — JAAS + Spring Security integration markers
+// ----------------------------------------------------------------------------
+
+// TestStruts_Auth_JAAS_Issue3089 proves that JAAS LoginContext usage in a
+// Struts interceptor is detected as auth coverage evidence.
+// Registry target: lang.java.framework.struts Auth/auth_coverage → partial.
+// Cite: internal/custom/java/struts_routes.go
+func TestStruts_Auth_JAAS_Issue3089(t *testing.T) {
+	source := `
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.Subject;
+import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
+
+public class JaasInterceptor extends AbstractInterceptor {
+    @Override
+    public String intercept(ActionInvocation invocation) throws Exception {
+        LoginContext lc = new LoginContext("appDomain", new SimpleCallbackHandler());
+        lc.login();
+        Subject subject = lc.getSubject();
+        // proceed with authenticated subject
+        return invocation.invoke();
+    }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "JaasInterceptor.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_AUTH_JAAS" {
+			found = true
+			if e.Properties["auth_type"] != "jaas" {
+				t.Errorf("[#3089 auth_coverage] expected auth_type=jaas, got %v", e.Properties["auth_type"])
+			}
+			if e.Properties["framework"] != "struts" {
+				t.Errorf("[#3089 auth_coverage] expected framework=struts, got %v", e.Properties["framework"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3089 auth_coverage] expected INFERRED_FROM_STRUTS_AUTH_JAAS entity")
+	}
+}
+
+// TestStruts_Auth_SpringSecurity_Issue3089 proves that Spring Security markers
+// (SecurityContextHolder, @PreAuthorize) are detected as auth evidence in a
+// Struts+Spring integration scenario.
+func TestStruts_Auth_SpringSecurity_Issue3089(t *testing.T) {
+	source := `
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.Authentication;
+import com.opensymphony.xwork2.ActionSupport;
+
+public class SecureAction extends ActionSupport {
+    public String execute() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            return LOGIN;
+        }
+        return SUCCESS;
+    }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "SecureAction.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_AUTH_SPRING_SECURITY" {
+			found = true
+			if e.Properties["auth_type"] != "spring_security" {
+				t.Errorf("[#3089 auth_coverage] expected auth_type=spring_security, got %v", e.Properties["auth_type"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("[#3089 auth_coverage] expected INFERRED_FROM_STRUTS_AUTH_SPRING_SECURITY entity")
+	}
+}
+
+// TestStruts_Auth_SpringPreAuthorize_Issue3089 proves that @PreAuthorize
+// annotation is detected as Spring Security auth evidence.
+func TestStruts_Auth_SpringPreAuthorize_Issue3089(t *testing.T) {
+	source := `
+import org.springframework.security.access.prepost.PreAuthorize;
+import com.opensymphony.xwork2.ActionSupport;
+
+public class AdminAction extends ActionSupport {
+    @PreAuthorize("hasRole('ADMIN')")
+    public String adminOnly() { return SUCCESS; }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "AdminAction.java",
+	})
+
+	found := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_AUTH_SPRING_SECURITY" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("[#3089 auth_coverage] expected INFERRED_FROM_STRUTS_AUTH_SPRING_SECURITY for @PreAuthorize")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Gating: extractor must not fire for wrong framework or absent signal
+// ----------------------------------------------------------------------------
+
+// TestStruts_Gating_WrongFramework_Issue3089 confirms the extractor does not
+// fire for non-struts frameworks.
+func TestStruts_Gating_WrongFramework_Issue3089(t *testing.T) {
+	source := `
+import org.apache.struts2.convention.annotation.Action;
+import com.opensymphony.xwork2.ActionSupport;
+
+public class UserAction extends ActionSupport {
+    @Action("/users/list")
+    public String list() { return SUCCESS; }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_boot", // wrong framework
+		FilePath:  "UserAction.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3089 gating] expected 0 entities for framework=spring_boot, got %d", len(r.Entities))
+	}
+}
+
+// TestStruts_Gating_NoSignal_Issue3089 confirms the extractor no-ops on Java
+// files with no Struts signals.
+func TestStruts_Gating_NoSignal_Issue3089(t *testing.T) {
+	source := `
+public class OrderService {
+    public Order findById(long id) { return null; }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "OrderService.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3089 gating] expected 0 entities for file without Struts signal, got %d", len(r.Entities))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// AOP: not_applicable — Struts uses interceptors, not AspectJ AOP
+// ----------------------------------------------------------------------------
+
+// TestStruts_AOP_NotApplicable_Issue3089 confirms that the Spring AOP
+// extractor does NOT fire for framework=struts.
+// Registry target: AOP/advice_attribution, AOP/aspect_extraction,
+//
+//	AOP/pointcut_resolution → not_applicable.
+func TestStruts_AOP_NotApplicable_Issue3089(t *testing.T) {
+	source := `
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import com.opensymphony.xwork2.ActionSupport;
+
+// Note: @Aspect is NOT a Struts concept — Spring AOP extractor must not
+// fire for framework=struts. Struts uses its interceptor chain for AOP-like
+// cross-cutting concerns, not AspectJ.
+@Aspect
+public class LoggingAspect {
+    @Before("execution(* com.example.*.*(..))")
+    public void logBefore() {}
+}
+`
+	r := ExtractSpringAOP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "LoggingAspect.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3089 aop-not-applicable] Spring AOP extractor must not fire for framework=struts, got %d entities", len(r.Entities))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Comprehensive: full Struts app with routes, interceptors, and auth
+// ----------------------------------------------------------------------------
+
+// TestStruts_FullApp_Issue3089 verifies a realistic Struts app with @Action
+// routes, custom interceptors, and auth integration all extracted correctly.
+// This is the comprehensive proving test that justifies partial status for
+// route_extraction, middleware_coverage, and auth_coverage.
+func TestStruts_FullApp_Issue3089(t *testing.T) {
+	source := `
+package com.example;
+
+import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.Namespace;
+import org.apache.struts2.convention.annotation.Result;
+import com.opensymphony.xwork2.ActionSupport;
+import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
+import com.opensymphony.xwork2.ActionInvocation;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Namespace("/api")
+public class CustomerAction extends ActionSupport {
+
+    @Action(value="/customers/list")
+    @Result(name="success", location="customers.jsp")
+    public String list() {
+        return SUCCESS;
+    }
+
+    @Action(value="/customers/new")
+    public String create() {
+        return SUCCESS;
+    }
+
+    @Action(value="/customers/{id}")
+    public String show() {
+        return SUCCESS;
+    }
+
+    @Action(value="/customers/{id}/delete")
+    public String delete() {
+        return SUCCESS;
+    }
+}
+
+class SecurityInterceptor extends AbstractInterceptor {
+    @Override
+    public String intercept(ActionInvocation invocation) throws Exception {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            return LOGIN;
+        }
+        return invocation.invoke();
+    }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "CustomerAction.java",
+	})
+
+	// Validate routes (namespace + action paths)
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_ACTION_ANNOTATION" {
+			routes[e.Properties["path"].(string)] = true
+		}
+	}
+	for _, want := range []string{
+		"/api/customers/list",
+		"/api/customers/new",
+		"/api/customers/{id}",
+		"/api/customers/{id}/delete",
+	} {
+		if !routes[want] {
+			t.Errorf("[#3089 full-app] expected route %q, got %v", want, routes)
+		}
+	}
+
+	// Validate interceptor middleware
+	foundInterceptor := false
+	for _, e := range r.Entities {
+		if e.Kind == "Middleware" && e.Provenance == "INFERRED_FROM_STRUTS_INTERCEPTOR" {
+			foundInterceptor = true
+		}
+	}
+	if !foundInterceptor {
+		t.Errorf("[#3089 full-app] expected Middleware entity for SecurityInterceptor")
+	}
+
+	// Validate auth (Spring Security marker in the interceptor)
+	foundAuth := false
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_AUTH_SPRING_SECURITY" {
+			foundAuth = true
+		}
+	}
+	if !foundAuth {
+		t.Errorf("[#3089 full-app] expected INFERRED_FROM_STRUTS_AUTH_SPRING_SECURITY entity")
+	}
+}
+
+// TestStruts_XMLAndAnnotation_Coexist_Issue3089 ensures that annotation-based
+// and XML-based route extraction can coexist in the same test run.
+func TestStruts_XMLAndAnnotation_Coexist_Issue3089(t *testing.T) {
+	xmlSource := `<?xml version="1.0" encoding="UTF-8"?>
+<struts>
+    <package name="default" namespace="/legacy" extends="struts-default">
+        <action name="home" class="com.example.HomeAction">
+            <result>/home.jsp</result>
+        </action>
+    </package>
+</struts>
+`
+	rXML := ExtractStruts(PatternContext{
+		Source:    xmlSource,
+		Language:  "java",
+		Framework: "struts2",
+		FilePath:  "struts.xml",
+	})
+
+	javaSource := `
+import org.apache.struts2.convention.annotation.Action;
+import com.opensymphony.xwork2.ActionSupport;
+
+public class HomeAction extends ActionSupport {
+    @Action("/home/index")
+    public String index() { return SUCCESS; }
+}
+`
+	rJava := ExtractStruts(PatternContext{
+		Source:    javaSource,
+		Language:  "java",
+		Framework: "struts2",
+		FilePath:  "HomeAction.java",
+	})
+
+	xmlRoutes := 0
+	for _, e := range rXML.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_XML_ACTION" {
+			xmlRoutes++
+		}
+	}
+	if xmlRoutes == 0 {
+		t.Errorf("[#3089 coexist] expected XML action routes, got 0")
+	}
+
+	annotationRoutes := 0
+	for _, e := range rJava.Entities {
+		if e.Provenance == "INFERRED_FROM_STRUTS_ACTION_ANNOTATION" {
+			annotationRoutes++
+		}
+	}
+	if annotationRoutes == 0 {
+		t.Errorf("[#3089 coexist] expected annotation-based routes, got 0")
+	}
+}
+
+// TestStruts_RouteProperties_Issue3089 confirms that route entities carry
+// the expected properties (framework, route_type, http_verb, path).
+func TestStruts_RouteProperties_Issue3089(t *testing.T) {
+	source := `
+import org.apache.struts2.convention.annotation.Action;
+import com.opensymphony.xwork2.ActionSupport;
+
+public class ItemAction extends ActionSupport {
+    @Action("/items/list")
+    public String list() { return SUCCESS; }
+}
+`
+	r := ExtractStruts(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  "ItemAction.java",
+	})
+
+	for _, e := range r.Entities {
+		if e.Provenance != "INFERRED_FROM_STRUTS_ACTION_ANNOTATION" {
+			continue
+		}
+		if e.Properties["framework"] != "struts" {
+			t.Errorf("[#3089] expected framework=struts, got %v", e.Properties["framework"])
+		}
+		if e.Properties["route_type"] != "annotation" {
+			t.Errorf("[#3089] expected route_type=annotation, got %v", e.Properties["route_type"])
+		}
+		if e.Properties["path"] != "/items/list" {
+			t.Errorf("[#3089] expected path=/items/list, got %v", e.Properties["path"])
+		}
+		return
+	}
+	t.Errorf("[#3089] expected at least one INFERRED_FROM_STRUTS_ACTION_ANNOTATION entity")
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -334,6 +334,8 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeJavalin(string(content), emit)
 		// Vert.x (#3086): lambda DSL `router.get("/path").handler(...)` routing.
 		synthesizeVertx(string(content), emit)
+		// Struts (#3089): @Action annotation + struts.xml <action> routing.
+		synthesizeStruts(string(content), emit)
 		// Consumer side (#721): HttpClient / RestTemplate /
 		// WebClient / OkHttp / Apache HttpClient / Retrofit.
 		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
@@ -872,6 +874,65 @@ func synthesizeVertx(content string, emit emitFn) {
 		rawPath := m[2]
 		canonical := httproutes.Canonicalize(httproutes.FrameworkVertx, rawPath)
 		emit(verb, canonical, "vertx", "Route", "")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Struts (Java) — @Action annotation + struts.xml routing (#3089)
+// ---------------------------------------------------------------------------
+
+// strutsActionAnnotationSynthRe captures @Action(value="/path") and the
+// shorthand @Action("/path") on Struts 2 action classes or methods.
+// Capture group 1: the path string.
+var strutsActionAnnotationSynthRe = regexp.MustCompile(
+	`@Action\s*\(\s*(?:value\s*=\s*)?"([^"]+)"`)
+
+// strutsNamespaceSynthRe captures @Namespace("/prefix") at the class level.
+var strutsNamespaceSynthRe = regexp.MustCompile(
+	`@Namespace\s*\(\s*"([^"]+)"`)
+
+// synthesizeStruts scans a Java file for Struts 2 @Action annotation route
+// declarations and emits one http_endpoint_definition per annotated action.
+// Struts routes do not carry an explicit HTTP verb (all HTTP methods can
+// reach an action), so we emit "ANY" as the canonical method. The path is
+// the value attribute of @Action, optionally prefixed by @Namespace.
+//
+// FrameworkSpring is reused for canonicalization because Struts 2 uses the
+// same {param} curly-brace parameter syntax as Spring and JAX-RS.
+func synthesizeStruts(content string, emit emitFn) {
+	// File-signal gate: require a Struts-specific import or annotation.
+	if !strings.Contains(content, "@Action") &&
+		!strings.Contains(content, "ActionSupport") &&
+		!strings.Contains(content, "org.apache.struts2") &&
+		!strings.Contains(content, "opensymphony") {
+		return
+	}
+
+	// Detect package-level @Namespace prefix.
+	namespace := ""
+	if m := strutsNamespaceSynthRe.FindStringSubmatch(content); len(m) >= 2 {
+		namespace = strings.TrimRight(m[1], "/")
+		if namespace == "/" {
+			namespace = ""
+		}
+	}
+
+	for _, m := range strutsActionAnnotationSynthRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		rawPath := m[1]
+		fullPath := rawPath
+		if namespace != "" && !strings.HasPrefix(rawPath, namespace) {
+			if !strings.HasPrefix(rawPath, "/") {
+				rawPath = "/" + rawPath
+			}
+			fullPath = namespace + rawPath
+		} else if !strings.HasPrefix(rawPath, "/") {
+			fullPath = "/" + rawPath
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, fullPath)
+		emit("ANY", canonical, "struts", "Route", "")
 	}
 }
 


### PR DESCRIPTION
## Summary

- New `ExtractStruts` extractor (`internal/custom/java/struts_routes.go`) handles both @Action annotation routes and struts.xml `<action>` XML config mappings, Interceptor/AbstractInterceptor middleware detection, and JAAS/Spring Security auth markers
- `synthesizeStruts` added to `internal/engine/http_endpoint_synthesis.go` for `http_endpoint_definition` synthesis from `@Action` annotations
- 19 unit tests in `internal/custom/java/struts_routes_test.go` covering annotation routes, XML config, namespace prefixes, interceptors, auth, gating, and AOP not-applicable
- Struts added to `junit5Frameworks` for `tests_linkage` coverage
- 12 cells flipped: 3 → partial (route_extraction, middleware_coverage, auth_coverage), 9 → not_applicable (DI×3, AOP×3, Transactions×3)

## Cells flipped

| Cell | Before | After |
|---|---|---|
| Routing/route_extraction | missing | partial |
| Middleware/middleware_coverage | missing | partial |
| Auth/auth_coverage | missing | partial |
| DI/di_binding_extraction | missing | not_applicable |
| DI/di_injection_point | missing | not_applicable |
| DI/di_scope_resolution | missing | not_applicable |
| AOP/advice_attribution | missing | not_applicable |
| AOP/aspect_extraction | missing | not_applicable |
| AOP/pointcut_resolution | missing | not_applicable |
| Transactions/transaction_boundary_extraction | missing | not_applicable |
| Transactions/transaction_propagation | missing | not_applicable |
| Transactions/transaction_rollback_rules | missing | not_applicable |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/engine/ ./internal/custom/java/ ./internal/types/ ./tools/coverage/` — all pass
- [x] `coverage validate` — 0 errors
- [x] `coverage fmt --check` — ok
- [x] `coverage gen` — byte-stable (idempotent second run)
- [x] 19 dedicated Struts tests in struts_routes_test.go (all pass)

Closes #3089

🤖 Generated with [Claude Code](https://claude.com/claude-code)