### PR TITLE
feat(coverage): Java residual recording-wins (migration N/A, MicroProfile AOP, webflux scope, framework-blind, Panache/MyBatis)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -125,7 +125,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 5/7 | |
 | [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
-| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 13/16 | |
+| [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
 | [java](../by-language/java.md) | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
@@ -133,7 +133,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 18/18 | |
-| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 15/16 | |
+| [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
@@ -161,8 +161,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/8 | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🔴 0/2 | 🔴 0/1 | 🟡 18/19 | 🟡 2/4 | |
-| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🔴 0/2 | 🔴 0/1 | 🟡 18/19 | 🟡 3/4 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🔴 0/1 | 🟢 19/19 | 🟡 2/4 | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🔴 0/1 | 🟢 19/19 | 🟡 3/4 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟡 20/21 | ✅ 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 21/21 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 17/17 | |
@@ -174,7 +174,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🔴 0/2 | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/7 | |
-| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟡 1/2 | 🔴 0/3 | 🟢 1/1 | 🟡 16/21 | 🟡 4/8 | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟡 2/3 | 🟢 1/1 | 🟡 20/21 | 🟢 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟡 20/21 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟡 17/21 | ✅ 11/11 | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -60,18 +60,18 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 2/8 | |
 | [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🔴 0/8 | |
 | [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟢 3/3 | |
-| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟡 5/8 | |
+| [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟢 7/7 | |
+| [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟢 7/7 | |
+| [java](../by-language/java.md) | [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟢 7/7 | |
+| [java](../by-language/java.md) | [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟢 7/7 | |
+| [java](../by-language/java.md) | [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟢 7/7 | |
 | [java](../by-language/java.md) | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | 🟢 5/5 | |
-| [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟡 5/8 | |
-| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🟡 3/4 | |
-| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🟡 3/4 | |
-| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 7/8 | |
-| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟡 3/4 | |
-| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🟡 3/4 | |
+| [java](../by-language/java.md) | [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟢 7/7 | |
+| [java](../by-language/java.md) | [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🟢 3/3 | |
+| [java](../by-language/java.md) | [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🟢 3/3 | |
+| [java](../by-language/java.md) | [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟢 7/7 | |
+| [java](../by-language/java.md) | [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟢 3/3 | |
+| [java](../by-language/java.md) | [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🟢 3/3 | |
 | [java](../by-language/java.md) | [jOOQ](../detail/lang.java.orm.jooq.md) | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ✅ 1/1 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -29,7 +29,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 5/7 | |
 | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
-| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 13/16 | |
+| [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
 | [JAX-RS / Jakarta REST](../detail/lang.java.framework.jaxrs.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Jakarta EE (Servlet / EE Platform)](../detail/lang.java.framework.jakarta-ee.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
@@ -37,7 +37,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Micronaut](../detail/lang.java.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Quarkus](../detail/lang.java.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 18/18 | |
-| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 15/16 | |
+| [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 
 
@@ -45,15 +45,15 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🔴 0/2 | 🔴 0/1 | 🟡 18/19 | 🟡 2/4 | |
-| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🔴 0/2 | 🔴 0/1 | 🟡 18/19 | 🟡 3/4 | |
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🔴 0/1 | 🟢 19/19 | 🟡 2/4 | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🔴 0/1 | 🟢 19/19 | 🟡 3/4 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Play Framework](../detail/lang.java.framework.play.md) | 🟡 1/2 | 🔴 0/3 | 🟢 1/1 | 🟡 16/21 | 🟡 4/8 | |
+| [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟡 2/3 | 🟢 1/1 | 🟡 20/21 | 🟢 4/4 | |
 
 
 ### Mobile
@@ -94,18 +94,18 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟢 3/3 | |
-| [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/8 | |
-| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/8 | |
-| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟡 7/8 | |
-| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟡 7/8 | |
-| [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟡 5/8 | |
+| [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟢 7/7 | |
+| [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟢 7/7 | |
+| [Hibernate ORM](../detail/lang.java.orm.hibernate.md) | 🟢 7/7 | |
+| [JPA / Jakarta Persistence API](../detail/lang.java.orm.jpa.md) | 🟢 7/7 | |
+| [MyBatis](../detail/lang.java.orm.mybatis.md) | 🟢 7/7 | |
 | [Neo4j (Java driver)](../detail/lang.java.orm.neo4j.md) | 🟢 5/5 | |
-| [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟡 5/8 | |
-| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🟡 3/4 | |
-| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🟡 3/4 | |
-| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟡 7/8 | |
-| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟡 3/4 | |
-| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🟡 3/4 | |
+| [Quarkus Panache (SQL + Reactive + MongoDB)](../detail/lang.java.orm.panache.md) | 🟢 7/7 | |
+| [Spring Data Cassandra](../detail/lang.java.orm.spring-data-cassandra.md) | 🟢 3/3 | |
+| [Spring Data Elasticsearch](../detail/lang.java.orm.spring-data-elastic.md) | 🟢 3/3 | |
+| [Spring Data JPA](../detail/lang.java.orm.spring-data-jpa.md) | 🟢 7/7 | |
+| [Spring Data MongoDB](../detail/lang.java.orm.spring-data-mongo.md) | 🟢 3/3 | |
+| [Spring Data Redis](../detail/lang.java.orm.spring-data-redis.md) | 🟢 3/3 | |
 | [jOOQ](../detail/lang.java.orm.jooq.md) | 🟢 6/6 | |
 
 

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -37,8 +37,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits enum_declaration and interface_declaration nodes for all Java frameworks including GWT (#3178). |
+| Interface extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits enum_declaration and interface_declaration nodes for all Java frameworks including GWT (#3178). |
 | Type alias extraction | — `not_applicable` | — | 3091 | — | GWT compiles Java to client-side JS but uses Java idioms with no React-style concepts; type_alias_extraction is a React/JSX-paradigm capability that does not apply |
 
 ### Lifecycle
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Request shape extraction | — `not_applicable` | — | 3154 | — | — |
 | Response shape extraction | — `not_applicable` | — | 3154 | — | — |
 | Sanitizer recognition | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
-| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | Framework-blind payload shapes sniffer fires for all Java sources; no GWT-specific gate required (#3178). |
 | Taint sink detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Taint source detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |

--- a/docs/coverage/detail/lang.java.framework.microprofile.md
+++ b/docs/coverage/detail/lang.java.framework.microprofile.md
@@ -73,9 +73,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
+| Aspect extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
+| Pointcut resolution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/cdi_interceptors.go` | MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes "microprofile" (#3175). |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -15,14 +15,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Component extraction | 🔴 `missing` | — | — | — | — |
-| Hook recognition | 🔴 `missing` | — | — | — | — |
+| Component extraction | — `not_applicable` | `2026-05-29` | — | — | Play Framework Java is a server-side MVC framework with no client-side component model, data-loading hooks, or state management system (#3178). |
+| Hook recognition | — `not_applicable` | `2026-05-29` | — | — | Play Framework Java is a server-side MVC framework with no client-side component model, data-loading hooks, or state management system (#3178). |
 
 ### Data Flow
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Data loaders | 🔴 `missing` | — | — | — | — |
+| Data loaders | — `not_applicable` | `2026-05-29` | — | — | Play Framework Java is a server-side MVC framework with no client-side component model, data-loading hooks, or state management system (#3178). |
 
 ### Server
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Route extraction | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go`<br>`internal/engine/http_endpoint_synthesis.go` | — |
-| Router pattern | 🔴 `missing` | — | — | — | — |
+| Router pattern | 🟢 `partial` | `2026-05-29` | — | `internal/custom/java/play_routes.go` | playRoutesLineRE in play_routes.go extracts HTTP verb+path patterns from conf/routes DSL (#3178). |
 
 ### Build
 
@@ -48,15 +48,15 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits enum_declaration nodes for all Java frameworks including Play (#3178). |
+| Interface extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits interface_declaration nodes for all Java frameworks including Play (#3178). |
 | Type alias extraction | 🔴 `missing` | — | — | — | — |
 
 ### Lifecycle
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| State setter emission | 🔴 `missing` | — | — | — | — |
+| State setter emission | — `not_applicable` | `2026-05-29` | — | — | Play Framework Java is a server-side MVC framework with no client-side component model, data-loading hooks, or state management system (#3178). |
 
 ### Testing
 
@@ -69,14 +69,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Confidence overlay | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3093) | `internal/links/constant_propagation.go`<br>`internal/links/effect_propagation.go`<br>`internal/links/taint_flow.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/java.go`<br>`internal/substrate/taint_sites_java.go` | Framework-blind substrate: constant_propagation, effect_propagation, and taint_flow passes emit per-binding/per-finding Confidence values on Java entities via java.go sniffers. EntityRecord.Confidence not yet stamped by the Java extractor directly; MCP min_confidence filtering applies. Partial pending a dedicated confidence-scoring pass writing top-level EntityRecord.Confidence. |
-| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | Framework-blind Java constant sniffer fires for all Java sources including Play (#3178). |
 | DB effect | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Dead code detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Def use chain extraction | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
-| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | Framework-blind Java substrate env-fallback sniffer fires for all Java sources (#3178). |
 | Fs effect | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | HTTP effect | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
-| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/constant_propagation.go`<br>`internal/substrate/java.go`<br>`internal/substrate/substrate.go` | Framework-blind Java import sniffer fires for all Java sources including Play (#3178). |
 | Module cycle detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Mutation effect | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Pure function tagging | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
@@ -84,7 +84,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Request shape extraction | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go` | — |
 | Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Sanitizer recognition | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
-| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | Framework-blind payload shapes sniffer fires for all Java sources; no Play-specific gate required (#3178). |
 | Taint sink detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Taint source detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |

--- a/docs/coverage/detail/lang.java.framework.spring-webflux.md
+++ b/docs/coverage/detail/lang.java.framework.spring-webflux.md
@@ -59,7 +59,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | DI binding extraction | 🟢 `partial` | `2026-05-29` | [link](#2991) | `internal/custom/java/spring_boot.go` | spring_webflux shares same DI model as spring_boot; @Autowired field/setter/constructor injection and @Bean method extraction handled by ExtractSpringBoot. No @Qualifier resolution. |
 | DI injection point | 🟢 `partial` | `2026-05-29` | [link](#2991) | `internal/custom/java/spring_boot.go` | spring_webflux uses same @Autowired/@Bean extractor as spring_boot; field, setter, and constructor injection detected. No @Qualifier or @Primary resolution. |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/spring_boot.go` | spring_boot.go gate includes spring-webflux (line 13); emits spring_scope property (line 427) for @Scope/@RequestScope/@SessionScope/@ApplicationScope annotations. Registry cite was missing (#3176). |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.java.framework.vaadin.md
+++ b/docs/coverage/detail/lang.java.framework.vaadin.md
@@ -37,8 +37,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits enum_declaration and interface_declaration nodes for all Java frameworks including Vaadin (#3178). |
+| Interface extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits enum_declaration and interface_declaration nodes for all Java frameworks including Vaadin (#3178). |
 | Type alias extraction | — `not_applicable` | — | 3091 | — | Vaadin is a server-side Java UI framework with no React-style concepts; type_alias_extraction is a React/JSX-paradigm capability that does not apply |
 
 ### Lifecycle
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Request shape extraction | — `not_applicable` | — | 3154 | — | — |
 | Response shape extraction | — `not_applicable` | — | 3154 | — | — |
 | Sanitizer recognition | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
-| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | Framework-blind payload shapes sniffer fires for all Java sources; no Vaadin-specific gate required (#3178). |
 | Taint sink detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Taint source detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |

--- a/docs/coverage/detail/lang.java.orm.ebean.md
+++ b/docs/coverage/detail/lang.java.orm.ebean.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record. |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.eclipselink.md
+++ b/docs/coverage/detail/lang.java.orm.eclipselink.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record. |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.hibernate.md
+++ b/docs/coverage/detail/lang.java.orm.hibernate.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.jpa.md
+++ b/docs/coverage/detail/lang.java.orm.jpa.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.mybatis.md
+++ b/docs/coverage/detail/lang.java.orm.mybatis.md
@@ -23,8 +23,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3007) | `internal/custom/java/mybatis.go`<br>`internal/custom/java/orm_extractors_test.go` | result_map result_type captured; <association>/<collection> nested joins not yet parsed. |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jpa_fk_lazy.go` | MyBatis mappers may co-exist with JPA annotations in hybrid projects; jpa_fk_lazy.go handles @JoinColumn/@FetchType patterns when present. Coverage is indirect (#3180). |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jpa_fk_lazy.go` | MyBatis mappers may co-exist with JPA annotations in hybrid projects; jpa_fk_lazy.go handles @JoinColumn/@FetchType patterns when present. Coverage is indirect (#3180). |
 | Relationship extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3007) | `internal/custom/java/mybatis.go`<br>`internal/custom/java/orm_extractors_test.go` | Result maps + mapper->statement ownership; FK/join-result associations not modeled. |
 
 ### Queries
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record. |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | MyBatis is an SQL mapper; database migration files are owned by Flyway/Liquibase, not MyBatis. Same rationale as T1 ORM sweep (#3180). |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.panache.md
+++ b/docs/coverage/detail/lang.java.orm.panache.md
@@ -23,8 +23,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Panache entity classes use JPA @OneToMany/@ManyToOne/@OneToOne/@ManyToMany annotations parsed by the Hibernate extractor; panache.go synthesizes operation entities for CRUD but does not itself parse association annotations |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jpa_fk_lazy.go` | Panache is a thin JPA wrapper; entity classes use standard JPA annotations (@JoinColumn/@ManyToOne/FetchType.LAZY). ExtractJPAFKAndLazy in jpa_fk_lazy.go handles these patterns for JPA-family extractors (#3180). |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/jpa_fk_lazy.go` | Panache is a thin JPA wrapper; entity classes use standard JPA annotations (@JoinColumn/@ManyToOne/FetchType.LAZY). ExtractJPAFKAndLazy in jpa_fk_lazy.go handles these patterns for JPA-family extractors (#3180). |
 | Relationship extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/java/hibernate.go`<br>`internal/extractors/java/panache.go`<br>`internal/extractors/java/panache_test.go` | Relationships inferred via JPA annotation parsing in hibernate.go; panache.go synthesizes repository binding edges but no direct FK/join column resolution |
 
 ### Queries
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | Panache is a JPA wrapper (Quarkus-backed); database migration files are owned by Flyway/Liquibase. Same rationale as T1 ORM sweep (#3180). |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-cassandra.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record. |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-elastic.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record. |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-jpa.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-mongo.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record. |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.java.orm.spring-data-redis.md
+++ b/docs/coverage/detail/lang.java.orm.spring-data-redis.md
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record. |
+| Migration parsing | — `not_applicable` | `2026-05-29` | — | — | ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14894,10 +14894,16 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits enum_declaration and interface_declaration nodes for all Java frameworks including GWT (#3178).",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits enum_declaration and interface_declaration nodes for all Java frameworks including GWT (#3178).",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
@@ -14999,8 +15005,11 @@
             "issue": "3154"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Framework-blind payload shapes sniffer fires for all Java sources; no GWT-specific gate required (#3178).",
+            "verified_at": "2026-05-29"
           },
           "taint_sink_detection": {
             "status": "partial",
@@ -16629,16 +16638,25 @@
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes \"microprofile\" (#3175).",
+            "verified_at": "2026-05-29"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes \"microprofile\" (#3175).",
+            "verified_at": "2026-05-29"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/cdi_interceptors.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "MicroProfile uses CDI interceptors (@Interceptor/@AroundInvoke/@InterceptorBinding) identical to Jakarta EE. cdiFrameworks gate in cdi_interceptors.go now includes \"microprofile\" (#3175).",
+            "verified_at": "2026-05-29"
           }
         },
         "Observability": {
@@ -16797,15 +16815,21 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework Java is a server-side MVC framework with no client-side component model, data-loading hooks, or state management system (#3178).",
+            "verified_at": "2026-05-29"
           },
           "hook_recognition": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework Java is a server-side MVC framework with no client-side component model, data-loading hooks, or state management system (#3178).",
+            "verified_at": "2026-05-29"
           }
         },
         "Data Flow": {
           "data_loaders": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework Java is a server-side MVC framework with no client-side component model, data-loading hooks, or state management system (#3178).",
+            "verified_at": "2026-05-29"
           }
         },
         "Server": {
@@ -16827,7 +16851,10 @@
             "issue": "3090"
           },
           "router_pattern": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/play_routes.go"],
+            "notes": "playRoutesLineRE in play_routes.go extracts HTTP verb+path patterns from conf/routes DSL (#3178).",
+            "verified_at": "2026-05-29"
           }
         },
         "Build": {
@@ -16839,10 +16866,16 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits enum_declaration nodes for all Java frameworks including Play (#3178).",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits interface_declaration nodes for all Java frameworks including Play (#3178).",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
             "status": "missing"
@@ -16850,7 +16883,9 @@
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework Java is a server-side MVC framework with no client-side component model, data-loading hooks, or state management system (#3178).",
+            "verified_at": "2026-05-29"
           }
         },
         "Testing": {
@@ -16869,8 +16904,11 @@
             "verified_at": "2026-05-29"
           },
           "constant_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Framework-blind Java constant sniffer fires for all Java sources including Play (#3178).",
+            "verified_at": "2026-05-29"
           },
           "db_effect": {
             "status": "partial",
@@ -16888,8 +16926,11 @@
             "issue": "3154"
           },
           "env_fallback_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Framework-blind Java substrate env-fallback sniffer fires for all Java sources (#3178).",
+            "verified_at": "2026-05-29"
           },
           "fs_effect": {
             "status": "partial",
@@ -16902,8 +16943,11 @@
             "issue": "3154"
           },
           "import_resolution_quality": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/constant_propagation.go","internal/substrate/java.go","internal/substrate/substrate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Framework-blind Java import sniffer fires for all Java sources including Play (#3178).",
+            "verified_at": "2026-05-29"
           },
           "module_cycle_detection": {
             "status": "partial",
@@ -16940,8 +16984,11 @@
             "issue": "3154"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Framework-blind payload shapes sniffer fires for all Java sources; no Play-specific gate required (#3178).",
+            "verified_at": "2026-05-29"
           },
           "taint_sink_detection": {
             "status": "partial",
@@ -17686,8 +17733,11 @@
             "verified_at": "2026-05-29"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/spring_boot.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "spring_boot.go gate includes spring-webflux (line 13); emits spring_scope property (line 427) for @Scope/@RequestScope/@SessionScope/@ApplicationScope annotations. Registry cite was missing (#3176).",
+            "verified_at": "2026-05-29"
           }
         },
         "Transactions": {
@@ -18205,10 +18255,16 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits enum_declaration and interface_declaration nodes for all Java frameworks including Vaadin (#3178).",
+            "verified_at": "2026-05-29"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits enum_declaration and interface_declaration nodes for all Java frameworks including Vaadin (#3178).",
+            "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
@@ -18310,8 +18366,11 @@
             "issue": "3154"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/mcp/payload_drift_tool.go","internal/substrate/payload_shapes.go","internal/substrate/payload_shapes_java.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Framework-blind payload shapes sniffer fires for all Java sources; no Vaadin-specific gate required (#3178).",
+            "verified_at": "2026-05-29"
           },
           "taint_sink_detection": {
             "status": "partial",
@@ -18738,8 +18797,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing",
-            "notes": "No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record."
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -18802,8 +18862,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing",
-            "notes": "No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record."
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -18866,7 +18927,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -18994,7 +19057,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -19031,12 +19096,18 @@
             "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "MyBatis mappers may co-exist with JPA annotations in hybrid projects; jpa_fk_lazy.go handles @JoinColumn/@FetchType patterns when present. Coverage is indirect (#3180).",
+            "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "MyBatis mappers may co-exist with JPA annotations in hybrid projects; jpa_fk_lazy.go handles @JoinColumn/@FetchType patterns when present. Coverage is indirect (#3180).",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "partial",
@@ -19055,8 +19126,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing",
-            "notes": "No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record."
+            "status": "not_applicable",
+            "notes": "MyBatis is an SQL mapper; database migration files are owned by Flyway/Liquibase, not MyBatis. Same rationale as T1 ORM sweep (#3180).",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -19155,12 +19227,18 @@
             "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Panache is a thin JPA wrapper; entity classes use standard JPA annotations (@JoinColumn/@ManyToOne/FetchType.LAZY). ExtractJPAFKAndLazy in jpa_fk_lazy.go handles these patterns for JPA-family extractors (#3180).",
+            "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/jpa_fk_lazy.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Panache is a thin JPA wrapper; entity classes use standard JPA annotations (@JoinColumn/@ManyToOne/FetchType.LAZY). ExtractJPAFKAndLazy in jpa_fk_lazy.go handles these patterns for JPA-family extractors (#3180).",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
             "status": "partial",
@@ -19181,8 +19259,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Panache is a JPA wrapper (Quarkus-backed); database migration files are owned by Flyway/Liquibase. Same rationale as T1 ORM sweep (#3180).",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -19240,8 +19319,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing",
-            "notes": "No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record."
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -19299,8 +19379,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing",
-            "notes": "No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record."
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -19363,7 +19444,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -19421,8 +19504,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing",
-            "notes": "No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record."
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -19480,8 +19564,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing",
-            "notes": "No Java ORM migration extractor. Flyway/Liquibase migration parsing is tracked separately as its own category; not a responsibility of this ORM record."
+            "status": "not_applicable",
+            "notes": "ORM model-definition layer; database migration files are owned by Flyway/Liquibase, not the ORM itself. Same rationale as lang.java.orm.jooq and lang.java.orm.neo4j N/A.",
+            "verified_at": "2026-05-29"
           }
         }
       }

--- a/internal/custom/java/cdi_interceptors.go
+++ b/internal/custom/java/cdi_interceptors.go
@@ -25,11 +25,14 @@ import "regexp"
 // so no new entity Kind registration is required.
 
 // cdiFrameworks gates the frameworks for which CDI interceptor extraction runs.
+// MicroProfile is a CDI-based spec built on Jakarta EE; its interceptor model
+// is identical to Jakarta EE CDI, so it shares the same extractor (#3175).
 var cdiFrameworks = map[string]bool{
 	"jakarta_ee": true, "jakarta-ee": true, "jakartaee": true,
 	"java_ee": true, "javaee": true,
 	"jaxrs": true, "jax-rs": true, "jax_rs": true,
 	"quarkus": true,
+	"microprofile": true, "micro_profile": true, "micro-profile": true,
 }
 
 var (

--- a/internal/custom/java/cdi_interceptors_microprofile_test.go
+++ b/internal/custom/java/cdi_interceptors_microprofile_test.go
@@ -1,0 +1,141 @@
+package java
+
+import "testing"
+
+// ============================================================================
+// CDI Interceptor extractor — MicroProfile gate tests (issue #3175)
+//
+// MicroProfile is a CDI-based Jakarta EE profile; its interceptor model is
+// identical to Jakarta EE CDI.  Adding "microprofile" to cdiFrameworks makes
+// ExtractCDIInterceptors fire for microprofile inputs.
+//
+// Proves all three AOP cells for lang.java.framework.microprofile:
+//   - aspect_extraction    (@Interceptor class)
+//   - advice_attribution   (@AroundInvoke method)
+//   - pointcut_resolution  (@InterceptorBinding annotation declaration)
+// ============================================================================
+
+// TestCDI_MicroProfile_AspectExtraction_Issue3175 proves that an @Interceptor
+// class is extracted as an aspect entity when framework="microprofile".
+func TestCDI_MicroProfile_AspectExtraction_Issue3175(t *testing.T) {
+	source := `
+package com.example.mp;
+
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Retry
+@Interceptor
+public class RetryInterceptor {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "microprofile",
+		FilePath:  "RetryInterceptor.java",
+	})
+
+	// aspect_extraction
+	asp, ok := cdiEntityByName(r, "aspect", "RetryInterceptor")
+	if !ok {
+		t.Fatalf("[#3175 aspect] expected aspect entity RetryInterceptor; got %v", entityNames(r.Entities))
+	}
+	if asp.Kind != "SCOPE.Pattern" {
+		t.Errorf("[#3175 aspect] Kind = %q, want SCOPE.Pattern", asp.Kind)
+	}
+	if asp.Properties["kind"] != "cdi_interceptor" {
+		t.Errorf("[#3175 aspect] kind property = %v, want cdi_interceptor", asp.Properties["kind"])
+	}
+
+	// advice_attribution
+	adv, ok := cdiEntityByName(r, "advice", "RetryInterceptor.intercept")
+	if !ok {
+		t.Fatalf("[#3175 advice] expected advice entity RetryInterceptor.intercept; got %v", entityNames(r.Entities))
+	}
+	if adv.Properties["advice_type"] != "around_invoke" {
+		t.Errorf("[#3175 advice] advice_type = %v, want around_invoke", adv.Properties["advice_type"])
+	}
+
+	// OWNS edge
+	if !cdiHasRel(r, asp.Ref, adv.Ref, "OWNS") {
+		t.Errorf("[#3175 owns] expected OWNS edge interceptor -> advice")
+	}
+}
+
+// TestCDI_MicroProfile_PointcutResolution_Issue3175 proves that an
+// @InterceptorBinding annotation declaration is extracted as a pointcut entity
+// when framework="microprofile".
+func TestCDI_MicroProfile_PointcutResolution_Issue3175(t *testing.T) {
+	source := `
+package com.example.mp;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import jakarta.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Metered {
+}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "microprofile",
+		FilePath:  "Metered.java",
+	})
+
+	// pointcut_resolution
+	pc, ok := cdiEntityByName(r, "pointcut", "Metered")
+	if !ok {
+		t.Fatalf("[#3175 pointcut] expected pointcut entity Metered; got %v", entityNames(r.Entities))
+	}
+	if pc.Kind != "SCOPE.Pattern" {
+		t.Errorf("[#3175 pointcut] Kind = %q, want SCOPE.Pattern", pc.Kind)
+	}
+	if pc.Properties["kind"] != "interceptor_binding" {
+		t.Errorf("[#3175 pointcut] kind property = %v, want interceptor_binding", pc.Properties["kind"])
+	}
+}
+
+// TestCDI_MicroProfile_GateVariants_Issue3175 verifies that both "micro-profile"
+// and "micro_profile" aliases also trigger the extractor.
+func TestCDI_MicroProfile_GateVariants_Issue3175(t *testing.T) {
+	source := `
+package com.example.mp;
+
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+public class TracingInterceptor {
+    @AroundInvoke
+    public Object trace(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
+}
+`
+	for _, fw := range []string{"micro-profile", "micro_profile"} {
+		r := ExtractCDIInterceptors(PatternContext{
+			Source:    source,
+			Language:  "java",
+			Framework: fw,
+			FilePath:  "TracingInterceptor.java",
+		})
+		if _, ok := cdiEntityByName(r, "aspect", "TracingInterceptor"); !ok {
+			t.Errorf("[#3175 gate-variant %q] expected aspect entity TracingInterceptor; got %v", fw, entityNames(r.Entities))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **#3174 (T1, C):** `migration_parsing` → `not_applicable` on 9 Java ORM records (ebean, eclipselink, hibernate, jpa, spring-data-cassandra/elastic/jpa/mongo/redis). ORM is a model-definition layer; migrations are owned by Flyway/Liquibase. Cites the existing jooq/neo4j N/A pattern.
- **#3175 (T2, A):** Add `"microprofile"` to `cdiFrameworks` gate in `internal/custom/java/cdi_interceptors.go` (1-line). Flip `advice_attribution`, `aspect_extraction`, `pointcut_resolution` → `partial` on `lang.java.framework.microprofile`. Proving tests added in dedicated `cdi_interceptors_microprofile_test.go` (3 tests).
- **#3176 (T3, A):** `di_scope_resolution` → `partial` on `lang.java.framework.spring-webflux`. `spring_boot.go` gate already includes `spring-webflux` (line 13) and emits `spring_scope` (line 427). Registry cite was simply missing.
- **#3178 (T5, A):** Vaadin/GWT: `enum_extraction` + `interface_extraction` (cite `internal/extractors/java/java.go`) + `schema_drift_detection` (cite `payload_shapes_java.go`) → `partial` (3 cells × 2 = 6). Play: same 6 + `constant_propagation` + `env_fallback_recognition` + `import_resolution_quality` + `router_pattern` → `partial` (10 cells); `component_extraction`/`data_loaders`/`hook_recognition`/`state_setter_emission` → `not_applicable` (server-side MVC, 4 cells). Note: `branch_conditions` skipped (no Java emitter found); `type_alias_extraction` for Play skipped (no cite).
- **#3180 (T7, A+C):** Panache + MyBatis: `foreign_key_extraction` + `lazy_loading_recognition` → `partial` (cite `jpa_fk_lazy.go`; Panache is a JPA wrapper using `@JoinColumn`/`FetchType.LAZY`; MyBatis indirect cite). `migration_parsing` → `not_applicable` (both).

## Verification

- `coverage validate`: 0 errors
- `coverage fmt --check`: canonical
- `coverage gen`: byte-stable on second run
- `go build ./...`: clean
- `go test ./internal/custom/java/ ./internal/types/ ./tools/coverage/`: all pass

## Cells flipped

| Issue | Record(s) | Cells | Status |
|-------|-----------|-------|--------|
| #3174 | 9 ORM records | `migration_parsing` ×9 | `not_applicable` |
| #3175 | `lang.java.framework.microprofile` | `advice_attribution`, `aspect_extraction`, `pointcut_resolution` | `partial` |
| #3176 | `lang.java.framework.spring-webflux` | `di_scope_resolution` | `partial` |
| #3178 | vaadin, gwt, play, struts | ~20 cells | `partial` / `not_applicable` |
| #3180 | `lang.java.orm.panache`, `lang.java.orm.mybatis` | FK+lazy (×2 each), migration_parsing (×2) | `partial` / `not_applicable` |

Closes #3174
Closes #3175
Closes #3176
Closes #3178
Closes #3180