### PR TITLE
feat(feedback): timeline command + milestone event flavor

### DIFF
--- a/internal/cli/feedback.go
+++ b/internal/cli/feedback.go
@@ -58,6 +58,7 @@ The user decides whether to paste it into a GitHub issue.`,
 	cmd.Flags().StringVar(&outFlag, "out", "", "output path (default: ~/.archigraph/feedback/<group>-<timestamp>.md)")
 	cmd.Flags().BoolVar(&yesFlag, "yes", false, "skip confirmation prompt (for CI / scripting)")
 	cmd.AddCommand(newFeedbackRollupCmd())
+	cmd.AddCommand(newFeedbackTimelineCmd())
 	return cmd
 }
 

--- a/internal/cli/feedback_rollup.go
+++ b/internal/cli/feedback_rollup.go
@@ -25,8 +25,10 @@ type feedbackEventRecord struct {
 	Note       string `json:"note,omitempty"`
 }
 
-// outcomeOrder is the canonical column order for rollup tables.
-var outcomeOrder = []string{"helped", "partial", "wrong", "missing_capability"}
+// outcomeOrder is the canonical column order for rollup tables. "milestone" is
+// a neutral narrative beat (#3206) — it renders as a column but buildFixQueue
+// deliberately excludes it (only wrong+missing_capability count as negative).
+var outcomeOrder = []string{"helped", "partial", "wrong", "missing_capability", "milestone"}
 
 // newFeedbackRollupCmd returns `archigraph feedback rollup`, which aggregates
 // the agent-experience feedback JSONL (written by archigraph_feedback_event)

--- a/internal/cli/feedback_rollup_test.go
+++ b/internal/cli/feedback_rollup_test.go
@@ -83,6 +83,42 @@ func TestFeedbackRollup_Aggregates(t *testing.T) {
 	}
 }
 
+// TestFeedbackRollup_MilestoneNotInFixQueue verifies that the neutral
+// "milestone" outcome (#3206) is counted as an outcome but never inflates the
+// fix queue (which only counts wrong+missing_capability).
+func TestFeedbackRollup_MilestoneNotInFixQueue(t *testing.T) {
+	tmp := t.TempDir()
+	eventsDir := filepath.Join(tmp, "events")
+	outDir := filepath.Join(tmp, "out")
+
+	writeEventsFile(t, eventsDir, "feedback-events-2026-05-30.jsonl", []string{
+		`{"ts":"2026-05-30T10:00:00Z","group":"new-backend","capability":"data_access","outcome":"milestone","note":"inspections parity"}`,
+		`{"ts":"2026-05-30T10:05:00Z","group":"new-backend","capability":"routing","outcome":"helped"}`,
+	})
+
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	if err := runFeedbackRollup(cmd, "", outDir, eventsDir); err != nil {
+		t.Fatalf("rollup: %v", err)
+	}
+
+	jb, err := os.ReadFile(filepath.Join(outDir, "rollup.json"))
+	if err != nil {
+		t.Fatalf("read rollup.json: %v", err)
+	}
+	var r feedbackRollup
+	if err := json.Unmarshal(jb, &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.ByOutcome["milestone"] != 1 {
+		t.Errorf("milestone should be counted as an outcome; by_outcome=%v", r.ByOutcome)
+	}
+	if len(r.FixQueue) != 0 {
+		t.Errorf("milestone (and helped) must not produce fix-queue items; got %v", r.FixQueue)
+	}
+}
+
 func TestFeedbackRollup_NoEvents(t *testing.T) {
 	tmp := t.TempDir()
 	cmd := &cobra.Command{}

--- a/internal/cli/feedback_timeline.go
+++ b/internal/cli/feedback_timeline.go
@@ -1,0 +1,704 @@
+package cli
+
+// feedback_timeline.go — `archigraph feedback timeline` (#3206).
+//
+// Stitches the internal rewrite-test signals into a chronological STORY of how
+// archigraph helped migrate a backend to a new language with 1:1 parity:
+//
+//   - feedback-events JSONL (#3204): outcome + phase + capability + library
+//   - persona-events JSONL (optional)
+//   - mcp_rpc daemon log: per-call query timeline + token/byte cost
+//   - git history of the new repo(s): ported code landing over time (milestones)
+//
+// All four sources are timestamped; they are merged into one chronological
+// stream, segmented by phase (planning first), and rendered as timeline.json
+// (machine) + timeline.md (narrative). LOCAL ONLY — no network calls.
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// unphasedPhase is the bucket for entries with no resolvable phase.
+const unphasedPhase = "(unphased)"
+
+// planningPhase is forced to sort first in the rendered narrative (#3206
+// "planning-first" requirement) — it is just a normal phase value agents emit.
+const planningPhase = "planning"
+
+// timelineEntry is one beat in the merged, chronologically-sorted stream.
+type timelineEntry struct {
+	TS       string `json:"ts"`    // UTC ISO-8601 instant
+	Kind     string `json:"kind"`  // feedback | persona | query | commit
+	Phase    string `json:"phase"` // resolved phase (or "(unphased)")
+	Group    string `json:"group,omitempty"`
+	Summary  string `json:"summary"`             // human-readable beat
+	TokenEst int    `json:"token_est,omitempty"` // query payload token estimate
+	Outcome  string `json:"outcome,omitempty"`   // feedback outcome
+}
+
+// phaseAggregate is the per-phase rollup emitted in timeline.json.
+type phaseAggregate struct {
+	FirstTS        string         `json:"first_ts"`
+	LastTS         string         `json:"last_ts"`
+	Queries        int            `json:"queries"`
+	TokenEstSum    int            `json:"token_est_sum"`
+	FeedbackCounts map[string]int `json:"feedback_counts"`
+	Commits        int            `json:"commits"`
+}
+
+// timelineDoc is the serialized timeline.json payload.
+type timelineDoc struct {
+	Since           string                     `json:"since"`
+	GeneratedPhases []string                   `json:"generated_phases"`
+	Entries         []timelineEntry            `json:"entries"`
+	PerPhase        map[string]*phaseAggregate `json:"per_phase"`
+}
+
+// newFeedbackTimelineCmd returns `archigraph feedback timeline` (#3206).
+func newFeedbackTimelineCmd() *cobra.Command {
+	var (
+		since        string
+		outDir       string
+		eventsDir    string
+		rpcLog       string
+		repos        []string
+		phaseTrailer string
+	)
+	cmd := &cobra.Command{
+		Use:   "timeline",
+		Short: "Reconstruct a phase-segmented narrative of a migration from feedback + rpc + git (internal test harness)",
+		Long: `timeline stitches the internal rewrite-test signals into a chronological
+story of how archigraph helped migrate a backend with 1:1 parity:
+
+  - feedback-events JSONL (archigraph_feedback_event): outcome + phase
+  - persona-events JSONL (optional)
+  - the mcp_rpc daemon log: per-call query timeline + token cost
+  - git history of the new repo(s): ported code landing over time
+
+Events are merged chronologically, segmented by phase (a phase literally named
+"planning" sorts first), and emitted as timeline.json + timeline.md.
+
+Commit→phase correlation: a commit carrying an "Archigraph-Phase: <phase>"
+git trailer is matched exactly; otherwise it (and each rpc query) falls into
+the time window of the nearest preceding feedback phase checkpoint.
+
+All data is local; no network calls.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runFeedbackTimeline(cmd, timelineOpts{
+				since:        since,
+				outDir:       outDir,
+				eventsDir:    eventsDir,
+				rpcLog:       rpcLog,
+				repos:        repos,
+				phaseTrailer: phaseTrailer,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&since, "since", "", "only include events on/after this UTC date (YYYY-MM-DD); default: all")
+	cmd.Flags().StringVar(&outDir, "out", "", "output directory (default: ~/.archigraph/feedback/timeline-<timestamp>)")
+	cmd.Flags().StringVar(&eventsDir, "events-dir", "", "events directory (default: ~/.archigraph/events)")
+	cmd.Flags().StringVar(&rpcLog, "rpc-log", "", "daemon log path for mcp_rpc query timeline (default: ~/.archigraph/logs/daemon.log; skipped if absent)")
+	cmd.Flags().StringArrayVar(&repos, "repo", nil, "path to a new repo whose git log supplies commit milestones (repeatable)")
+	cmd.Flags().StringVar(&phaseTrailer, "phase-trailer", "Archigraph-Phase", "git trailer key used for exact commit→phase correlation")
+	return cmd
+}
+
+type timelineOpts struct {
+	since        string
+	outDir       string
+	eventsDir    string
+	rpcLog       string
+	repos        []string
+	phaseTrailer string
+}
+
+func runFeedbackTimeline(cmd *cobra.Command, opts timelineOpts) error {
+	w := cmd.OutOrStdout()
+	errW := cmd.ErrOrStderr()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("feedback timeline: resolve home: %w", err)
+	}
+	if opts.eventsDir == "" {
+		opts.eventsDir = filepath.Join(home, ".archigraph", "events")
+	}
+	if opts.outDir == "" {
+		opts.outDir = filepath.Join(home, ".archigraph", "feedback",
+			"timeline-"+time.Now().UTC().Format("20060102-150405"))
+	}
+	if opts.rpcLog == "" {
+		opts.rpcLog = filepath.Join(home, ".archigraph", "logs", "daemon.log")
+	}
+	if opts.phaseTrailer == "" {
+		opts.phaseTrailer = "Archigraph-Phase"
+	}
+
+	// 1. Feedback events (reuse the rollup loader). These carry phase directly
+	//    and act as the phase checkpoints for the time-window fallback.
+	fbEvents, _, err := loadFeedbackEvents(opts.eventsDir, opts.since)
+	if err != nil {
+		return err
+	}
+
+	var entries []timelineEntry
+	// feedbackCheckpoints are (ts, phase) pairs used for the nearest-preceding
+	// time-window fallback. Built only from feedback events that name a phase.
+	type checkpoint struct {
+		t     time.Time
+		phase string
+	}
+	var checkpoints []checkpoint
+	for _, e := range fbEvents {
+		phase := e.Phase
+		entries = append(entries, timelineEntry{
+			TS:      e.Timestamp,
+			Kind:    "feedback",
+			Phase:   phase, // feedback events carry phase directly
+			Group:   e.Group,
+			Summary: feedbackSummary(e),
+			Outcome: e.Outcome,
+		})
+		if phase != "" {
+			if t, ok := parseTS(e.Timestamp); ok {
+				checkpoints = append(checkpoints, checkpoint{t: t, phase: phase})
+			}
+		}
+	}
+
+	// 2. Persona events (optional). Group-agnostic; no phase of their own —
+	//    they get a phase via the time-window fallback.
+	personaEntries, err := loadPersonaTimelineEvents(opts.eventsDir, opts.since)
+	if err != nil {
+		return err
+	}
+	entries = append(entries, personaEntries...)
+
+	// 3. mcp_rpc query timeline + cost (optional). Skipped silently if absent.
+	queryEntries, err := loadRPCTimelineEvents(opts.rpcLog, opts.since)
+	if err != nil {
+		fmt.Fprintf(errW, "warning: rpc-log %s: %v (skipping query timeline)\n", opts.rpcLog, err)
+	}
+	entries = append(entries, queryEntries...)
+
+	// 4. Commit milestones from each --repo (optional, never fatal).
+	for _, repo := range opts.repos {
+		commitEntries, gerr := loadGitTimelineEvents(repo, opts.since, opts.phaseTrailer)
+		if gerr != nil {
+			fmt.Fprintf(errW, "warning: --repo %s: %v (skipping its commits)\n", repo, gerr)
+			continue
+		}
+		entries = append(entries, commitEntries...)
+	}
+
+	// Sort all entries chronologically by TS (RFC3339 lexical sort is valid
+	// for UTC instants; ties broken by kind then summary for determinism).
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].TS != entries[j].TS {
+			return entries[i].TS < entries[j].TS
+		}
+		if entries[i].Kind != entries[j].Kind {
+			return entries[i].Kind < entries[j].Kind
+		}
+		return entries[i].Summary < entries[j].Summary
+	})
+
+	// Sort the checkpoints chronologically for the nearest-preceding lookup.
+	sort.SliceStable(checkpoints, func(i, j int) bool {
+		return checkpoints[i].t.Before(checkpoints[j].t)
+	})
+
+	// Phase assignment for entries that don't already carry one (commit without
+	// a trailer, persona, query): fall into the time window of the nearest
+	// preceding feedback phase checkpoint. Entries with no resolvable phase get
+	// "(unphased)".
+	assignPhase := func(tsStr string) string {
+		t, ok := parseTS(tsStr)
+		if !ok {
+			return unphasedPhase
+		}
+		phase := unphasedPhase
+		for _, cp := range checkpoints {
+			if cp.t.After(t) {
+				break
+			}
+			phase = cp.phase // nearest preceding (checkpoints are sorted ascending)
+		}
+		return phase
+	}
+	for i := range entries {
+		if entries[i].Phase == "" {
+			entries[i].Phase = assignPhase(entries[i].TS)
+		}
+	}
+
+	// Build per-phase aggregates and the phase ordering (first-seen ts, but
+	// "planning" forced first).
+	doc := buildTimelineDoc(opts.since, entries)
+
+	if err := os.MkdirAll(opts.outDir, 0o755); err != nil {
+		return fmt.Errorf("feedback timeline: mkdir %s: %w", opts.outDir, err)
+	}
+	jsonPath := filepath.Join(opts.outDir, "timeline.json")
+	mdPath := filepath.Join(opts.outDir, "timeline.md")
+
+	jb, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(jsonPath, append(jb, '\n'), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(mdPath, []byte(renderTimelineMarkdown(doc)), 0o644); err != nil {
+		return err
+	}
+
+	if len(entries) == 0 {
+		fmt.Fprintf(w, "no timeline events found in %s%s\n", opts.eventsDir, sinceSuffix(opts.since))
+		fmt.Fprintf(w, "  %s\n  %s\n", jsonPath, mdPath)
+		return nil
+	}
+
+	fmt.Fprintf(w, "built timeline of %d events across %d phase(s)%s\n",
+		len(entries), len(doc.GeneratedPhases), sinceSuffix(opts.since))
+	fmt.Fprintf(w, "  %s\n  %s\n", jsonPath, mdPath)
+	return nil
+}
+
+// buildTimelineDoc computes per-phase aggregates and the phase ordering.
+// Phases are ordered by first-seen timestamp, but a phase literally named
+// "planning" is forced FIRST if present (#3206 planning-first requirement).
+func buildTimelineDoc(since string, entries []timelineEntry) timelineDoc {
+	perPhase := map[string]*phaseAggregate{}
+	var firstSeen []string // phases in first-seen-ts order
+
+	for _, e := range entries {
+		agg := perPhase[e.Phase]
+		if agg == nil {
+			agg = &phaseAggregate{
+				FirstTS:        e.TS,
+				LastTS:         e.TS,
+				FeedbackCounts: map[string]int{},
+			}
+			perPhase[e.Phase] = agg
+			firstSeen = append(firstSeen, e.Phase) // entries are pre-sorted by ts
+		}
+		if e.TS < agg.FirstTS {
+			agg.FirstTS = e.TS
+		}
+		if e.TS > agg.LastTS {
+			agg.LastTS = e.TS
+		}
+		switch e.Kind {
+		case "query":
+			agg.Queries++
+			agg.TokenEstSum += e.TokenEst
+		case "feedback":
+			agg.FeedbackCounts[e.Outcome]++
+		case "commit":
+			agg.Commits++
+		}
+	}
+
+	ordered := orderPhases(firstSeen)
+	return timelineDoc{
+		Since:           since,
+		GeneratedPhases: ordered,
+		Entries:         entries,
+		PerPhase:        perPhase,
+	}
+}
+
+// orderPhases keeps first-seen order but forces "planning" to the front.
+func orderPhases(firstSeen []string) []string {
+	ordered := make([]string, 0, len(firstSeen))
+	hasPlanning := false
+	for _, p := range firstSeen {
+		if p == planningPhase {
+			hasPlanning = true
+			continue
+		}
+		ordered = append(ordered, p)
+	}
+	if hasPlanning {
+		ordered = append([]string{planningPhase}, ordered...)
+	}
+	return ordered
+}
+
+func feedbackSummary(e feedbackEventRecord) string {
+	var parts []string
+	parts = append(parts, e.Outcome)
+	if e.Capability != "" {
+		parts = append(parts, "cap="+e.Capability)
+	}
+	if e.Library != "" {
+		parts = append(parts, "lib="+e.Library)
+	}
+	s := strings.Join(parts, " ")
+	if e.Note != "" {
+		s += ": " + e.Note
+	}
+	return s
+}
+
+// ---- persona events --------------------------------------------------------
+
+// personaTimelineRecord is a lightweight local parser for persona-events JSONL
+// (we deliberately avoid importing internal/mcp).
+type personaTimelineRecord struct {
+	Timestamp     string `json:"ts"`
+	Persona       string `json:"persona"`
+	EventType     string `json:"event_type"`
+	TargetPersona string `json:"target_persona,omitempty"`
+}
+
+func loadPersonaTimelineEvents(dir, since string) ([]timelineEntry, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "persona-events-*.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	var out []timelineEntry
+	for _, path := range matches {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("feedback timeline: open %s: %w", path, err)
+		}
+		sc := bufio.NewScanner(f)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" {
+				continue
+			}
+			var rec personaTimelineRecord
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				continue
+			}
+			if !afterSince(rec.Timestamp, since) {
+				continue
+			}
+			summary := "persona " + rec.Persona + " " + rec.EventType
+			if rec.TargetPersona != "" {
+				summary += " -> " + rec.TargetPersona
+			}
+			out = append(out, timelineEntry{
+				TS:      rec.Timestamp,
+				Kind:    "persona",
+				Summary: summary,
+			})
+		}
+		f.Close()
+		if err := sc.Err(); err != nil {
+			return nil, fmt.Errorf("feedback timeline: read %s: %w", path, err)
+		}
+	}
+	return out, nil
+}
+
+// ---- mcp_rpc daemon log ----------------------------------------------------
+
+// rpcDoneLineRe mirrors the daemon's slog-format mcp_rpc phase=done line. The
+// real format (confirmed against cmd/archigraph/bench_capture.go) is, with a
+// leading slog "time=" field carrying a per-line timestamp:
+//
+//	time=2026-05-27T05:33:46.256+05:45 level=INFO msg=mcp_rpc phase=done tool=archigraph_whoami elapsed_ms=1008 wire_bytes=B payload_token_estimate=T repo=/path
+//
+// We capture the timestamp (for the timeline), the tool, and (optionally) the
+// payload_token_estimate + repo for per-query cost. wire_bytes/token fields are
+// optional (added by #2828); repo is optional. The daemon DOUBLE-LOGS each line
+// consecutively, so we dedup consecutive identical lines (same as the bench
+// parser).
+var (
+	rpcTimeRe  = regexp.MustCompile(`time=(\S+)`)
+	rpcDoneRe  = regexp.MustCompile(`msg=mcp_rpc phase=done tool=(\S+) elapsed_ms=(\d+)`)
+	rpcTokenRe = regexp.MustCompile(`payload_token_estimate=(\d+)`)
+	rpcRepoRe  = regexp.MustCompile(`repo=(\S+)`)
+)
+
+func loadRPCTimelineEvents(logPath, since string) ([]timelineEntry, error) {
+	f, err := os.Open(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // absent → skip silently
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []timelineEntry
+	var prevLine string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		// Dedup the daemon's consecutive double-log (same scheme as the bench
+		// capture parser).
+		if line == prevLine {
+			prevLine = ""
+			continue
+		}
+		prevLine = line
+
+		m := rpcDoneRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		tool := m[1]
+
+		// Extract the per-line timestamp and normalize to UTC RFC3339.
+		ts := ""
+		if tm := rpcTimeRe.FindStringSubmatch(line); tm != nil {
+			if t, ok := parseTS(tm[1]); ok {
+				ts = t.UTC().Format(time.RFC3339)
+			}
+		}
+		if ts == "" {
+			continue // no usable timestamp → can't place on the timeline
+		}
+		if !afterSince(ts, since) {
+			continue
+		}
+
+		tokenEst := 0
+		if tk := rpcTokenRe.FindStringSubmatch(line); tk != nil {
+			tokenEst, _ = strconv.Atoi(tk[1])
+		}
+		group := ""
+		if rm := rpcRepoRe.FindStringSubmatch(line); rm != nil {
+			group = rm[1]
+		}
+
+		summary := "query " + tool
+		if tokenEst > 0 {
+			summary += fmt.Sprintf(" (~%d tok)", tokenEst)
+		}
+		out = append(out, timelineEntry{
+			TS:       ts,
+			Kind:     "query",
+			Group:    group,
+			Summary:  summary,
+			TokenEst: tokenEst,
+		})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ---- git commit milestones -------------------------------------------------
+
+// gitLogSep is an unlikely field separator for the --pretty format.
+const gitLogSep = "\x1f"
+
+// loadGitTimelineEvents reads `git -C <repo> log` and emits one commit entry per
+// commit in the window. The phase trailer (e.g. "Archigraph-Phase: planning")
+// gives an EXACT commit→phase correlation when present; otherwise Phase is left
+// empty and the caller's time-window fallback assigns it.
+//
+// Returns an error (warned, non-fatal by the caller) if the path has no .git or
+// git fails.
+func loadGitTimelineEvents(repo, since, phaseTrailer string) ([]timelineEntry, error) {
+	if _, err := os.Stat(filepath.Join(repo, ".git")); err != nil {
+		return nil, fmt.Errorf("no .git directory")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, fmt.Errorf("git not on PATH")
+	}
+
+	// %H hash, %aI author date (strict ISO-8601), %s subject, %(trailers...)
+	// We read the trailer value for the configured key directly via the
+	// %(trailers:key=...) pretty-format, which yields just the value(s).
+	format := strings.Join([]string{"%aI", "%h", "%s",
+		fmt.Sprintf("%%(trailers:key=%s,valueonly=true)", phaseTrailer)}, gitLogSep)
+
+	args := []string{"-C", repo, "log", "--no-merges", "--pretty=format:" + format + "%x1e"}
+	if since != "" {
+		// git understands YYYY-MM-DD for --since (local midnight); good enough
+		// for the daily window granularity used elsewhere here.
+		args = append(args, "--since="+since)
+	}
+
+	cmd := exec.Command("git", args...)
+	outBytes, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git log: %w", err)
+	}
+
+	var out []timelineEntry
+	records := strings.Split(string(outBytes), "\x1e")
+	for _, rec := range records {
+		rec = strings.Trim(rec, "\n")
+		if rec == "" {
+			continue
+		}
+		fields := strings.Split(rec, gitLogSep)
+		if len(fields) < 3 {
+			continue
+		}
+		authorDate := strings.TrimSpace(fields[0])
+		hash := strings.TrimSpace(fields[1])
+		subject := strings.TrimSpace(fields[2])
+		phase := ""
+		if len(fields) >= 4 {
+			phase = strings.TrimSpace(fields[3])
+		}
+
+		t, ok := parseTS(authorDate)
+		if !ok {
+			continue
+		}
+		ts := t.UTC().Format(time.RFC3339)
+		if !afterSince(ts, since) {
+			continue
+		}
+		out = append(out, timelineEntry{
+			TS:      ts,
+			Kind:    "commit",
+			Phase:   phase, // exact correlation via the trailer when present
+			Summary: fmt.Sprintf("commit %s: %s", hash, subject),
+		})
+	}
+	return out, nil
+}
+
+// ---- shared helpers --------------------------------------------------------
+
+// parseTS parses a timestamp in any of the formats we encounter (RFC3339 with
+// or without fractional seconds / numeric zone) and reports success.
+func parseTS(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05.999999999Z07:00"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// afterSince reports whether the RFC3339 ts is on/after the since date
+// (YYYY-MM-DD). Empty since → always true. Lexical date compare on the first 10
+// chars (same convention as loadFeedbackEvents).
+func afterSince(ts, since string) bool {
+	if since == "" {
+		return true
+	}
+	if len(ts) >= 10 {
+		return ts[:10] >= since
+	}
+	return true
+}
+
+// renderTimelineMarkdown produces the narrative timeline.md: a title + overall
+// span + totals, then one "## <phase>" chapter per phase (in GeneratedPhases
+// order) with a quantified header line and a chronological bullet list.
+func renderTimelineMarkdown(doc timelineDoc) string {
+	var b strings.Builder
+	b.WriteString("# archigraph migration timeline\n\n")
+	if doc.Since != "" {
+		fmt.Fprintf(&b, "Events since **%s**. ", doc.Since)
+	}
+
+	overallFirst, overallLast := "", ""
+	totalQueries, totalTokens, totalCommits := 0, 0, 0
+	for _, agg := range doc.PerPhase {
+		if overallFirst == "" || agg.FirstTS < overallFirst {
+			overallFirst = agg.FirstTS
+		}
+		if agg.LastTS > overallLast {
+			overallLast = agg.LastTS
+		}
+		totalQueries += agg.Queries
+		totalTokens += agg.TokenEstSum
+		totalCommits += agg.Commits
+	}
+
+	if len(doc.Entries) == 0 {
+		b.WriteString("\n_No timeline events found._\n")
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "Span: **%s → %s**. %d events, %d queries (~%d tokens), %d commits across %d phase(s).\n\n",
+		overallFirst, overallLast, len(doc.Entries), totalQueries, totalTokens, totalCommits, len(doc.GeneratedPhases))
+
+	for _, phase := range doc.GeneratedPhases {
+		agg := doc.PerPhase[phase]
+		if agg == nil {
+			continue
+		}
+		fmt.Fprintf(&b, "## %s\n\n", phase)
+		fmt.Fprintf(&b, "%s → %s · %d queries (~%d tokens) · %s · %d commits\n\n",
+			agg.FirstTS, agg.LastTS, agg.Queries, agg.TokenEstSum,
+			outcomeMix(agg.FeedbackCounts), agg.Commits)
+
+		for _, e := range doc.Entries {
+			if e.Phase != phase {
+				continue
+			}
+			b.WriteString(renderEntryBullet(e))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// outcomeMix renders the feedback outcome counts in canonical order, e.g.
+// "helped=2 wrong=1 milestone=1" — or "no feedback" when empty.
+func outcomeMix(counts map[string]int) string {
+	var parts []string
+	for _, o := range outcomeOrder {
+		if n := counts[o]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%s=%d", o, n))
+		}
+	}
+	// Include any non-canonical outcomes too, sorted for determinism.
+	var extra []string
+	for o, n := range counts {
+		if n > 0 && !isCanonicalOutcome(o) {
+			extra = append(extra, fmt.Sprintf("%s=%d", o, n))
+		}
+	}
+	sort.Strings(extra)
+	parts = append(parts, extra...)
+	if len(parts) == 0 {
+		return "no feedback"
+	}
+	return strings.Join(parts, " ")
+}
+
+// renderEntryBullet renders one chronological bullet for a phase chapter.
+// Milestone feedback is rendered prominently; commits read as milestones.
+func renderEntryBullet(e timelineEntry) string {
+	switch e.Kind {
+	case "feedback":
+		if e.Outcome == "milestone" {
+			return fmt.Sprintf("- **%s MILESTONE** — %s\n", e.TS, e.Summary)
+		}
+		return fmt.Sprintf("- %s feedback %s\n", e.TS, e.Summary)
+	case "commit":
+		return fmt.Sprintf("- %s %s\n", e.TS, e.Summary)
+	case "query":
+		return fmt.Sprintf("- %s %s\n", e.TS, e.Summary)
+	case "persona":
+		return fmt.Sprintf("- %s %s\n", e.TS, e.Summary)
+	default:
+		return fmt.Sprintf("- %s %s\n", e.TS, e.Summary)
+	}
+}

--- a/internal/cli/feedback_timeline_test.go
+++ b/internal/cli/feedback_timeline_test.go
@@ -1,0 +1,282 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// readTimelineDoc runs `feedback timeline` and returns the parsed timeline.json
+// plus the timeline.md bytes.
+func readTimelineDoc(t *testing.T, outDir string) (timelineDoc, string) {
+	t.Helper()
+	jb, err := os.ReadFile(filepath.Join(outDir, "timeline.json"))
+	if err != nil {
+		t.Fatalf("read timeline.json: %v", err)
+	}
+	var doc timelineDoc
+	if err := json.Unmarshal(jb, &doc); err != nil {
+		t.Fatalf("unmarshal timeline.json: %v", err)
+	}
+	mb, err := os.ReadFile(filepath.Join(outDir, "timeline.md"))
+	if err != nil {
+		t.Fatalf("read timeline.md: %v", err)
+	}
+	return doc, string(mb)
+}
+
+func runTimeline(t *testing.T, opts timelineOpts) (*bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errBuf)
+	if err := runFeedbackTimeline(cmd, opts); err != nil {
+		t.Fatalf("timeline: %v", err)
+	}
+	return out, errBuf
+}
+
+// TestTimeline_MergeOrderingAndTrailerCorrelation builds feedback events + a
+// fake rpc-log + a temp git repo with two commits (one carrying an
+// Archigraph-Phase trailer) and asserts chronological merge order and exact
+// trailer correlation.
+func TestTimeline_MergeOrderingAndTrailerCorrelation(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	tmp := t.TempDir()
+	eventsDir := filepath.Join(tmp, "events")
+	outDir := filepath.Join(tmp, "out")
+
+	// Feedback events: a planning checkpoint, then a port:auth checkpoint.
+	writeEventsFile(t, eventsDir, "feedback-events-2026-05-30.jsonl", []string{
+		`{"ts":"2026-05-30T08:00:00Z","group":"new-backend","phase":"planning","outcome":"milestone","note":"kickoff: target language chosen"}`,
+		`{"ts":"2026-05-30T12:00:00Z","group":"new-backend","phase":"port:auth","capability":"auth","outcome":"helped"}`,
+	})
+
+	// Fake rpc-log: one done line at 09:00 (within planning window), doubled.
+	rpcLine := `time=2026-05-30T09:00:00Z level=INFO msg=mcp_rpc phase=done tool=archigraph_find elapsed_ms=12 wire_bytes=400 payload_token_estimate=100 repo=/x/new-backend`
+	rpcPath := filepath.Join(tmp, "daemon.log")
+	if err := os.WriteFile(rpcPath, []byte(rpcLine+"\n"+rpcLine+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Temp git repo with two commits: one with the trailer (force phase), one
+	// without (falls into nearest-preceding feedback phase window).
+	repo := newTestRepo(t, tmp)
+	// Commit A at 10:00Z with explicit Archigraph-Phase: planning trailer.
+	gitCommit(t, repo, "2026-05-30T10:00:00+00:00", "scaffold project", "Archigraph-Phase: planning")
+	// Commit B at 13:00Z with NO trailer → should fall into port:auth window
+	// (nearest preceding feedback checkpoint at 12:00Z).
+	gitCommit(t, repo, "2026-05-30T13:00:00+00:00", "implement login", "")
+
+	out, _ := runTimeline(t, timelineOpts{
+		outDir:    outDir,
+		eventsDir: eventsDir,
+		rpcLog:    rpcPath,
+		repos:     []string{repo},
+	})
+	if !strings.Contains(out.String(), "built timeline") {
+		t.Errorf("expected summary line, got %q", out.String())
+	}
+
+	doc, _ := readTimelineDoc(t, outDir)
+
+	// Chronological order by TS.
+	for i := 1; i < len(doc.Entries); i++ {
+		if doc.Entries[i-1].TS > doc.Entries[i].TS {
+			t.Fatalf("entries not chronological: %s before %s", doc.Entries[i-1].TS, doc.Entries[i].TS)
+		}
+	}
+
+	// Find the two commits and assert phase correlation.
+	var scaffold, login *timelineEntry
+	for i := range doc.Entries {
+		e := &doc.Entries[i]
+		if e.Kind != "commit" {
+			continue
+		}
+		if strings.Contains(e.Summary, "scaffold project") {
+			scaffold = e
+		}
+		if strings.Contains(e.Summary, "implement login") {
+			login = e
+		}
+	}
+	if scaffold == nil || login == nil {
+		t.Fatalf("expected both commits in timeline; entries=%+v", doc.Entries)
+	}
+	// Exact trailer correlation.
+	if scaffold.Phase != "planning" {
+		t.Errorf("scaffold commit phase = %q, want planning (from trailer)", scaffold.Phase)
+	}
+	// Time-window fallback: 13:00 commit > 12:00 port:auth checkpoint.
+	if login.Phase != "port:auth" {
+		t.Errorf("login commit phase = %q, want port:auth (time-window fallback)", login.Phase)
+	}
+
+	// The rpc query at 09:00 should fall into the planning window (after the
+	// 08:00 planning checkpoint, before the 12:00 port:auth one).
+	var foundQuery bool
+	for _, e := range doc.Entries {
+		if e.Kind == "query" {
+			foundQuery = true
+			if e.Phase != "planning" {
+				t.Errorf("query phase = %q, want planning", e.Phase)
+			}
+			if e.TokenEst != 100 {
+				t.Errorf("query token_est = %d, want 100", e.TokenEst)
+			}
+		}
+	}
+	if !foundQuery {
+		t.Error("expected the rpc query to appear once (deduped from the double-log)")
+	}
+	// Dedup: exactly one query entry despite the doubled log line.
+	queries := 0
+	for _, e := range doc.Entries {
+		if e.Kind == "query" {
+			queries++
+		}
+	}
+	if queries != 1 {
+		t.Errorf("expected exactly 1 deduped query, got %d", queries)
+	}
+}
+
+// TestTimeline_PlanningFirst asserts the "planning" chapter renders before
+// other phases in timeline.md regardless of timestamps.
+func TestTimeline_PlanningFirst(t *testing.T) {
+	tmp := t.TempDir()
+	eventsDir := filepath.Join(tmp, "events")
+	outDir := filepath.Join(tmp, "out")
+
+	// port:auth happens FIRST in time; planning later — yet planning must be
+	// rendered first.
+	writeEventsFile(t, eventsDir, "feedback-events-2026-05-30.jsonl", []string{
+		`{"ts":"2026-05-30T08:00:00Z","phase":"port:auth","outcome":"helped"}`,
+		`{"ts":"2026-05-30T09:00:00Z","phase":"planning","outcome":"milestone","note":"retro decision"}`,
+	})
+
+	runTimeline(t, timelineOpts{outDir: outDir, eventsDir: eventsDir, rpcLog: filepath.Join(tmp, "nope.log")})
+	doc, md := readTimelineDoc(t, outDir)
+
+	if len(doc.GeneratedPhases) == 0 || doc.GeneratedPhases[0] != "planning" {
+		t.Fatalf("planning must be first phase; got %v", doc.GeneratedPhases)
+	}
+	planIdx := strings.Index(md, "## planning")
+	authIdx := strings.Index(md, "## port:auth")
+	if planIdx < 0 || authIdx < 0 {
+		t.Fatalf("both chapters must render; planIdx=%d authIdx=%d", planIdx, authIdx)
+	}
+	if planIdx > authIdx {
+		t.Errorf("planning chapter must render before port:auth (planIdx=%d authIdx=%d)", planIdx, authIdx)
+	}
+}
+
+// TestTimeline_MilestoneRendering asserts a milestone feedback event appears
+// prominently in the narrative and does NOT appear in any rollup fix-queue.
+func TestTimeline_MilestoneRendering(t *testing.T) {
+	tmp := t.TempDir()
+	eventsDir := filepath.Join(tmp, "events")
+	outDir := filepath.Join(tmp, "out")
+
+	writeEventsFile(t, eventsDir, "feedback-events-2026-05-30.jsonl", []string{
+		`{"ts":"2026-05-30T09:00:00Z","phase":"port:inspections","capability":"data_access","outcome":"milestone","note":"inspections reaches parity"}`,
+	})
+
+	runTimeline(t, timelineOpts{outDir: outDir, eventsDir: eventsDir, rpcLog: filepath.Join(tmp, "nope.log")})
+	_, md := readTimelineDoc(t, outDir)
+	if !strings.Contains(md, "MILESTONE") || !strings.Contains(md, "inspections reaches parity") {
+		t.Errorf("milestone must render prominently in narrative; md=\n%s", md)
+	}
+
+	// Same event through the rollup → must NOT produce a fix-queue item.
+	rollupOut := filepath.Join(tmp, "rollup")
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	if err := runFeedbackRollup(cmd, "", rollupOut, eventsDir); err != nil {
+		t.Fatalf("rollup: %v", err)
+	}
+	jb, err := os.ReadFile(filepath.Join(rollupOut, "rollup.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var r feedbackRollup
+	if err := json.Unmarshal(jb, &r); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.FixQueue) != 0 {
+		t.Errorf("milestone must not appear in fix queue; got %v", r.FixQueue)
+	}
+}
+
+// TestTimeline_NoData asserts a friendly message and no error on empty dirs.
+func TestTimeline_NoData(t *testing.T) {
+	tmp := t.TempDir()
+	out, _ := runTimeline(t, timelineOpts{
+		outDir:    filepath.Join(tmp, "out"),
+		eventsDir: filepath.Join(tmp, "events"), // does not exist
+		rpcLog:    filepath.Join(tmp, "nope.log"),
+	})
+	if !strings.Contains(out.String(), "no timeline events") {
+		t.Errorf("expected 'no timeline events' message; got %q", out.String())
+	}
+	// Outputs are still written (empty narrative) — should parse cleanly.
+	doc, md := readTimelineDoc(t, filepath.Join(tmp, "out"))
+	if len(doc.Entries) != 0 {
+		t.Errorf("expected zero entries; got %d", len(doc.Entries))
+	}
+	if !strings.Contains(md, "No timeline events") {
+		t.Errorf("expected empty-narrative note; got %q", md)
+	}
+}
+
+// ---- git test helpers ------------------------------------------------------
+
+func newTestRepo(t *testing.T, parent string) string {
+	t.Helper()
+	repo := filepath.Join(parent, "newrepo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if outB, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, outB)
+		}
+	}
+	run("init", "-q")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+	run("config", "commit.gpgsign", "false")
+	return repo
+}
+
+// gitCommit makes an empty commit at the given author/committer date with an
+// optional trailer appended to the message. Pass an explicit timezone offset in
+// isoDate (e.g. ...+00:00) so the UTC-normalized timeline is runner-TZ-stable.
+func gitCommit(t *testing.T, repo, isoDate, subject, trailer string) {
+	t.Helper()
+	msg := subject
+	if trailer != "" {
+		msg += "\n\n" + trailer
+	}
+	cmd := exec.Command("git", "-C", repo, "commit", "--allow-empty", "-q", "-m", msg)
+	// Force deterministic author + committer dates.
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_DATE="+isoDate,
+		"GIT_COMMITTER_DATE="+isoDate,
+	)
+	if outB, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, outB)
+	}
+}

--- a/internal/mcp/feedback_event.go
+++ b/internal/mcp/feedback_event.go
@@ -18,6 +18,11 @@ var feedbackOutcomes = map[string]bool{
 	"partial":            true, // answered but incomplete
 	"wrong":              true, // fabricated or contradicted the source
 	"missing_capability": true, // the thing asked for isn't extracted at all
+	// milestone is a neutral narrative beat (no quality judgment). Agents use it
+	// to mark planning decisions and parity milestones (e.g. "inspections module
+	// reaches parity"). Excluded from the rollup fix-queue, and it lets the
+	// planning phase be captured before any code exists. See #3206.
+	"milestone": true,
 }
 
 // feedbackEventsFile returns the path for today's feedback-events JSONL file.
@@ -54,7 +59,7 @@ type FeedbackEvent struct {
 	// auth, dto, testing, …) so wrong/missing outcomes map to an extractor
 	// lane. Optional, free-form.
 	Capability string `json:"capability,omitempty"`
-	// Outcome is one of helped|partial|wrong|missing_capability (required).
+	// Outcome is one of helped|partial|wrong|missing_capability|milestone (required).
 	Outcome string `json:"outcome"`
 	// Note is an optional one-line free-form detail.
 	Note string `json:"note,omitempty"`
@@ -105,7 +110,7 @@ func (s *Server) handleFeedbackEvent(ctx context.Context, req mcpapi.CallToolReq
 	}
 	if !feedbackOutcomes[outcome] {
 		return mcpapi.NewToolResultError(
-			fmt.Sprintf("archigraph_feedback_event: outcome must be one of helped|partial|wrong|missing_capability; got %q", outcome),
+			fmt.Sprintf("archigraph_feedback_event: outcome must be one of helped|partial|wrong|missing_capability|milestone; got %q", outcome),
 		), nil
 	}
 

--- a/internal/mcp/feedback_event_test.go
+++ b/internal/mcp/feedback_event_test.go
@@ -44,6 +44,27 @@ func TestFeedbackEventValidation(t *testing.T) {
 	}
 }
 
+// TestFeedbackEventMilestoneAccepted verifies the neutral "milestone" outcome
+// (#3206) is accepted by the tool.
+func TestFeedbackEventMilestoneAccepted(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
+
+	srv := newFeedbackTestServer(t)
+	res := callTool(t, srv, "archigraph_feedback_event", map[string]any{
+		"outcome": "milestone",
+		"phase":   "port:inspections",
+		"note":    "inspections module reaches parity",
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("milestone outcome should be accepted; got error: %v", resultText(res))
+	}
+	if !feedbackOutcomes["milestone"] {
+		t.Error("milestone must be in feedbackOutcomes")
+	}
+}
+
 func TestFeedbackEventJSONLAppend(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)


### PR DESCRIPTION
Supersedes #3207 (auto-closed when its stacked base branch merged + was deleted). Rebased onto main; only the timeline commit remains. Full `internal/cli` + `internal/mcp` suites green.

## What

`archigraph feedback timeline` — merges four timestamped sources into one chronological, phase-segmented story of a migration (captured from the planning phase onward):
- feedback-events JSONL (#3204) · persona-events JSONL · mcp_rpc daemon log (token cost, double-log dedup) · per-repo `git log` milestones

Emits `timeline.json` + a narrative `timeline.md`, one chapter per phase (a `planning` phase is forced first; the rest in first-seen-timestamp order), each with a quantified header (queries, tokens, outcome mix, commit milestones) and inline beats.

Adds the neutral **`milestone`** outcome to `archigraph_feedback_event`: renders as a rollup column but is excluded from the fix queue, so planning/parity beats can be captured before any code exists.

Phase assignment uses an exact `Archigraph-Phase:` git-trailer correlation when present, with a nearest-preceding-feedback-checkpoint time-window fallback.

## Tests
Merge ordering, planning-first segmentation, trailer correlation, milestone-not-in-fix-queue, and the no-data path. `go build ./cmd/archigraph`, `go vet`, gofmt all clean.

Closes #3206