### PR TITLE
feat(coverage): Spring WebFlux functional routing + WebFilter

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -133,7 +133,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 18/18 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟡 2/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 15/16 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 15/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -25,7 +25,7 @@ Back to [summary](../summary.md).
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 18/18 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟡 2/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 15/16 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 15/16 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 
 

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/java/frameworks/spring_webflux.yaml`<br>`internal/engine/spring_routes.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/spring_routes.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-29` | 3080 | `internal/custom/java/spring_webflux_routes.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`testdata/fixtures/sources/java/spring_webflux/RouterConfig.java` | — |
 
 ### Auth
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | 3080 | `internal/custom/java/spring_webflux_routes.go`<br>`testdata/fixtures/sources/java/spring_webflux/RouterConfig.java` | WebFilter implementations detected via 'implements WebFilter' class declaration; Middleware entities emitted with middleware_type=web_filter and filter_class. Multiple WebFilter classes in one file each produce a distinct entity. |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -17602,8 +17602,10 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_webflux_routes.go","internal/engine/http_endpoint_synthesis.go","testdata/fixtures/sources/java/spring_webflux/RouterConfig.java"],
+            "issue": "3080",
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {
@@ -17632,8 +17634,10 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/links/effect_propagation.go","internal/links/module_cycle_pass.go","internal/substrate/def_use_java.go","internal/substrate/effect_sinks_java.go","internal/substrate/entry_points_java.go","internal/substrate/taint_sites_java.go","internal/substrate/template_pattern_java.go"],
-            "issue": "3154"
+            "cites": ["internal/custom/java/spring_webflux_routes.go","testdata/fixtures/sources/java/spring_webflux/RouterConfig.java"],
+            "issue": "3080",
+            "notes": "WebFilter implementations detected via 'implements WebFilter' class declaration; Middleware entities emitted with middleware_type=web_filter and filter_class. Multiple WebFilter classes in one file each produce a distinct entity.",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {

--- a/internal/custom/java/spring_webflux_routes.go
+++ b/internal/custom/java/spring_webflux_routes.go
@@ -1,0 +1,211 @@
+package java
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Spring WebFlux functional routing + WebFilter extractor.
+//
+// Spring WebFlux supports two programming models:
+//
+//  1. Annotation-based (@RestController / @GetMapping etc.) — already handled
+//     by spring_routes.go + java_annotation_routes.go.
+//
+//  2. Functional DSL (RouterFunction / RouterFunctions.route()) — this file.
+//
+// # Functional DSL patterns extracted
+//
+//   - RouterFunctions.route().GET("/path", handler) chain
+//   - RouterFunctions.route(GET("/path"), handler) fluent builder
+//   - @Bean RouterFunction<ServerResponse> methods whose body chains
+//     .GET/.POST/.PUT/.DELETE/.PATCH
+//
+// # Middleware patterns extracted
+//
+//   - Classes that implement WebFilter: filter(ServerWebExchange, WebFilterChain)
+//
+// Coverage cells delivered (#3080):
+//   - Routing:    route_extraction  → partial
+//   - Middleware: middleware_coverage → partial
+//
+// Refs: https://docs.spring.io/spring-framework/docs/current/reference/html/web-reactive.html
+
+// springWebFluxFrameworks is the set of framework identifiers that activate
+// this extractor.
+var springWebFluxFrameworks = map[string]bool{
+	"spring_webflux":  true,
+	"spring-webflux":  true,
+	"springwebflux":   true,
+}
+
+var (
+	// Functional DSL — chained verb form:
+	//   RouterFunctions.route()
+	//     .GET("/path", handler)
+	//     .POST("/path", handler)
+	//     ...
+	// Also matches the two-argument route() overload:
+	//   RouterFunctions.route(GET("/path"), handler)
+	// Capture group 1: HTTP verb; capture group 2: path string.
+	webFluxChainedRE = regexp.MustCompile(
+		`\.\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"`)
+
+	// Static predicate overload: RouterFunctions.route(GET("/path"), handler)
+	// Capture group 1: verb; capture group 2: path.
+	webFluxStaticPredicateRE = regexp.MustCompile(
+		`\bRequestPredicates\s*\.\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"`)
+
+	// RouterFunctions.route() — file-level signal that functional routing is present.
+	webFluxRouterFunctionsRE = regexp.MustCompile(
+		`\bRouterFunctions\s*\.\s*route\s*\(`)
+
+	// @Bean RouterFunction declaration — gate for bean-backed functional routers.
+	webFluxBeanRouterFunctionRE = regexp.MustCompile(
+		`@Bean\b[^;{]*?\bRouterFunction\b`)
+
+	// WebFilter implementation — middleware detection.
+	// Matches: implements WebFilter  (possibly with other interfaces).
+	webFilterImplRE = regexp.MustCompile(
+		`\bclass\s+(\w+)\b[^{]*\bimplements\b[^{]*\bWebFilter\b`)
+
+	// filter() method inside a WebFilter — confirms the impl is genuine and
+	// lets us find the line number precisely.
+	webFilterMethodRE = regexp.MustCompile(
+		`\bpublic\s+(?:Mono<Void>|reactor\.core\.publisher\.Mono<Void>)\s+filter\s*\(`)
+)
+
+// ExtractSpringWebFlux runs the Spring WebFlux functional routing + WebFilter
+// extractor. It emits:
+//   - Route entities for each functional-DSL endpoint
+//   - Middleware entities for each WebFilter implementation
+func ExtractSpringWebFlux(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !springWebFluxFrameworks[ctx.Framework] {
+		return result
+	}
+
+	// Quick-exit: no WebFlux signals in this file.
+	if !strings.Contains(ctx.Source, "RouterFunction") &&
+		!strings.Contains(ctx.Source, "RouterFunctions") &&
+		!strings.Contains(ctx.Source, "WebFilter") &&
+		!strings.Contains(ctx.Source, "RequestPredicates") {
+		return result
+	}
+
+	seen := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+	_ = seenRels // relationships reserved for future handler attribution
+
+	// -----------------------------------------------------------------------
+	// Route extraction: functional DSL
+	// -----------------------------------------------------------------------
+
+	// Only scan files that contain RouterFunctions.route() or a @Bean RouterFunction
+	// to avoid false positives from annotation-based controllers that happen to
+	// mention "RouterFunction" in an import.
+	hasFunctionalRouting := webFluxRouterFunctionsRE.MatchString(ctx.Source) ||
+		webFluxBeanRouterFunctionRE.MatchString(ctx.Source)
+
+	if hasFunctionalRouting {
+		// Form 1: chained .GET("/path", ...) / .POST("/path", ...) etc.
+		for _, idx := range webFluxChainedRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+			if len(idx) < 6 {
+				continue
+			}
+			verb := ctx.Source[idx[2]:idx[3]]
+			rawPath := ctx.Source[idx[4]:idx[5]]
+
+			ref := fmt.Sprintf("spring_webflux:route:%s:%s:%s", verb, rawPath, ctx.FilePath)
+			e := SecondaryEntity{
+				Name:       rawPath,
+				Kind:       "Route",
+				SourceFile: ctx.FilePath,
+				LineStart:  lineOf(ctx.Source, idx[0]),
+				Provenance: "INFERRED_FROM_SPRING_WEBFLUX_ROUTE",
+				Ref:        ref,
+				Properties: map[string]any{
+					"http_verb":  verb,
+					"path":       rawPath,
+					"framework":  "spring_webflux",
+					"route_type": "functional_dsl",
+				},
+			}
+			addEntity(&result, seen, e)
+		}
+
+		// Form 2: RequestPredicates.GET("/path") — two-argument route() overload.
+		for _, idx := range webFluxStaticPredicateRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+			if len(idx) < 6 {
+				continue
+			}
+			verb := ctx.Source[idx[2]:idx[3]]
+			rawPath := ctx.Source[idx[4]:idx[5]]
+
+			ref := fmt.Sprintf("spring_webflux:route:predicate:%s:%s:%s", verb, rawPath, ctx.FilePath)
+			e := SecondaryEntity{
+				Name:       rawPath,
+				Kind:       "Route",
+				SourceFile: ctx.FilePath,
+				LineStart:  lineOf(ctx.Source, idx[0]),
+				Provenance: "INFERRED_FROM_SPRING_WEBFLUX_PREDICATE_ROUTE",
+				Ref:        ref,
+				Properties: map[string]any{
+					"http_verb":  verb,
+					"path":       rawPath,
+					"framework":  "spring_webflux",
+					"route_type": "predicate_dsl",
+				},
+			}
+			addEntity(&result, seen, e)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Middleware: WebFilter implementations
+	// -----------------------------------------------------------------------
+	for _, idx := range webFilterImplRE.FindAllStringSubmatchIndex(ctx.Source, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		className := ctx.Source[idx[2]:idx[3]]
+		ref := fmt.Sprintf("spring_webflux:middleware:webfilter:%s:%s", className, ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       className,
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, idx[0]),
+			Provenance: "INFERRED_FROM_SPRING_WEBFLUX_WEBFILTER",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "spring_webflux",
+				"middleware_type": "web_filter",
+				"filter_class":    className,
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	// Also detect filter() method as a secondary confirmation / line-number
+	// anchor if no class-level WebFilter impl was found.
+	if webFilterMethodRE.MatchString(ctx.Source) && !webFilterImplRE.MatchString(ctx.Source) {
+		pos := webFilterMethodRE.FindStringIndex(ctx.Source)
+		ref := fmt.Sprintf("spring_webflux:middleware:webfilter_method:%s", ctx.FilePath)
+		e := SecondaryEntity{
+			Name:       "WebFilter",
+			Kind:       "Middleware",
+			SourceFile: ctx.FilePath,
+			LineStart:  lineOf(ctx.Source, pos[0]),
+			Provenance: "INFERRED_FROM_SPRING_WEBFLUX_WEBFILTER",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":       "spring_webflux",
+				"middleware_type": "web_filter",
+			},
+		}
+		addEntity(&result, seen, e)
+	}
+
+	return result
+}

--- a/internal/custom/java/spring_webflux_routes_test.go
+++ b/internal/custom/java/spring_webflux_routes_test.go
@@ -1,0 +1,426 @@
+package java
+
+// Dedicated tests for the Spring WebFlux functional routing + WebFilter
+// extractor (issue #3080).
+//
+// These tests validate ExtractSpringWebFlux in spring_webflux_routes.go.
+// DO NOT add these tests to extractors_test.go.
+
+import (
+	"testing"
+)
+
+// ctx constructs a PatternContext for spring_webflux framework.
+func webfluxCtx(source, file string) PatternContext {
+	return PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "spring_webflux",
+		FilePath:  file,
+	}
+}
+
+// hasRouteWithVerb returns true if result contains at least one Route entity
+// whose http_verb property equals verb and whose Name (path) equals path.
+func hasRouteWithVerb(result PatternResult, verb, path string) bool {
+	for _, e := range result.Entities {
+		if e.Kind != "Route" {
+			continue
+		}
+		if e.Name != path {
+			continue
+		}
+		if v, ok := e.Properties["http_verb"]; ok && v == verb {
+			return true
+		}
+	}
+	return false
+}
+
+// hasMiddlewareClass returns true if result contains a Middleware entity for
+// className.
+func hasMiddlewareClass(result PatternResult, className string) bool {
+	for _, e := range result.Entities {
+		if e.Kind != "Middleware" {
+			continue
+		}
+		if e.Name == className {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// route_extraction — chained builder DSL
+// ============================================================================
+
+func TestExtractSpringWebFlux_ChainedRoutes(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class RouterConfig {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .GET("/users", handler::listUsers)
+                .POST("/users", handler::createUser)
+                .GET("/users/{id}", handler::getUser)
+                .PUT("/users/{id}", handler::updateUser)
+                .DELETE("/users/{id}", handler::deleteUser)
+                .PATCH("/users/{id}/status", handler::patchStatus)
+                .build();
+    }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "RouterConfig.java"))
+
+	want := []struct{ verb, path string }{
+		{"GET", "/users"},
+		{"POST", "/users"},
+		{"GET", "/users/{id}"},
+		{"PUT", "/users/{id}"},
+		{"DELETE", "/users/{id}"},
+		{"PATCH", "/users/{id}/status"},
+	}
+	for _, w := range want {
+		if !hasRouteWithVerb(result, w.verb, w.path) {
+			t.Errorf("expected Route %s %s, not found in %+v", w.verb, w.path, entitySummary(result))
+		}
+	}
+}
+
+// ============================================================================
+// route_extraction — two-argument predicate DSL
+// ============================================================================
+
+func TestExtractSpringWebFlux_PredicateRoutes(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class OrderRouter {
+    @Bean
+    public RouterFunction<ServerResponse> orderRoutes() {
+        return RouterFunctions
+                .route(RequestPredicates.GET("/orders"), handler::listOrders)
+                .andRoute(RequestPredicates.POST("/orders"), handler::createOrder)
+                .andRoute(RequestPredicates.GET("/orders/{orderId}"), handler::getOrder)
+                .andRoute(RequestPredicates.DELETE("/orders/{orderId}"), handler::cancelOrder);
+    }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "OrderRouter.java"))
+
+	want := []struct{ verb, path string }{
+		{"GET", "/orders"},
+		{"POST", "/orders"},
+		{"GET", "/orders/{orderId}"},
+		{"DELETE", "/orders/{orderId}"},
+	}
+	for _, w := range want {
+		if !hasRouteWithVerb(result, w.verb, w.path) {
+			t.Errorf("expected Route %s %s, not found in %+v", w.verb, w.path, entitySummary(result))
+		}
+	}
+}
+
+// ============================================================================
+// route_extraction — path parameters canonicalized
+// ============================================================================
+
+func TestExtractSpringWebFlux_PathParams(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class OrgRouter {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .GET("/orgs/{orgId}/repos/{repoId}", handler::getRepo)
+                .DELETE("/orgs/{orgId}/repos/{repoId}", handler::deleteRepo)
+                .build();
+    }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "OrgRouter.java"))
+
+	if !hasRouteWithVerb(result, "GET", "/orgs/{orgId}/repos/{repoId}") {
+		t.Errorf("expected GET /orgs/{orgId}/repos/{repoId}, got %+v", entitySummary(result))
+	}
+	if !hasRouteWithVerb(result, "DELETE", "/orgs/{orgId}/repos/{repoId}") {
+		t.Errorf("expected DELETE /orgs/{orgId}/repos/{repoId}, got %+v", entitySummary(result))
+	}
+}
+
+// ============================================================================
+// route_extraction — provenance + framework property
+// ============================================================================
+
+func TestExtractSpringWebFlux_RouteProperties(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+public class Cfg {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .GET("/health", req -> ServerResponse.ok().build())
+                .build();
+    }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "Cfg.java"))
+	if len(result.Entities) == 0 {
+		t.Fatal("expected at least one entity")
+	}
+	var found *SecondaryEntity
+	for i := range result.Entities {
+		if result.Entities[i].Kind == "Route" && result.Entities[i].Name == "/health" {
+			found = &result.Entities[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("Route /health not found")
+	}
+	if found.Properties["framework"] != "spring_webflux" {
+		t.Errorf("expected framework=spring_webflux, got %v", found.Properties["framework"])
+	}
+	if found.Provenance == "" {
+		t.Error("expected non-empty provenance")
+	}
+}
+
+// ============================================================================
+// middleware_coverage — WebFilter implementation
+// ============================================================================
+
+func TestExtractSpringWebFlux_WebFilter(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+public class RequestLoggingFilter implements WebFilter {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        System.out.println(exchange.getRequest().getPath());
+        return chain.filter(exchange);
+    }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "RequestLoggingFilter.java"))
+
+	if !hasMiddlewareClass(result, "RequestLoggingFilter") {
+		t.Errorf("expected Middleware entity for RequestLoggingFilter, got %+v", entitySummary(result))
+	}
+}
+
+func TestExtractSpringWebFlux_MultipleWebFilters(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+public class AuthFilter implements WebFilter {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange);
+    }
+}
+
+class RateLimitFilter implements WebFilter {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange);
+    }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "Filters.java"))
+
+	if !hasMiddlewareClass(result, "AuthFilter") {
+		t.Errorf("expected Middleware entity for AuthFilter, got %+v", entitySummary(result))
+	}
+	if !hasMiddlewareClass(result, "RateLimitFilter") {
+		t.Errorf("expected Middleware entity for RateLimitFilter, got %+v", entitySummary(result))
+	}
+}
+
+// ============================================================================
+// middleware_coverage — properties
+// ============================================================================
+
+func TestExtractSpringWebFlux_WebFilterProperties(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+public class CorsFilter implements WebFilter {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange);
+    }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "CorsFilter.java"))
+	var found *SecondaryEntity
+	for i := range result.Entities {
+		if result.Entities[i].Kind == "Middleware" {
+			found = &result.Entities[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected Middleware entity")
+	}
+	if found.Properties["middleware_type"] != "web_filter" {
+		t.Errorf("expected middleware_type=web_filter, got %v", found.Properties["middleware_type"])
+	}
+	if found.Properties["framework"] != "spring_webflux" {
+		t.Errorf("expected framework=spring_webflux, got %v", found.Properties["framework"])
+	}
+}
+
+// ============================================================================
+// Quick-exit: no-op for non-WebFlux files
+// ============================================================================
+
+func TestExtractSpringWebFlux_NoSignalNoOp(t *testing.T) {
+	src := `package com.example;
+
+public class OrderService {
+    public String findById(long id) { return null; }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "OrderService.java"))
+	if len(result.Entities) != 0 {
+		t.Errorf("expected 0 entities for plain Java class, got %d: %+v",
+			len(result.Entities), entitySummary(result))
+	}
+}
+
+func TestExtractSpringWebFlux_WrongLanguageNoOp(t *testing.T) {
+	ctx := PatternContext{
+		Source:    "RouterFunctions.route().GET(\"/users\", h)",
+		Language:  "python",
+		Framework: "spring_webflux",
+		FilePath:  "app.py",
+	}
+	result := ExtractSpringWebFlux(ctx)
+	if len(result.Entities) != 0 {
+		t.Errorf("expected 0 entities for wrong language, got %d", len(result.Entities))
+	}
+}
+
+// ============================================================================
+// Fixture file smoke test
+// ============================================================================
+
+func TestExtractSpringWebFlux_FixtureFile(t *testing.T) {
+	src := `package com.example.webflux;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class RouterConfig {
+    @Bean
+    public RouterFunction<ServerResponse> userRoutes() {
+        return RouterFunctions.route()
+                .GET("/users", userHandler::listUsers)
+                .POST("/users", userHandler::createUser)
+                .GET("/users/{id}", userHandler::getUser)
+                .PUT("/users/{id}", userHandler::updateUser)
+                .DELETE("/users/{id}", userHandler::deleteUser)
+                .build();
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> orderRoutes() {
+        return RouterFunctions
+                .route(RequestPredicates.GET("/orders"), orderHandler::listOrders)
+                .andRoute(RequestPredicates.POST("/orders"), orderHandler::createOrder);
+    }
+}
+
+class RequestLoggingFilter implements WebFilter {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange);
+    }
+}
+
+class AuthenticationFilter implements WebFilter {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange);
+    }
+}
+`
+	result := ExtractSpringWebFlux(webfluxCtx(src, "RouterConfig.java"))
+
+	wantRoutes := []struct{ verb, path string }{
+		{"GET", "/users"},
+		{"POST", "/users"},
+		{"GET", "/users/{id}"},
+		{"PUT", "/users/{id}"},
+		{"DELETE", "/users/{id}"},
+		{"GET", "/orders"},
+		{"POST", "/orders"},
+	}
+	for _, w := range wantRoutes {
+		if !hasRouteWithVerb(result, w.verb, w.path) {
+			t.Errorf("fixture: expected Route %s %s, got %+v", w.verb, w.path, entitySummary(result))
+		}
+	}
+
+	wantFilters := []string{"RequestLoggingFilter", "AuthenticationFilter"}
+	for _, cls := range wantFilters {
+		if !hasMiddlewareClass(result, cls) {
+			t.Errorf("fixture: expected Middleware %s, got %+v", cls, entitySummary(result))
+		}
+	}
+}
+
+// ============================================================================
+// helpers
+// ============================================================================
+
+func entitySummary(result PatternResult) []string {
+	var s []string
+	for _, e := range result.Entities {
+		s = append(s, e.Kind+":"+e.Name)
+	}
+	return s
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -340,6 +340,9 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizePlay(string(content), path, emit)
 		// Akka-HTTP (#3092): directive DSL `path("foo", () -> get(() -> ...))` routing.
 		synthesizeAkkaHTTP(string(content), emit)
+		// Spring WebFlux (#3080): functional DSL RouterFunctions.route().GET(...)
+		// and WebFilter middleware detection.
+		synthesizeSpringWebFlux(string(content), emit)
 		// Consumer side (#721): HttpClient / RestTemplate /
 		// WebClient / OkHttp / Apache HttpClient / Retrofit.
 		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
@@ -1087,6 +1090,80 @@ func synthesizeAkkaHTTP(content string, emit emitFn) {
 				emit(verb, canonical, "akka-http", "Route", "")
 			}
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Spring WebFlux (Java) — functional DSL routing (#3080)
+// ---------------------------------------------------------------------------
+
+// webFluxChainedSynthRe captures chained .GET("/path", ...) / .POST("/path", ...)
+// method calls in a RouterFunctions.route() builder chain. These are always
+// uppercase method names used as direct DSL verbs on the RequestPredicates API.
+var webFluxChainedSynthRe = regexp.MustCompile(
+	`\.\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"`)
+
+// webFluxPredicateSynthRe captures the two-argument overload:
+//
+//	RouterFunctions.route(RequestPredicates.GET("/path"), handler)
+var webFluxPredicateSynthRe = regexp.MustCompile(
+	`\bRequestPredicates\s*\.\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"`)
+
+// synthesizeSpringWebFlux scans a Java file for Spring WebFlux functional-DSL
+// route registrations and emits one http_endpoint_definition per (verb, path)
+// pair.
+//
+// Two forms are detected:
+//  1. Chained builder: RouterFunctions.route().GET("/path", handler)
+//  2. Static predicate: RouterFunctions.route(RequestPredicates.GET("/path"), handler)
+//
+// Spring WebFlux uses `{param}` curly-brace path parameters (same as Spring
+// MVC), so FrameworkSpring is passed to Canonicalize.
+func synthesizeSpringWebFlux(content string, emit emitFn) {
+	// File-signal gate: require RouterFunction / RouterFunctions / RequestPredicates.
+	if !strings.Contains(content, "RouterFunction") &&
+		!strings.Contains(content, "RouterFunctions") &&
+		!strings.Contains(content, "RequestPredicates") {
+		return
+	}
+	// Secondary gate: must have the route() call or a @Bean RouterFunction annotation
+	// to confirm this is functional-DSL routing (not just an import or comment).
+	if !strings.Contains(content, "route(") && !strings.Contains(content, "RouterFunction<") {
+		return
+	}
+
+	seen := make(map[string]bool)
+
+	// Form 1: chained .GET/.POST/... verbs.
+	for _, m := range webFluxChainedSynthRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		verb := m[1]
+		rawPath := m[2]
+		key := verb + ":" + rawPath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, rawPath)
+		emit(verb, canonical, "spring_webflux", "Route", "")
+	}
+
+	// Form 2: RequestPredicates.GET("/path") — deduplicate against form 1.
+	for _, m := range webFluxPredicateSynthRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		verb := m[1]
+		rawPath := m[2]
+		key := verb + ":" + rawPath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, rawPath)
+		emit(verb, canonical, "spring_webflux", "Route", "")
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis_webflux_3080_test.go
+++ b/internal/engine/http_endpoint_synthesis_webflux_3080_test.go
@@ -1,0 +1,168 @@
+package engine
+
+// Spring WebFlux functional routing synthesis tests for issue #3080.
+// These tests verify that synthesizeSpringWebFlux in http_endpoint_synthesis.go
+// correctly emits http_endpoint_definition entities for RouterFunctions.route()
+// functional-DSL routes.
+
+import (
+	"testing"
+)
+
+// TestSynth_SpringWebFlux_ChainedRoutes_Issue3080 verifies that Spring WebFlux
+// functional-DSL chained .GET/.POST/... routes are synthesised into
+// http_endpoint_definition entities with correct (verb, canonical-path) IDs.
+// Registry target: lang.java.framework.spring-webflux Routing/route_extraction → partial.
+// Cite: internal/engine/http_endpoint_synthesis.go (synthesizeSpringWebFlux)
+func TestSynth_SpringWebFlux_ChainedRoutes_Issue3080(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class RouterConfig {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .GET("/users", handler::listUsers)
+                .POST("/users", handler::createUser)
+                .GET("/users/{id}", handler::getUser)
+                .PUT("/users/{id}", handler::updateUser)
+                .DELETE("/users/{id}", handler::deleteUser)
+                .build();
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/RouterConfig.java", src)
+	want := []string{
+		"http:GET:/users",
+		"http:POST:/users",
+		"http:GET:/users/{id}",
+		"http:PUT:/users/{id}",
+		"http:DELETE:/users/{id}",
+	}
+	requireContains(t, got, want, "Spring WebFlux chained routes")
+}
+
+// TestSynth_SpringWebFlux_PredicateRoutes_Issue3080 verifies that Spring WebFlux
+// two-argument RouterFunctions.route(RequestPredicates.GET("/path"), handler)
+// routes are synthesised correctly.
+func TestSynth_SpringWebFlux_PredicateRoutes_Issue3080(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class OrderRouter {
+    @Bean
+    public RouterFunction<ServerResponse> orderRoutes() {
+        return RouterFunctions
+                .route(RequestPredicates.GET("/orders"), handler::listOrders)
+                .andRoute(RequestPredicates.POST("/orders"), handler::createOrder)
+                .andRoute(RequestPredicates.GET("/orders/{orderId}"), handler::getOrder)
+                .andRoute(RequestPredicates.DELETE("/orders/{orderId}"), handler::cancelOrder);
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/OrderRouter.java", src)
+	want := []string{
+		"http:GET:/orders",
+		"http:POST:/orders",
+		"http:GET:/orders/{orderId}",
+		"http:DELETE:/orders/{orderId}",
+	}
+	requireContains(t, got, want, "Spring WebFlux predicate routes")
+}
+
+// TestSynth_SpringWebFlux_PathParams_Issue3080 verifies that Spring WebFlux
+// {param} curly-brace path parameters are canonicalised correctly.
+func TestSynth_SpringWebFlux_PathParams_Issue3080(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class OrgRouter {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .GET("/orgs/{orgId}/repos/{repoId}", handler::getRepo)
+                .PATCH("/orgs/{orgId}/repos/{repoId}/status", handler::patchStatus)
+                .build();
+    }
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/OrgRouter.java", src)
+	want := []string{
+		"http:GET:/orgs/{orgId}/repos/{repoId}",
+		"http:PATCH:/orgs/{orgId}/repos/{repoId}/status",
+	}
+	requireContains(t, got, want, "Spring WebFlux path params")
+}
+
+// TestSynth_SpringWebFlux_NoSignalNoOp_Issue3080 verifies that the synthesizer
+// no-ops on Java files without any Spring WebFlux signal.
+func TestSynth_SpringWebFlux_NoSignalNoOp_Issue3080(t *testing.T) {
+	src := `package com.example;
+
+public class OrderService {
+    public Order findById(long id) { return null; }
+    public void save(Order o) {}
+}
+`
+	got, _ := runDetect(t, "java", "src/main/java/com/example/OrderService.java", src)
+	// Ensure no spurious spring_webflux endpoints were emitted.
+	for _, id := range got {
+		// The synthesis assigns framework "spring_webflux" in the entity
+		// properties but the ID itself is http:<VERB>:<PATH>. We check that
+		// no http:* IDs with unusual paths appear — the plain OrderService
+		// file has no route patterns at all.
+		_ = id
+	}
+	// No assertion needed beyond "it did not panic" — the file has no
+	// RouterFunction / RequestPredicates / WebFilter signals.
+}
+
+// TestSynth_SpringWebFlux_FrameworkLabel_Issue3080 verifies that synthesised
+// entities carry the framework label "spring_webflux".
+func TestSynth_SpringWebFlux_FrameworkLabel_Issue3080(t *testing.T) {
+	src := `package com.example;
+
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+public class Cfg {
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return RouterFunctions.route()
+                .GET("/health", req -> ServerResponse.ok().build())
+                .build();
+    }
+}
+`
+	ids, res := runDetect(t, "java", "src/main/java/com/example/Cfg.java", src)
+	// Find the http_endpoint_definition for GET /health and verify its
+	// framework property is "spring_webflux".
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:GET:/health" {
+			fw := e.Properties["framework"]
+			if fw != "spring_webflux" {
+				t.Errorf("expected framework=spring_webflux, got %q", fw)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("http:GET:/health not found in synthesised entities; got IDs: %v", ids)
+	}
+}

--- a/testdata/fixtures/sources/java/spring_webflux/RouterConfig.java
+++ b/testdata/fixtures/sources/java/spring_webflux/RouterConfig.java
@@ -1,0 +1,165 @@
+package com.example.webflux;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Spring WebFlux functional routing fixture for #3080.
+ *
+ * Demonstrates:
+ *   - Functional DSL route registration via RouterFunctions.route() chained builder
+ *     (route_extraction, endpoint_synthesis)
+ *   - Functional DSL route registration via RouterFunctions.route(predicate, handler)
+ *     two-argument overload (route_extraction)
+ *   - WebFilter middleware implementation (middleware_coverage)
+ *   - Path parameters in {param} curly-brace style
+ */
+@Configuration
+public class RouterConfig {
+
+    private final UserHandler userHandler;
+    private final OrderHandler orderHandler;
+
+    public RouterConfig(UserHandler userHandler, OrderHandler orderHandler) {
+        this.userHandler = userHandler;
+        this.orderHandler = orderHandler;
+    }
+
+    // -----------------------------------------------------------------------
+    // Functional DSL — chained builder form (route_extraction)
+    // -----------------------------------------------------------------------
+    @Bean
+    public RouterFunction<ServerResponse> userRoutes() {
+        return RouterFunctions.route()
+                .GET("/users", userHandler::listUsers)
+                .POST("/users", userHandler::createUser)
+                .GET("/users/{id}", userHandler::getUser)
+                .PUT("/users/{id}", userHandler::updateUser)
+                .DELETE("/users/{id}", userHandler::deleteUser)
+                .build();
+    }
+
+    // -----------------------------------------------------------------------
+    // Functional DSL — two-argument predicate form (route_extraction)
+    // -----------------------------------------------------------------------
+    @Bean
+    public RouterFunction<ServerResponse> orderRoutes() {
+        return RouterFunctions
+                .route(RequestPredicates.GET("/orders"), orderHandler::listOrders)
+                .andRoute(RequestPredicates.POST("/orders"), orderHandler::createOrder)
+                .andRoute(RequestPredicates.GET("/orders/{orderId}"), orderHandler::getOrder)
+                .andRoute(RequestPredicates.PUT("/orders/{orderId}"), orderHandler::updateOrder)
+                .andRoute(RequestPredicates.DELETE("/orders/{orderId}"), orderHandler::cancelOrder);
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested router with path prefix (route_extraction)
+    // -----------------------------------------------------------------------
+    @Bean
+    public RouterFunction<ServerResponse> adminRoutes() {
+        return RouterFunctions.route()
+                .path("/admin", builder -> builder
+                        .GET("/stats", req -> ServerResponse.ok()
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .bodyValue("{}"))
+                        .DELETE("/cache", req -> ServerResponse.ok().build()))
+                .build();
+    }
+}
+
+// -----------------------------------------------------------------------
+// WebFilter middleware (middleware_coverage)
+// -----------------------------------------------------------------------
+
+/**
+ * RequestLoggingFilter logs every incoming request before it reaches a handler.
+ * Implements WebFilter to plug into the reactive filter chain.
+ */
+class RequestLoggingFilter implements WebFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        System.out.printf("[REQ] %s %s%n",
+                exchange.getRequest().getMethod(),
+                exchange.getRequest().getPath());
+        return chain.filter(exchange);
+    }
+}
+
+/**
+ * AuthenticationFilter validates the Authorization header for all requests
+ * under /api/**. Demonstrates middleware_coverage with conditional logic.
+ */
+class AuthenticationFilter implements WebFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String path = exchange.getRequest().getPath().value();
+        if (!path.startsWith("/api/")) {
+            return chain.filter(exchange);
+        }
+        String authHeader = exchange.getRequest().getHeaders().getFirst("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            exchange.getResponse().setStatusCode(org.springframework.http.HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+        return chain.filter(exchange);
+    }
+}
+
+// Placeholder handler classes — present to make the file self-contained.
+class UserHandler {
+    public Mono<ServerResponse> listUsers(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.ok().bodyValue(Flux.empty());
+    }
+    public Mono<ServerResponse> createUser(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.status(201).build();
+    }
+    public Mono<ServerResponse> getUser(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.ok().build();
+    }
+    public Mono<ServerResponse> updateUser(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.ok().build();
+    }
+    public Mono<ServerResponse> deleteUser(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.noContent().build();
+    }
+}
+
+class OrderHandler {
+    public Mono<ServerResponse> listOrders(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.ok().bodyValue(Flux.empty());
+    }
+    public Mono<ServerResponse> createOrder(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.status(201).build();
+    }
+    public Mono<ServerResponse> getOrder(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.ok().build();
+    }
+    public Mono<ServerResponse> updateOrder(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.ok().build();
+    }
+    public Mono<ServerResponse> cancelOrder(
+            org.springframework.web.reactive.function.server.ServerRequest req) {
+        return ServerResponse.noContent().build();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ExtractSpringWebFlux` in `internal/custom/java/spring_webflux_routes.go`: detects functional-DSL route registrations (`RouterFunctions.route().GET/POST/...` chained builder + `RouterFunctions.route(RequestPredicates.GET(...), handler)` predicate form) and `WebFilter` implementations as middleware entities.
- Adds `synthesizeSpringWebFlux` in `internal/engine/http_endpoint_synthesis.go`: endpoint-synthesis pass emitting `http_endpoint_definition` per (verb, canonical-path) pair; wired into the Java switch case.
- Comprehensive fixture at `testdata/fixtures/sources/java/spring_webflux/RouterConfig.java`.
- Dedicated test files: `spring_webflux_routes_test.go` (10 tests) and `http_endpoint_synthesis_webflux_3080_test.go` (5 tests) — neither touches `extractors_test.go`.
- Flips `lang.java.framework.spring-webflux` → `route_extraction: partial` and updates `middleware_coverage` cites/notes.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/engine/ ./internal/custom/java/ ./internal/types/ ./tools/coverage/` — all pass
- [x] `coverage validate` — 0 errors
- [x] `coverage fmt --check` — canonical
- [x] `coverage gen` — byte-stable (run twice, same output)
- [ ] `coverage delta --lang java --post <PR#>` — to be posted after PR creation

Closes #3080

🤖 Generated with [Claude Code](https://claude.com/claude-code)