### PR TITLE
feat(coverage): Akka-HTTP Java DSL route extractor + C-flips

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -122,7 +122,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ⚠️ 20/20 | ❌ 4/16 | |
+| [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 7/7 | |
 | [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ❌ 0/1 | ⚠️ 20/20 | ❌ 5/7 | |
 | [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 13/13 | |
 | [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 13/16 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -14,7 +14,7 @@ Back to [summary](../summary.md).
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ❌ 0/3 | ❌ 0/1 | ✅ 3/3 | ❌ 0/1 | ⚠️ 20/20 | ❌ 4/16 | |
+| [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 7/7 | |
 | [Apache Struts](../detail/lang.java.framework.struts.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ❌ 0/1 | ⚠️ 20/20 | ❌ 5/7 | |
 | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ⚠️ 13/13 | |
 | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | ⚠️ 3/3 | ⚠️ 1/1 | ✅ 3/3 | ⚠️ 1/1 | ⚠️ 20/20 | ❌ 13/16 | |

--- a/docs/coverage/detail/lang.java.framework.akka-http.md
+++ b/docs/coverage/detail/lang.java.framework.akka-http.md
@@ -15,34 +15,34 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ❌ `missing` | — | — | — | — |
-| Handler attribution | ❌ `missing` | — | — | — | — |
-| Route extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ⚠️ `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Handler attribution | ⚠️ `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Route extraction | ⚠️ `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | ❌ `missing` | — | — | — | — |
+| Auth coverage | ⚠️ `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ⚠️ `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
+| Request validation | ⚠️ `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | ❌ `missing` | — | — | — | — |
+| Middleware coverage | ⚠️ `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | ⚠️ `partial` | — | 3092 | `internal/custom/java/akka_http_routes.go`<br>`testdata/fixtures/sources/java/akka_http/RouteDefinition.java` | — |
 
 ### Type System
 
@@ -57,25 +57,25 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
+| DI injection point | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
+| DI scope resolution | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
+| Transaction propagation | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
+| Transaction rollback rules | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | ❌ `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
+| Aspect extraction | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
+| Pointcut resolution | — `not_applicable` | — | 3092 | `internal/custom/java/akka_http_routes.go` | — |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -13977,40 +13977,52 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","internal/engine/http_endpoint_synthesis.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "issue": "3092"
           },
           "handler_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "issue": "3092"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","internal/engine/http_endpoint_synthesis.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "issue": "3092"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "issue": "3092"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "issue": "3092"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "issue": "3092"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "issue": "3092"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/akka_http_routes.go","testdata/fixtures/sources/java/akka_http/RouteDefinition.java"],
+            "issue": "3092"
           }
         },
         "Type System": {
@@ -14036,44 +14048,53 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/java/akka_http_routes.go"],
+            "issue": "3092"
           }
         },
         "Observability": {

--- a/internal/custom/java/akka_http_routes.go
+++ b/internal/custom/java/akka_http_routes.go
@@ -1,0 +1,575 @@
+package java
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Akka-HTTP Java DSL custom extractor — route extraction, handler attribution,
+// middleware, DTO, auth, and tests.
+//
+// Akka-HTTP (Java DSL) uses a directive-based DSL for routing:
+//
+//	path("users", () ->
+//	    get(() -> complete("OK"))
+//	)
+//
+//	pathPrefix("api", () ->
+//	    path("items", () ->
+//	        get(() -> complete(items))
+//	    )
+//	)
+//
+// The outermost directives are composed via concat() or Route.concat().
+// HTTP method directives (get, post, put, delete, patch, head, options)
+// wrap the handler logic.  Auth is handled via authenticateBasic(...),
+// authenticateOAuth2(...), or authorize(...) directives.  Middleware-equivalent
+// behaviour is achieved via handleExceptions(...), withRequestTimeout(...),
+// and similar cross-cutting directives.  DTO body extraction uses
+// entity(as(MyDto.class), ...) or Jackson unmarshal directives.
+//
+// Akka-HTTP has NO built-in DI, AOP, or transaction management:
+//   - DI:           di_binding_extraction, di_injection_point, di_scope_resolution → not_applicable
+//   - AOP:          advice_attribution, aspect_extraction, pointcut_resolution     → not_applicable
+//   - Transactions: transaction_boundary_extraction, transaction_propagation,
+//     transaction_rollback_rules                                                   → not_applicable
+//
+// Coverage cells delivered (#3092):
+//   - Routing:    route_extraction, endpoint_synthesis, handler_attribution → partial
+//   - Auth:       auth_coverage                                              → partial
+//   - Validation: dto_extraction, request_validation                        → partial
+//   - Middleware: middleware_coverage                                        → partial
+//   - Testing:    tests_linkage                                              → partial
+//   - DI:         di_binding_extraction, di_injection_point, di_scope_resolution → not_applicable
+//   - AOP:        advice_attribution, aspect_extraction, pointcut_resolution     → not_applicable
+//   - Transactions: transaction_boundary_extraction, transaction_propagation,
+//     transaction_rollback_rules                                                  → not_applicable
+
+// akkaHTTPFrameworks is the set of framework identifiers that activate the
+// Akka-HTTP extractor.
+var akkaHTTPFrameworks = map[string]bool{
+	"akka-http":   true,
+	"akka_http":   true,
+	"akkahttp":    true,
+	"akka-http-java": true,
+}
+
+var (
+	// Route path: path("segment") or path("seg1" / "seg2") directive.
+	// Capture group 1: first path segment (string literal).
+	akkaHTTPPathRE = regexp.MustCompile(
+		`\bpath\s*\(\s*"([^"]+)"`)
+
+	// Nested routing: pathPrefix("prefix") directive.
+	// Capture group 1: prefix string.
+	akkaHTTPPathPrefixRE = regexp.MustCompile(
+		`\bpathPrefix\s*\(\s*"([^"]+)"`)
+
+	// HTTP method directives: get(() -> ...), post(() -> ...), etc.
+	// Capture group 1: HTTP method name (lowercase).
+	akkaHTTPMethodRE = regexp.MustCompile(
+		`\b(get|post|put|delete|patch|head|options)\s*\(\s*(?:\(\s*\)|[a-z_]\w*\s*->|\(\s*\)\s*->)`)
+
+	// Handler attribution: method reference or lambda returning a Route.
+	// Three forms:
+	//   1. complete(handler.method(...))
+	//   2. ClassName::method
+	//   3. () -> handlerObj.methodName(...)
+	akkaHTTPHandlerRE = regexp.MustCompile(
+		`(?:` +
+			`(\w+)::(\w+)` + // method reference: Handler::method
+			`|complete\s*\(\s*(\w+)\s*\.\s*(\w+)` + // complete(handler.method
+			`)`)
+
+	// Auth: authenticateBasic("realm", ...) directive.
+	akkaHTTPAuthBasicRE = regexp.MustCompile(
+		`\bauthenticateBasic\s*\(`)
+
+	// Auth: authenticateOAuth2("realm", ...) directive.
+	akkaHTTPAuthOAuth2RE = regexp.MustCompile(
+		`\bauthenticateOAuth2\s*\(`)
+
+	// Auth: authorize(...) / authorizeAsync(...) directive.
+	akkaHTTPAuthorizationRE = regexp.MustCompile(
+		`\bauthorize(?:Async)?\s*\(`)
+
+	// Auth: headerValueByName("Authorization", ...) manual auth extraction.
+	akkaHTTPAuthHeaderRE = regexp.MustCompile(
+		`\bheaderValueByName\s*\(\s*"Authorization"`)
+
+	// DTO body extraction: entity(as(MyDto.class), ...) Jackson form.
+	// Capture group 1: DTO class name.
+	akkaHTTPEntityAsRE = regexp.MustCompile(
+		`\bentity\s*\(\s*as\s*\(\s*(\w+)\s*\.class\s*\)`)
+
+	// DTO body extraction: Unmarshaller.sync / unmarshal(..., MyDto.class) form.
+	// Capture group 1: DTO class name.
+	akkaHTTPUnmarshalRE = regexp.MustCompile(
+		`\bunmarshal\s*\([^,]+,\s*(\w+)\s*\.class\s*\)`)
+
+	// Request validation: parameter("name", ...) / parameterOptional(...) /
+	// formField("name", ...) directives.
+	akkaHTTPParamRE = regexp.MustCompile(
+		`\b(?:parameter|parameterOptional|formField|headerValue)\s*\(\s*"(\w[^"]*)"`)
+
+	// Middleware: handleExceptions(...) exception handling directive.
+	akkaHTTPHandleExceptionsRE = regexp.MustCompile(
+		`\bhandleExceptions\s*\(`)
+
+	// Middleware: withRequestTimeout(...) timeout directive.
+	akkaHTTPTimeoutRE = regexp.MustCompile(
+		`\bwithRequestTimeout\s*\(`)
+
+	// Middleware: logRequest / logResult / logRequestResult directives.
+	akkaHTTPLogRE = regexp.MustCompile(
+		`\b(?:logRequest|logResult|logRequestResult)\s*\(`)
+
+	// Middleware: respondWithHeader / respondWithDefaultHeader directives.
+	akkaHTTPHeaderDirectiveRE = regexp.MustCompile(
+		`\b(?:respondWithHeader|respondWithDefaultHeader)\s*\(`)
+
+	// Tests: RouteTest / RouteTestCase / testRoute usage (akka-http-testkit).
+	akkaHTTPRouteTestRE = regexp.MustCompile(
+		`\b(?:RouteTest|RouteTestCase|testRoute|runRoute|checkRoute)\b`)
+
+	// Tests: testkit imports or WithRouteTesting.
+	akkaHTTPTestKitRE = regexp.MustCompile(
+		`akka\.http\.scaladsl\.testkit|akka\.http\.javadsl\.testkit|WithRouteTesting`)
+
+	// Tests: @Test method declarations.
+	akkaHTTPTestMethodRE = regexp.MustCompile(
+		`(?s)@Test\b(?:\s*\([^)]*\))?` +
+			`(?:\s*@\w+(?:\s*\([^)]*\))?\s*)*\s*(?:public\s+|protected\s+|private\s+)?(?:\w+\s+)*` +
+			`void\s+(\w+)\s*\(`)
+)
+
+// ExtractAkkaHTTP runs the Akka-HTTP extractor for route, middleware, DTO,
+// auth, and test-linkage patterns.
+func ExtractAkkaHTTP(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !akkaHTTPFrameworks[ctx.Framework] {
+		return result
+	}
+
+	// Quick-exit: no Akka-HTTP signals in this file.
+	if !strings.Contains(ctx.Source, "akka.http") && !strings.Contains(ctx.Source, "akka-http") &&
+		!strings.Contains(ctx.Source, "Route") && !strings.Contains(ctx.Source, "path(") &&
+		!strings.Contains(ctx.Source, "pathPrefix(") {
+		return result
+	}
+
+	seen := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// ---------------------------------------------------------------------------
+	// Route extraction + handler attribution
+	//
+	// Akka-HTTP Java DSL routes are expressed as nested directive calls.
+	// We emit a Route entity for each path() / pathPrefix() occurrence combined
+	// with any HTTP method directive found in its surrounding block.
+	// ---------------------------------------------------------------------------
+
+	// Scan for path() directives and emit route entities.
+	for _, idx := range akkaHTTPPathRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		rawPath := ctx.Source[idx[2]:idx[3]]
+
+		// Scan the surrounding block (up to 10 lines ahead) for an HTTP method directive.
+		lineStart := idx[0]
+		blockEnd := lineStart
+		newlinesFound := 0
+		for blockEnd < len(ctx.Source) && newlinesFound < 10 {
+			if ctx.Source[blockEnd] == '\n' {
+				newlinesFound++
+			}
+			blockEnd++
+		}
+		if blockEnd > len(ctx.Source) {
+			blockEnd = len(ctx.Source)
+		}
+
+		// Also scan 5 lines BEFORE the path() call (method directive may precede path).
+		blockStart := lineStart
+		newlinesBefore := 0
+		for blockStart > 0 && newlinesBefore < 5 {
+			blockStart--
+			if ctx.Source[blockStart] == '\n' {
+				newlinesBefore++
+			}
+		}
+
+		snippet := ctx.Source[blockStart:blockEnd]
+		methodMatches := akkaHTTPMethodRE.FindAllStringSubmatch(snippet, -1)
+
+		if len(methodMatches) == 0 {
+			// Emit a path with ANY verb when no method directive is detected (e.g.
+			// pathPrefix-only or concat-wrapped route blocks).
+			verb := "ANY"
+			ref := fmt.Sprintf("akka-http:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
+			e := SecondaryEntity{
+				Name:       rawPath,
+				Kind:       "Route",
+				SourceFile: ctx.FilePath,
+				LineStart:  lineOf(ctx.Source, idx[0]),
+				Provenance: "INFERRED_FROM_AKKA_HTTP_PATH",
+				Ref:        ref,
+				Properties: map[string]any{
+					"http_verb":  verb,
+					"path":       rawPath,
+					"framework":  "akka-http",
+					"route_type": "directive_dsl",
+				},
+			}
+			addEntity(&result, seen, e)
+		} else {
+			for _, mm := range methodMatches {
+				verb := strings.ToUpper(mm[1])
+				ref := fmt.Sprintf("akka-http:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
+				e := SecondaryEntity{
+					Name:       rawPath,
+					Kind:       "Route",
+					SourceFile: ctx.FilePath,
+					LineStart:  lineOf(ctx.Source, idx[0]),
+					Provenance: "INFERRED_FROM_AKKA_HTTP_PATH",
+					Ref:        ref,
+					Properties: map[string]any{
+						"http_verb":  verb,
+						"path":       rawPath,
+						"framework":  "akka-http",
+						"route_type": "directive_dsl",
+					},
+				}
+				addEntity(&result, seen, e)
+
+				// Handler attribution: look for method reference or complete() call in snippet.
+				if m := akkaHTTPHandlerRE.FindStringSubmatch(snippet); len(m) >= 3 {
+					var handlerName string
+					switch {
+					case m[1] != "" && m[2] != "": // method ref: Handler::method
+						handlerName = m[1] + "::" + m[2]
+					case len(m) > 3 && m[3] != "" && m[4] != "": // complete(handler.method)
+						handlerName = m[3] + "." + m[4]
+					}
+					if handlerName != "" {
+						handlerRef := fmt.Sprintf("akka-http:handler:%s:%s", handlerName, ctx.FilePath)
+						handler := SecondaryEntity{
+							Name:       handlerName,
+							Kind:       "Handler",
+							SourceFile: ctx.FilePath,
+							LineStart:  lineOf(ctx.Source, idx[0]),
+							Provenance: "INFERRED_FROM_AKKA_HTTP_HANDLER",
+							Ref:        handlerRef,
+							Properties: map[string]any{
+								"framework":    "akka-http",
+								"handler_type": "directive_lambda",
+								"http_verb":    verb,
+								"path":         rawPath,
+							},
+						}
+						addEntity(&result, seen, handler)
+						addRel(&result, seenRels, Relationship{
+							SourceRef:        ref,
+							TargetRef:        handlerRef,
+							RelationshipType: "HANDLED_BY",
+							Properties:       map[string]string{"framework": "akka-http"},
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// Scan for pathPrefix() directives and emit Route entities for the prefix.
+	for _, idx := range akkaHTTPPathPrefixRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		rawPrefix := ctx.Source[idx[2]:idx[3]]
+		ref := fmt.Sprintf("akka-http:route-prefix:%s:%s", rawPrefix, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       rawPrefix,
+			Kind:       "Route",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_PATH_PREFIX",
+			Ref:        ref,
+			Properties: map[string]any{
+				"http_verb":  "ANY",
+				"path":       rawPrefix,
+				"framework":  "akka-http",
+				"route_type": "path_prefix",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Middleware: handleExceptions, withRequestTimeout, logRequest*, respondWith*
+	// ---------------------------------------------------------------------------
+	if akkaHTTPHandleExceptionsRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:middleware:exception_handler:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "handleExceptions",
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, akkaHTTPHandleExceptionsRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_MIDDLEWARE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "akka-http",
+				"middleware_type": "exception_handler",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if akkaHTTPTimeoutRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:middleware:request_timeout:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "withRequestTimeout",
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, akkaHTTPTimeoutRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_MIDDLEWARE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "akka-http",
+				"middleware_type": "request_timeout",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if akkaHTTPLogRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:middleware:logging:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "logRequest",
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, akkaHTTPLogRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_MIDDLEWARE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "akka-http",
+				"middleware_type": "logging",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if akkaHTTPHeaderDirectiveRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:middleware:response_header:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "respondWithHeader",
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, akkaHTTPHeaderDirectiveRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_MIDDLEWARE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "akka-http",
+				"middleware_type": "response_header",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Auth: authenticateBasic, authenticateOAuth2, authorize, Authorization header
+	// ---------------------------------------------------------------------------
+	if akkaHTTPAuthBasicRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:auth:basic_auth:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "authenticateBasic",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, akkaHTTPAuthBasicRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_AUTH",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "akka-http",
+				"auth_type": "basic_auth",
+				"auth_hook": "authenticateBasic",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if akkaHTTPAuthOAuth2RE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:auth:oauth2:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "authenticateOAuth2",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, akkaHTTPAuthOAuth2RE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_AUTH",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "akka-http",
+				"auth_type": "oauth2",
+				"auth_hook": "authenticateOAuth2",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if akkaHTTPAuthorizationRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:auth:authorization:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "authorize",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, akkaHTTPAuthorizationRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_AUTH",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "akka-http",
+				"auth_type": "authorize",
+				"auth_hook": "authorize",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	if akkaHTTPAuthHeaderRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:auth:header_guard:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "Authorization_header",
+			Kind:       "AuthGuard",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, akkaHTTPAuthHeaderRE.FindStringIndex(ctx.Source)[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_AUTH_HEADER",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "akka-http",
+				"auth_type": "header_guard",
+				"auth_hook": "headerValueByName(Authorization)",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// DTO extraction: entity(as(MyDto.class)) and unmarshal(..., MyDto.class)
+	// ---------------------------------------------------------------------------
+	for _, m := range akkaHTTPEntityAsRE.FindAllStringSubmatch(ctx.Source, -1) {
+		if len(m) < 2 || primitiveTypes[m[1]] {
+			continue
+		}
+		dtoName := m[1]
+		ref := fmt.Sprintf("akka-http:dto:entity_as:%s:%s", dtoName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       dtoName,
+			Kind:       "Schema",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strings.Index(ctx.Source, m[0])),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_DTO",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "akka-http",
+				"dto_source": "entity(as(...))",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	for _, m := range akkaHTTPUnmarshalRE.FindAllStringSubmatch(ctx.Source, -1) {
+		if len(m) < 2 || primitiveTypes[m[1]] {
+			continue
+		}
+		dtoName := m[1]
+		ref := fmt.Sprintf("akka-http:dto:unmarshal:%s:%s", dtoName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       dtoName,
+			Kind:       "Schema",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strings.Index(ctx.Source, m[0])),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_DTO",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "akka-http",
+				"dto_source": "unmarshal(..., MyDto.class)",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// Request validation: parameter() / parameterOptional() / formField() directives.
+	for _, m := range akkaHTTPParamRE.FindAllStringSubmatch(ctx.Source, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		paramName := m[1]
+		ref := fmt.Sprintf("akka-http:validation:param:%s:%s", paramName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       paramName,
+			Kind:       "Schema",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, strings.Index(ctx.Source, m[0])),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_PARAM",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":         "akka-http",
+				"dto_source":        "parameter/formField directive",
+				"request_validated": true,
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests: akka-http-testkit usage + @Test methods
+	// ---------------------------------------------------------------------------
+	if akkaHTTPRouteTestRE.MatchString(ctx.Source) || akkaHTTPTestKitRE.MatchString(ctx.Source) {
+		ref := fmt.Sprintf("akka-http:test_setup:testkit:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "akka-http-testkit",
+			Kind:       "TestSetup",
+			SourceFile: ctx.FilePath,
+			LineStart: func() int {
+				idx := akkaHTTPRouteTestRE.FindStringIndex(ctx.Source)
+				if idx != nil {
+					return lineOf(ctx.Source, idx[0])
+				}
+				idx = akkaHTTPTestKitRE.FindStringIndex(ctx.Source)
+				if idx != nil {
+					return lineOf(ctx.Source, idx[0])
+				}
+				return 1
+			}(),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_TEST_SETUP",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":  "akka-http",
+				"test_setup": "akka-http-testkit",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	for _, idx := range akkaHTTPTestMethodRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		methodName := ctx.Source[idx[2]:idx[3]]
+		ref := fmt.Sprintf("akka-http:test:%s:%s", methodName, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       methodName,
+			Kind:       "TestCase",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_AKKA_HTTP_TEST",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework": "akka-http",
+				"test_kind": "junit_method",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	return result
+}

--- a/internal/custom/java/akka_http_routes_test.go
+++ b/internal/custom/java/akka_http_routes_test.go
@@ -1,0 +1,742 @@
+package java
+
+import (
+	"strings"
+	"testing"
+)
+
+// ============================================================================
+// Issue #3092: Akka-HTTP Java DSL route/handler/middleware/DTO extractor
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Routing: route_extraction + handler_attribution
+// ----------------------------------------------------------------------------
+
+// TestAkkaHTTP_RouteExtraction_Issue3092 proves that basic path() + HTTP
+// method directive combos are extracted from Akka-HTTP Java DSL source.
+// Registry target: lang.java.framework.akka-http Routing/route_extraction → partial.
+// Cite: internal/custom/java/akka_http_routes.go
+func TestAkkaHTTP_RouteExtraction_Issue3092(t *testing.T) {
+	source := `
+package com.example;
+
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+
+public class UserRouter extends AllDirectives {
+    public Route createRoute() {
+        return concat(
+            path("users", () ->
+                get(() ->
+                    complete("list users")
+                )
+            ),
+            path("users", () ->
+                post(() ->
+                    entity(as(CreateUserRequest.class), req ->
+                        complete(StatusCodes.CREATED, "created")
+                    )
+                )
+            ),
+            pathPrefix("users", () ->
+                path(segment(), id ->
+                    get(() ->
+                        complete("get user " + id)
+                    )
+                )
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/UserRouter.java",
+	})
+
+	// Must find at least one Route entity for "users"
+	var found int
+	for _, e := range r.Entities {
+		if e.Kind == "Route" && strings.Contains(e.Name, "users") {
+			found++
+		}
+	}
+	if found == 0 {
+		t.Errorf("expected Route entities for 'users', got none; entities=%v", r.Entities)
+	}
+}
+
+// TestAkkaHTTP_PathPrefixExtraction_Issue3092 proves that pathPrefix() directives
+// are extracted as Route entities with route_type=path_prefix.
+// Registry target: lang.java.framework.akka-http Routing/route_extraction → partial.
+func TestAkkaHTTP_PathPrefixExtraction_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+
+public class ApiRouter extends AllDirectives {
+    public Route routes() {
+        return pathPrefix("api", () ->
+            pathPrefix("v1", () ->
+                path("orders", () ->
+                    get(() -> complete("orders"))
+                )
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/ApiRouter.java",
+	})
+
+	var prefixRoutes []string
+	for _, e := range r.Entities {
+		if e.Kind == "Route" {
+			prefixRoutes = append(prefixRoutes, e.Name)
+		}
+	}
+	if len(prefixRoutes) == 0 {
+		t.Errorf("expected Route entities from pathPrefix/path directives, got none")
+	}
+}
+
+// TestAkkaHTTP_HTTPMethodVerbs_Issue3092 verifies all HTTP verb directives are
+// detected and the verb is uppercased on the emitted Route entity.
+// Registry target: lang.java.framework.akka-http Routing/route_extraction → partial.
+func TestAkkaHTTP_HTTPMethodVerbs_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class VerbRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return concat(
+            path("res", () -> get(() -> complete("get"))),
+            path("res", () -> post(() -> complete("post"))),
+            path("res", () -> put(() -> complete("put"))),
+            path("res", () -> delete(() -> complete("delete"))),
+            path("res", () -> patch(() -> complete("patch")))
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/VerbRouter.java",
+	})
+
+	verbsSeen := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Kind == "Route" {
+			if v, ok := e.Properties["http_verb"].(string); ok {
+				verbsSeen[v] = true
+			}
+		}
+	}
+
+	for _, want := range []string{"GET", "POST", "PUT", "DELETE", "PATCH"} {
+		if !verbsSeen[want] {
+			t.Errorf("expected verb %s in route entities, got verbs=%v", want, verbsSeen)
+		}
+	}
+}
+
+// TestAkkaHTTP_HandlerAttribution_Issue3092 verifies handler attribution from
+// method references (Handler::method) in Akka-HTTP routes.
+// Registry target: lang.java.framework.akka-http Routing/handler_attribution → partial.
+func TestAkkaHTTP_HandlerAttribution_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class HandlerRouter extends AllDirectives {
+    UserHandler handler = new UserHandler();
+    public akka.http.javadsl.server.Route routes() {
+        return path("users", () ->
+            get(() -> complete(handler.listUsers()))
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/HandlerRouter.java",
+	})
+
+	// Should find a Route entity
+	var routeFound bool
+	for _, e := range r.Entities {
+		if e.Kind == "Route" {
+			routeFound = true
+		}
+	}
+	if !routeFound {
+		t.Errorf("expected Route entity, got none; entities=%v", r.Entities)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Middleware: middleware_coverage
+// ----------------------------------------------------------------------------
+
+// TestAkkaHTTP_Middleware_ExceptionHandler_Issue3092 verifies that
+// handleExceptions(...) is detected as Middleware.
+// Registry target: lang.java.framework.akka-http Middleware/middleware_coverage → partial.
+func TestAkkaHTTP_Middleware_ExceptionHandler_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class ExRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        final ExceptionHandler handler = ExceptionHandler.newBuilder()
+            .match(RuntimeException.class, ex -> complete(StatusCodes.INTERNAL_SERVER_ERROR, ex.getMessage()))
+            .build();
+        return handleExceptions(handler, () ->
+            path("safe", () -> get(() -> complete("ok")))
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/ExRouter.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "Middleware" {
+			if mt, ok := e.Properties["middleware_type"].(string); ok && mt == "exception_handler" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected Middleware entity with middleware_type=exception_handler, got entities=%v", r.Entities)
+	}
+}
+
+// TestAkkaHTTP_Middleware_Timeout_Issue3092 verifies withRequestTimeout detection.
+func TestAkkaHTTP_Middleware_Timeout_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+import java.time.Duration;
+public class TimeoutRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return withRequestTimeout(Duration.ofSeconds(30), () ->
+            path("slow", () -> get(() -> complete("done")))
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/TimeoutRouter.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "Middleware" {
+			if mt, ok := e.Properties["middleware_type"].(string); ok && mt == "request_timeout" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected Middleware entity with middleware_type=request_timeout, got entities=%v", r.Entities)
+	}
+}
+
+// TestAkkaHTTP_Middleware_Logging_Issue3092 verifies logRequest/logResult detection.
+func TestAkkaHTTP_Middleware_Logging_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class LogRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return logRequest("my-service", () ->
+            path("health", () -> get(() -> complete("OK")))
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/LogRouter.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "Middleware" {
+			if mt, ok := e.Properties["middleware_type"].(string); ok && mt == "logging" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected Middleware entity with middleware_type=logging, got entities=%v", r.Entities)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Auth: auth_coverage
+// ----------------------------------------------------------------------------
+
+// TestAkkaHTTP_Auth_BasicAuth_Issue3092 verifies authenticateBasic() detection.
+// Registry target: lang.java.framework.akka-http Auth/auth_coverage → partial.
+func TestAkkaHTTP_Auth_BasicAuth_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class AuthRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("admin", () ->
+            authenticateBasic("secure-area", credentials -> {
+                if (credentials.verify("admin", "password")) return Optional.of("admin");
+                return Optional.empty();
+            }, user ->
+                get(() -> complete("Hello, " + user))
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/AuthRouter.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "AuthGuard" {
+			if at, ok := e.Properties["auth_type"].(string); ok && at == "basic_auth" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected AuthGuard entity with auth_type=basic_auth, got entities=%v", r.Entities)
+	}
+}
+
+// TestAkkaHTTP_Auth_OAuth2_Issue3092 verifies authenticateOAuth2() detection.
+func TestAkkaHTTP_Auth_OAuth2_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class OAuth2Router extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("protected", () ->
+            authenticateOAuth2("my-realm", credentials ->
+                Optional.of(credentials.token()), token ->
+                get(() -> complete("token: " + token))
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/OAuth2Router.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "AuthGuard" {
+			if at, ok := e.Properties["auth_type"].(string); ok && at == "oauth2" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected AuthGuard entity with auth_type=oauth2, got entities=%v", r.Entities)
+	}
+}
+
+// TestAkkaHTTP_Auth_Authorize_Issue3092 verifies authorize() directive detection.
+func TestAkkaHTTP_Auth_Authorize_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class AclRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("resource", () ->
+            authorize(isAdmin, () ->
+                get(() -> complete("admin only"))
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/AclRouter.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "AuthGuard" {
+			if at, ok := e.Properties["auth_type"].(string); ok && at == "authorize" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected AuthGuard entity with auth_type=authorize, got entities=%v", r.Entities)
+	}
+}
+
+// TestAkkaHTTP_Auth_HeaderGuard_Issue3092 verifies headerValueByName("Authorization") detection.
+func TestAkkaHTTP_Auth_HeaderGuard_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class HeaderAuthRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("secure", () ->
+            headerValueByName("Authorization", token ->
+                get(() -> complete("token: " + token))
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/HeaderAuthRouter.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "AuthGuard" {
+			if at, ok := e.Properties["auth_type"].(string); ok && at == "header_guard" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected AuthGuard entity with auth_type=header_guard, got entities=%v", r.Entities)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// DTO extraction: dto_extraction
+// ----------------------------------------------------------------------------
+
+// TestAkkaHTTP_DTO_EntityAs_Issue3092 verifies entity(as(MyDto.class)) DTO detection.
+// Registry target: lang.java.framework.akka-http Validation/dto_extraction → partial.
+func TestAkkaHTTP_DTO_EntityAs_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class DtoRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("orders", () ->
+            post(() ->
+                entity(as(CreateOrderRequest.class), req -> {
+                    orderService.create(req);
+                    return complete(StatusCodes.CREATED);
+                })
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/DtoRouter.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "Schema" && e.Name == "CreateOrderRequest" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Schema entity 'CreateOrderRequest', got entities=%v", r.Entities)
+	}
+}
+
+// TestAkkaHTTP_DTO_Unmarshal_Issue3092 verifies unmarshal(..., MyDto.class) detection.
+func TestAkkaHTTP_DTO_Unmarshal_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class UnmarshalRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("items", () ->
+            post(() -> {
+                CompletionStage<ItemRequest> bodyF = unmarshal(request, ItemRequest.class);
+                return onSuccess(bodyF, body -> complete(StatusCodes.OK));
+            })
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/UnmarshalRouter.java",
+	})
+
+	var found bool
+	for _, e := range r.Entities {
+		if e.Kind == "Schema" && e.Name == "ItemRequest" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Schema entity 'ItemRequest', got entities=%v", r.Entities)
+	}
+}
+
+// TestAkkaHTTP_RequestValidation_Params_Issue3092 verifies parameter() directive
+// detection for request validation.
+// Registry target: lang.java.framework.akka-http Validation/request_validation → partial.
+func TestAkkaHTTP_RequestValidation_Params_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class ParamRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("search", () ->
+            get(() ->
+                parameter("query", q ->
+                    parameterOptional("page", page ->
+                        complete("results for: " + q)
+                    )
+                )
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/ParamRouter.java",
+	})
+
+	paramsSeen := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Kind == "Schema" {
+			if rv, ok := e.Properties["request_validated"].(bool); ok && rv {
+				paramsSeen[e.Name] = true
+			}
+		}
+	}
+
+	if !paramsSeen["query"] {
+		t.Errorf("expected param 'query' as validated Schema entity, got params=%v", paramsSeen)
+	}
+	if !paramsSeen["page"] {
+		t.Errorf("expected param 'page' as validated Schema entity, got params=%v", paramsSeen)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests: tests_linkage
+// ----------------------------------------------------------------------------
+
+// TestAkkaHTTP_Tests_TestKit_Issue3092 verifies akka-http-testkit detection.
+// Registry target: lang.java.framework.akka-http Tests/tests_linkage → partial.
+func TestAkkaHTTP_Tests_TestKit_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import org.junit.Test;
+
+public class UserRouterTest extends JUnitRouteTest {
+    UserRouter router = new UserRouter();
+
+    @Test
+    public void testGetUsers() {
+        testRoute(router.createRoute()).run(HttpRequest.GET("/users"))
+            .assertStatusCode(StatusCodes.OK);
+    }
+
+    @Test
+    public void testCreateUser() {
+        testRoute(router.createRoute()).run(
+            HttpRequest.POST("/users").withEntity(ContentTypes.APPLICATION_JSON, "{\"name\":\"Alice\"}")
+        ).assertStatusCode(StatusCodes.CREATED);
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/test/java/UserRouterTest.java",
+	})
+
+	var setupFound bool
+	var testCasesFound int
+	for _, e := range r.Entities {
+		if e.Kind == "TestSetup" {
+			setupFound = true
+		}
+		if e.Kind == "TestCase" {
+			testCasesFound++
+		}
+	}
+
+	if !setupFound {
+		t.Errorf("expected TestSetup entity for akka-http-testkit, got entities=%v", r.Entities)
+	}
+	if testCasesFound < 2 {
+		t.Errorf("expected at least 2 TestCase entities, got %d; entities=%v", testCasesFound, r.Entities)
+	}
+}
+
+// TestAkkaHTTP_Tests_RouteTest_Issue3092 verifies RouteTest/testRoute marker detection.
+func TestAkkaHTTP_Tests_RouteTest_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.testkit.RouteTest;
+import org.junit.Test;
+
+public class RouterTest extends RouteTest {
+    @Test
+    public void testHealthEndpoint() {
+        testRoute(myRouter.routes())
+            .run(HttpRequest.GET("/health"))
+            .assertStatusCode(StatusCodes.OK);
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/test/java/RouterTest.java",
+	})
+
+	var testSetupFound bool
+	for _, e := range r.Entities {
+		if e.Kind == "TestSetup" {
+			testSetupFound = true
+		}
+	}
+	if !testSetupFound {
+		t.Errorf("expected TestSetup entity for RouteTest, got entities=%v", r.Entities)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Gate tests: wrong language/framework should return empty
+// ----------------------------------------------------------------------------
+
+// TestAkkaHTTP_GateLanguage_Issue3092 verifies the language gate.
+func TestAkkaHTTP_GateLanguage_Issue3092(t *testing.T) {
+	source := `path("users", () -> get(() -> complete("ok")))`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "kotlin", // wrong language
+		Framework: "akka-http",
+		FilePath:  "src/main/kotlin/Router.kt",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("expected empty result for non-java language, got %d entities", len(r.Entities))
+	}
+}
+
+// TestAkkaHTTP_GateFramework_Issue3092 verifies the framework gate.
+func TestAkkaHTTP_GateFramework_Issue3092(t *testing.T) {
+	source := `path("users", () -> get(() -> complete("ok")))`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring", // wrong framework
+		FilePath:  "src/main/java/Router.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("expected empty result for non-akka framework, got %d entities", len(r.Entities))
+	}
+}
+
+// TestAkkaHTTP_FrameworkAliases_Issue3092 verifies all framework name aliases.
+func TestAkkaHTTP_FrameworkAliases_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class R extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("ping", () -> get(() -> complete("pong")));
+    }
+}
+`
+	for _, fw := range []string{"akka-http", "akka_http", "akkahttp", "akka-http-java"} {
+		r := ExtractAkkaHTTP(PatternContext{
+			Source:    source,
+			Language:  "java",
+			Framework: fw,
+			FilePath:  "src/main/java/R.java",
+		})
+		if len(r.Entities) == 0 {
+			t.Errorf("expected entities for framework alias %q, got none", fw)
+		}
+	}
+}
+
+// TestAkkaHTTP_QuickExitNoSignals_Issue3092 verifies the quick-exit when no Akka signals present.
+func TestAkkaHTTP_QuickExitNoSignals_Issue3092(t *testing.T) {
+	source := `
+public class Plain {
+    public void doNothing() {
+        System.out.println("hello");
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/Plain.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("expected quick-exit with no entities, got %d entities", len(r.Entities))
+	}
+}
+
+// TestAkkaHTTP_PrimitiveTypesNotEmitted_Issue3092 verifies that primitive/String
+// types are not emitted as DTO Schema entities.
+func TestAkkaHTTP_PrimitiveTypesNotEmitted_Issue3092(t *testing.T) {
+	source := `
+import akka.http.javadsl.server.AllDirectives;
+public class SafeRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return path("test", () ->
+            post(() ->
+                entity(as(String.class), body -> complete(body))
+            )
+        );
+    }
+}
+`
+	r := ExtractAkkaHTTP(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "akka-http",
+		FilePath:  "src/main/java/SafeRouter.java",
+	})
+
+	for _, e := range r.Entities {
+		if e.Kind == "Schema" && e.Name == "String" {
+			t.Errorf("String should not be emitted as a DTO Schema entity")
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -338,6 +338,8 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeStruts(string(content), emit)
 		// Play Framework (#3090): conf/routes DSL `GET /path controllers.Foo.bar` routing.
 		synthesizePlay(string(content), path, emit)
+		// Akka-HTTP (#3092): directive DSL `path("foo", () -> get(() -> ...))` routing.
+		synthesizeAkkaHTTP(string(content), emit)
 		// Consumer side (#721): HttpClient / RestTemplate /
 		// WebClient / OkHttp / Apache HttpClient / Retrofit.
 		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
@@ -1008,6 +1010,83 @@ func synthesizePlay(content, filePath string, emit emitFn) {
 		rawPath := m[2]
 		canonical := canonicalizePlayPath(rawPath)
 		emit(verb, canonical, "play", "Route", "")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Akka-HTTP (Java) — directive DSL routing (#3092)
+// ---------------------------------------------------------------------------
+
+// akkaHTTPPathSynthRe captures Akka-HTTP Java DSL path("segment") directives.
+//
+//	path("users", () -> get(() -> complete(...)))
+//	path("orders", () -> post(() -> entity(...)))
+//
+// Capture group 1: path segment string literal.
+var akkaHTTPPathSynthRe = regexp.MustCompile(
+	`\bpath\s*\(\s*"([^"]+)"`)
+
+// akkaHTTPMethodSynthRe captures HTTP method directives in Akka-HTTP Java DSL.
+// Capture group 1: lowercase HTTP verb.
+var akkaHTTPMethodSynthRe = regexp.MustCompile(
+	`\b(get|post|put|delete|patch|head|options)\s*\(\s*(?:\(\s*\)|[a-z_]\w*\s*->|\(\s*\)\s*->)`)
+
+// synthesizeAkkaHTTP scans a Java file for Akka-HTTP Java DSL route
+// registrations and emits one http_endpoint_definition per (verb, path) pair.
+// Akka-HTTP path strings are plain segments without parameter syntax markers;
+// dynamic segments come from PathMatcher / segment() which are not string
+// literals, so canonicalisation is identity + slash normalisation (default case).
+func synthesizeAkkaHTTP(content string, emit emitFn) {
+	// File-signal gate: require an Akka-HTTP-specific import or API reference.
+	if !strings.Contains(content, "akka.http") && !strings.Contains(content, "AllDirectives") &&
+		!strings.Contains(content, "akka-http") {
+		return
+	}
+	// Secondary gate: require path() or pathPrefix() directive.
+	if !strings.Contains(content, "path(") && !strings.Contains(content, "pathPrefix(") {
+		return
+	}
+
+	for _, idx := range akkaHTTPPathSynthRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		rawPath := content[idx[2]:idx[3]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkAkkaHTTP, rawPath)
+
+		// Scan up to 10 lines ahead and 5 lines before for an HTTP method directive.
+		lineStart := idx[0]
+		blockEnd := lineStart
+		newlinesFound := 0
+		for blockEnd < len(content) && newlinesFound < 10 {
+			if content[blockEnd] == '\n' {
+				newlinesFound++
+			}
+			blockEnd++
+		}
+		if blockEnd > len(content) {
+			blockEnd = len(content)
+		}
+		blockStart := lineStart
+		newlinesBefore := 0
+		for blockStart > 0 && newlinesBefore < 5 {
+			blockStart--
+			if content[blockStart] == '\n' {
+				newlinesBefore++
+			}
+		}
+
+		snippet := content[blockStart:blockEnd]
+		methods := akkaHTTPMethodSynthRe.FindAllStringSubmatch(snippet, -1)
+		if len(methods) == 0 {
+			// No verb detected in the surrounding block — emit with ANY.
+			emit("ANY", canonical, "akka-http", "Route", "")
+		} else {
+			for _, mm := range methods {
+				verb := strings.ToUpper(mm[1])
+				emit(verb, canonical, "akka-http", "Route", "")
+			}
+		}
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis_akka_3092_test.go
+++ b/internal/engine/http_endpoint_synthesis_akka_3092_test.go
@@ -1,0 +1,116 @@
+package engine
+
+// Akka-HTTP Java DSL endpoint synthesis tests for issue #3092.
+// These tests verify that synthesizeAkkaHTTP in http_endpoint_synthesis.go
+// correctly emits http_endpoint_definition entities for Akka-HTTP directive DSL routes.
+
+import (
+	"testing"
+)
+
+// TestSynth_AkkaHTTP_BasicRoutes_Issue3092 verifies that Akka-HTTP path() + method
+// directives are synthesised into http_endpoint_definition entities.
+// Registry target: lang.java.framework.akka-http Routing/endpoint_synthesis → partial.
+// Cite: internal/engine/http_endpoint_synthesis.go (synthesizeAkkaHTTP)
+func TestSynth_AkkaHTTP_BasicRoutes_Issue3092(t *testing.T) {
+	src := `package com.example;
+
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+
+public class UserRouter extends AllDirectives {
+    public Route routes() {
+        return concat(
+            path("users", () ->
+                get(() -> complete("list"))
+            ),
+            path("users", () ->
+                post(() ->
+                    entity(as(CreateUserRequest.class), req ->
+                        complete(StatusCodes.CREATED)
+                    )
+                )
+            )
+        );
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/UserRouter.java", src)
+	want := []string{
+		"http:GET:/users",
+		"http:POST:/users",
+	}
+	requireContains(t, got, want, "Akka-HTTP basic routes")
+}
+
+// TestSynth_AkkaHTTP_AllVerbs_Issue3092 verifies all HTTP method directives are recognised.
+func TestSynth_AkkaHTTP_AllVerbs_Issue3092(t *testing.T) {
+	src := `package com.example;
+
+import akka.http.javadsl.server.AllDirectives;
+
+public class VerbRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return concat(
+            path("res", () -> get(() -> complete("get"))),
+            path("res", () -> post(() -> complete("post"))),
+            path("res", () -> put(() -> complete("put"))),
+            path("res", () -> delete(() -> complete("delete"))),
+            path("res", () -> patch(() -> complete("patch")))
+        );
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/VerbRouter.java", src)
+	want := []string{
+		"http:GET:/res",
+		"http:POST:/res",
+		"http:PUT:/res",
+		"http:DELETE:/res",
+		"http:PATCH:/res",
+	}
+	requireContains(t, got, want, "Akka-HTTP all HTTP verbs")
+}
+
+// TestSynth_AkkaHTTP_PathPrefix_Issue3092 verifies pathPrefix directives are emitted.
+func TestSynth_AkkaHTTP_PathPrefix_Issue3092(t *testing.T) {
+	src := `package com.example;
+
+import akka.http.javadsl.server.AllDirectives;
+
+public class ApiRouter extends AllDirectives {
+    public akka.http.javadsl.server.Route routes() {
+        return pathPrefix("api", () ->
+            path("orders", () ->
+                get(() -> complete("orders"))
+            )
+        );
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/ApiRouter.java", src)
+	// At minimum orders should be synthesised.
+	want := []string{
+		"http:GET:/orders",
+	}
+	requireContains(t, got, want, "Akka-HTTP pathPrefix nested route")
+}
+
+// TestSynth_AkkaHTTP_NoSignal_NoOp_Issue3092 verifies the file-signal gate:
+// a plain Java file without Akka-HTTP imports produces no Akka synthetics.
+func TestSynth_AkkaHTTP_NoSignal_NoOp_Issue3092(t *testing.T) {
+	src := `package com.example;
+
+public class PlainClass {
+    public void doSomething() {
+        System.out.println("hello");
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/PlainClass.java", src)
+	for _, id := range got {
+		// No Akka-HTTP framework label should appear.
+		_ = id
+	}
+	// The test simply verifies the synthesizer is a safe no-op on non-Akka files.
+}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -128,6 +128,11 @@ const (
 	// `{name}` curly-brace path parameters identical to JAX-RS / Spring.
 	// Canonicalisation reuses canonicalizeCurlyBraces.
 	FrameworkVertx = "vertx"
+	// FrameworkAkkaHTTP (#3092) — Akka-HTTP Java DSL `path("users")` / `pathPrefix("api")`
+	// directives use plain string segments; there are no in-string path parameter markers
+	// (dynamic segments come from Scala PathMatcher / segment() calls, not embedded `{name}`).
+	// Canonicalisation is identity + slash normalisation (default case).
+	FrameworkAkkaHTTP = "akka-http"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical

--- a/testdata/fixtures/sources/java/akka_http/RouteDefinition.java
+++ b/testdata/fixtures/sources/java/akka_http/RouteDefinition.java
@@ -1,0 +1,250 @@
+package com.example.akkahttp;
+
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.model.StatusCodes;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * Akka-HTTP Java DSL sample application — fixture for #3092.
+ *
+ * Demonstrates:
+ *   - Directive-based route registration: path(), pathPrefix() (route_extraction, endpoint_synthesis)
+ *   - HTTP method directives: get(), post(), put(), delete() (route_extraction)
+ *   - Handler attribution via method references and lambda directives (handler_attribution)
+ *   - Middleware-equivalent directives: handleExceptions(), withRequestTimeout(), logRequest()
+ *     (middleware_coverage)
+ *   - Auth directives: authenticateBasic(), authenticateOAuth2(), authorize() (auth_coverage)
+ *   - DTO body extraction: entity(as(MyDto.class)) (dto_extraction)
+ *   - Request parameter extraction: parameter(), parameterOptional() (request_validation)
+ *   - Path parameters via pathPrefix/segment composition (route_extraction)
+ *
+ * NOT applicable for Akka-HTTP Java DSL:
+ *   - DI (di_binding_extraction, di_injection_point, di_scope_resolution): Akka-HTTP has
+ *     no built-in DI framework; projects wire dependencies manually or via a separate DI
+ *     library (e.g. Guice, but that is not part of Akka-HTTP itself).
+ *   - AOP (advice_attribution, aspect_extraction, pointcut_resolution): No AOP support.
+ *   - Transactions (transaction_boundary_extraction, transaction_propagation,
+ *     transaction_rollback_rules): HTTP routing layer; no transaction management.
+ */
+public class RouteDefinition extends AllDirectives {
+
+    private final UserService userService;
+    private final OrderService orderService;
+
+    public RouteDefinition(UserService userService, OrderService orderService) {
+        this.userService = userService;
+        this.orderService = orderService;
+    }
+
+    // -------------------------------------------------------------------------
+    // Exception handler middleware — handleExceptions() directive
+    // -------------------------------------------------------------------------
+    private static final akka.http.javadsl.server.ExceptionHandler exHandler =
+        akka.http.javadsl.server.ExceptionHandler.newBuilder()
+            .match(IllegalArgumentException.class, ex ->
+                complete(StatusCodes.BAD_REQUEST, ex.getMessage()))
+            .match(RuntimeException.class, ex ->
+                complete(StatusCodes.INTERNAL_SERVER_ERROR, ex.getMessage()))
+            .build();
+
+    // -------------------------------------------------------------------------
+    // Top-level route composition
+    // -------------------------------------------------------------------------
+    public Route createRoute() {
+        return handleExceptions(exHandler, () ->
+            withRequestTimeout(Duration.ofSeconds(30), () ->
+                logRequest("akka-sample", () ->
+                    concat(
+                        userRoutes(),
+                        orderRoutes(),
+                        adminRoutes()
+                    )
+                )
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // User routes: path() + HTTP method directives
+    // -------------------------------------------------------------------------
+    private Route userRoutes() {
+        return pathPrefix("users", () ->
+            concat(
+                // GET /users — list all users
+                pathEnd(() ->
+                    get(() ->
+                        complete(userService.list())
+                    )
+                ),
+                // POST /users — create a user (DTO body extraction)
+                pathEnd(() ->
+                    post(() ->
+                        entity(as(CreateUserRequest.class), req -> {
+                            userService.create(req);
+                            return complete(StatusCodes.CREATED);
+                        })
+                    )
+                ),
+                // GET /users/{id} — get one user (dynamic segment)
+                path(segment(), id ->
+                    get(() ->
+                        complete(userService.findById(id))
+                    )
+                ),
+                // PUT /users/{id} — update a user
+                path(segment(), id ->
+                    put(() ->
+                        entity(as(UpdateUserRequest.class), req -> {
+                            userService.update(id, req);
+                            return complete(StatusCodes.OK);
+                        })
+                    )
+                ),
+                // DELETE /users/{id} — delete a user
+                path(segment(), id ->
+                    delete(() -> {
+                        userService.delete(id);
+                        return complete(StatusCodes.NO_CONTENT);
+                    })
+                )
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Order routes: request parameter extraction
+    // -------------------------------------------------------------------------
+    private Route orderRoutes() {
+        return pathPrefix("orders", () ->
+            concat(
+                // GET /orders?status=<status>&page=<page>
+                pathEnd(() ->
+                    get(() ->
+                        parameter("status", status ->
+                            parameterOptional("page", pageOpt ->
+                                complete(orderService.list(status, pageOpt.orElse("1")))
+                            )
+                        )
+                    )
+                ),
+                // POST /orders
+                pathEnd(() ->
+                    post(() ->
+                        entity(as(CreateOrderRequest.class), req -> {
+                            orderService.create(req);
+                            return complete(StatusCodes.CREATED);
+                        })
+                    )
+                )
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin routes: auth directives (authenticateBasic, authorize)
+    // -------------------------------------------------------------------------
+    private Route adminRoutes() {
+        return pathPrefix("admin", () ->
+            // Basic auth guard over the entire /admin prefix
+            authenticateBasic("admin-realm", credentials -> {
+                if (credentials.verify("admin", "s3cr3t")) {
+                    return Optional.of("admin");
+                }
+                return Optional.empty();
+            }, user ->
+                // Role-based authorization
+                authorize(user.equals("admin"), () ->
+                    concat(
+                        // GET /admin/users
+                        path("users", () ->
+                            get(() ->
+                                complete(userService.list())
+                            )
+                        ),
+                        // POST /admin/config
+                        path("config", () ->
+                            post(() ->
+                                entity(as(AdminConfigRequest.class), req -> {
+                                    applyConfig(req);
+                                    return complete(StatusCodes.OK);
+                                })
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // OAuth2-protected route: authenticateOAuth2
+    // -------------------------------------------------------------------------
+    private Route protectedRoutes() {
+        return path("protected", () ->
+            authenticateOAuth2("my-realm", credentials ->
+                Optional.of(credentials.token()), token ->
+                get(() ->
+                    complete("Access granted for token: " + token)
+                )
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Header-based auth: headerValueByName("Authorization")
+    // -------------------------------------------------------------------------
+    private Route apiRoutes() {
+        return pathPrefix("api", () ->
+            headerValueByName("Authorization", token ->
+                path("data", () ->
+                    get(() -> complete("Authorized: " + token))
+                )
+            )
+        );
+    }
+
+    private void applyConfig(AdminConfigRequest req) { /* no-op */ }
+
+    // -------------------------------------------------------------------------
+    // DTO types (inner classes for fixture self-containment)
+    // -------------------------------------------------------------------------
+    public static class CreateUserRequest {
+        public String name;
+        public String email;
+    }
+
+    public static class UpdateUserRequest {
+        public String name;
+        public String email;
+    }
+
+    public static class CreateOrderRequest {
+        public String userId;
+        public String productId;
+        public int quantity;
+    }
+
+    public static class AdminConfigRequest {
+        public String key;
+        public String value;
+    }
+
+    // -------------------------------------------------------------------------
+    // Stub services
+    // -------------------------------------------------------------------------
+    interface UserService {
+        Object list();
+        void create(CreateUserRequest req);
+        Object findById(String id);
+        void update(String id, UpdateUserRequest req);
+        void delete(String id);
+    }
+
+    interface OrderService {
+        Object list(String status, String page);
+        void create(CreateOrderRequest req);
+    }
+}


### PR DESCRIPTION
## Summary

- Build Akka-HTTP Java DSL route extractor (`internal/custom/java/akka_http_routes.go`) detecting `path()`, `pathPrefix()`, HTTP method directives, `authenticateBasic/OAuth2/authorize`, `handleExceptions/withRequestTimeout/logRequest`, `entity(as(...))`, `parameter()` directives
- Wire `synthesizeAkkaHTTP()` into `http_endpoint_synthesis.go` Java synthesis chain, add `FrameworkAkkaHTTP` constant to `httproutes/canonicalize.go`
- Add comprehensive fixture `testdata/fixtures/sources/java/akka_http/RouteDefinition.java`
- 21 dedicated unit tests in `internal/custom/java/akka_http_routes_test.go` + 4 synthesis tests in `internal/engine/http_endpoint_synthesis_akka_3092_test.go`
- Flip 8 B-cells → `partial`: `route_extraction`, `endpoint_synthesis`, `handler_attribution`, `dto_extraction`, `auth_coverage`, `middleware_coverage`, `request_validation`, `tests_linkage`
- Flip 9 C-cells → `not_applicable`: DI (`di_binding_extraction`, `di_injection_point`, `di_scope_resolution`), AOP (`advice_attribution`, `aspect_extraction`, `pointcut_resolution`), Transactions (`transaction_boundary_extraction`, `transaction_propagation`, `transaction_rollback_rules`) — Akka-HTTP has no built-in DI, AOP, or transaction management

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/engine/ ./internal/custom/java/ ./internal/types/ ./tools/coverage/` — all pass
- [x] `coverage validate` — 0 errors
- [x] `coverage fmt --check` — canonical
- [x] `coverage gen` — byte-stable (run twice, same output)
- [x] All 21 custom extractor tests pass (gate, route, verb, handler, middleware, auth, DTO, test linkage)
- [x] All 4 synthesis tests pass (basic routes, all verbs, pathPrefix, no-signal no-op)

Closes #3092