### PR TITLE
feat(feedback): agent-experience capture + rollup (internal rewrite-test harness)

### DIFF
--- a/internal/cli/feedback.go
+++ b/internal/cli/feedback.go
@@ -57,6 +57,7 @@ The user decides whether to paste it into a GitHub issue.`,
 	cmd.Flags().StringVar(&groupFlag, "group", "", "group name (default: inferred from current directory)")
 	cmd.Flags().StringVar(&outFlag, "out", "", "output path (default: ~/.archigraph/feedback/<group>-<timestamp>.md)")
 	cmd.Flags().BoolVar(&yesFlag, "yes", false, "skip confirmation prompt (for CI / scripting)")
+	cmd.AddCommand(newFeedbackRollupCmd())
 	return cmd
 }
 

--- a/internal/cli/feedback_rollup.go
+++ b/internal/cli/feedback_rollup.go
@@ -1,0 +1,304 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// feedbackEventRecord mirrors mcp.FeedbackEvent for parsing the JSONL written
+// by archigraph_feedback_event. Kept local to avoid a cli→mcp import.
+type feedbackEventRecord struct {
+	Timestamp  string `json:"ts"`
+	Group      string `json:"group,omitempty"`
+	Phase      string `json:"phase,omitempty"`
+	Library    string `json:"library,omitempty"`
+	Capability string `json:"capability,omitempty"`
+	Outcome    string `json:"outcome"`
+	Note       string `json:"note,omitempty"`
+}
+
+// outcomeOrder is the canonical column order for rollup tables.
+var outcomeOrder = []string{"helped", "partial", "wrong", "missing_capability"}
+
+// newFeedbackRollupCmd returns `archigraph feedback rollup`, which aggregates
+// the agent-experience feedback JSONL (written by archigraph_feedback_event)
+// into an analyzable bundle. Internal testing harness (#3204).
+func newFeedbackRollupCmd() *cobra.Command {
+	var (
+		since     string
+		outDir    string
+		eventsDir string
+	)
+	cmd := &cobra.Command{
+		Use:   "rollup",
+		Short: "Aggregate agent-experience feedback events into a report (internal test harness)",
+		Long: `rollup scans the local feedback-events JSONL (written by the
+archigraph_feedback_event MCP tool) and produces an analyzable bundle:
+outcome distribution per group, per capability, and per library, plus a ranked
+"fix queue" of the capabilities and libraries with the most wrong/missing
+outcomes.
+
+It is an internal testing aid (e.g. for an end-to-end backend rewrite). All
+data is local; no network calls.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runFeedbackRollup(cmd, since, outDir, eventsDir)
+		},
+	}
+	cmd.Flags().StringVar(&since, "since", "", "only include events on/after this UTC date (YYYY-MM-DD); default: all")
+	cmd.Flags().StringVar(&outDir, "out", "", "output directory (default: ~/.archigraph/feedback/rollup-<timestamp>)")
+	cmd.Flags().StringVar(&eventsDir, "events-dir", "", "events directory (default: ~/.archigraph/events)")
+	return cmd
+}
+
+func runFeedbackRollup(cmd *cobra.Command, since, outDir, eventsDir string) error {
+	w := cmd.OutOrStdout()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("feedback rollup: resolve home: %w", err)
+	}
+	if eventsDir == "" {
+		eventsDir = filepath.Join(home, ".archigraph", "events")
+	}
+	if outDir == "" {
+		outDir = filepath.Join(home, ".archigraph", "feedback",
+			"rollup-"+time.Now().UTC().Format("20060102-150405"))
+	}
+
+	events, scanned, err := loadFeedbackEvents(eventsDir, since)
+	if err != nil {
+		return err
+	}
+	if len(events) == 0 {
+		fmt.Fprintf(w, "no feedback events found in %s%s\n", eventsDir, sinceSuffix(since))
+		return nil
+	}
+
+	agg := aggregateFeedback(events)
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("feedback rollup: mkdir %s: %w", outDir, err)
+	}
+	jsonPath := filepath.Join(outDir, "rollup.json")
+	mdPath := filepath.Join(outDir, "rollup.md")
+
+	jb, err := json.MarshalIndent(agg, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(jsonPath, append(jb, '\n'), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(mdPath, []byte(renderFeedbackMarkdown(agg, since)), 0o644); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "rolled up %d feedback events (from %d JSONL files)%s\n",
+		agg.TotalEvents, scanned, sinceSuffix(since))
+	fmt.Fprintf(w, "  %s\n  %s\n", jsonPath, mdPath)
+	return nil
+}
+
+func sinceSuffix(since string) string {
+	if since == "" {
+		return ""
+	}
+	return " since " + since
+}
+
+// loadFeedbackEvents reads feedback-events-*.jsonl from dir, filtering to lines
+// whose ts date is >= since (when set). Returns events, files-scanned, error.
+func loadFeedbackEvents(dir, since string) ([]feedbackEventRecord, int, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "feedback-events-*.jsonl"))
+	if err != nil {
+		return nil, 0, err
+	}
+	sort.Strings(matches)
+	var out []feedbackEventRecord
+	scanned := 0
+	for _, path := range matches {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, scanned, fmt.Errorf("feedback rollup: open %s: %w", path, err)
+		}
+		scanned++
+		sc := bufio.NewScanner(f)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" {
+				continue
+			}
+			var rec feedbackEventRecord
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				continue // skip malformed lines rather than abort the rollup
+			}
+			if since != "" && rec.Timestamp != "" {
+				// ts is RFC3339; lexical date compare on the first 10 chars works.
+				if len(rec.Timestamp) >= 10 && rec.Timestamp[:10] < since {
+					continue
+				}
+			}
+			out = append(out, rec)
+		}
+		f.Close()
+		if err := sc.Err(); err != nil {
+			return nil, scanned, fmt.Errorf("feedback rollup: read %s: %w", path, err)
+		}
+	}
+	return out, scanned, nil
+}
+
+// feedbackRollup is the aggregated, serializable result.
+type feedbackRollup struct {
+	TotalEvents  int                       `json:"total_events"`
+	ByOutcome    map[string]int            `json:"by_outcome"`
+	ByGroup      map[string]map[string]int `json:"by_group"`
+	ByCapability map[string]map[string]int `json:"by_capability"`
+	ByLibrary    map[string]map[string]int `json:"by_library"`
+	// FixQueue ranks capabilities+libraries by negative outcomes (wrong +
+	// missing_capability), highest first — the prioritized work list.
+	FixQueue []fixQueueItem `json:"fix_queue"`
+}
+
+type fixQueueItem struct {
+	Dimension string `json:"dimension"` // "capability" | "library"
+	Key       string `json:"key"`
+	Negative  int    `json:"negative"` // wrong + missing_capability
+	Total     int    `json:"total"`
+}
+
+func aggregateFeedback(events []feedbackEventRecord) feedbackRollup {
+	r := feedbackRollup{
+		ByOutcome:    map[string]int{},
+		ByGroup:      map[string]map[string]int{},
+		ByCapability: map[string]map[string]int{},
+		ByLibrary:    map[string]map[string]int{},
+	}
+	bump := func(m map[string]map[string]int, key, outcome string) {
+		if key == "" {
+			key = "(unspecified)"
+		}
+		if m[key] == nil {
+			m[key] = map[string]int{}
+		}
+		m[key][outcome]++
+	}
+	for _, e := range events {
+		r.TotalEvents++
+		r.ByOutcome[e.Outcome]++
+		bump(r.ByGroup, e.Group, e.Outcome)
+		bump(r.ByCapability, e.Capability, e.Outcome)
+		bump(r.ByLibrary, e.Library, e.Outcome)
+	}
+	r.FixQueue = buildFixQueue(r.ByCapability, "capability")
+	r.FixQueue = append(r.FixQueue, buildFixQueue(r.ByLibrary, "library")...)
+	sort.SliceStable(r.FixQueue, func(i, j int) bool {
+		if r.FixQueue[i].Negative != r.FixQueue[j].Negative {
+			return r.FixQueue[i].Negative > r.FixQueue[j].Negative
+		}
+		return r.FixQueue[i].Key < r.FixQueue[j].Key
+	})
+	return r
+}
+
+func buildFixQueue(m map[string]map[string]int, dim string) []fixQueueItem {
+	var out []fixQueueItem
+	for key, counts := range m {
+		neg := counts["wrong"] + counts["missing_capability"]
+		if neg == 0 {
+			continue
+		}
+		total := 0
+		for _, n := range counts {
+			total += n
+		}
+		out = append(out, fixQueueItem{Dimension: dim, Key: key, Negative: neg, Total: total})
+	}
+	return out
+}
+
+func renderFeedbackMarkdown(r feedbackRollup, since string) string {
+	var b strings.Builder
+	b.WriteString("# archigraph feedback rollup\n\n")
+	if since != "" {
+		fmt.Fprintf(&b, "Events since **%s**. ", since)
+	}
+	fmt.Fprintf(&b, "Total events: **%d**\n\n", r.TotalEvents)
+
+	b.WriteString("## Outcomes\n\n| Outcome | Count |\n|---|---:|\n")
+	for _, o := range outcomeOrder {
+		fmt.Fprintf(&b, "| %s | %d |\n", o, r.ByOutcome[o])
+	}
+	b.WriteString("\n")
+
+	writeMatrix(&b, "By group (old vs new)", r.ByGroup)
+	writeMatrix(&b, "By capability", r.ByCapability)
+	writeMatrix(&b, "By library / framework", r.ByLibrary)
+
+	b.WriteString("## Fix queue (most wrong/missing first)\n\n")
+	if len(r.FixQueue) == 0 {
+		b.WriteString("_No wrong or missing-capability outcomes recorded._\n")
+		return b.String()
+	}
+	b.WriteString("| Dimension | Key | Negative (wrong+missing) | Total |\n|---|---|---:|---:|\n")
+	for _, it := range r.FixQueue {
+		fmt.Fprintf(&b, "| %s | %s | %d | %d |\n", it.Dimension, it.Key, it.Negative, it.Total)
+	}
+	return b.String()
+}
+
+func writeMatrix(b *strings.Builder, title string, m map[string]map[string]int) {
+	fmt.Fprintf(b, "## %s\n\n", title)
+	if len(m) == 0 {
+		b.WriteString("_none_\n\n")
+		return
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	b.WriteString("| Key |")
+	for _, o := range outcomeOrder {
+		fmt.Fprintf(b, " %s |", o)
+	}
+	b.WriteString(" total |\n|---|")
+	for range outcomeOrder {
+		b.WriteString("---:|")
+	}
+	b.WriteString("---:|\n")
+	for _, k := range keys {
+		fmt.Fprintf(b, "| %s |", k)
+		total := 0
+		for _, o := range outcomeOrder {
+			fmt.Fprintf(b, " %d |", m[k][o])
+			total += m[k][o]
+		}
+		// include any non-canonical outcomes in the total
+		for o, n := range m[k] {
+			if !isCanonicalOutcome(o) {
+				total += n
+			}
+		}
+		fmt.Fprintf(b, " %d |\n", total)
+	}
+	b.WriteString("\n")
+}
+
+func isCanonicalOutcome(o string) bool {
+	for _, c := range outcomeOrder {
+		if c == o {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/feedback_rollup_test.go
+++ b/internal/cli/feedback_rollup_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func writeEventsFile(t *testing.T, dir, name string, lines []string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := ""
+	for _, l := range lines {
+		body += l + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFeedbackRollup_Aggregates(t *testing.T) {
+	tmp := t.TempDir()
+	eventsDir := filepath.Join(tmp, "events")
+	outDir := filepath.Join(tmp, "out")
+
+	writeEventsFile(t, eventsDir, "feedback-events-2026-05-30.jsonl", []string{
+		`{"ts":"2026-05-30T10:00:00Z","group":"upvate-core","library":"pymongo","capability":"data_access","outcome":"missing_capability"}`,
+		`{"ts":"2026-05-30T10:05:00Z","group":"upvate-core","library":"drf","capability":"routing","outcome":"helped"}`,
+		`{"ts":"2026-05-30T10:06:00Z","group":"new-backend","library":"typeorm","capability":"data_access","outcome":"partial"}`,
+		`{"ts":"2026-05-30T10:07:00Z","group":"new-backend","library":"class-validator","capability":"dto","outcome":"wrong"}`,
+		`not-json-skip-me`,
+	})
+	// An older file that should be excluded by --since.
+	writeEventsFile(t, eventsDir, "feedback-events-2026-05-01.jsonl", []string{
+		`{"ts":"2026-05-01T10:00:00Z","group":"upvate-core","capability":"auth","outcome":"wrong"}`,
+	})
+
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	if err := runFeedbackRollup(cmd, "2026-05-15", outDir, eventsDir); err != nil {
+		t.Fatalf("rollup: %v", err)
+	}
+
+	jb, err := os.ReadFile(filepath.Join(outDir, "rollup.json"))
+	if err != nil {
+		t.Fatalf("read rollup.json: %v", err)
+	}
+	var r feedbackRollup
+	if err := json.Unmarshal(jb, &r); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4 valid events on/after 2026-05-15 (the older auth/wrong excluded, junk skipped).
+	if r.TotalEvents != 4 {
+		t.Fatalf("TotalEvents = %d, want 4", r.TotalEvents)
+	}
+	if r.ByOutcome["wrong"] != 1 || r.ByOutcome["missing_capability"] != 1 || r.ByOutcome["helped"] != 1 {
+		t.Errorf("by_outcome = %v", r.ByOutcome)
+	}
+	if r.ByGroup["upvate-core"]["missing_capability"] != 1 {
+		t.Errorf("group upvate-core missing = %v", r.ByGroup["upvate-core"])
+	}
+	// Fix queue: data_access (missing) + dto (wrong) + class-validator/typeorm? + pymongo.
+	if len(r.FixQueue) == 0 {
+		t.Fatal("expected non-empty fix queue")
+	}
+	// The auth/wrong from the excluded older file must NOT appear.
+	for _, it := range r.FixQueue {
+		if it.Key == "auth" {
+			t.Error("excluded older event leaked into fix queue")
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "rollup.md")); err != nil {
+		t.Errorf("rollup.md not written: %v", err)
+	}
+}
+
+func TestFeedbackRollup_NoEvents(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	if err := runFeedbackRollup(cmd, "", filepath.Join(tmp, "out"), filepath.Join(tmp, "events")); err != nil {
+		t.Fatalf("rollup with no events should not error: %v", err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("no feedback events")) {
+		t.Errorf("expected 'no feedback events' message, got %q", out.String())
+	}
+}

--- a/internal/mcp/feedback_event.go
+++ b/internal/mcp/feedback_event.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// feedbackOutcomes is the allowed set of outcome values for
+// archigraph_feedback_event. These map to the rollup's quality buckets.
+var feedbackOutcomes = map[string]bool{
+	"helped":             true, // the graph answered well / saved work
+	"partial":            true, // answered but incomplete
+	"wrong":              true, // fabricated or contradicted the source
+	"missing_capability": true, // the thing asked for isn't extracted at all
+}
+
+// feedbackEventsFile returns the path for today's feedback-events JSONL file.
+// It shares the persona events directory (~/.archigraph/events) and rotates by
+// calendar date. LOCAL ONLY — same privacy promise as persona telemetry.
+func feedbackEventsFile() (string, error) {
+	dir, err := personaEventsDir()
+	if err != nil {
+		return "", err
+	}
+	date := time.Now().UTC().Format("2006-01-02")
+	return filepath.Join(dir, fmt.Sprintf("feedback-events-%s.jsonl", date)), nil
+}
+
+// FeedbackEvent is one agent-experience datum captured during a test run
+// (e.g. an internal backend rewrite). It records how a real archigraph
+// interaction went, tagged so a later rollup can compare groups (old vs new)
+// and map shortfalls to fixable extractor lanes.
+//
+// LOCAL ONLY — never transmitted remotely.
+type FeedbackEvent struct {
+	// Timestamp is the UTC ISO-8601 instant the event was recorded.
+	Timestamp string `json:"ts"`
+	// Group is the archigraph group the interaction was about (enables
+	// old-vs-new comparison). Optional but strongly recommended.
+	Group string `json:"group,omitempty"`
+	// Phase is a free-form label for the work in progress, e.g.
+	// "port:inspections". Optional.
+	Phase string `json:"phase,omitempty"`
+	// Library is the framework or library in play, e.g. "pymongo",
+	// "typeorm", "class-validator". Optional.
+	Library string `json:"library,omitempty"`
+	// Capability uses the coverage-matrix taxonomy (data_access, routing,
+	// auth, dto, testing, …) so wrong/missing outcomes map to an extractor
+	// lane. Optional, free-form.
+	Capability string `json:"capability,omitempty"`
+	// Outcome is one of helped|partial|wrong|missing_capability (required).
+	Outcome string `json:"outcome"`
+	// Note is an optional one-line free-form detail.
+	Note string `json:"note,omitempty"`
+}
+
+// appendFeedbackEvent writes one JSON line to the daily feedback JSONL file.
+// Append-only on a local filesystem; safe to call concurrently.
+func appendFeedbackEvent(evt FeedbackEvent) (string, error) {
+	path, err := feedbackEventsFile()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("feedback_event: mkdir %s: %w", dir, err)
+	}
+	line, err := json.Marshal(evt)
+	if err != nil {
+		return "", fmt.Errorf("feedback_event: marshal event: %w", err)
+	}
+	line = append(line, '\n')
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("feedback_event: open %s: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(line); err != nil {
+		return "", fmt.Errorf("feedback_event: write event: %w", err)
+	}
+	return path, nil
+}
+
+// handleFeedbackEvent is the handler for archigraph_feedback_event (#3204).
+//
+// Agents call this opportunistically during a test run — when an archigraph
+// answer was wrong/incomplete or a library wasn't recognized — and at phase
+// checkpoints. Events append to:
+//
+//	~/.archigraph/events/feedback-events-YYYY-MM-DD.jsonl
+//
+// Privacy guarantee: LOCAL ONLY. No remote emission. Recording failures never
+// block the agent — the tool returns a non-error result with a warning.
+func (s *Server) handleFeedbackEvent(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	outcome, err := req.RequireString("outcome")
+	if err != nil {
+		return mcpapi.NewToolResultError("archigraph_feedback_event: outcome (string, required): " + err.Error()), nil
+	}
+	if !feedbackOutcomes[outcome] {
+		return mcpapi.NewToolResultError(
+			fmt.Sprintf("archigraph_feedback_event: outcome must be one of helped|partial|wrong|missing_capability; got %q", outcome),
+		), nil
+	}
+
+	ts := time.Now().UTC().Format(time.RFC3339)
+	evt := FeedbackEvent{
+		Timestamp:  ts,
+		Group:      argString(req, "group", ""),
+		Phase:      argString(req, "phase", ""),
+		Library:    argString(req, "library", ""),
+		Capability: argString(req, "capability", ""),
+		Outcome:    outcome,
+		Note:       argString(req, "note", ""),
+	}
+
+	if _, writeErr := appendFeedbackEvent(evt); writeErr != nil {
+		return jsonResult(map[string]any{
+			"recorded": false,
+			"ts":       ts,
+			"warning":  writeErr.Error(),
+		}), nil
+	}
+	return jsonResult(map[string]any{
+		"recorded": true,
+		"ts":       ts,
+	}), nil
+}

--- a/internal/mcp/feedback_event_test.go
+++ b/internal/mcp/feedback_event_test.go
@@ -1,0 +1,90 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newFeedbackTestServer(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(regPath, []byte(`{"groups":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+func TestFeedbackEventValidation(t *testing.T) {
+	srv := newFeedbackTestServer(t)
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{"missing outcome", map[string]any{"group": "g"}},
+		{"invalid outcome", map[string]any{"outcome": "nope"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := callTool(t, srv, "archigraph_feedback_event", tc.args)
+			if res == nil || !res.IsError {
+				t.Fatalf("expected error result for %q", tc.name)
+			}
+			if !containsStr(resultText(res), "outcome") {
+				t.Errorf("expected error to mention outcome; got %q", resultText(res))
+			}
+		})
+	}
+}
+
+func TestFeedbackEventJSONLAppend(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
+
+	srv := newFeedbackTestServer(t)
+	res := callTool(t, srv, "archigraph_feedback_event", map[string]any{
+		"outcome":    "missing_capability",
+		"group":      "upvate-core",
+		"phase":      "port:inspections",
+		"library":    "pymongo",
+		"capability": "data_access",
+		"note":       "no mongo collection nodes",
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("unexpected error: %v", resultText(res))
+	}
+
+	path, err := feedbackEventsFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open jsonl: %v", err)
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	if !sc.Scan() {
+		t.Fatal("expected at least one line in feedback JSONL")
+	}
+	var evt FeedbackEvent
+	if err := json.Unmarshal(sc.Bytes(), &evt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if evt.Outcome != "missing_capability" || evt.Group != "upvate-core" ||
+		evt.Library != "pymongo" || evt.Capability != "data_access" {
+		t.Errorf("event roundtrip mismatch: %+v", evt)
+	}
+	if evt.Timestamp == "" {
+		t.Error("expected timestamp to be set")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -401,7 +401,7 @@ func (s *Server) registerTools() {
 		mcpapi.WithArray("fields"),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
-		mcpapi.WithAny("ref"),                                  // PH1c: optional git ref; defaults to CWD HEAD ref
+		mcpapi.WithAny("ref"),                                        // PH1c: optional git ref; defaults to CWD HEAD ref
 		mcpapi.WithNumber("min_confidence", mcpapi.DefaultNumber(0)), // #2769 Phase 1C
 	), s.wrap("archigraph_find", s.handleQueryGraph))
 
@@ -513,7 +513,6 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_security_findings", s.handleSecurityFindings))
-
 
 	// #2774 / #2775 — Phase 3A pure-function tagging. Lists function-
 	// like entities with no detected effects per the Phase 1A propag-
@@ -1003,6 +1002,21 @@ func (s *Server) registerTools() {
 		mcpapi.WithArray("chain"),
 		mcpapi.WithAny("metadata"),
 	), s.wrap("archigraph_persona_event", s.handlePersonaEvent))
+
+	// archigraph_feedback_event — agent-experience feedback for internal test
+	// runs (#3204). Agents call this opportunistically when an answer is
+	// wrong/incomplete or a library isn't recognized, and at phase checkpoints.
+	// Appends to ~/.archigraph/events/feedback-events-YYYY-MM-DD.jsonl (LOCAL ONLY).
+	// Aggregated by `archigraph feedback rollup`. Internal testing harness.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_feedback_event",
+		mcpapi.WithDescription("Record agent-experience feedback (outcome=helped|partial|wrong|missing_capability) for a test run. LOCAL ONLY."),
+		mcpapi.WithString("outcome", mcpapi.Required()),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("phase"),
+		mcpapi.WithAny("library"),
+		mcpapi.WithAny("capability"),
+		mcpapi.WithAny("note"),
+	), s.wrap("archigraph_feedback_event", s.handleFeedbackEvent))
 
 	// archigraph_mcp_metrics — per-tool session metrics + daily rollup (#2192).
 	// Returns in-memory per-tool counters (calls, errors, p50/p95 ms) for the

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1009,7 +1009,7 @@ func (s *Server) registerTools() {
 	// Appends to ~/.archigraph/events/feedback-events-YYYY-MM-DD.jsonl (LOCAL ONLY).
 	// Aggregated by `archigraph feedback rollup`. Internal testing harness.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_feedback_event",
-		mcpapi.WithDescription("Record agent-experience feedback (outcome=helped|partial|wrong|missing_capability) for a test run. LOCAL ONLY."),
+		mcpapi.WithDescription("Record agent-experience feedback for a test run. LOCAL ONLY."),
 		mcpapi.WithString("outcome", mcpapi.Required()),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("phase"),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -575,6 +575,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_subgraph",
 		// #2474 persona lifecycle telemetry
 		"archigraph_persona_event",
+		// #3204 agent-experience feedback (internal test harness)
+		"archigraph_feedback_event",
 		// #2192 MCP session metrics
 		"archigraph_mcp_metrics",
 		// #2658 NAVIGATES_TO query tool (Phase 2 of #2655)
@@ -680,8 +682,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_payload_drift (#2770 Phase 2A drift findings).
 	// +1 archigraph_security_findings (#2772 Phase 2B taint-flow).
 	// +4 archigraph_pure_functions/_import_cycles/_def_use/_template_patterns (#2774/#2775 Phase 3 misc).
-	if got := len(allRegisteredTools); got != 53 {
-		t.Errorf("expected 53 registered tools, got %d — update this count if tools are added/removed (added archigraph_security_findings #2772 + Phase 3 misc #2774/#2775: pure_functions, import_cycles, def_use, template_patterns)", got)
+	// +1 archigraph_feedback_event (#3204 agent-experience feedback, internal test harness).
+	if got := len(allRegisteredTools); got != 54 {
+		t.Errorf("expected 54 registered tools, got %d — update this count if tools are added/removed (added archigraph_feedback_event #3204)", got)
 	}
 }
 
@@ -3173,7 +3176,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_cross_links":   {"group": "g", "action": "list"},
 		"archigraph_license_audit": {"group": "g"},
 		// #2474 persona lifecycle telemetry
-		"archigraph_persona_event": {"persona": "architect", "event_type": "invoke"},
+		"archigraph_persona_event":  {"persona": "architect", "event_type": "invoke"},
+		"archigraph_feedback_event": {"outcome": "helped"},
 		// #2192 MCP session metrics
 		"archigraph_mcp_metrics": {"days": float64(1)},
 		// #2658 NAVIGATES_TO Phase 2 query tool
@@ -3235,8 +3239,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 53 {
-		t.Errorf("expected 53 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_security_findings #2772 + Phase 3 misc #2774/#2775: pure_functions, import_cycles, def_use, template_patterns)", len(tools))
+	if len(tools) != 54 {
+		t.Errorf("expected 54 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_feedback_event #3204)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
## What

The internal rewrite-test feedback harness from #3204: capture how archigraph actually performs during an end-to-end test (old Django/Python → new NestJS) and roll it up for analysis.

## Pieces

**1. `archigraph_feedback_event` MCP tool** (sibling of `archigraph_persona_event`)
Agents emit, opportunistically and at phase checkpoints:
```
{ outcome: helped|partial|wrong|missing_capability,  // required
  group, phase, library, capability, note }          // optional
```
- `capability` uses the **coverage-matrix taxonomy** (data_access/routing/auth/dto/testing) so every wrong/missing outcome maps to a fixable extractor lane.
- Appends **LOCAL ONLY** to `~/.archigraph/events/feedback-events-YYYY-MM-DD.jsonl`, reusing the proven persona-telemetry JSONL machinery (daily rotation, concurrency-safe, never transmitted).
- Recording failures never block the agent.

**2. `archigraph feedback rollup`**
```
archigraph feedback rollup [--since YYYY-MM-DD] [--out <dir>] [--events-dir <dir>]
```
Aggregates the JSONL into `rollup.json` + `rollup.md`:
- outcome distribution per **group** (auto old-vs-new), per **capability**, per **library**
- a ranked **fix queue** (capabilities + libraries with the most wrong+missing, highest first) — the prioritized work list
- malformed lines skipped; `--since` filters by event date; no network.

## Why

Pairs with #3203 (MongoDB data-access extraction): a `capability=data_access, outcome=missing, library=pymongo` event is exactly the signal that quantifies that gap and later validates the fix. Internal testing harness — not surfaced to real users.

## Tests
- mcp: outcome validation (missing/invalid rejected), JSONL roundtrip with all fields.
- cli: aggregation correctness, `--since` exclusion, malformed-line skip, no-events path.
- `go vet` + `go build ./cmd/archigraph` clean; new/edited files gofmt-clean.

Closes #3204
Relates to #3203

🤖 Generated with [Claude Code](https://claude.com/claude-code)