### PR TITLE
fix(extraction): stop extracting React-Query queryKeys as HTTP endpoint calls

### DIFF
--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -366,7 +366,7 @@ var jsArrowFnTemplateRe = regexp.MustCompile(
 // body is a template literal. Used by canonicalizeTemplateLiteralCore
 // (issue #2708) to inline factory callsites.
 //
-// Only the simple shape `const NAME = (a, b) => `+"`"+`...`+"`"+`` is captured.
+// Only the simple shape `const NAME = (a, b) => `+"`"+`...`+"`"+“ is captured.
 // Multi-statement bodies, conditional returns, async/await wrappers, and
 // tagged templates are NOT captured — those callsites keep their existing
 // `{param}` placeholder behaviour.
@@ -1800,65 +1800,38 @@ func synthesizeWrapperCalls(content string, funcs []jsFuncSpan, syms map[string]
 	}
 }
 
-// synthesizeReactQueryCalls emits FETCHES edges for React Query / SWR /
-// RTK Query patterns that wrap callApi-style invocations (#806 beyond-minimum).
+// synthesizeReactQueryCalls emits FETCHES edges for RTK Query createApi
+// endpoint-builder patterns (#806 beyond-minimum).
 //
 // Recognized patterns:
-//   - useQuery({ queryKey: ['resource'], queryFn: () => callApi('resource', 'GET') })
-//     → FETCHES to /resource/
 //   - createApi builder.query({ query: () => 'resource' })
 //     → FETCHES to /resource/
 //
+// IMPORTANT (#3171): React Query / SWR `queryKey` and `mutationKey` arrays are
+// CACHE KEYS, not request URLs. Code such as
+//
+//	useQuery({ queryKey: ['scoped-permissions'], queryFn: () => api.get('permissions/123/scope_permissions') })
+//
+// names its cache entry 'scoped-permissions' — a logical label that very often
+// does NOT match any backend path. Treating the queryKey first element as an
+// endpoint path fabricated phantom calls (e.g. /scoped-permissions) that no
+// backend exposes, inflating cross-repo orphan counts and producing confidently
+// wrong MCP answers. The REAL endpoint is whatever the queryFn / mutationFn body
+// invokes (fetch / axios / a service method), which is already extracted by
+// synthesizeFetchAxios and the http-wrapper passes. We therefore do NOT derive
+// any endpoint from queryKey / mutationKey arrays here.
+//
+// RTK Query's `builder.query({ query: () => 'users' })` is different: the arrow
+// return value IS the literal request path, so it remains a valid endpoint
+// source and is kept below.
+//
 // The enclosing function at the call site is used as source_caller.
 func synthesizeReactQueryCalls(content string, funcs []jsFuncSpan, syms map[string]string, emit emitFn) {
-	// #2117: include useMutation / useSuspenseQuery in early-exit check.
-	if !strings.Contains(content, "useQuery") && !strings.Contains(content, "useMutation") &&
-		!strings.Contains(content, "createApi") && !strings.Contains(content, "builder.") {
+	// Only RTK Query builder endpoints are synthesized here; useQuery /
+	// useMutation key arrays are intentionally ignored (#3171).
+	_ = syms
+	if !strings.Contains(content, "createApi") && !strings.Contains(content, "builder.") {
 		return
-	}
-
-	// useQuery / useSuspenseQuery ({ queryKey: ['resource'], ... }) patterns.
-	for _, m := range useQueryKeyRe.FindAllStringSubmatchIndex(content, -1) {
-		if len(m) < 4 {
-			continue
-		}
-		resource := content[m[2]:m[3]]
-		if resource == "" {
-			continue
-		}
-		normalized := normalizeBareName(resource)
-		if normalized == "" || normalized == "/" {
-			continue
-		}
-		// Resolve via const symbol table (in case the key is a constant name).
-		if resolved, ok := syms[resource]; ok {
-			normalized = normalizeBareName(resolved)
-		}
-		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, normalized)
-		caller := enclosingJSFuncAt(funcs, m[0])
-		emit("GET", canonical, "react_query", "Function", caller)
-	}
-
-	// useMutation({ mutationKey: ['resource'], ... }) patterns — #2117.
-	// Mutations default to POST; the mutationKey first string names the resource.
-	for _, m := range useMutationKeyRe.FindAllStringSubmatchIndex(content, -1) {
-		if len(m) < 4 {
-			continue
-		}
-		resource := content[m[2]:m[3]]
-		if resource == "" {
-			continue
-		}
-		normalized := normalizeBareName(resource)
-		if normalized == "" || normalized == "/" {
-			continue
-		}
-		if resolved, ok := syms[resource]; ok {
-			normalized = normalizeBareName(resolved)
-		}
-		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, normalized)
-		caller := enclosingJSFuncAt(funcs, m[0])
-		emit("POST", canonical, "react_query_mutation", "Function", caller)
 	}
 
 	// RTK Query builder.query/mutation patterns.

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -60,6 +60,21 @@ func requireContains(t *testing.T, got, want []string, label string) {
 	}
 }
 
+// requireNotContains asserts that none of the unwanted IDs appear in got.
+// Used to prove phantom endpoints (e.g. React-Query cache keys mistaken for
+// URLs, #3171) are NOT synthesized.
+func requireNotContains(t *testing.T, got, unwanted []string, label string) {
+	t.Helper()
+	for _, u := range unwanted {
+		for _, g := range got {
+			if g == u {
+				t.Errorf("%s: phantom synthetic %q should NOT be present (got: %v)", label, u, got)
+				break
+			}
+		}
+	}
+}
+
 // TestSynth_Flask covers @app.route(methods=["GET","POST"]), @bp.get(),
 // and Flask path converters.
 func TestSynth_Flask(t *testing.T) {

--- a/internal/engine/http_wrapper_detection_test.go
+++ b/internal/engine/http_wrapper_detection_test.go
@@ -287,18 +287,63 @@ func TestIsHTTPWrapperHeuristic_ConfigOverride(t *testing.T) {
 // React Query / SWR / RTK Query beyond-minimum
 // ---------------------------------------------------------------------------
 
-// TestSynth806_ReactQueryUseQuery verifies that useQuery with a string key
-// matching a resource name emits a FETCHES edge to the normalized path.
+// TestSynth806_ReactQueryUseQuery verifies that the REAL endpoint inside a
+// useQuery's queryFn is captured. The endpoint comes from the queryFn body
+// (the fetch call) — NOT from the queryKey array. See #3171: the queryKey is a
+// cache key, not a URL.
 func TestSynth806_ReactQueryUseQuery(t *testing.T) {
 	src := `import { useQuery } from '@tanstack/react-query';
 
 export function useUsers() {
-  return useQuery({ queryKey: ['users'], queryFn: () => callApi('users', 'GET') });
+  return useQuery({ queryKey: ['users'], queryFn: () => fetch('/users') });
 }
 `
 	got, _ := runDetect(t, "typescript", "806-rq-useQuery.ts", src)
 	want := []string{"http:GET:/users"}
-	requireContains(t, got, want, "#806 React Query useQuery queryKey resource name")
+	requireContains(t, got, want, "#806 React Query useQuery queryFn real call")
+}
+
+// TestSynth3171_QueryKeyNotEndpoint is the proving fixture for #3171: a
+// React-Query queryKey/mutationKey that does NOT match any URL must NOT
+// fabricate an endpoint, while the REAL call in the same queryFn/mutationFn
+// must still be extracted.
+//
+// Before the fix, archigraph emitted phantom calls GET /scoped-permissions and
+// POST /role-permissions (the cache keys). The cache keys are logical labels;
+// the real endpoint is the literal URL passed to fetch/axios. This proves both
+// halves: (a) no phantom from the key array, (b) the real URL survives.
+func TestSynth3171_QueryKeyNotEndpoint(t *testing.T) {
+	src := `import { useQuery, useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+
+export function useScopedPermissions(id) {
+  return useQuery({
+    queryKey: ['scoped-permissions', id],
+    queryFn: () => axios.get('/permissions/123/scope_permissions'),
+  });
+}
+
+export function useAssignRole() {
+  return useMutation({
+    mutationKey: ['role-permissions'],
+    mutationFn: (body) => axios.post('/permissions/assign_role', body),
+  });
+}
+`
+	got, _ := runDetect(t, "typescript", "3171-querykey.ts", src)
+
+	// (a) The cache keys must NOT become endpoints.
+	requireNotContains(t, got, []string{
+		"http:GET:/scoped-permissions",
+		"http:POST:/role-permissions",
+		"http:GET:/role-permissions",
+	}, "#3171 queryKey/mutationKey cache keys must not be endpoints")
+
+	// (b) The real URLs passed to axios.get / axios.post must still be extracted.
+	requireContains(t, got, []string{
+		"http:GET:/permissions/123/scope_permissions",
+		"http:POST:/permissions/assign_role",
+	}, "#3171 real queryFn/mutationFn calls still extracted")
 }
 
 // TestSynth806_RTKQueryBuilderQuery verifies that RTK Query


### PR DESCRIPTION
## Root cause
`synthesizeReactQueryCalls` in `internal/engine/http_endpoint_client_synthesis.go` treated the first string of a React-Query/SWR `queryKey` / `mutationKey` array as an endpoint path (via `useQueryKeyRe` / `useMutationKeyRe`). But those arrays are **cache keys**, not URLs.

Example:
```ts
useQuery({ queryKey: ['scoped-permissions'], queryFn: () => api.get('permissions/123/scope_permissions') })
```
emitted a phantom `GET /scoped-permissions` that no backend exposes. The real call is `permissions/{id}/scope_permissions` (PermissionViewSet).

## Impact
- Fabricated endpoints (`/scoped-permissions`, `/role-permissions`, `/inspection-notes`, `/inspections-counts`, `/inspections-group`, ...) → MCP answered bench q2 & q10 confidently wrong.
- Inflated/unreliable cross-repo orphan counts (q9 was arithmetically impossible: 248 resolved + 184 orphan = 432 > 380 total). Many "orphan" cross-repo calls were phantoms that were never real HTTP calls.
- #1 reason MCP lost the upvate quality bench to grep.

## Fix
Removed the `queryKey` / `mutationKey` endpoint-synthesis blocks. The REAL endpoint is whatever the `queryFn` / `mutationFn` body invokes (fetch / axios / a service method), which is already extracted by `synthesizeFetchAxios` and the http-wrapper passes. RTK Query's `builder.query({ query: () => 'users' })` is **kept** — there the arrow return value genuinely is the literal request path.

## Proving fixture
`TestSynth3171_QueryKeyNotEndpoint` asserts:
- (a) `queryKey:['scoped-permissions']` / `mutationKey:['role-permissions']` produce **no** `/scoped-permissions` or `/role-permissions` endpoint;
- (b) the real `axios.get('/permissions/123/scope_permissions')` / `axios.post('/permissions/assign_role')` in the same hooks **are** still extracted.

`TestSynth806_ReactQueryUseQuery` updated to assert the `queryFn` call (not the key) is the endpoint source. Notably, every other React-Query unit test (`TestSynth2117_*`) still passes unchanged — their real calls were always detected by the proper fetch/axios/wrapper passes; only the test that relied purely on the key happening to equal the URL needed updating.

## Cross-repo count impact
On a React codebase this removes roughly one phantom endpoint per distinct `queryKey`/`mutationKey` array (typically one per data-fetching hook). On upvate that was on the order of ~50-300 of the 307 reported cross-repo "orphan" calls (the bench flagged the orphan total as arithmetically impossible), so expect the orphan rate to drop sharply and the resolver gap to read accurately after re-index.

Closes #3171

🤖 Generated with [Claude Code](https://claude.com/claude-code)