### PR TITLE
feat(cli): non-interactive `archigraph group add` for agents/CI

### DIFF
--- a/internal/cli/group.go
+++ b/internal/cli/group.go
@@ -1,0 +1,298 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/archigraph/internal/daemon/client"
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/install/detect"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// newGroupCmd returns the `archigraph group` parent command. Today it hosts a
+// single subcommand, `add`, the non-interactive counterpart to `wizard` so
+// agents and CI can register a group without a TTY. It is grouped under a
+// parent (rather than flat like delete/remove) to leave room for future
+// machine-friendly group operations.
+func newGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "group",
+		Short: "Manage archigraph groups (non-interactive)",
+	}
+	cmd.AddCommand(newGroupAddCmd())
+	return cmd
+}
+
+func newGroupAddCmd() *cobra.Command {
+	var (
+		repoArgs  []string
+		reposCSV  string
+		groupDocs string
+		watchers  bool
+		gitHooks  bool
+		rules     bool
+		mcp       bool
+		runInst   bool
+		doIndex   bool
+		jsonOut   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "add <group>",
+		Short: "Register a group non-interactively (scriptable wizard)",
+		Long: `add registers a new group entirely from flags — no prompts — so agents
+and CI can automate setup. It runs the same transaction as the interactive
+wizard: it writes the per-group fleet config, registers the group in the
+global registry, writes per-repo committed manifests, and (unless
+--install=false) runs the install transaction (git hooks, IDE rules files,
+MCP settings, watchers).
+
+Repos are supplied with --repo, repeatable, as either "slug=path" or a bare
+"path" (the slug then defaults to the directory basename). --repos accepts a
+comma-separated list of bare paths as a convenience.
+
+With --index, the group is indexed via the daemon after registration so the
+graph is queryable immediately (requires a running daemon).
+
+The command is idempotent: re-running updates the registry entry in place and
+overwrites the fleet config atomically.
+
+MCP-server registration is machine-level and group-agnostic (one daemon serves
+all groups), so adding a group never duplicates the mcp.json entry — query the
+new group immediately via the 'group' MCP parameter.
+
+Examples:
+  archigraph group add new-backend --repo core=/abs/path/to/repo --index
+  archigraph group add legacy --repo /abs/api --repo /abs/web --no-watchers --json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gaFlags := groupAddFlags{
+				repoArgs:  repoArgs,
+				reposCSV:  reposCSV,
+				groupDocs: groupDocs,
+				watchers:  watchers,
+				gitHooks:  gitHooks,
+				rules:     rules,
+				mcp:       mcp,
+				runInst:   runInst,
+				doIndex:   doIndex,
+				jsonOut:   jsonOut,
+			}
+			return runGroupAddImpl(cmd, args[0], gaFlags, "")
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&repoArgs, "repo", nil,
+		`repo to include as "slug=path" or bare "path" (repeatable)`)
+	cmd.Flags().StringVar(&reposCSV, "repos", "",
+		"comma-separated bare repo paths (slug defaults to basename)")
+	cmd.Flags().StringVar(&groupDocs, "group-docs", "",
+		"optional path to shared group docs")
+	cmd.Flags().BoolVar(&watchers, "watchers", false,
+		"install OS watcher units for each repo")
+	cmd.Flags().BoolVar(&gitHooks, "git-hooks", true,
+		"install git hooks (post-merge/checkout reindex)")
+	cmd.Flags().BoolVar(&rules, "rules", true,
+		"write per-repo IDE rules files (CLAUDE.md/.cursorrules/.windsurfrules/AGENTS.md)")
+	cmd.Flags().BoolVar(&mcp, "mcp", true,
+		"register/refresh MCP settings (machine-level; safe to leave on)")
+	cmd.Flags().BoolVar(&runInst, "install", true,
+		"run the install transaction (hooks/rules/mcp/watchers)")
+	cmd.Flags().BoolVar(&doIndex, "index", false,
+		"index the group via the daemon after registering (requires a running daemon)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON result")
+	return cmd
+}
+
+type groupAddFlags struct {
+	repoArgs  []string
+	reposCSV  string
+	groupDocs string
+	watchers  bool
+	gitHooks  bool
+	rules     bool
+	mcp       bool
+	runInst   bool
+	doIndex   bool
+	jsonOut   bool
+}
+
+type groupAddRepo struct {
+	Slug string `json:"slug"`
+	Path string `json:"path"`
+}
+
+type groupAddResult struct {
+	Group      string         `json:"group"`
+	ConfigPath string         `json:"config_path"`
+	Repos      []groupAddRepo `json:"repos"`
+	Installed  *installCounts `json:"installed,omitempty"`
+	Indexed    bool           `json:"indexed"`
+}
+
+type installCounts struct {
+	Hooks    int `json:"hooks"`
+	Watchers int `json:"watchers"`
+	MCP      int `json:"mcp"`
+}
+
+// runGroupAddImpl implements `group add` with an injectable daemon socket path
+// (empty → real client.Dial). Tests pass a stub socket so --index needs no real
+// daemon.
+func runGroupAddImpl(cmd *cobra.Command, group string, f groupAddFlags, socketPath string) error {
+	out := cmd.OutOrStdout()
+
+	repos, err := parseRepoSpecs(f.repoArgs, f.reposCSV)
+	if err != nil {
+		return err
+	}
+	if len(repos) == 0 {
+		return errors.New("supply at least one repo via --repo or --repos")
+	}
+
+	cfg := &registry.GroupConfig{Name: group, GroupDocs: f.groupDocs}
+	cfg.Features.Watchers = f.watchers
+	cfg.Features.GitHooks = f.gitHooks
+	for _, r := range repos {
+		cfg.Repos = append(cfg.Repos, registry.Repo{
+			Slug:  r.Slug,
+			Path:  r.Path,
+			Stack: registry.StackList{detect.Stack(r.Path)},
+		})
+	}
+
+	// JSON mode suppresses the helper's human-readable progress lines.
+	applyOut := out
+	if f.jsonOut {
+		applyOut = io.Discard
+	}
+	res, err := applyGroupConfig(applyOut, cfg, groupApplyOptions{
+		RunInstall:   f.runInst,
+		SkipHooks:    !f.gitHooks,
+		SkipWatchers: !f.watchers,
+		SkipMCP:      !f.mcp,
+		SkipRules:    !f.rules,
+	})
+	if err != nil {
+		return err
+	}
+
+	indexed := false
+	if f.doIndex {
+		if err := indexGroup(group, socketPath); err != nil {
+			return fmt.Errorf("index group %q: %w", group, err)
+		}
+		indexed = true
+	}
+
+	cfgPath, _ := registry.ConfigPathFor(group)
+	result := groupAddResult{
+		Group:      group,
+		ConfigPath: cfgPath,
+		Repos:      repos,
+		Indexed:    indexed,
+	}
+	if res != nil {
+		result.Installed = &installCounts{
+			Hooks:    len(res.HooksInstalled),
+			Watchers: len(res.WatcherUnits),
+			MCP:      len(res.MCPSettings),
+		}
+	}
+
+	if f.jsonOut {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	fmt.Fprintf(out, "registered group %q (%d repos: %s)\n",
+		group, len(repos), strings.Join(repoSlugs(repos), ", "))
+	if indexed {
+		fmt.Fprintln(out, "indexed via daemon")
+	}
+	return nil
+}
+
+// parseRepoSpecs turns --repo entries ("slug=path" or bare "path") and the
+// --repos CSV (bare paths) into absolute-path repo specs. Slugs default to the
+// directory basename. Order is preserved; --repo entries come before --repos.
+func parseRepoSpecs(repoArgs []string, reposCSV string) ([]groupAddRepo, error) {
+	var out []groupAddRepo
+	add := func(slug, path string) error {
+		abs, err := filepath.Abs(strings.TrimSpace(path))
+		if err != nil {
+			return err
+		}
+		if slug == "" {
+			slug = filepath.Base(abs)
+		}
+		out = append(out, groupAddRepo{Slug: slug, Path: abs})
+		return nil
+	}
+	for _, raw := range repoArgs {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		slug, path := "", raw
+		if i := strings.Index(raw, "="); i >= 0 {
+			slug, path = strings.TrimSpace(raw[:i]), strings.TrimSpace(raw[i+1:])
+		}
+		if path == "" {
+			return nil, fmt.Errorf("invalid --repo %q: empty path", raw)
+		}
+		if err := add(slug, path); err != nil {
+			return nil, err
+		}
+	}
+	for _, p := range splitCSV(reposCSV) {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if err := add("", p); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func repoSlugs(repos []groupAddRepo) []string {
+	out := make([]string, len(repos))
+	for i, r := range repos {
+		out[i] = r.Slug
+	}
+	return out
+}
+
+// indexGroup dials the daemon and rebuilds the whole group (all repos). An
+// empty socketPath uses the real client.Dial; tests inject a stub socket.
+func indexGroup(group, socketPath string) error {
+	var (
+		c   *client.Client
+		err error
+	)
+	if socketPath != "" {
+		c, err = client.DialPath(socketPath)
+	} else {
+		c, err = client.Dial()
+	}
+	if err != nil {
+		if errors.Is(err, client.ErrDaemonNotRunning) {
+			return errDaemonNotRunning
+		}
+		return err
+	}
+	defer c.Close()
+
+	_, err = c.Rebuild(proto.RebuildArgs{Group: group})
+	return err
+}

--- a/internal/cli/group_test.go
+++ b/internal/cli/group_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+func TestParseRepoSpecs(t *testing.T) {
+	tmp := t.TempDir()
+	a := filepath.Join(tmp, "alpha")
+	b := filepath.Join(tmp, "beta")
+	c := filepath.Join(tmp, "gamma")
+
+	repos, err := parseRepoSpecs([]string{"core=" + a, b}, c)
+	if err != nil {
+		t.Fatalf("parseRepoSpecs: %v", err)
+	}
+	if len(repos) != 3 {
+		t.Fatalf("want 3 repos, got %d: %+v", len(repos), repos)
+	}
+	// Explicit slug honored.
+	if repos[0].Slug != "core" || repos[0].Path != a {
+		t.Errorf("repo0 = %+v, want slug=core path=%s", repos[0], a)
+	}
+	// Bare --repo path → slug = basename.
+	if repos[1].Slug != "beta" || repos[1].Path != b {
+		t.Errorf("repo1 = %+v, want slug=beta path=%s", repos[1], b)
+	}
+	// CSV path → slug = basename.
+	if repos[2].Slug != "gamma" || repos[2].Path != c {
+		t.Errorf("repo2 = %+v, want slug=gamma path=%s", repos[2], c)
+	}
+}
+
+func TestParseRepoSpecs_EmptyPathErrors(t *testing.T) {
+	if _, err := parseRepoSpecs([]string{"slug="}, ""); err == nil {
+		t.Fatal("expected error for empty path, got nil")
+	}
+}
+
+func TestGroupAdd_RegistersConfigAndJSON(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	repoB := filepath.Join(home, "repos", "beta")
+	makeRepo(t, repoA)
+	makeRepo(t, repoB)
+
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+
+	err := runGroupAddImpl(cmd, "demo", groupAddFlags{
+		repoArgs: []string{"core=" + repoA, repoB},
+		watchers: false,
+		gitHooks: true,
+		rules:    false, // skip writing IDE rules files in the sandbox
+		mcp:      false, // skip MCP registration
+		runInst:  true,
+		doIndex:  false, // no daemon in unit test
+		jsonOut:  true,
+	}, "")
+	if err != nil {
+		t.Fatalf("group add: %v\n%s", err, out.String())
+	}
+
+	// Registry has the group.
+	groups, err := registry.Groups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found *registry.GroupRef
+	for i := range groups {
+		if groups[i].Name == "demo" {
+			found = &groups[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("group demo not registered; groups=%+v", groups)
+	}
+
+	// Fleet config has both repos with the right slugs.
+	cfg, err := registry.LoadGroupConfig(found.ConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Repos) != 2 {
+		t.Fatalf("want 2 repos in config, got %d", len(cfg.Repos))
+	}
+	if cfg.Repos[0].Slug != "core" || cfg.Repos[1].Slug != "beta" {
+		t.Errorf("slugs = %q,%q; want core,beta", cfg.Repos[0].Slug, cfg.Repos[1].Slug)
+	}
+
+	// JSON result is well-formed.
+	var res groupAddResult
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("json output: %v\n%s", err, out.String())
+	}
+	if res.Group != "demo" || len(res.Repos) != 2 || res.Indexed {
+		t.Errorf("result = %+v, want group=demo, 2 repos, indexed=false", res)
+	}
+	if res.Installed == nil {
+		t.Error("expected installed counts in result")
+	}
+}
+
+func TestGroupAdd_NoReposErrors(t *testing.T) {
+	withSandboxHome(t)
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runGroupAddImpl(cmd, "demo", groupAddFlags{runInst: false}, ""); err == nil {
+		t.Fatal("expected error when no repos supplied")
+	}
+}
+
+func TestGroupAdd_Idempotent(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repoA)
+
+	run := func() error {
+		cmd := &cobra.Command{}
+		cmd.SetOut(&bytes.Buffer{})
+		return runGroupAddImpl(cmd, "demo", groupAddFlags{
+			repoArgs: []string{repoA},
+			rules:    false, mcp: false, runInst: true, jsonOut: true,
+		}, "")
+	}
+	if err := run(); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if err := run(); err != nil {
+		t.Fatalf("second add (idempotent): %v", err)
+	}
+	groups, err := registry.Groups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, g := range groups {
+		if g.Name == "demo" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("group registered %d times, want exactly 1 (idempotent)", n)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -64,6 +64,7 @@ func newRoot() *cobra.Command {
 		newCleanupCmd(),
 		newDocgenCmd(),
 		newRegisterCmd(),
+		newGroupCmd(),
 		newRemoveCmd(),
 		newDeleteCmd(),
 		newBranchesCmd(),
@@ -133,6 +134,8 @@ Daemon modes (S7):
                                   Switch operational mode + restart daemon
 
 Lifecycle:
+  group add <group> --repo slug=path [--index] [--json]
+                                       Register a group non-interactively (scriptable wizard; for agents/CI)
   remove <group> <slug> [--ref <ref>]  Remove a single repo from a group
   delete <group>                       Delete an entire group and all its repos
   branches [group]                     List per-ref graph tiers + lifecycle management

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -145,39 +145,66 @@ func runWizard(out io.Writer, opts wizardOptions) error {
 		cfg.GroupDocs = opts.GroupDocs
 	}
 
-	// Step 5 — save config + register group.
+	// Steps 5-7 — persist + register + manifests + install. Shared with the
+	// non-interactive `group add` command via applyGroupConfig.
+	_, err = applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
+	return err
+}
+
+// groupApplyOptions controls the side-effecting half of group registration
+// (the part after a GroupConfig has been assembled, whether interactively by
+// the wizard or from flags by `group add`).
+type groupApplyOptions struct {
+	RunInstall   bool
+	SkipHooks    bool
+	SkipWatchers bool
+	SkipMCP      bool
+	SkipRules    bool
+}
+
+// applyGroupConfig persists the group config, registers it in the global
+// registry, writes the per-repo committed manifests, and — unless RunInstall
+// is false — runs the install transaction (git hooks, IDE rules files, MCP
+// settings, watchers, gated by the Skip* toggles and the config's Features).
+// It returns the install result (nil when RunInstall is false) so callers can
+// report or serialize what was written. Idempotent: re-running updates the
+// registry entry in place and overwrites the config atomically.
+func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOptions) (*install.Result, error) {
 	cfgPath, err := registry.ConfigPathFor(cfg.Name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
-		return err
+		return nil, err
 	}
 	if err := registry.AddGroup(cfg.Name, cfgPath); err != nil {
-		return err
+		return nil, err
 	}
 	fmt.Fprintf(out, "saved %s\n", cfgPath)
 
-	// Step 6 — write committed manifest in each repo.
 	if err := writeManifests(cfg); err != nil {
 		fmt.Fprintf(out, "warning: writing manifest: %v\n", err)
 	}
 
-	// Step 7 — install.
-	if opts.RunInstall {
-		bin, _ := os.Executable()
-		res, err := install.Apply(install.Options{
-			Group:   cfg.Name,
-			Config:  cfg,
-			BinPath: bin,
-		})
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(out, "installed %d hooks, %d watchers, %d MCP entries\n",
-			len(res.HooksInstalled), len(res.WatcherUnits), len(res.MCPSettings))
+	if !ga.RunInstall {
+		return nil, nil
 	}
-	return nil
+	bin, _ := os.Executable()
+	res, err := install.Apply(install.Options{
+		Group:          cfg.Name,
+		Config:         cfg,
+		BinPath:        bin,
+		SkipHooks:      ga.SkipHooks,
+		SkipWatchers:   ga.SkipWatchers,
+		SkipMCP:        ga.SkipMCP,
+		SkipRulesFiles: ga.SkipRules,
+	})
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintf(out, "installed %d hooks, %d watchers, %d MCP entries\n",
+		len(res.HooksInstalled), len(res.WatcherUnits), len(res.MCPSettings))
+	return res, nil
 }
 
 // discoverCandidates returns absolute paths to repos selected for this


### PR DESCRIPTION
## What

Adds `archigraph group add` — the non-interactive, scriptable counterpart to the interactive `wizard`, so agents and CI can register a group without a TTY.

```
archigraph group add new-backend --repo core=/abs/path/to/repo --index
archigraph group add legacy --repo /abs/api --repo /abs/web --no-watchers --json
```

## Why

There was no headless path that runs the **full** group-registration transaction. The only options were the interactive `wizard` (can't be driven by an agent) or hand-writing the fleet JSON + `rebuild` (skips the install transaction: per-repo rules files, hooks, MCP). This closes that gap.

Surfaced during a backend-rewrite use case where an agent needs to register an isolated new-backend group fully and headlessly.

## How

- `--repo` (repeatable) accepts `slug=path` or a bare `path` (slug defaults to basename); `--repos` CSV for bare paths. Gives **explicit slug control** the wizard lacked (it forced `filepath.Base`).
- `--index` dials the daemon and rebuilds the group so the graph is queryable immediately.
- `--json` emits a machine-readable result; per-step skip toggles `--watchers/--git-hooks/--rules/--mcp/--install`.
- **Idempotent**: re-running updates the registry entry in place and overwrites the fleet config atomically.
- **Reuses** the wizard's write transaction via a new shared `applyGroupConfig` helper — no forked logic. `wizard` now calls the same helper (behavior unchanged; `TestWizardNonInteractive` still passes).
- Daemon socket is injectable for tests, mirroring the `delete`/`remove` pattern.

Note: MCP-server registration is machine-level and group-agnostic (one daemon serves all groups), so adding a group never duplicates the mcp.json entry — documented in the command help.

## Tests

`internal/cli/group_test.go`: `parseRepoSpecs` (slug=path / bare / CSV / empty-path error), register-config-and-JSON shape, no-repos error, and idempotency (double-add → one registry entry). Full `internal/cli` suite + `go build ./cmd/archigraph` green; gofmt clean.

Closes #3201

🤖 Generated with [Claude Code](https://claude.com/claude-code)