### PR TITLE
feat(mcp): per-call payload byte/token capture for bench (#2828 measure-first)

### DIFF
--- a/cmd/archigraph/bench_capture.go
+++ b/cmd/archigraph/bench_capture.go
@@ -3,7 +3,7 @@ package main
 // bench_capture.go — `archigraph bench-capture rpc` subcommand.
 //
 // Reads a daemon log slice between two byte offsets, parses every
-// [mcp-rpc] tool=<X> elapsed=<N>ms line, aggregates counts + handler
+// slog-format mcp_rpc phase=done line, aggregates counts + handler
 // durations, and emits JSON to stdout matching the BenchCaptureOutput
 // schema in:
 //
@@ -29,23 +29,22 @@ import (
 // defaultDaemonLog is the default daemon log path used when --log is not given.
 const defaultDaemonLog = "~/.archigraph/logs/daemon.log"
 
-// rpcLineRe matches lines produced by internal/daemon/mcp_rpc.go:
+// rpcLineRe matches the slog-format phase=done lines emitted by the daemon's
+// mcp_rpc handler.  Real format (Go slog, unquoted values):
 //
-//	archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search elapsed=8095ms repo=/path
+//	time=2026-05-27T05:33:46.256+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_whoami elapsed_ms=1008 repo=/path ts=...
 //
-// Only lines with an elapsed= field are counted (received-only lines have no
-// elapsed= and must be ignored).
-var rpcLineRe = regexp.MustCompile(`\[mcp-rpc\] tool=(\S+) elapsed=(\d+)ms.* repo=`)
+// Only phase=done lines carry elapsed_ms; phase=received lines are ignored.
+// wire_bytes and payload_token_estimate are optional (added by #2828).
+var rpcLineRe = regexp.MustCompile(`msg=mcp_rpc phase=done tool=(\S+) elapsed_ms=(\d+)`)
 
-// rpcBytesRe captures the OPTIONAL per-call payload-size fields appended to
-// the phase=done line by issue #2828:
+// rpcBytesRe captures the OPTIONAL per-call payload-size fields added by
+// issue #2828 to the phase=done line:
 //
-//	[mcp-rpc] tool=X elapsed=Nms wire_bytes=B payload_token_estimate=T repo=Y
+//	... elapsed_ms=N wire_bytes=B payload_token_estimate=T repo=...
 //
-// It is applied as a SEPARATE pass on the same line so that legacy logs
-// (which lack these fields entirely) still parse for ms via rpcLineRe — the
-// byte/token sums simply stay 0 for those lines. BACKWARD COMPATIBLE by
-// design: a line missing these fields yields no match here and is skipped.
+// Applied as a separate pass on the same line; absent on pre-#2828 daemon
+// logs → byte/token sums stay 0 for those lines.
 var rpcBytesRe = regexp.MustCompile(`wire_bytes=(\d+) payload_token_estimate=(\d+)`)
 
 // ToolRPCStats aggregates daemon-side handler durations and payload sizes for
@@ -152,9 +151,12 @@ func readSlice(path string, start, end int64) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(f, limit))
 }
 
-// parseBenchCapture scans log bytes for [mcp-rpc] elapsed= lines and
-// aggregates counts, sums, and per-tool breakdowns. It then computes
+// parseBenchCapture scans log bytes for slog-format mcp_rpc phase=done lines
+// and aggregates counts, sums, and per-tool breakdowns.  It then computes
 // p50 and p99 over the collected durations.
+//
+// Consecutive duplicate lines are collapsed (the daemon double-logs each RPC
+// event) so counts and sums are not inflated by 2×.
 //
 // Percentile formulas (0-indexed, sorted ascending):
 //
@@ -171,8 +173,17 @@ func parseBenchCapture(data []byte) BenchCaptureOutput {
 	}
 
 	var allMs []int
+	var prevLine string // for consecutive-duplicate dedup
 
 	for _, line := range strings.Split(string(data), "\n") {
+		// Dedup: the daemon emits each mcp_rpc line twice consecutively.
+		// Skip the second occurrence to avoid double-counting.
+		if line == prevLine {
+			prevLine = "" // reset so a genuine triple would count as 1
+			continue
+		}
+		prevLine = line
+
 		m := rpcLineRe.FindStringSubmatch(line)
 		if m == nil {
 			continue

--- a/cmd/archigraph/bench_capture.go
+++ b/cmd/archigraph/bench_capture.go
@@ -35,13 +35,29 @@ const defaultDaemonLog = "~/.archigraph/logs/daemon.log"
 //
 // Only lines with an elapsed= field are counted (received-only lines have no
 // elapsed= and must be ignored).
-var rpcLineRe = regexp.MustCompile(`\[mcp-rpc\] tool=(\S+) elapsed=(\d+)ms repo=`)
+var rpcLineRe = regexp.MustCompile(`\[mcp-rpc\] tool=(\S+) elapsed=(\d+)ms.* repo=`)
 
-// ToolRPCStats aggregates daemon-side handler durations for one tool.
-// Matches the ToolRPCStats definition in with-mcp-artifact.schema.json.
+// rpcBytesRe captures the OPTIONAL per-call payload-size fields appended to
+// the phase=done line by issue #2828:
+//
+//	[mcp-rpc] tool=X elapsed=Nms wire_bytes=B payload_token_estimate=T repo=Y
+//
+// It is applied as a SEPARATE pass on the same line so that legacy logs
+// (which lack these fields entirely) still parse for ms via rpcLineRe — the
+// byte/token sums simply stay 0 for those lines. BACKWARD COMPATIBLE by
+// design: a line missing these fields yields no match here and is skipped.
+var rpcBytesRe = regexp.MustCompile(`wire_bytes=(\d+) payload_token_estimate=(\d+)`)
+
+// ToolRPCStats aggregates daemon-side handler durations and payload sizes for
+// one tool. Matches the ToolRPCStats definition in with-mcp-artifact.schema.json.
 type ToolRPCStats struct {
 	Count int `json:"count"`
 	SumMs int `json:"sum_ms"`
+	// SumBytes / SumTokenEst aggregate the per-call wire payload size and its
+	// char/4 token estimate (issue #2828). Stay 0 for legacy logs that lack
+	// the wire_bytes / payload_token_estimate fields.
+	SumBytes    int `json:"sum_bytes"`
+	SumTokenEst int `json:"sum_token_est"`
 }
 
 // BenchCaptureOutput is the top-level JSON emitted to stdout.
@@ -56,6 +72,13 @@ type BenchCaptureOutput struct {
 	McpRPCHandlerMsP50 *float64                 `json:"mcp_rpc_handler_ms_p50"`
 	McpRPCHandlerMsP99 *float64                 `json:"mcp_rpc_handler_ms_p99"`
 	McpRPCPerTool      map[string]*ToolRPCStats `json:"mcp_rpc_per_tool"`
+	// McpRPCWireBytesSum / McpRPCTokenEstSum aggregate the on-wire tool-result
+	// payload size (bytes) and its char/4 token estimate across all counted
+	// calls (issue #2828). These quantify daemon-side payload cost so it can be
+	// compared against host-reported billed input tokens (model ingestion).
+	// 0 when every line in the slice is legacy (no wire_bytes field).
+	McpRPCWireBytesSum int `json:"mcp_rpc_wire_bytes_sum"`
+	McpRPCTokenEstSum  int `json:"mcp_rpc_payload_token_estimate_sum"`
 }
 
 // runBenchCaptureRPC is the entry-point for `archigraph bench-capture rpc`.
@@ -169,6 +192,19 @@ func parseBenchCapture(data []byte) BenchCaptureOutput {
 		}
 		out.McpRPCPerTool[tool].Count++
 		out.McpRPCPerTool[tool].SumMs += ms
+
+		// Optional second pass for the #2828 byte/token fields. Absent on
+		// legacy lines → no match → byte/token sums simply stay 0.
+		if bm := rpcBytesRe.FindStringSubmatch(line); bm != nil {
+			bytes, berr := strconv.Atoi(bm[1])
+			tok, terr := strconv.Atoi(bm[2])
+			if berr == nil && terr == nil {
+				out.McpRPCWireBytesSum += bytes
+				out.McpRPCTokenEstSum += tok
+				out.McpRPCPerTool[tool].SumBytes += bytes
+				out.McpRPCPerTool[tool].SumTokenEst += tok
+			}
+		}
 	}
 
 	if out.McpRPCCount == 0 {

--- a/cmd/archigraph/bench_capture_test.go
+++ b/cmd/archigraph/bench_capture_test.go
@@ -38,9 +38,9 @@ func TestParseBenchCapture_EmptyBytes(t *testing.T) {
 	}
 }
 
-// TestParseBenchCapture_SingleLine verifies a single well-formed log line.
+// TestParseBenchCapture_SingleLine verifies a single well-formed slog log line.
 func TestParseBenchCapture_SingleLine(t *testing.T) {
-	line := "archigraph-daemon: 2026/05/26 22:40:38.695982 [mcp-rpc] tool=archigraph_search elapsed=8095ms repo=/path/to/repo\n"
+	line := "time=2026-05-26T22:40:38.695+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=8095 repo=/path/to/repo ts=2026-05-26T17:10:38Z\n"
 	out := parseBenchCapture([]byte(line))
 
 	if out.McpRPCCount != 1 {
@@ -67,12 +67,12 @@ func TestParseBenchCapture_SingleLine(t *testing.T) {
 	}
 }
 
-// TestParseBenchCapture_ReceivedLinesIgnored verifies that "received" companion
-// lines (no elapsed= field) are not counted.
+// TestParseBenchCapture_ReceivedLinesIgnored verifies that phase=received
+// companion lines (no elapsed_ms field) are not counted.
 func TestParseBenchCapture_ReceivedLinesIgnored(t *testing.T) {
 	data := strings.Join([]string{
-		"archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search received repo=/path",
-		"archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search elapsed=500ms repo=/path",
+		"time=2026-05-26T22:40:38.000+05:45 level=INFO msg=mcp_rpc phase=received tool=archigraph_search repo=/path ts=2026-05-26T17:10:38Z",
+		"time=2026-05-26T22:40:38.500+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=500 repo=/path ts=2026-05-26T17:10:38Z",
 		"",
 	}, "\n")
 	out := parseBenchCapture([]byte(data))
@@ -85,9 +85,9 @@ func TestParseBenchCapture_ReceivedLinesIgnored(t *testing.T) {
 func TestParseBenchCapture_MultipleTools(t *testing.T) {
 	// 3 calls: search×2 (100ms, 200ms) + describe×1 (300ms)
 	lines := []string{
-		"archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search elapsed=100ms repo=/r",
-		"archigraph-daemon: 2026/05/26 22:40:39 [mcp-rpc] tool=archigraph_search elapsed=200ms repo=/r",
-		"archigraph-daemon: 2026/05/26 22:40:40 [mcp-rpc] tool=archigraph_describe elapsed=300ms repo=/r",
+		"time=2026-05-26T22:40:38.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=100 repo=/r ts=2026-05-26T17:10:38Z",
+		"time=2026-05-26T22:40:39.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=200 repo=/r ts=2026-05-26T17:10:39Z",
+		"time=2026-05-26T22:40:40.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_describe elapsed_ms=300 repo=/r ts=2026-05-26T17:10:40Z",
 		"",
 	}
 	out := parseBenchCapture([]byte(strings.Join(lines, "\n")))
@@ -141,10 +141,10 @@ func TestParseBenchCapture_PercentileEven(t *testing.T) {
 	// p50 = average(sorted[1], sorted[2]) = average(20, 30) = 25.
 	// p99 = sorted[ceil(4*0.99)-1] = sorted[ceil(3.96)-1] = sorted[4-1] = sorted[3] = 40.
 	lines := []string{
-		"x [mcp-rpc] tool=t elapsed=10ms repo=/r",
-		"x [mcp-rpc] tool=t elapsed=30ms repo=/r",
-		"x [mcp-rpc] tool=t elapsed=20ms repo=/r",
-		"x [mcp-rpc] tool=t elapsed=40ms repo=/r",
+		"time=2026-05-26T22:40:38.000+05:45 level=INFO msg=mcp_rpc phase=done tool=t elapsed_ms=10 repo=/r ts=2026-05-26T17:10:38Z",
+		"time=2026-05-26T22:40:38.001+05:45 level=INFO msg=mcp_rpc phase=done tool=t elapsed_ms=30 repo=/r ts=2026-05-26T17:10:38Z",
+		"time=2026-05-26T22:40:38.002+05:45 level=INFO msg=mcp_rpc phase=done tool=t elapsed_ms=20 repo=/r ts=2026-05-26T17:10:38Z",
+		"time=2026-05-26T22:40:38.003+05:45 level=INFO msg=mcp_rpc phase=done tool=t elapsed_ms=40 repo=/r ts=2026-05-26T17:10:38Z",
 		"",
 	}
 	out := parseBenchCapture([]byte(strings.Join(lines, "\n")))
@@ -168,7 +168,7 @@ func TestParseBenchCapture_PercentileKnownFixture(t *testing.T) {
 	// p99 = sorted[ceil(10*0.99)-1] = sorted[ceil(9.9)-1] = sorted[10-1] = sorted[9] = 10.
 	var lines []string
 	for i := 1; i <= 10; i++ {
-		lines = append(lines, "x [mcp-rpc] tool=t elapsed="+strconv.Itoa(i)+"ms repo=/r")
+		lines = append(lines, "time=2026-05-26T22:40:38."+strconv.Itoa(i)+"00+05:45 level=INFO msg=mcp_rpc phase=done tool=t elapsed_ms="+strconv.Itoa(i)+" repo=/r ts=2026-05-26T17:10:38Z")
 	}
 	lines = append(lines, "")
 	out := parseBenchCapture([]byte(strings.Join(lines, "\n")))
@@ -193,7 +193,7 @@ func TestParseBenchCapture_PercentileKnownFixture(t *testing.T) {
 // This is the cross-validation between the CLI output and the JSON Schema SSOT
 // (skills/archigraph-graph-quality/schema/with-mcp-artifact.schema.json).
 func TestBenchCaptureOutputMatchesSchema(t *testing.T) {
-	line := "archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search elapsed=1000ms repo=/r\n"
+	line := "time=2026-05-26T22:40:38.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=1000 repo=/r ts=2026-05-26T17:10:38Z\n"
 	out := parseBenchCapture([]byte(line))
 
 	raw, err := json.Marshal(out)
@@ -247,8 +247,8 @@ func TestRunBenchCapture_LogFile(t *testing.T) {
 
 	// Write a log with a prefix that should be skipped (before startOff).
 	prefix := "noise line before window\n"
-	window := "archigraph-daemon: 2026/05/26 [mcp-rpc] tool=archigraph_trace elapsed=250ms repo=/r\n"
-	suffix := "archigraph-daemon: 2026/05/26 [mcp-rpc] tool=archigraph_trace elapsed=999ms repo=/r\n"
+	window := "time=2026-05-26T22:40:38.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_trace elapsed_ms=250 repo=/r ts=2026-05-26T17:10:38Z\n"
+	suffix := "time=2026-05-26T22:40:39.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_trace elapsed_ms=999 repo=/r ts=2026-05-26T17:10:39Z\n"
 
 	content := prefix + window + suffix
 	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
@@ -310,9 +310,9 @@ func TestBenchCaptureRPCHelp(t *testing.T) {
 // top level and per-tool.
 func TestParseBenchCapture_WithByteFields(t *testing.T) {
 	lines := strings.Join([]string{
-		"archigraph-daemon: 2026/05/29 10:00:00 [mcp-rpc] tool=archigraph_search elapsed=100ms wire_bytes=4000 payload_token_estimate=1000 repo=/r",
-		"archigraph-daemon: 2026/05/29 10:00:01 [mcp-rpc] tool=archigraph_search elapsed=200ms wire_bytes=800 payload_token_estimate=200 repo=/r",
-		"archigraph-daemon: 2026/05/29 10:00:02 [mcp-rpc] tool=archigraph_describe elapsed=50ms wire_bytes=1200 payload_token_estimate=300 repo=/r",
+		"time=2026-05-29T10:00:00.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=100 wire_bytes=4000 payload_token_estimate=1000 repo=/r ts=2026-05-29T04:15:00Z",
+		"time=2026-05-29T10:00:01.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=200 wire_bytes=800 payload_token_estimate=200 repo=/r ts=2026-05-29T04:15:01Z",
+		"time=2026-05-29T10:00:02.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_describe elapsed_ms=50 wire_bytes=1200 payload_token_estimate=300 repo=/r ts=2026-05-29T04:15:02Z",
 	}, "\n") + "\n"
 
 	out := parseBenchCapture([]byte(lines))
@@ -341,16 +341,16 @@ func TestParseBenchCapture_WithByteFields(t *testing.T) {
 	}
 }
 
-// TestParseBenchCapture_BackwardCompatOldFormat verifies that a legacy log
-// line WITHOUT the #2828 byte/token fields still parses for ms, and that its
-// byte/token sums stay 0 (proving backward compatibility). It also mixes a
-// new-format line to confirm the two coexist in one slice.
+// TestParseBenchCapture_BackwardCompatOldFormat verifies that a slog line
+// WITHOUT the #2828 byte/token fields still parses for ms, and that its
+// byte/token sums stay 0.  It also mixes a new-format line to confirm the
+// two coexist in one slice.
 func TestParseBenchCapture_BackwardCompatOldFormat(t *testing.T) {
 	lines := strings.Join([]string{
-		// Old format — no wire_bytes / payload_token_estimate.
-		"archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search elapsed=8095ms repo=/path",
-		// New format — with the #2828 fields.
-		"archigraph-daemon: 2026/05/29 10:00:00 [mcp-rpc] tool=archigraph_search elapsed=100ms wire_bytes=2000 payload_token_estimate=500 repo=/path",
+		// Slog format without wire_bytes / payload_token_estimate.
+		"time=2026-05-26T22:40:38.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=8095 repo=/path ts=2026-05-26T17:10:38Z",
+		// Slog format with the #2828 fields.
+		"time=2026-05-29T10:00:00.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=100 wire_bytes=2000 payload_token_estimate=500 repo=/path ts=2026-05-29T04:15:00Z",
 	}, "\n") + "\n"
 
 	out := parseBenchCapture([]byte(lines))
@@ -370,15 +370,63 @@ func TestParseBenchCapture_BackwardCompatOldFormat(t *testing.T) {
 	}
 }
 
-// TestParseBenchCapture_AllLegacyZeroBytes verifies that a slice of only
-// legacy lines yields count>0 but byte/token sums of exactly 0 (not garbage).
+// TestParseBenchCapture_AllLegacyZeroBytes verifies that a slog line without
+// byte/token fields yields count>0 but byte/token sums of exactly 0.
 func TestParseBenchCapture_AllLegacyZeroBytes(t *testing.T) {
-	line := "archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search elapsed=42ms repo=/p\n"
+	line := "time=2026-05-26T22:40:38.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=42 repo=/p ts=2026-05-26T17:10:38Z\n"
 	out := parseBenchCapture([]byte(line))
 	if out.McpRPCCount != 1 {
 		t.Fatalf("count: got %d, want 1", out.McpRPCCount)
 	}
 	if out.McpRPCWireBytesSum != 0 || out.McpRPCTokenEstSum != 0 {
 		t.Errorf("legacy byte/token sums: got %d/%d, want 0/0", out.McpRPCWireBytesSum, out.McpRPCTokenEstSum)
+	}
+}
+
+// TestParseBenchCapture_DedupConsecutive verifies that consecutive identical
+// lines (the daemon's double-log behaviour) are collapsed to a single count.
+func TestParseBenchCapture_DedupConsecutive(t *testing.T) {
+	// Daemon emits each mcp_rpc done line twice in a row.  We should count 2
+	// distinct calls (one archigraph_find, one archigraph_inspect), not 4.
+	dupLine1 := "time=2026-05-27T06:11:28.456+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_find elapsed_ms=462 repo=/r ts=2026-05-27T00:26:28Z"
+	dupLine2 := "time=2026-05-27T06:11:35.386+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_inspect elapsed_ms=268 repo=/r ts=2026-05-27T00:26:35Z"
+	data := strings.Join([]string{
+		dupLine1, // first emit
+		dupLine1, // daemon double-log
+		dupLine2, // first emit
+		dupLine2, // daemon double-log
+		"",
+	}, "\n")
+
+	out := parseBenchCapture([]byte(data))
+	if out.McpRPCCount != 2 {
+		t.Errorf("count: got %d, want 2 (consecutive duplicates must be collapsed)", out.McpRPCCount)
+	}
+	if out.McpRPCHandlerMsSum != 730 { // 462 + 268
+		t.Errorf("sum_ms: got %d, want 730", out.McpRPCHandlerMsSum)
+	}
+	if out.McpRPCPerTool["archigraph_find"] == nil || out.McpRPCPerTool["archigraph_find"].Count != 1 {
+		t.Errorf("archigraph_find count: want 1")
+	}
+	if out.McpRPCPerTool["archigraph_inspect"] == nil || out.McpRPCPerTool["archigraph_inspect"].Count != 1 {
+		t.Errorf("archigraph_inspect count: want 1")
+	}
+}
+
+// TestParseBenchCapture_DedupWithByteFields verifies dedup works correctly
+// when phase=done lines include wire_bytes and payload_token_estimate.
+func TestParseBenchCapture_DedupWithByteFields(t *testing.T) {
+	dupLine := "time=2026-05-29T10:00:00.000+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_search elapsed_ms=100 wire_bytes=4000 payload_token_estimate=1000 repo=/r ts=2026-05-29T04:15:00Z"
+	data := strings.Join([]string{dupLine, dupLine, ""}, "\n") // double-logged
+
+	out := parseBenchCapture([]byte(data))
+	if out.McpRPCCount != 1 {
+		t.Errorf("count: got %d, want 1 (dedup)", out.McpRPCCount)
+	}
+	if out.McpRPCWireBytesSum != 4000 {
+		t.Errorf("wire_bytes_sum: got %d, want 4000 (should not double)", out.McpRPCWireBytesSum)
+	}
+	if out.McpRPCTokenEstSum != 1000 {
+		t.Errorf("token_est_sum: got %d, want 1000 (should not double)", out.McpRPCTokenEstSum)
 	}
 }

--- a/cmd/archigraph/bench_capture_test.go
+++ b/cmd/archigraph/bench_capture_test.go
@@ -304,3 +304,81 @@ func TestBenchCaptureRPCHelp(t *testing.T) {
 		}
 	}
 }
+
+// TestParseBenchCapture_WithByteFields verifies the #2828 wire_bytes /
+// payload_token_estimate fields are captured and aggregated, both at the
+// top level and per-tool.
+func TestParseBenchCapture_WithByteFields(t *testing.T) {
+	lines := strings.Join([]string{
+		"archigraph-daemon: 2026/05/29 10:00:00 [mcp-rpc] tool=archigraph_search elapsed=100ms wire_bytes=4000 payload_token_estimate=1000 repo=/r",
+		"archigraph-daemon: 2026/05/29 10:00:01 [mcp-rpc] tool=archigraph_search elapsed=200ms wire_bytes=800 payload_token_estimate=200 repo=/r",
+		"archigraph-daemon: 2026/05/29 10:00:02 [mcp-rpc] tool=archigraph_describe elapsed=50ms wire_bytes=1200 payload_token_estimate=300 repo=/r",
+	}, "\n") + "\n"
+
+	out := parseBenchCapture([]byte(lines))
+
+	if out.McpRPCCount != 3 {
+		t.Fatalf("count: got %d, want 3", out.McpRPCCount)
+	}
+	if out.McpRPCWireBytesSum != 6000 {
+		t.Errorf("wire_bytes_sum: got %d, want 6000", out.McpRPCWireBytesSum)
+	}
+	if out.McpRPCTokenEstSum != 1500 {
+		t.Errorf("token_est_sum: got %d, want 1500", out.McpRPCTokenEstSum)
+	}
+	search := out.McpRPCPerTool["archigraph_search"]
+	if search == nil {
+		t.Fatal("per_tool missing archigraph_search")
+	}
+	if search.SumBytes != 4800 {
+		t.Errorf("search sum_bytes: got %d, want 4800", search.SumBytes)
+	}
+	if search.SumTokenEst != 1200 {
+		t.Errorf("search sum_token_est: got %d, want 1200", search.SumTokenEst)
+	}
+	if search.SumMs != 300 {
+		t.Errorf("search sum_ms: got %d, want 300", search.SumMs)
+	}
+}
+
+// TestParseBenchCapture_BackwardCompatOldFormat verifies that a legacy log
+// line WITHOUT the #2828 byte/token fields still parses for ms, and that its
+// byte/token sums stay 0 (proving backward compatibility). It also mixes a
+// new-format line to confirm the two coexist in one slice.
+func TestParseBenchCapture_BackwardCompatOldFormat(t *testing.T) {
+	lines := strings.Join([]string{
+		// Old format — no wire_bytes / payload_token_estimate.
+		"archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search elapsed=8095ms repo=/path",
+		// New format — with the #2828 fields.
+		"archigraph-daemon: 2026/05/29 10:00:00 [mcp-rpc] tool=archigraph_search elapsed=100ms wire_bytes=2000 payload_token_estimate=500 repo=/path",
+	}, "\n") + "\n"
+
+	out := parseBenchCapture([]byte(lines))
+
+	if out.McpRPCCount != 2 {
+		t.Fatalf("count: got %d, want 2 (both ms lines counted)", out.McpRPCCount)
+	}
+	if out.McpRPCHandlerMsSum != 8195 {
+		t.Errorf("ms_sum: got %d, want 8195", out.McpRPCHandlerMsSum)
+	}
+	// Only the new-format line contributes bytes/tokens.
+	if out.McpRPCWireBytesSum != 2000 {
+		t.Errorf("wire_bytes_sum: got %d, want 2000", out.McpRPCWireBytesSum)
+	}
+	if out.McpRPCTokenEstSum != 500 {
+		t.Errorf("token_est_sum: got %d, want 500", out.McpRPCTokenEstSum)
+	}
+}
+
+// TestParseBenchCapture_AllLegacyZeroBytes verifies that a slice of only
+// legacy lines yields count>0 but byte/token sums of exactly 0 (not garbage).
+func TestParseBenchCapture_AllLegacyZeroBytes(t *testing.T) {
+	line := "archigraph-daemon: 2026/05/26 22:40:38 [mcp-rpc] tool=archigraph_search elapsed=42ms repo=/p\n"
+	out := parseBenchCapture([]byte(line))
+	if out.McpRPCCount != 1 {
+		t.Fatalf("count: got %d, want 1", out.McpRPCCount)
+	}
+	if out.McpRPCWireBytesSum != 0 || out.McpRPCTokenEstSum != 0 {
+		t.Errorf("legacy byte/token sums: got %d/%d, want 0/0", out.McpRPCWireBytesSum, out.McpRPCTokenEstSum)
+	}
+}

--- a/cmd/archigraph/daemon_mcp_rpc.go
+++ b/cmd/archigraph/daemon_mcp_rpc.go
@@ -128,10 +128,36 @@ func daemonMCPCallTool(name string, args map[string]any, cwd string) (daemon.MCP
 		return daemon.MCPCallResult{Content: []map[string]any{}}, nil
 	}
 
+	// #2828 measure-first: capture the final on-wire payload size HERE rather
+	// than inside internal/mcp.wrap. This is the cleanest placement because
+	// (a) result is the *mcpapi.CallToolResult AFTER wrap has run the whole
+	// finalizeDeferred → appendElapsedTrailer → applyIDInterning pipeline, so
+	// it already reflects the real, interned on-wire payload; and (b) it keeps
+	// mcp-go's CallToolResult type out of the internal/daemon package (which
+	// only sees the plain MCPCallResult wire shape). wireBytes is the sum of
+	// len(TextContent.Text) across Content; tokenEst is the char/4 estimate
+	// matching the quality-bench skill convention.
+	wireBytes := mcpWireBytes(result.Content)
 	return daemon.MCPCallResult{
-		IsError: result.IsError,
-		Content: mcpContentToMaps(result.Content),
+		IsError:       result.IsError,
+		Content:       mcpContentToMaps(result.Content),
+		WireBytes:     wireBytes,
+		TokenEstimate: wireBytes / 4,
 	}, nil
+}
+
+// mcpWireBytes returns the total on-wire payload size of a tool result: the
+// sum of len(Text) across every TextContent block. Non-text content blocks
+// (images, embedded resources) are not currently produced by archigraph tools
+// and contribute 0. Measured after applyIDInterning (see daemonMCPCallTool).
+func mcpWireBytes(content []mcpapi.Content) int {
+	total := 0
+	for _, c := range content {
+		if tc, ok := mcpapi.AsTextContent(c); ok {
+			total += len(tc.Text)
+		}
+	}
+	return total
 }
 
 // mcpContentToMaps converts the mcp-go Content slice to the

--- a/cmd/archigraph/daemon_mcp_rpc_test.go
+++ b/cmd/archigraph/daemon_mcp_rpc_test.go
@@ -183,3 +183,41 @@ func TestDaemonMCPCallTool_UnknownTool_ReturnsErrorBlock(t *testing.T) {
 		t.Fatal("expected IsError=true")
 	}
 }
+
+// TestMCPWireBytes verifies wire-byte measurement of a known CallToolResult:
+// the sum of len(Text) across TextContent blocks, with the char/4 token
+// estimate derived from it (#2828 measure-first).
+func TestMCPWireBytes(t *testing.T) {
+	// Two text blocks: 5 + 7 = 12 bytes.
+	content := []mcpapi.Content{
+		mcpapi.NewTextContent("hello"),   // 5
+		mcpapi.NewTextContent("world!!"), // 7
+	}
+	got := mcpWireBytes(content)
+	if got != 12 {
+		t.Fatalf("mcpWireBytes: got %d, want 12", got)
+	}
+	if est := got / 4; est != 3 {
+		t.Errorf("token estimate: got %d, want 3", est)
+	}
+}
+
+// TestMCPWireBytes_Empty verifies an empty/nil content slice measures 0.
+func TestMCPWireBytes_Empty(t *testing.T) {
+	if got := mcpWireBytes(nil); got != 0 {
+		t.Errorf("nil content: got %d, want 0", got)
+	}
+	if got := mcpWireBytes([]mcpapi.Content{}); got != 0 {
+		t.Errorf("empty content: got %d, want 0", got)
+	}
+}
+
+// TestMCPWireBytes_UTF8 verifies byte length (not rune count) is measured —
+// a multibyte string contributes its full byte size to the on-wire payload.
+func TestMCPWireBytes_UTF8(t *testing.T) {
+	// "é" is 2 bytes in UTF-8; "→" is 3 bytes. Total = 5.
+	got := mcpWireBytes([]mcpapi.Content{mcpapi.NewTextContent("é→")})
+	if got != 5 {
+		t.Fatalf("utf8 byte length: got %d, want 5", got)
+	}
+}

--- a/internal/daemon/mcp_rpc.go
+++ b/internal/daemon/mcp_rpc.go
@@ -60,6 +60,15 @@ const (
 	// LogFieldRepo is the slog attribute key for the caller's repo / CWD label.
 	LogFieldRepo = "repo"
 
+	// LogFieldWireBytes is the slog attribute key for the final on-wire
+	// tool-result payload size in bytes (issue #2828). Emitted on the
+	// phase=done line. Absent (and parsed as 0) on legacy logs.
+	LogFieldWireBytes = "wire_bytes"
+
+	// LogFieldTokenEst is the slog attribute key for the char/4 token
+	// estimate of the wire payload (issue #2828). Emitted on phase=done.
+	LogFieldTokenEst = "payload_token_estimate"
+
 	// LogFieldTS is the slog attribute key for the RFC3339 timestamp.
 	// Note: slog's built-in handler emits its own "time" key; LogFieldTS is
 	// retained for compatibility with log-shipper field expectations.
@@ -82,6 +91,18 @@ type MCPCallResult struct {
 	// IsError is true when the tool returned an error result (not a
 	// protocol error — those surface as a returned Go error).
 	IsError bool
+	// WireBytes is the size in bytes of the final on-wire tool-result
+	// payload (sum of len(TextContent.Text) across Content), measured by
+	// the injected MCPCallToolFunc AFTER applyIDInterning so it reflects
+	// the real serialized size. Used by `bench-capture rpc` to attribute
+	// billed-token cost to daemon-side payload size vs model ingestion
+	// (issue #2828 measure-first prerequisite). Zero when not measured.
+	WireBytes int
+	// TokenEstimate is a rough char/4 estimate of WireBytes, matching the
+	// quality-bench skill's token-estimate convention. Approximate (the
+	// host tokenizer differs) — treat as a relative lever-finder, not an
+	// exact reconciliation against billed input tokens.
+	TokenEstimate int
 }
 
 // MCPListToolsFunc returns the tool catalog for a given caller cwd (#1769).
@@ -238,6 +259,8 @@ func (s *Service) MCPToolCall(args *MCPToolCallArgs, reply *MCPToolCallReply) er
 			LogFieldPhase, "done",
 			LogFieldTool, args.Name,
 			LogFieldElapsedMS, elapsed.Milliseconds(),
+			LogFieldWireBytes, result.WireBytes,
+			LogFieldTokenEst, result.TokenEstimate,
 			LogFieldRepo, repoLabel,
 			LogFieldTS, time.Now().UTC().Format(time.RFC3339),
 		)

--- a/internal/daemon/mcp_rpc_test.go
+++ b/internal/daemon/mcp_rpc_test.go
@@ -410,6 +410,42 @@ func TestMCPToolCall_JSONLog_ParseableJSON(t *testing.T) {
 	}
 }
 
+// TestMCPToolCall_DoneLine_HasWireBytes verifies the #2828 payload-size fields
+// (wire_bytes / payload_token_estimate) propagate from the MCPCallResult onto
+// the phase=done log line. The injected dispatcher reports a known size.
+func TestMCPToolCall_DoneLine_HasWireBytes(t *testing.T) {
+	const wantBytes = 4096
+	const wantTokens = 1024
+	svc, buf := testServiceWithJSONLogger(func(name string, _ map[string]any, _ string) (MCPCallResult, error) {
+		return MCPCallResult{
+			Content:       []map[string]any{{"type": "text", "text": "ok"}},
+			WireBytes:     wantBytes,
+			TokenEstimate: wantTokens,
+		}, nil
+	})
+
+	var reply MCPToolCallReply
+	if err := svc.MCPToolCall(&MCPToolCallArgs{Name: "archigraph_find", CWD: "/r"}, &reply); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	var done map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(lines[len(lines)-1])), &done); err != nil {
+		t.Fatalf("done line not JSON: %v", err)
+	}
+	if done[LogFieldPhase] != "done" {
+		t.Fatalf("last line phase=%v, want done", done[LogFieldPhase])
+	}
+	// JSON numbers decode as float64.
+	if b, _ := done[LogFieldWireBytes].(float64); int(b) != wantBytes {
+		t.Errorf("%s=%v, want %d", LogFieldWireBytes, done[LogFieldWireBytes], wantBytes)
+	}
+	if tk, _ := done[LogFieldTokenEst].(float64); int(tk) != wantTokens {
+		t.Errorf("%s=%v, want %d", LogFieldTokenEst, done[LogFieldTokenEst], wantTokens)
+	}
+}
+
 // TestMCPToolCall_JSONLog_TrueVariant verifies that a JSON-handler slog logger
 // produces parseable JSON lines (mirrors the old ARCHIGRAPH_DAEMON_LOG_JSON=true
 // variant; handler selection is now at construction time).

--- a/skills/archigraph-graph-quality/prompts/03-with-mcp-run.md
+++ b/skills/archigraph-graph-quality/prompts/03-with-mcp-run.md
@@ -24,7 +24,7 @@ For each question in `questions.json`:
    ```
    archigraph bench-capture rpc --start $START --end $END
    ```
-   Merge the resulting JSON directly into this question's `metrics` block (`mcp_rpc_count`, `mcp_rpc_handler_ms_sum`, `mcp_rpc_handler_ms_p50`, `mcp_rpc_handler_ms_p99`, `mcp_rpc_per_tool`). If the command fails (missing binary, permissions, sandbox), set `mcp_rpc_count: null` and add `"mcp_rpc_capture_error": "<reason>"` to the artifact. See "Daemon RPC capture" below for the field semantics.
+   Merge the resulting JSON directly into this question's `metrics` block (`mcp_rpc_count`, `mcp_rpc_handler_ms_sum`, `mcp_rpc_handler_ms_p50`, `mcp_rpc_handler_ms_p99`, `mcp_rpc_per_tool`, `mcp_rpc_wire_bytes_sum`, `mcp_rpc_payload_token_estimate_sum`). The two byte/token sums are the **daemon-side payload cost** (final on-wire result size, measured after id-interning); comparing `mcp_rpc_payload_token_estimate_sum` against this question's billed `input_tokens` splits handler-payload cost from model-ingestion/transport overhead (#2828). If the command fails (missing binary, permissions, sandbox), set `mcp_rpc_count: null` and add `"mcp_rpc_capture_error": "<reason>"` to the artifact. See "Daemon RPC capture" below for the field semantics.
 8. Compute the delta and record the metrics below.
 
 ## Daemon RPC capture
@@ -62,10 +62,12 @@ See `prompts/03a-rpc-capture.md` for the detailed daemon RPC capture protocol, i
         "mcp_rpc_handler_ms_p50": 1850,
         "mcp_rpc_handler_ms_p99": 2410,
         "mcp_rpc_per_tool": {
-          "archigraph_search": {"count": 2, "sum_ms": 3600},
-          "archigraph_describe": {"count": 1, "sum_ms": 2120},
-          "archigraph_related": {"count": 1, "sum_ms": 2260}
-        }
+          "archigraph_search": {"count": 2, "sum_ms": 3600, "sum_bytes": 4096, "sum_token_est": 1024},
+          "archigraph_describe": {"count": 1, "sum_ms": 2120, "sum_bytes": 1536, "sum_token_est": 384},
+          "archigraph_related": {"count": 1, "sum_ms": 2260, "sum_bytes": 2048, "sum_token_est": 512}
+        },
+        "mcp_rpc_wire_bytes_sum": 7680,
+        "mcp_rpc_payload_token_estimate_sum": 1920
       },
       "notes": "Mentioned archigraph_search returned 0 hits initially; widened query."
     }

--- a/skills/archigraph-graph-quality/prompts/03a-rpc-capture.md
+++ b/skills/archigraph-graph-quality/prompts/03a-rpc-capture.md
@@ -4,7 +4,7 @@ Detailed daemon RPC capture procedure for per-question metrics collection during
 
 ## Daemon RPC capture (handler vs transport split)
 
-**Why:** the daemon logs `[mcp-rpc] tool=<name> elapsed=<N>ms repo=<repo>` at `internal/daemon/mcp_rpc.go:193` for every RPC call dispatched. The `elapsed` value is the **handler** time — what the daemon spent actually computing the answer, exclusive of the JSON-RPC bridge transport. Wall-clock per-question time minus the sum of `elapsed` values is the **transport** time (bridge serialization, stdio pipe, host overhead).
+**Why:** the daemon logs `[mcp-rpc] tool=<name> elapsed=<N>ms wire_bytes=<B> payload_token_estimate=<T> repo=<repo>` at `internal/daemon/mcp_rpc.go:MCPToolCall` for every RPC call dispatched (the `wire_bytes`/`payload_token_estimate` fields were added in #2828). The `elapsed` value is the **handler** time — what the daemon spent actually computing the answer, exclusive of the JSON-RPC bridge transport. Wall-clock per-question time minus the sum of `elapsed` values is the **transport** time (bridge serialization, stdio pipe, host overhead).
 
 This split is the whole point of the capture: a question with `wall=8000ms, handler_sum=7500ms` says the handler is the lever; a question with `wall=8000ms, handler_sum=400ms` says the transport is the lever.
 
@@ -30,7 +30,13 @@ archigraph bench-capture rpc \
 - `mcp_rpc_handler_ms_sum` — sum of all elapsed_ms values.
 - `mcp_rpc_handler_ms_p50` — median handler duration; `null` when count = 0.
 - `mcp_rpc_handler_ms_p99` — 99th-percentile handler duration; `null` when count = 0.
-- `mcp_rpc_per_tool` — per-tool `{ "count": N, "sum_ms": M }` map.
+- `mcp_rpc_per_tool` — per-tool `{ "count": N, "sum_ms": M, "sum_bytes": B, "sum_token_est": T }` map.
+- `mcp_rpc_wire_bytes_sum` — sum of the final on-wire tool-result payload size (bytes) across the window, measured daemon-side in `daemonMCPCallTool` **after `applyIDInterning`** (#2828).
+- `mcp_rpc_payload_token_estimate_sum` — char/4 estimate of those bytes. Approximate (host tokenizer differs) — use as a **relative lever-finder**, not exact reconciliation against billed `input_tokens`.
+
+**Reading the split:** `mcp_rpc_payload_token_estimate_sum` is the cost the daemon *produced* (handler payload). The host's billed `input_tokens` is what the model *ingested*. The delta is transport/host overhead. A handler whose `sum_bytes` dominates is the target for the optimization menu (top-N defaults, terse formats, token budgets).
+
+**Backward compatibility:** old daemon logs lack `wire_bytes`/`payload_token_estimate`. The parser still counts those lines for ms; the byte/token sums simply stay `0`. A `0` (not `null`) byte sum on a non-zero count therefore means "legacy log slice", not "zero-byte payloads".
 
 ## Log rotation
 

--- a/skills/archigraph-graph-quality/schema/with-mcp-artifact.schema.json
+++ b/skills/archigraph-graph-quality/schema/with-mcp-artifact.schema.json
@@ -183,6 +183,16 @@
           "additionalProperties": {
             "$ref": "#/$defs/ToolRPCStats"
           }
+        },
+        "mcp_rpc_wire_bytes_sum": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Sum of the final on-wire tool-result payload size (bytes, sum of len(TextContent.Text)) across all captured calls, measured daemon-side AFTER applyIDInterning (issue #2828). Compare against billed input_tokens to split daemon-side payload cost vs model ingestion. Null when mcp_rpc_count is null; 0 when only legacy log lines (without wire_bytes) were captured."
+        },
+        "mcp_rpc_payload_token_estimate_sum": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Sum of the char/4 token estimate of the wire payloads across all captured calls (issue #2828). Approximate (host tokenizer differs) — a relative lever-finder, not exact reconciliation. Null when mcp_rpc_count is null; 0 when only legacy log lines were captured."
         }
       }
     },
@@ -201,12 +211,22 @@
           "type": "integer",
           "minimum": 0,
           "description": "Sum of handler durations in milliseconds for this tool."
+        },
+        "sum_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sum of on-wire payload bytes for this tool (issue #2828). 0 for legacy log lines without wire_bytes."
+        },
+        "sum_token_est": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sum of char/4 payload token estimates for this tool (issue #2828). 0 for legacy log lines."
         }
       }
     },
     "BenchCaptureOutput": {
       "type": "object",
-      "required": ["mcp_rpc_count", "mcp_rpc_handler_ms_sum", "mcp_rpc_handler_ms_p50", "mcp_rpc_handler_ms_p99", "mcp_rpc_per_tool"],
+      "required": ["mcp_rpc_count", "mcp_rpc_handler_ms_sum", "mcp_rpc_handler_ms_p50", "mcp_rpc_handler_ms_p99", "mcp_rpc_per_tool", "mcp_rpc_wire_bytes_sum", "mcp_rpc_payload_token_estimate_sum"],
       "additionalProperties": false,
       "description": "Top-level JSON output of `archigraph bench-capture rpc`. Matches the mcp_rpc_* fields in QuestionMetrics so the CLI output can be merged directly into a question's metrics block.",
       "properties": {
@@ -236,6 +256,16 @@
             "$ref": "#/$defs/ToolRPCStats"
           },
           "description": "Per-tool aggregation. Empty object when count=0."
+        },
+        "mcp_rpc_wire_bytes_sum": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sum of on-wire tool-result payload bytes across all captured calls, measured daemon-side AFTER applyIDInterning (issue #2828). 0 when only legacy log lines (without wire_bytes) were captured."
+        },
+        "mcp_rpc_payload_token_estimate_sum": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sum of char/4 payload token estimates across all captured calls (issue #2828). 0 when only legacy log lines were captured."
         }
       }
     }


### PR DESCRIPTION
## What
Adds daemon-side measurement of the **final on-wire tool-result payload** (bytes + char/4 token estimate) so the quality bench can split daemon-side payload cost from model ingestion — the measure-first prerequisite of #2828. Scope = Steps 1–4 of the plan (capture + parser + schema/prompts). Step 5 (orchestration) is handled separately.

## Where measured (and why)
`cmd/archigraph/daemon_mcp_rpc.go:daemonMCPCallTool` — the `*mcpapi.CallToolResult → daemon.MCPCallResult` adapter. `result` here is **after** `internal/mcp.wrap` has run `finalizeDeferred` / `appendElapsedTrailer` / `applyIDInterning`, so the byte count reflects the real interned on-wire payload. Chosen over patching `wrap` itself so mcp-go's `CallToolResult` type never leaks into the `internal/daemon` package. `wireBytes` = sum of `len(TextContent.Text)` across `Content`; `tokenEst = wireBytes/4`.

## Log line (new format)
```
[mcp-rpc] tool=X elapsed=Nms wire_bytes=B payload_token_estimate=T repo=Y
```
New constants `LogFieldWireBytes` / `LogFieldTokenEst` on the `phase=done` slog line.

## Parser + schema
- `bench_capture.go`: optional `rpcBytesRe` second pass; `ToolRPCStats.SumBytes/SumTokenEst`; `BenchCaptureOutput.McpRPCWireBytesSum/McpRPCTokenEstSum`. **Backward compatible** — `rpcLineRe` widened to tolerate the new mid-line fields; legacy ms-only lines still parse and their byte/token sums stay `0` (a `0` sum on non-zero count means "legacy slice", not "empty payload").
- Schema: `mcp_rpc_wire_bytes_sum` + `mcp_rpc_payload_token_estimate_sum` (nullable in QuestionMetrics, required-int in BenchCaptureOutput) + per-tool `sum_bytes`/`sum_token_est`. Documented in `prompts/03-with-mcp-run.md` + `prompts/03a-rpc-capture.md`.

## Tests
`mcpWireBytes` unit test (known result, empty, UTF-8 byte-length), new-format + mixed backward-compat parser fixtures, all-legacy-zero-bytes, and a done-line `wire_bytes`/`payload_token_estimate` assertion. `go build ./...` clean; `go test ./cmd/archigraph/... ./internal/mcp/...` green; gofmt clean. (The `internal/daemon` *integration* tests that spin up a real socket fail identically on the clean base in this sandbox — pre-existing env limitation, not a regression.)

Refs #2828