### PR TITLE
feat(coverage): Strawberry-GraphQL route extraction

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -94,7 +94,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [python](../by-language/python.md) | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [python](../by-language/python.md) | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
-| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 2/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -28,7 +28,7 @@ Back to [summary](../summary.md).
 | [Robyn](../detail/lang.python.framework.robyn.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [Sanic](../detail/lang.python.framework.sanic.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [Starlette](../detail/lang.python.framework.starlette.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
-| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | 🟡 2/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
 | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟡 5/7 | |
 

--- a/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
+++ b/docs/coverage/detail/lang.python.framework.strawberry-graphql.md
@@ -15,9 +15,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/graphql/frameworks/strawberry_python.yaml`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
-| Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | 3066 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/graphql/frameworks/strawberry_python.yaml`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | 3066 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
+| Route extraction | ✅ `full` | `2026-05-29` | 3066 | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/rules/python/frameworks/strawberry_graphql.yaml` | — |
 
 ### Auth
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -37797,18 +37797,22 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/graphql/frameworks/strawberry_python.yaml","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/graphql/frameworks/strawberry_python.yaml","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+            "issue": "3066",
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+            "issue": "3066",
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/rules/python/frameworks/strawberry_graphql.yaml"],
+            "issue": "3066",
+            "verified_at": "2026-05-29"
           }
         },
         "Auth": {

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -377,6 +377,11 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeFalcon(string(content), emitDef)
 		synthesizeHug(string(content), emitDef)
 		synthesizeQuart(string(content), emitDef)
+		// #3066 — Strawberry GraphQL operation synthesis. Maps @strawberry.type
+		// root classes (Query / Mutation / Subscription) and their methods to
+		// http:GRAPHQL:/graphql/<Root>/<field> synthetics. Gated on "strawberry"
+		// in the file so it is a no-op on all other Python framework files.
+		synthesizeStrawberry(string(content), emitDef)
 		// Producer side: Flask + FastAPI run FIRST so their synthetics —
 		// which carry a real handler function name as source_handler —
 		// claim each ID before the Django composed-route pass walks the
@@ -2746,6 +2751,136 @@ func synthesizeQuart(content string, emit emitDefFn) {
 		}
 		for _, verb := range methods {
 			emit(verb, canonical, "quart", "Controller", handler, defLine)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Strawberry GraphQL (Python) — #3066
+// ---------------------------------------------------------------------------
+//
+// Strawberry is a code-first GraphQL library for Python. Schemas are defined
+// by decorating Python classes with @strawberry.type and individual resolver
+// methods with @strawberry.field (or leaving them undecorated — any public
+// method in a @strawberry.type class is a potential resolver field).
+//
+// The three GraphQL root types are:
+//
+//	@strawberry.type
+//	class Query:
+//	    def users(self) -> list[User]: ...
+//
+//	@strawberry.type
+//	class Mutation:
+//	    @strawberry.mutation
+//	    def create_user(self, name: str) -> User: ...
+//
+//	@strawberry.type
+//	class Subscription:
+//	    @strawberry.subscription
+//	    async def user_added(self) -> typing.AsyncGenerator[User, None]: ...
+//
+// We map each method on a root type to:
+//
+//	http:GRAPHQL:/graphql/<RootType>/<fieldName>
+//
+// Handler attribution: the resolver method name is the handler (as
+// SCOPE.Operation:<ClassName>.<method>).
+//
+// Detection is gated on the presence of "strawberry" in the file so the
+// synthesizer is a no-op on plain Flask/FastAPI/etc. files.
+
+// strawberryRootTypeRe matches a `@strawberry.type` (or @strawberry.mutation /
+// @strawberry.subscription) decorator immediately preceding a class named
+// Query, Mutation, or Subscription.
+//
+// Capture groups:
+//
+//	1 = root type name (Query | Mutation | Subscription)
+var strawberryRootTypeRe = regexp.MustCompile(
+	`(?m)@strawberry\.(?:type|mutation|subscription)\s*\n(?:[ \t]*@[^\n]+\n)*[ \t]*class\s+(Query|Mutation|Subscription)\s*[:(]`,
+)
+
+// strawberryMethodRe matches a public method inside a class body. It matches
+// `def <name>(self` and optionally `async def <name>(self`.
+//
+// Capture groups:
+//
+//	1 = method name
+var strawberryMethodRe = regexp.MustCompile(
+	`(?m)^[ \t]+(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(\s*self`,
+)
+
+func synthesizeStrawberry(content string, emit emitDefFn) {
+	// File-signal gate: require a strawberry marker.
+	if !strings.Contains(content, "strawberry") {
+		return
+	}
+
+	// Find all @strawberry.type class declarations for the three root types.
+	for _, rm := range strawberryRootTypeRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(rm) < 4 {
+			continue
+		}
+		rootType := content[rm[2]:rm[3]] // "Query" | "Mutation" | "Subscription"
+
+		// Locate the class body by finding the colon that ends the class
+		// declaration line and scanning forward to find the indented block.
+		// We use a simplified approach: find all method defs in the class body
+		// by scanning from the class header until the next unindented line
+		// (i.e., the next `class` / top-level statement).
+		classStart := rm[1] // byte offset right after the class header match
+		// Find the end of the class body: next line that starts with a
+		// non-whitespace character (top-level), or end of file.
+		classEnd := len(content)
+		// Scan from classStart for the next occurrence of a line that begins
+		// with a non-space, non-tab character and is not a blank line or
+		// comment. We walk line by line.
+		searchIn := content[classStart:]
+		lines := strings.Split(searchIn, "\n")
+		bodyEnd := len(searchIn)
+		for i, line := range lines {
+			if i == 0 {
+				// The first "line" is the tail of the class header — skip it.
+				continue
+			}
+			if len(line) == 0 {
+				continue // blank line — still inside the class
+			}
+			if line[0] != ' ' && line[0] != '\t' {
+				// Top-level line — class body ends here.
+				bodyEnd = 0
+				for j := 0; j < i; j++ {
+					bodyEnd += len(lines[j]) + 1 // +1 for '\n'
+				}
+				break
+			}
+		}
+		classBody := content[classStart : classStart+bodyEnd]
+		classEnd = classStart + bodyEnd
+		_ = classEnd
+
+		// Extract each public method in the class body.
+		seen := map[string]bool{}
+		for _, mm := range strawberryMethodRe.FindAllStringSubmatchIndex(classBody, -1) {
+			if len(mm) < 4 {
+				continue
+			}
+			methodName := classBody[mm[2]:mm[3]]
+			// Skip dunder methods and already-seen names.
+			if strings.HasPrefix(methodName, "_") || seen[methodName] {
+				continue
+			}
+			seen[methodName] = true
+
+			// Compute the absolute def-line in the file (not just the class body).
+			methodOffsetInFile := classStart + mm[2]
+			defLine := lineOfOffset(content, methodOffsetInFile)
+
+			path := "/graphql/" + rootType + "/" + methodName
+			canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
+			handlerRef := rootType + "." + methodName
+			emit("GRAPHQL", canonical, "strawberry-graphql", "SCOPE.Operation", handlerRef, defLine)
 		}
 	}
 }

--- a/internal/engine/http_endpoint_synthesis_strawberry_3066_test.go
+++ b/internal/engine/http_endpoint_synthesis_strawberry_3066_test.go
@@ -1,0 +1,247 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestSynth_Strawberry_Query covers @strawberry.type Query with plain resolver
+// methods. #3066.
+func TestSynth_Strawberry_Query(t *testing.T) {
+	src := `import strawberry
+import typing
+
+@strawberry.type
+class Query:
+    def users(self) -> typing.List[str]:
+        return []
+
+    def user(self, id: int) -> str:
+        return ""
+
+    def health(self) -> str:
+        return "ok"
+
+schema = strawberry.Schema(query=Query)
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/users",
+		"http:GRAPHQL:/graphql/Query/user",
+		"http:GRAPHQL:/graphql/Query/health",
+	}
+	requireContains(t, got, want, "Strawberry Query")
+
+	// Verify framework label and handler attribution.
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Query/users")
+	if e == nil {
+		t.Fatalf("Strawberry Query: missing http:GRAPHQL:/graphql/Query/users")
+	}
+	if e.Properties["framework"] != "strawberry-graphql" {
+		t.Errorf("Strawberry Query: framework = %q, want strawberry-graphql", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:Query.users" {
+		t.Errorf("Strawberry Query: source_handler = %q, want SCOPE.Operation:Query.users", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("Strawberry Query: StartLine not stamped on users resolver")
+	}
+}
+
+// TestSynth_Strawberry_Mutation covers @strawberry.type Mutation with
+// @strawberry.mutation decorated methods. #3066.
+func TestSynth_Strawberry_Mutation(t *testing.T) {
+	src := `import strawberry
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def create_user(self, name: str) -> str:
+        return name
+
+    @strawberry.mutation
+    def delete_user(self, id: int) -> bool:
+        return True
+
+schema = strawberry.Schema(mutation=Mutation)
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Mutation/create_user",
+		"http:GRAPHQL:/graphql/Mutation/delete_user",
+	}
+	requireContains(t, got, want, "Strawberry Mutation")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Mutation/create_user")
+	if e == nil {
+		t.Fatalf("Strawberry Mutation: missing http:GRAPHQL:/graphql/Mutation/create_user")
+	}
+	if e.Properties["framework"] != "strawberry-graphql" {
+		t.Errorf("Strawberry Mutation: framework = %q, want strawberry-graphql", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:Mutation.create_user" {
+		t.Errorf("Strawberry Mutation: source_handler = %q, want SCOPE.Operation:Mutation.create_user", e.Properties["source_handler"])
+	}
+	if e.StartLine == 0 {
+		t.Errorf("Strawberry Mutation: StartLine not stamped on create_user resolver")
+	}
+}
+
+// TestSynth_Strawberry_Subscription covers @strawberry.type Subscription with
+// async generator methods. #3066.
+func TestSynth_Strawberry_Subscription(t *testing.T) {
+	src := `import strawberry
+import typing
+import asyncio
+
+@strawberry.type
+class Subscription:
+    @strawberry.subscription
+    async def user_added(self) -> typing.AsyncGenerator[str, None]:
+        while True:
+            await asyncio.sleep(1)
+            yield "user"
+
+    @strawberry.subscription
+    async def message_sent(self, channel: str) -> typing.AsyncGenerator[str, None]:
+        while True:
+            await asyncio.sleep(1)
+            yield ""
+
+schema = strawberry.Schema(subscription=Subscription)
+`
+	got, res := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Subscription/user_added",
+		"http:GRAPHQL:/graphql/Subscription/message_sent",
+	}
+	requireContains(t, got, want, "Strawberry Subscription")
+
+	e := findSynthDef(res, "http:GRAPHQL:/graphql/Subscription/user_added")
+	if e == nil {
+		t.Fatalf("Strawberry Subscription: missing http:GRAPHQL:/graphql/Subscription/user_added")
+	}
+	if e.Properties["framework"] != "strawberry-graphql" {
+		t.Errorf("Strawberry Subscription: framework = %q, want strawberry-graphql", e.Properties["framework"])
+	}
+	if e.Properties["source_handler"] != "SCOPE.Operation:Subscription.user_added" {
+		t.Errorf("Strawberry Subscription: source_handler = %q, want SCOPE.Operation:Subscription.user_added", e.Properties["source_handler"])
+	}
+}
+
+// TestSynth_Strawberry_CombinedSchema covers a schema file that defines all
+// three root types. #3066.
+func TestSynth_Strawberry_CombinedSchema(t *testing.T) {
+	src := `import strawberry
+import typing
+
+@strawberry.type
+class Query:
+    def books(self) -> typing.List[str]:
+        return []
+
+    def book(self, id: strawberry.ID) -> str:
+        return ""
+
+@strawberry.type
+class Mutation:
+    @strawberry.mutation
+    def add_book(self, title: str) -> str:
+        return title
+
+@strawberry.type
+class Subscription:
+    @strawberry.subscription
+    async def book_added(self) -> typing.AsyncGenerator[str, None]:
+        yield ""
+
+schema = strawberry.Schema(query=Query, mutation=Mutation, subscription=Subscription)
+`
+	got, _ := runDetect(t, "python", "schema.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/books",
+		"http:GRAPHQL:/graphql/Query/book",
+		"http:GRAPHQL:/graphql/Mutation/add_book",
+		"http:GRAPHQL:/graphql/Subscription/book_added",
+	}
+	requireContains(t, got, want, "Strawberry combined schema")
+}
+
+// TestSynth_Strawberry_DunderSkip asserts that __init__, __str__ and other
+// dunder methods on root types are not emitted as GraphQL operations. #3066.
+func TestSynth_Strawberry_DunderSkip(t *testing.T) {
+	src := `import strawberry
+
+@strawberry.type
+class Query:
+    def __init__(self):
+        pass
+
+    def users(self) -> list:
+        return []
+`
+	got, _ := runDetect(t, "python", "schema.py", src)
+	for _, id := range got {
+		if id == "http:GRAPHQL:/graphql/Query/__init__" {
+			t.Errorf("Strawberry: dunder __init__ should not be emitted as an operation")
+		}
+	}
+	want := []string{"http:GRAPHQL:/graphql/Query/users"}
+	requireContains(t, got, want, "Strawberry dunder skip")
+}
+
+// TestSynth_Strawberry_NoOpOnFlask asserts the Strawberry synthesizer does not
+// fire on a plain Flask file. #3066.
+func TestSynth_Strawberry_NoOpOnFlask(t *testing.T) {
+	src := `from flask import Flask
+
+app = Flask(__name__)
+
+@app.route("/ping")
+def ping():
+    return "pong"
+`
+	_, res := runDetect(t, "python", "flask_app.py", src)
+	e := findSynthDef(res, "http:GET:/ping")
+	if e == nil {
+		t.Fatalf("expected http:GET:/ping endpoint from Flask")
+	}
+	if e.Properties["framework"] != "flask" {
+		t.Errorf("framework = %q, want flask (Strawberry synthesizer must no-op on Flask files)", e.Properties["framework"])
+	}
+	// No GRAPHQL synthetics should exist.
+	for _, ent := range res.Entities {
+		if ent.Kind == httpEndpointDefinitionKind && ent.Properties["framework"] == "strawberry-graphql" {
+			t.Errorf("Strawberry synthesizer fired on Flask file, emitted: %s", ent.ID)
+		}
+	}
+}
+
+// TestSynth_Strawberry_FastAPIIntegration covers a typical pattern where
+// Strawberry is mounted on a FastAPI app. The Strawberry synthesizer should
+// emit GRAPHQL synthetics while FastAPI emits the mount route. #3066.
+func TestSynth_Strawberry_FastAPIIntegration(t *testing.T) {
+	src := `import strawberry
+from strawberry.fastapi import GraphQLRouter
+from fastapi import FastAPI
+
+@strawberry.type
+class Query:
+    def hello(self) -> str:
+        return "world"
+
+    def products(self) -> list:
+        return []
+
+schema = strawberry.Schema(query=Query)
+graphql_app = GraphQLRouter(schema)
+
+app = FastAPI()
+app.include_router(graphql_app, prefix="/graphql")
+`
+	got, _ := runDetect(t, "python", "main.py", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/hello",
+		"http:GRAPHQL:/graphql/Query/products",
+	}
+	requireContains(t, got, want, "Strawberry+FastAPI integration")
+}

--- a/internal/engine/rules/python/frameworks/strawberry_graphql.yaml
+++ b/internal/engine/rules/python/frameworks/strawberry_graphql.yaml
@@ -1,3 +1,9 @@
+# Strawberry GraphQL framework extraction rules.
+#
+# Top-level `frameworks:` key is consumed by the modular_loader (detection).
+# Top-level extraction keys (file_conventions, source_patterns,
+# relationship_rules) are consumed by FrameworkExtractionSchema.
+#
 frameworks:
   name: Strawberry GraphQL
   pypi_package: strawberry-graphql
@@ -23,3 +29,95 @@ frameworks:
     Often paired with FastAPI or Litestar.
 
     '
+
+# ---------------------------------------------------------------------------
+# Extraction schema (FrameworkExtractionSchema)
+# ---------------------------------------------------------------------------
+
+# file_conventions: glob -> entity_type mapping from file naming conventions.
+file_conventions:
+  - glob: "schema.py"
+    entity_type: Route
+    name_from: filename
+  - glob: "*/graphql/*.py"
+    entity_type: Route
+    name_from: filename
+  - glob: "*/graphql/schema.py"
+    entity_type: Route
+    name_from: filename
+
+# source_patterns: regex patterns that match Strawberry GraphQL constructs in
+# source files. name_group references the capture group that provides the
+# entity name.
+source_patterns:
+  # Root type declarations: @strawberry.type class Query / Mutation / Subscription
+  - pattern: "@strawberry\\.type\\s*\\nclass\\s+(Query|Mutation|Subscription)\\s*[:(]"
+    entity_type: Route
+    name_group: 1
+    scope: class
+  # Resolver methods decorated with @strawberry.field
+  - pattern: "@strawberry\\.field[\\s\\S]{0,80}?def\\s+(\\w+)\\s*\\(\\s*self"
+    entity_type: Route
+    name_group: 1
+    scope: function
+  # Mutation resolver methods decorated with @strawberry.mutation
+  - pattern: "@strawberry\\.mutation[\\s\\S]{0,80}?def\\s+(\\w+)\\s*\\(\\s*self"
+    entity_type: Route
+    name_group: 1
+    scope: function
+  # Subscription resolver methods decorated with @strawberry.subscription
+  - pattern: "@strawberry\\.subscription[\\s\\S]{0,80}?def\\s+(\\w+)\\s*\\(\\s*self"
+    entity_type: Route
+    name_group: 1
+    scope: function
+  # Schema instantiation: schema = strawberry.Schema(query=Query, ...)
+  - pattern: "(\\w+)\\s*=\\s*strawberry\\.Schema\\s*\\("
+    entity_type: Service
+    name_group: 1
+    scope: file
+  # Input type declarations: @strawberry.input class Foo
+  - pattern: "@strawberry\\.input\\s*\\nclass\\s+(\\w+)\\s*[:(]"
+    entity_type: Model
+    name_group: 1
+    scope: class
+  # Interface declarations: @strawberry.interface class Foo
+  - pattern: "@strawberry\\.interface\\s*\\nclass\\s+(\\w+)\\s*[:(]"
+    entity_type: Model
+    name_group: 1
+    scope: class
+  # FastAPI/Litestar router mount: GraphQLRouter(schema) or GraphQLView
+  - pattern: "(\\w+)\\s*=\\s*(?:GraphQLRouter|GraphQLView)\\s*\\("
+    entity_type: Route
+    name_group: 1
+    scope: file
+
+# relationship_rules: regex patterns that produce edges between entities.
+relationship_rules:
+  # Schema wires query root to service: strawberry.Schema(query=Query)
+  - pattern: "strawberry\\.Schema\\s*\\(.*?query\\s*=\\s*(\\w+)"
+    source_type: Service
+    target_type: Route
+    relationship: ROUTES_TO
+    source_group: 1
+    target_group: 1
+  # Schema wires mutation root to service: strawberry.Schema(mutation=Mutation)
+  - pattern: "strawberry\\.Schema\\s*\\(.*?mutation\\s*=\\s*(\\w+)"
+    source_type: Service
+    target_type: Route
+    relationship: ROUTES_TO
+    source_group: 1
+    target_group: 1
+  # Schema wires subscription root to service: strawberry.Schema(subscription=Subscription)
+  - pattern: "strawberry\\.Schema\\s*\\(.*?subscription\\s*=\\s*(\\w+)"
+    source_type: Service
+    target_type: Route
+    relationship: ROUTES_TO
+    source_group: 1
+    target_group: 1
+  # FastAPI mount: app.include_router(graphql_app, prefix="/graphql")
+  - pattern: "(\\w+)\\.include_router\\s*\\(\\s*(\\w+)"
+    source_type: Service
+    target_type: Route
+    relationship: ROUTES_TO
+    source_group: 1
+    target_group: 2


### PR DESCRIPTION
## Summary

- Add `synthesizeStrawberry()` to `http_endpoint_synthesis.go`: detects `@strawberry.type` root classes (Query / Mutation / Subscription) and emits `http:GRAPHQL:/graphql/<Root>/<field>` synthetics with handler attribution (`SCOPE.Operation:<Class>.<method>`) and StartLine stamping
- Extend `strawberry_graphql.yaml` with full extraction schema: `file_conventions`, `source_patterns` (root type decorators, resolver method decorators, schema instantiation, input/interface types, FastAPI/Litestar router mount), and `relationship_rules`
- 7 dedicated tests in `http_endpoint_synthesis_strawberry_3066_test.go` covering Query/Mutation/Subscription roots, combined schemas, dunder-method skip, Flask no-op guard, and FastAPI integration pattern
- Flip 3 coverage cells to `full`: `route_extraction`, `endpoint_synthesis`, `handler_attribution` on `lang.python.framework.strawberry-graphql`

## Test plan

- [x] `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` — all pass
- [x] `coverage validate` — 0 errors
- [x] `coverage fmt --check` — canonical
- [x] `coverage gen` — byte-stable

Closes #3066

🤖 Generated with [Claude Code](https://claude.com/claude-code)