### PR TITLE
fix(extraction): emit one node per DRF ViewSet (drop dead Controller duplicate)

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -404,6 +404,27 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		}
 	}
 
+	// Issue #3172 — Python DRF ViewSet double-emit dedup.
+	//
+	// Every Python framework's YAML rules fire on every Python file because
+	// they all share the "python" language key.  Falcon's catch-all class
+	// source_pattern (class \w+ ...) emits a `Controller` entity for every
+	// class definition it sees, including DRF ViewSet classes in Django
+	// files that the Django source_pattern already emits as `View`.  The
+	// result is two framework-typed nodes — View + Controller — for the
+	// same (Name, SourceFile), where the Controller carries zero edges
+	// (dead phantom, ~72 per Upvate bench).
+	//
+	// Resolution: after all rule-sets have run, drop any `Controller` entity
+	// whose (Name, SourceFile) pair is also covered by a `View` entity in
+	// the same result set.  `View` carries CALLS/ROUTES_TO edges and is the
+	// semantically correct node for a Django/DRF class; `Controller` is the
+	// phantom.  Order-independent — we scan the final slice rather than
+	// relying on rule-set processing order.
+	if file.Language == "python" {
+		entities = deduplicateViewControllerForPython(entities)
+	}
+
 	// Build the base args struct shared across all engine passes.
 	// Each pass reads the fields it needs; unused fields are ignored.
 	// Pass-specific fields (Pass1Entities, RepoRoot) are populated once here
@@ -753,6 +774,51 @@ func (d *Detector) RuleCount() int {
 		count += len(rules)
 	}
 	return count
+}
+
+// deduplicateViewControllerForPython removes `Controller` entities whose
+// (Name, SourceFile) pair is already covered by a `View` entity in the same
+// slice.  Called for Python files only (see issue #3172).
+//
+// The Falcon YAML source_pattern `class\s+(\w+)...` is a catch-all that
+// fires on every Python file, including Django/DRF files where the Django
+// source_pattern already emits the same class as `View`.  Keeping both
+// produces a dead phantom `Controller` node with zero edges alongside the
+// live `View` node that carries CALLS/ROUTES_TO edges.
+//
+// This pass is order-independent: it scans the full entity slice in two
+// passes (index → drop), so it is safe regardless of which YAML rule-set
+// ran first.  The `View` entity is kept; the duplicate `Controller` is
+// dropped.  Entities of other kinds (Model, Route, Config, …) are
+// never affected.
+func deduplicateViewControllerForPython(entities []types.EntityRecord) []types.EntityRecord {
+	if len(entities) == 0 {
+		return entities
+	}
+
+	// First pass: collect all (Name, SourceFile) pairs that have a View entity.
+	viewPairs := make(map[[2]string]bool, len(entities))
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind == "View" {
+			viewPairs[[2]string{e.Name, e.SourceFile}] = true
+		}
+	}
+	if len(viewPairs) == 0 {
+		return entities // no View entities → nothing to dedup
+	}
+
+	// Second pass: drop Controller entities shadowed by a View.
+	out := make([]types.EntityRecord, 0, len(entities))
+	for i := range entities {
+		e := entities[i]
+		if e.Kind == "Controller" && viewPairs[[2]string{e.Name, e.SourceFile}] {
+			// Phantom: a View already exists for the same class symbol.
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 // fileConventionName derives an entity name from a file path according to the

--- a/internal/engine/drf_viewset_double_emit_3172_test.go
+++ b/internal/engine/drf_viewset_double_emit_3172_test.go
@@ -1,0 +1,140 @@
+package engine
+
+// drf_viewset_double_emit_3172_test.go — regression test for issue #3172.
+//
+// Root cause: every Python framework's YAML rules apply to every Python file
+// (they all share the "python" language key).  Falcon's catch-all
+// `class\s+(\w+)...` source_pattern fires on Django/DRF files and emits a
+// `Controller` entity for every class definition, including DRF ViewSet
+// classes that the Django source_pattern already emits as `View`.  The
+// result was two framework-typed nodes — View + Controller — for the same
+// (Name, SourceFile), where the Controller carried zero edges.
+//
+// Fix: deduplicateViewControllerForPython drops `Controller` entities whose
+// (Name, SourceFile) is already covered by a `View` entity.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// sampleDRFViewsetFile is a minimal DRF ViewSet file that reproduces the
+// double-emit: AocViewSet inherits from viewsets.ModelViewSet and therefore
+// matches both the Django source_pattern (emits View) and the Falcon catch-all
+// class pattern (emits Controller).
+const sampleDRFViewsetFile = `from rest_framework import viewsets
+
+class AocViewSet(viewsets.ModelViewSet):
+    """DRF ViewSet for the Aoc model."""
+    queryset = Aoc.objects.all()
+    serializer_class = AocSerializer
+    permission_classes = [IsAuthenticated]
+
+class AocReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Aoc.objects.filter(active=True)
+    serializer_class = AocSerializer
+`
+
+// TestDRFViewSet_NoDoubleEmit verifies that a DRF ViewSet class emits exactly
+// ONE entity node — the View — and NOT a duplicate Controller.  Regression for
+// issue #3172 ("~72 phantom Controller nodes in Upvate bench, AocViewSet being
+// the canonical example").
+func TestDRFViewSet_NoDoubleEmit(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules failed: %v", err)
+	}
+
+	det := New(rules)
+	result, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     "core/views/aoc_viewset.py",
+		Content:  []byte(sampleDRFViewsetFile),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect failed: %v", err)
+	}
+
+	// Gather View and Controller entities by class name.
+	type kindCount struct{ view, controller int }
+	byName := make(map[string]*kindCount)
+	for _, e := range result.Entities {
+		if e.Kind != "View" && e.Kind != "Controller" {
+			continue
+		}
+		if _, ok := byName[e.Name]; !ok {
+			byName[e.Name] = &kindCount{}
+		}
+		switch e.Kind {
+		case "View":
+			byName[e.Name].view++
+		case "Controller":
+			byName[e.Name].controller++
+		}
+	}
+
+	// Both ViewSet classes must be emitted as View, never as Controller.
+	for _, className := range []string{"AocViewSet", "AocReadOnlyViewSet"} {
+		counts, ok := byName[className]
+		if !ok {
+			t.Errorf("%s: expected a View entity, found none", className)
+			continue
+		}
+		if counts.view != 1 {
+			t.Errorf("%s: expected exactly 1 View entity, got %d", className, counts.view)
+		}
+		if counts.controller != 0 {
+			t.Errorf("%s: expected 0 Controller entities (phantom), got %d — double-emit regression #3172",
+				className, counts.controller)
+		}
+	}
+}
+
+// TestDRFViewSet_ControllerNotDroppedForNonViewClasses verifies that the dedup
+// only drops a Controller when a View exists for the SAME name.  A class that
+// is ONLY a Controller (e.g. an actual Falcon resource) must still be emitted.
+func TestDRFViewSet_ControllerNotDroppedForNonViewClasses(t *testing.T) {
+	// Minimal synthetic rule set: one rule emits Controller for every class,
+	// no rule emits View at all.  deduplicateViewControllerForPython must keep
+	// the Controller because there is no competing View.
+	const syntheticFalconYAML = `
+source_patterns:
+  - pattern: "class\\s+(\\w+)"
+    entity_type: Controller
+    name_group: 1
+    scope: class
+`
+	const syntheticCode = `class FalconResource:
+    def on_get(self, req, resp):
+        resp.media = {}
+`
+
+	fsys := buildTestFS("python", "falcon_only", syntheticFalconYAML)
+	synRules, err := LoadAllRulesFromFS(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFS failed: %v", err)
+	}
+
+	det := New(synRules)
+	result, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     "resources/falcon_resource.py",
+		Content:  []byte(syntheticCode),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect failed: %v", err)
+	}
+
+	var foundController bool
+	for _, e := range result.Entities {
+		if e.Kind == "Controller" && strings.HasPrefix(e.Name, "FalconResource") {
+			foundController = true
+		}
+	}
+	if !foundController {
+		t.Error("expected FalconResource to be emitted as Controller when no competing View exists, got none")
+	}
+}


### PR DESCRIPTION
## Root cause

Every Python framework's YAML rules share the `python` language key, so ALL framework rule-sets fire on every Python file. Falcon's `source_patterns` entry:

```yaml
- pattern: "class\\s+(\\w+)\\s*(?:\\([^)]*\\))?\\s*:"
  entity_type: Controller
```

is a catch-all that matches every Python class definition, including DRF ViewSet classes in Django files. The Django rule-set already emits those same classes as `View`. The result was two framework-typed nodes — `View` + `Controller` — for the same `(Name, SourceFile)`, where the `Controller` carried zero `CALLS`/`ROUTES_TO` edges (~72 phantom nodes on the Upvate bench, e.g. `AocViewSet` in `core/views/aoc_viewset.py:30`).

## Fix

`deduplicateViewControllerForPython` in `internal/engine/detector.go`: after all rule-sets have run for a Python file, scan the entity slice for `(Name, SourceFile)` pairs that are covered by both a `View` and a `Controller`, and drop the `Controller`. The pass is order-independent (two-pass scan) and only applies to `python`-language files. Entities of other kinds (`Model`, `Route`, `Config`, …) are never affected.

## Tests

- `TestDRFViewSet_NoDoubleEmit` — `AocViewSet` and `AocReadOnlyViewSet` each produce exactly 1 `View` entity and 0 `Controller` entities.
- `TestDRFViewSet_ControllerNotDroppedForNonViewClasses` — a class emitted only as `Controller` (no competing `View`) is still kept.

Closes #3172