### PR TITLE
[JSTS coverage] T14: Knex migration extractor (schema/FK/association/relationship)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -76,7 +76,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | 🟡 2/6 | |
+| [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟢 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟢 5/5 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -130,7 +130,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [@elastic/elasticsearch](../detail/lang.jsts.driver.elastic.md) | ✅ 1/1 | |
 | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | ✅ 1/1 | |
 | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | ✅ 7/7 | |
-| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | 🟡 2/6 | |
+| [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | ✅ 6/6 | |
 | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟢 8/8 | |
 | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | ✅ 1/1 | |
 | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟢 5/5 | |

--- a/docs/coverage/detail/lang.jsts.orm.knex.md
+++ b/docs/coverage/detail/lang.jsts.orm.knex.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | Knex is a SQL query builder, not an ORM — it has no model/entity layer to extract. Persistent model_extraction belongs to Objection.js, which layers Active-Record models on top of Knex (see lang.jsts.orm.objection). |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ✅ `full` | `2026-05-30` | 3187 | `internal/custom/javascript/knex_migrations.go`<br>`internal/custom/javascript/knex_migrations_test.go` | Knex migration schema-builder DSL: knex.schema.createTable() emits SCOPE.Schema/model table entities and t.string()/t.integer()/... column builders emit SCOPE.Component/column entities. Proven by TestKnexMigrationSchemaExtraction / TestKnexMigrationColumnExtraction. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ✅ `full` | `2026-05-30` | 3187 | `internal/custom/javascript/knex_migrations.go`<br>`internal/custom/javascript/knex_migrations_test.go` | Each migration foreign key (.references().inTable() / .foreign().references().inTable()) yields a SCOPE.Pattern/relation association edge between the local column's table and the referenced table. Proven by TestKnexMigrationAssociationExtraction. |
+| Foreign key extraction | ✅ `full` | `2026-05-30` | 3187 | `internal/custom/javascript/knex_migrations.go`<br>`internal/custom/javascript/knex_migrations_test.go` | Resolves both .references('id').inTable('users') and explicit .foreign('col').references().inTable() chains, plus the qualified single-arg .references('table.column') spelling, into SCOPE.Component/foreign_key entities with ref_table/ref_column/local_column. Proven by TestKnexMigrationForeignKeyInline / TestKnexMigrationForeignKeyExplicit / TestKnexMigrationQualifiedReference. |
 | Lazy loading recognition | — `not_applicable` | — | 3071 | — | Knex is a SQL query builder with no ORM model layer; there is no relation or lazy-loading concept to extract. Lazy loading is not applicable. |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | ✅ `full` | `2026-05-30` | 3187 | `internal/custom/javascript/knex_migrations.go`<br>`internal/custom/javascript/knex_migrations_test.go` | Migration foreign keys are the only place Knex declares table relationships; each FK emits a SCOPE.Pattern/relation entity (relation_kind=belongs_to) capturing local column → referenced table. Proven by TestKnexMigrationRelationshipExtraction. |
 
 ### Queries
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -27084,18 +27084,27 @@
             "notes": "Knex is a SQL query builder, not an ORM — it has no model/entity layer to extract. Persistent model_extraction belongs to Objection.js, which layers Active-Record models on top of Knex (see lang.jsts.orm.objection)."
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/knex_migrations.go","internal/custom/javascript/knex_migrations_test.go"],
+            "issue": "3187",
+            "notes": "Knex migration schema-builder DSL: knex.schema.createTable() emits SCOPE.Schema/model table entities and t.string()/t.integer()/... column builders emit SCOPE.Component/column entities. Proven by TestKnexMigrationSchemaExtraction / TestKnexMigrationColumnExtraction.",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/knex_migrations.go","internal/custom/javascript/knex_migrations_test.go"],
+            "issue": "3187",
+            "notes": "Each migration foreign key (.references().inTable() / .foreign().references().inTable()) yields a SCOPE.Pattern/relation association edge between the local column's table and the referenced table. Proven by TestKnexMigrationAssociationExtraction.",
+            "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/knex_migrations.go","internal/custom/javascript/knex_migrations_test.go"],
+            "issue": "3187",
+            "notes": "Resolves both .references('id').inTable('users') and explicit .foreign('col').references().inTable() chains, plus the qualified single-arg .references('table.column') spelling, into SCOPE.Component/foreign_key entities with ref_table/ref_column/local_column. Proven by TestKnexMigrationForeignKeyInline / TestKnexMigrationForeignKeyExplicit / TestKnexMigrationQualifiedReference.",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
             "status": "not_applicable",
@@ -27103,8 +27112,11 @@
             "notes": "Knex is a SQL query builder with no ORM model layer; there is no relation or lazy-loading concept to extract. Lazy loading is not applicable."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/javascript/knex_migrations.go","internal/custom/javascript/knex_migrations_test.go"],
+            "issue": "3187",
+            "notes": "Migration foreign keys are the only place Knex declares table relationships; each FK emits a SCOPE.Pattern/relation entity (relation_kind=belongs_to) capturing local column → referenced table. Proven by TestKnexMigrationRelationshipExtraction.",
+            "verified_at": "2026-05-30"
           }
         },
         "Queries": {

--- a/internal/custom/javascript/knex_migrations.go
+++ b/internal/custom/javascript/knex_migrations.go
@@ -1,0 +1,284 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// knexMigrationsExtractor parses Knex migration / knexfile sources for the
+// schema-builder DSL and recovers the relational structure that the query-builder
+// expresses imperatively:
+//
+//   - knex.schema.createTable('users', (t) => { ... })  → table schema (SCOPE.Schema)
+//   - t.string('name') / t.integer('age') / ...         → columns      (SCOPE.Component/column)
+//   - t.integer('author_id')
+//     .references('id').inTable('users')             → foreign key  (SCOPE.Component/foreign_key)
+//   - t.foreign('author_id')
+//     .references('id').inTable('users')             → foreign key  (SCOPE.Component/foreign_key)
+//   - each FK additionally yields a relationship/association edge        (SCOPE.Pattern/relation)
+//
+// Knex is a query/schema builder (not an ORM), so there is no decorator/model
+// layer — the *migration* DDL is the only place the schema and its foreign-key
+// relationships are declared. This extractor therefore powers the
+// schema_extraction / foreign_key_extraction / association_extraction /
+// relationship_extraction capabilities for lang.jsts.orm.knex.
+//
+// The base knex.go extractor already emits migration-evolution ops
+// (create_table / add_column / index, SCOPE.Evolution) for migration_parsing;
+// this extractor is additive and emits the *relational* view. The two are
+// deduped downstream by (Kind, Name, Subtype), so the differing kinds coexist.
+func init() {
+	extreg.Register("custom_js_knex_migrations", &knexMigrationsExtractor{})
+}
+
+type knexMigrationsExtractor struct{}
+
+func (e *knexMigrationsExtractor) Language() string { return "custom_js_knex_migrations" }
+
+var (
+	// knex.schema.createTable('users', ...) — also createTableIfNotExists/alterTable/table.
+	// Group 1 = method, group 2 = table name literal.
+	reKnexMigTable = regexp.MustCompile(
+		`\.\s*(createTable|createTableIfNotExists|alterTable|table)\s*\(\s*['"]([A-Za-z0-9_.]+)['"]`,
+	)
+	// Column builder calls inside a table closure: t.string('name'), t.integer('age'),
+	// t.specificType('geom', 'point'). Group 1 = builder method, group 2 = column name.
+	reKnexMigColumn = regexp.MustCompile(
+		`\.\s*(increments|bigIncrements|integer|bigInteger|tinyint|smallint|mediumint|bigint|text|mediumtext|longtext|string|varchar|char|float|double|decimal|boolean|date|datetime|timestamp|time|binary|json|jsonb|uuid|enu|enum|specificType|geometry|point)\s*\(\s*['"]([A-Za-z0-9_]+)['"]`,
+	)
+	// Explicit foreign-key declaration: t.foreign('author_id').
+	// Group 1 = local column name.
+	reKnexMigForeign = regexp.MustCompile(
+		`\.\s*foreign\s*\(\s*['"]([A-Za-z0-9_]+)['"]`,
+	)
+	// FK target chain: .references('id').inTable('users')  (two-arg form) OR
+	//                  .references('users.id')              (qualified single-arg form).
+	// We match the .references(...) call and resolve .inTable(...) separately so
+	// either spelling produces a foreign_key + relation edge.
+	//
+	// reKnexMigReferences group 1 = referenced column or "table.column" literal.
+	reKnexMigReferences = regexp.MustCompile(
+		`\.\s*references\s*\(\s*['"]([A-Za-z0-9_.]+)['"]\s*\)`,
+	)
+	// .inTable('users') — referenced table for the immediately-preceding .references().
+	reKnexMigInTable = regexp.MustCompile(
+		`\.\s*inTable\s*\(\s*['"]([A-Za-z0-9_.]+)['"]\s*\)`,
+	)
+)
+
+func (e *knexMigrationsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.knex_migrations_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "knex"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+
+	// Gate to plausible Knex migration / knexfile sources to avoid emitting
+	// schema entities for unrelated table.* method calls in arbitrary code.
+	if !looksLikeKnexMigration(file.Path, src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// --- schema_extraction: tables -------------------------------------------
+	for _, m := range reKnexMigTable.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		table := src[m[4]:m[5]]
+		ent := makeEntity(table, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "knex", "table", table, "builder_method", method,
+			"provenance", "INFERRED_FROM_KNEX_MIGRATION_TABLE")
+		addEntity(ent)
+	}
+
+	// --- schema_extraction: columns ------------------------------------------
+	for _, m := range reKnexMigColumn.FindAllStringSubmatchIndex(src, -1) {
+		colType := src[m[2]:m[3]]
+		colName := src[m[4]:m[5]]
+		ent := makeEntity(colName, "SCOPE.Component", "column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "knex", "column", colName, "column_type", colType,
+			"provenance", "INFERRED_FROM_KNEX_MIGRATION_COLUMN")
+		addEntity(ent)
+	}
+
+	// --- foreign_key / association / relationship ----------------------------
+	// A foreign key in Knex is expressed as a .references()[.inTable()] chain,
+	// optionally anchored by .foreign('col') or .integer('col'). We collect the
+	// local column from the nearest preceding .foreign()/column builder and the
+	// referenced (table, column) from the .references()/.inTable() chain.
+	localCols := columnAnchors(src)
+	inTables := reKnexMigInTable.FindAllStringSubmatchIndex(src, -1)
+
+	for _, m := range reKnexMigReferences.FindAllStringSubmatchIndex(src, -1) {
+		refLiteral := src[m[2]:m[3]]
+		refOffset := m[0]
+
+		refTable, refCol := "", refLiteral
+		if dot := strings.LastIndex(refLiteral, "."); dot >= 0 {
+			// qualified "table.column" form
+			refTable = refLiteral[:dot]
+			refCol = refLiteral[dot+1:]
+		} else if it := nextInTableAfter(inTables, src, m[1]); it != "" {
+			// ".references('id').inTable('users')" form
+			refTable = it
+		}
+
+		localCol := nearestAnchorBefore(localCols, refOffset)
+
+		// foreign_key entity (foreign_key_extraction).
+		fkName := "fk:" + refLiteral
+		if localCol != "" {
+			fkName = fmt.Sprintf("fk:%s->%s", localCol, refLiteral)
+		}
+		fk := makeEntity(fkName, "SCOPE.Component", "foreign_key", file.Path, file.Language, lineOf(src, refOffset))
+		props := []string{
+			"framework", "knex",
+			"ref_column", refCol,
+			"provenance", "INFERRED_FROM_KNEX_MIGRATION_FK",
+		}
+		if refTable != "" {
+			props = append(props, "ref_table", refTable)
+		}
+		if localCol != "" {
+			props = append(props, "local_column", localCol)
+		}
+		setProps(&fk, props...)
+		addEntity(fk)
+
+		// relationship / association entity (relationship_extraction + association_extraction).
+		// Both capabilities are proven by the same FK-derived relation record:
+		// the migration's foreign key *is* the association between the two tables.
+		relName := "relation:" + refLiteral
+		if refTable != "" {
+			relName = "relation:->" + refTable
+			if localCol != "" {
+				relName = fmt.Sprintf("relation:%s->%s", localCol, refTable)
+			}
+		}
+		rel := makeEntity(relName, "SCOPE.Pattern", "relation", file.Path, file.Language, lineOf(src, refOffset))
+		relProps := []string{
+			"framework", "knex",
+			"relation_kind", "belongs_to",
+			"provenance", "INFERRED_FROM_KNEX_MIGRATION_FK",
+		}
+		if refTable != "" {
+			relProps = append(relProps, "ref_table", refTable)
+		}
+		if localCol != "" {
+			relProps = append(relProps, "local_column", localCol)
+		}
+		setProps(&rel, relProps...)
+		addEntity(rel)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// looksLikeKnexMigration returns true when the file path or content indicates a
+// Knex migration / knexfile rather than arbitrary source that happens to call a
+// method named table()/foreign().
+func looksLikeKnexMigration(path, src string) bool {
+	p := filepath.ToSlash(path)
+	base := strings.ToLower(filepath.Base(p))
+	if base == "knexfile.js" || base == "knexfile.ts" {
+		return true
+	}
+	inMigrationsDir := strings.Contains(p, "/migrations/") || strings.HasPrefix(p, "migrations/")
+	// Knex migration files export up/down and drive a schema builder.
+	hasSchemaBuilder := strings.Contains(src, ".schema.") ||
+		reKnexMigTable.MatchString(src)
+	if inMigrationsDir && hasSchemaBuilder {
+		return true
+	}
+	// Fall back to a strong content signal: a knex schema builder chain plus an
+	// FK/column DSL call. This catches inline migrations and seed/setup files.
+	if strings.Contains(src, ".schema.") && (reKnexMigForeign.MatchString(src) || reKnexMigReferences.MatchString(src) || reKnexMigTable.MatchString(src)) {
+		return true
+	}
+	return false
+}
+
+// anchor records a local FK-candidate column and the byte offset where it was declared.
+type anchor struct {
+	col    string
+	offset int
+}
+
+// columnAnchors collects all local-column declarations that can anchor a
+// subsequent .references() chain: explicit .foreign('col') calls and column
+// builders (t.integer('author_id')). Returned in source order.
+func columnAnchors(src string) []anchor {
+	var out []anchor
+	for _, m := range reKnexMigForeign.FindAllStringSubmatchIndex(src, -1) {
+		out = append(out, anchor{col: src[m[2]:m[3]], offset: m[0]})
+	}
+	for _, m := range reKnexMigColumn.FindAllStringSubmatchIndex(src, -1) {
+		out = append(out, anchor{col: src[m[4]:m[5]], offset: m[0]})
+	}
+	// Sort by offset so nearestAnchorBefore can scan in source order.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1].offset > out[j].offset; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// nearestAnchorBefore returns the column of the anchor with the greatest offset
+// strictly less than refOffset (the column that the .references() chain modifies).
+func nearestAnchorBefore(anchors []anchor, refOffset int) string {
+	col := ""
+	for _, a := range anchors {
+		if a.offset < refOffset {
+			col = a.col
+			continue
+		}
+		break
+	}
+	return col
+}
+
+// nextInTableAfter returns the table named by the first .inTable(...) match
+// whose start offset is at or after the given offset (the referenced table for
+// a two-arg .references('col').inTable('table') chain).
+func nextInTableAfter(inTables [][]int, src string, afterOffset int) string {
+	for _, m := range inTables {
+		if m[0] >= afterOffset {
+			return src[m[2]:m[3]]
+		}
+	}
+	return ""
+}

--- a/internal/custom/javascript/knex_migrations_test.go
+++ b/internal/custom/javascript/knex_migrations_test.go
@@ -1,0 +1,131 @@
+package javascript_test
+
+// Tests for issue #3187: Knex migration extractor (custom_js_knex_migrations).
+// Proves schema_extraction, foreign_key_extraction, association_extraction and
+// relationship_extraction for lang.jsts.orm.knex from the schema-builder DSL in
+// Knex migration files.
+//
+// These are the *proving fixtures* cited by the registry. They live in a
+// dedicated _test.go file (not the shared extractors_test.go).
+
+import (
+	"testing"
+)
+
+// goldenKnexMigration is a representative Knex migration exercising every
+// extracted pattern: createTable, column builders, an inline .references()
+// .inTable() FK, and an explicit .foreign().references().inTable() FK.
+const goldenKnexMigration = `
+exports.up = function (knex) {
+  return knex.schema
+    .createTable('users', (table) => {
+      table.increments('id').primary()
+      table.string('name').notNullable()
+      table.string('email').unique()
+    })
+    .createTable('posts', (table) => {
+      table.increments('id').primary()
+      table.string('title')
+      table.text('body')
+      table.integer('author_id').references('id').inTable('users')
+      table.integer('editor_id')
+      table.foreign('editor_id').references('id').inTable('users')
+    })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('posts').dropTableIfExists('users')
+}
+`
+
+func TestKnexMigrationSchemaExtraction(t *testing.T) {
+	ents := extract(t, "custom_js_knex_migrations", fi("migrations/001_init.js", "javascript", goldenKnexMigration))
+	if !containsEntity(ents, "SCOPE.Schema", "users") {
+		t.Error("expected users table schema entity (schema_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "posts") {
+		t.Error("expected posts table schema entity (schema_extraction)")
+	}
+}
+
+func TestKnexMigrationColumnExtraction(t *testing.T) {
+	ents := extract(t, "custom_js_knex_migrations", fi("migrations/001_init.js", "javascript", goldenKnexMigration))
+	if !containsEntity(ents, "SCOPE.Component", "name") {
+		t.Error("expected column entity 'name' (schema_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "email") {
+		t.Error("expected column entity 'email' (schema_extraction)")
+	}
+	if !containsSubtype(ents, "column") {
+		t.Error("expected column subtype entities from Knex column builders")
+	}
+}
+
+func TestKnexMigrationForeignKeyInline(t *testing.T) {
+	ents := extract(t, "custom_js_knex_migrations", fi("migrations/001_init.js", "javascript", goldenKnexMigration))
+	if !containsSubtype(ents, "foreign_key") {
+		t.Error("expected foreign_key entity from .references().inTable() chain (foreign_key_extraction)")
+	}
+	// The inline FK should resolve the local column author_id and ref table users.
+	if !containsEntity(ents, "SCOPE.Component", "fk:author_id->id") {
+		t.Error("expected fk:author_id->id foreign_key entity for inline .references('id').inTable('users')")
+	}
+}
+
+func TestKnexMigrationForeignKeyExplicit(t *testing.T) {
+	ents := extract(t, "custom_js_knex_migrations", fi("migrations/001_init.js", "javascript", goldenKnexMigration))
+	// The explicit t.foreign('editor_id').references('id').inTable('users') FK.
+	if !containsEntity(ents, "SCOPE.Component", "fk:editor_id->id") {
+		t.Error("expected fk:editor_id->id foreign_key entity for explicit .foreign().references().inTable()")
+	}
+}
+
+func TestKnexMigrationRelationshipExtraction(t *testing.T) {
+	ents := extract(t, "custom_js_knex_migrations", fi("migrations/001_init.js", "javascript", goldenKnexMigration))
+	if !containsSubtype(ents, "relation") {
+		t.Error("expected relation entity derived from FK (relationship_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "relation:author_id->users") {
+		t.Error("expected relation:author_id->users entity (association_extraction + relationship_extraction)")
+	}
+}
+
+func TestKnexMigrationAssociationExtraction(t *testing.T) {
+	ents := extract(t, "custom_js_knex_migrations", fi("migrations/001_init.js", "javascript", goldenKnexMigration))
+	// The association between posts.editor_id and users is the same FK-derived relation.
+	if !containsEntity(ents, "SCOPE.Pattern", "relation:editor_id->users") {
+		t.Error("expected relation:editor_id->users entity (association_extraction)")
+	}
+}
+
+// TestKnexMigrationQualifiedReference proves the single-arg qualified
+// .references('users.id') spelling is also resolved.
+func TestKnexMigrationQualifiedReference(t *testing.T) {
+	src := `
+exports.up = (knex) =>
+  knex.schema.createTable('comments', (table) => {
+    table.increments('id')
+    table.integer('post_id').references('posts.id')
+  })
+`
+	ents := extract(t, "custom_js_knex_migrations", fi("migrations/002_comments.ts", "typescript", src))
+	if !containsSubtype(ents, "foreign_key") {
+		t.Error("expected foreign_key entity for qualified .references('posts.id')")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "relation:post_id->posts") {
+		t.Error("expected relation:post_id->posts entity for qualified reference")
+	}
+}
+
+// TestKnexMigrationNonMigrationNoop proves the extractor gates on Knex-shaped
+// sources and does not emit schema entities for arbitrary table.* calls.
+func TestKnexMigrationNonMigrationNoop(t *testing.T) {
+	src := `
+const table = document.querySelector('table')
+table.string('not-a-column')
+`
+	ents := extract(t, "custom_js_knex_migrations", fi("ui/widget.ts", "typescript", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-Knex source, got %d", len(ents))
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -4799,3 +4799,51 @@ records:
             - file: internal/extractors/python/types_test.go
           issues_implemented: ["2989"]
           verified_at: "2026-05-29"
+
+  lang.jsts.orm.knex:
+    capabilities:
+      Models:
+        schema_extraction:
+          # #3187: knex.schema.createTable() -> SCOPE.Schema tables;
+          # t.string()/t.integer()/... column builders -> SCOPE.Component columns.
+          status: full
+          symbols:
+            - file: internal/custom/javascript/knex_migrations.go
+              functions: [Extract, looksLikeKnexMigration]
+          tests:
+            - file: internal/custom/javascript/knex_migrations_test.go
+          issues_implemented: ["3187"]
+          verified_at: "2026-05-30"
+      Relationships:
+        association_extraction:
+          # #3187: each migration FK yields a SCOPE.Pattern/relation association edge.
+          status: full
+          symbols:
+            - file: internal/custom/javascript/knex_migrations.go
+              functions: [Extract, columnAnchors, nearestAnchorBefore, nextInTableAfter]
+          tests:
+            - file: internal/custom/javascript/knex_migrations_test.go
+          issues_implemented: ["3187"]
+          verified_at: "2026-05-30"
+        foreign_key_extraction:
+          # #3187: .references().inTable() and .foreign().references().inTable()
+          # chains, plus qualified .references('table.col') -> SCOPE.Component/foreign_key.
+          status: full
+          symbols:
+            - file: internal/custom/javascript/knex_migrations.go
+              functions: [Extract, columnAnchors, nearestAnchorBefore, nextInTableAfter]
+          tests:
+            - file: internal/custom/javascript/knex_migrations_test.go
+          issues_implemented: ["3187"]
+          verified_at: "2026-05-30"
+        relationship_extraction:
+          # #3187: migration FKs are the only place Knex declares relationships;
+          # each emits a SCOPE.Pattern/relation (relation_kind=belongs_to).
+          status: full
+          symbols:
+            - file: internal/custom/javascript/knex_migrations.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/javascript/knex_migrations_test.go
+          issues_implemented: ["3187"]
+          verified_at: "2026-05-30"


### PR DESCRIPTION
## Summary
Implements **#3187**: a new Knex migration extractor that recovers the relational structure Knex declares imperatively in migration / knexfile sources, and flips the four `lang.jsts.orm.knex` capability cells (`schema_extraction`, `foreign_key_extraction`, `association_extraction`, `relationship_extraction`) from `missing` → `full`.

Knex is a query/schema builder with no model layer, so the **migration DDL is the only place** the schema and its foreign-key relationships are declared.

## What's new
New file `internal/custom/javascript/knex_migrations.go` registering `custom_js_knex_migrations` (auto-dispatched for js/ts via the existing `custom_js_` prefix). It emits:

| Pattern | Entity | Capability |
|---|---|---|
| `knex.schema.createTable('users', ...)` | `SCOPE.Schema` / `model` | schema_extraction |
| `t.string('name')` / `t.integer('age')` / … | `SCOPE.Component` / `column` | schema_extraction |
| `t.integer('author_id').references('id').inTable('users')` | `SCOPE.Component` / `foreign_key` | foreign_key_extraction |
| `t.foreign('editor_id').references('id').inTable('users')` | `SCOPE.Component` / `foreign_key` | foreign_key_extraction |
| qualified `.references('posts.id')` | `SCOPE.Component` / `foreign_key` | foreign_key_extraction |
| each FK | `SCOPE.Pattern` / `relation` (`relation_kind=belongs_to`) | relationship_extraction + association_extraction |

FK chains resolve the local column from the nearest preceding `.foreign()`/column builder and the referenced `(table, column)` from the `.references()`/`.inTable()` chain (both the two-arg and qualified single-arg spellings).

### Design notes
- **Additive, not a replacement.** The existing `knex.go` keeps emitting `SCOPE.Evolution` migration ops for `migration_parsing`; this extractor emits the *relational* view. The two coexist (deduped downstream by `Kind`/`Name`/`Subtype`).
- **Gated** by `looksLikeKnexMigration` (knexfile, `migrations/` dir + schema-builder, or strong `.schema.` + FK/table content signal) so arbitrary `table.*`/`foreign()` calls in unrelated code don't produce spurious schema entities — proven by `TestKnexMigrationNonMigrationNoop`.

## Proving fixtures
Dedicated `internal/custom/javascript/knex_migrations_test.go` (NOT the shared `extractors_test.go`) with a golden migration covering createTable + columns + inline FK + explicit `.foreign()` FK + qualified reference + the no-op gate. All four cells are cited to the extractor + this test file; each cell is `full` because the fixture proves it.

## Honesty / NA calls
- No cells flipped to `partial` — every targeted cell has a proving fixture, so all four are honest `full`.
- `lazy_loading_recognition` and `model_extraction` for knex remain `not_applicable` (unchanged) — Knex has no ORM model/relation layer; lazy loading and persistent models belong to Objection.js.

## Validation
- `go build ./...` ✓
- `go test ./internal/custom/javascript/... ./internal/extractors/... ./internal/types/ ./tools/coverage/...` ✓
- `go run ./tools/coverage validate` → 0 errors (pre-existing warnings only)
- `coverage fmt --check` → canonical ✓
- `coverage gen` → byte-stable (regenerated docs committed)
- `gofmt -l` on touched files → empty ✓

Closes #3187

🤖 Generated with [Claude Code](https://claude.com/claude-code)