### PR TITLE
feat(coverage): Python raw-driver schema_extraction (mysql/postgres/sqlite) [#3189]

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -116,7 +116,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟢 6/6 | |
 | [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |
 | [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟢 6/6 | |
-| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟡 1/2 | |
+| [python](../by-language/python.md) | [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟢 2/2 | |
 | [python](../by-language/python.md) | [Peewee](../detail/lang.python.orm.peewee.md) | 🟢 6/6 | |
 | [python](../by-language/python.md) | [Pony ORM](../detail/lang.python.orm.pony.md) | 🟢 6/6 | |
 | [python](../by-language/python.md) | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 8/8 | |
@@ -126,9 +126,9 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [python](../by-language/python.md) | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | 🟢 1/1 | |
 | [python](../by-language/python.md) | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | 🟢 1/1 | |
 | [python](../by-language/python.md) | [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | 🟢 1/1 | |
-| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | 🟡 1/2 | |
+| [python](../by-language/python.md) | [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | 🟢 2/2 | |
 | [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | ✅ 1/1 | |
-| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟡 1/2 | |
+| [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟢 2/2 | |
 | [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟡 1/6 | |
 | [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | 🟡 2/8 | |
 | [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟡 2/8 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -92,7 +92,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟢 6/6 | |
 | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |
 | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟢 6/6 | |
-| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟡 1/2 | |
+| [MySQL (PyMySQL / mysqlclient)](../detail/lang.python.driver.mysql.md) | 🟢 2/2 | |
 | [Peewee](../detail/lang.python.orm.peewee.md) | 🟢 6/6 | |
 | [Pony ORM](../detail/lang.python.orm.pony.md) | 🟢 6/6 | |
 | [SQLAlchemy](../detail/lang.python.orm.sqlalchemy.md) | ✅ 8/8 | |
@@ -102,9 +102,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [cassandra-driver](../detail/lang.python.driver.cassandra.md) | 🟢 1/1 | |
 | [elasticsearch-py](../detail/lang.python.driver.elastic.md) | 🟢 1/1 | |
 | [neo4j (Python driver)](../detail/lang.python.driver.neo4j.md) | 🟢 1/1 | |
-| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | 🟡 1/2 | |
+| [psycopg / asyncpg (PostgreSQL drivers)](../detail/lang.python.driver.postgres.md) | 🟢 2/2 | |
 | [redis-py](../detail/lang.python.driver.redis.md) | ✅ 1/1 | |
-| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟡 1/2 | |
+| [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟢 2/2 | |
 
 
 ## Other

--- a/docs/coverage/detail/lang.python.driver.mysql.md
+++ b/docs/coverage/detail/lang.python.driver.mysql.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3189 | `internal/custom/python/driver_schema.go` | Heuristic: parses CREATE TABLE DDL embedded in raw-driver cursor.execute(...) string literals into SCOPE.Schema table + column entities. Single-literal SQL only; string-concatenated DDL not stitched. |
 
 ### Relationships
 

--- a/docs/coverage/detail/lang.python.driver.postgres.md
+++ b/docs/coverage/detail/lang.python.driver.postgres.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3189 | `internal/custom/python/driver_schema.go` | Heuristic: parses CREATE TABLE DDL embedded in raw-driver cursor.execute(...) string literals into SCOPE.Schema table + column entities. Single-literal SQL only; string-concatenated DDL not stitched. |
 
 ### Relationships
 

--- a/docs/coverage/detail/lang.python.driver.sqlite.md
+++ b/docs/coverage/detail/lang.python.driver.sqlite.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3189 | `internal/custom/python/driver_schema.go` | Heuristic: parses CREATE TABLE DDL embedded in raw-driver cursor.execute(...) string literals into SCOPE.Schema table + column entities. Single-literal SQL only; executescript multi-statement DDL supported. |
 
 ### Relationships
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -33592,8 +33592,11 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/driver_schema.go"],
+            "issue": "3189",
+            "notes": "Heuristic: parses CREATE TABLE DDL embedded in raw-driver cursor.execute(...) string literals into SCOPE.Schema table + column entities. Single-literal SQL only; string-concatenated DDL not stitched.",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
@@ -33688,8 +33691,11 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/driver_schema.go"],
+            "issue": "3189",
+            "notes": "Heuristic: parses CREATE TABLE DDL embedded in raw-driver cursor.execute(...) string literals into SCOPE.Schema table + column entities. Single-literal SQL only; string-concatenated DDL not stitched.",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
@@ -33786,8 +33792,11 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/driver_schema.go"],
+            "issue": "3189",
+            "notes": "Heuristic: parses CREATE TABLE DDL embedded in raw-driver cursor.execute(...) string literals into SCOPE.Schema table + column entities. Single-literal SQL only; executescript multi-statement DDL supported.",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {

--- a/internal/custom/python/driver_schema.go
+++ b/internal/custom/python/driver_schema.go
@@ -1,0 +1,238 @@
+package python
+
+// driver_schema.go — raw-driver schema extraction for the MySQL, PostgreSQL,
+// and SQLite Python drivers (pymysql / mysqlclient, psycopg2 / asyncpg,
+// sqlite3).
+//
+// Issue #3189 — Raw driver schema_extraction extractor (mysql/postgres/sqlite).
+//
+// Pattern: raw drivers do not model schema as Python classes; instead the
+// schema is embedded in SQL string literals passed to `cursor.execute(...)`
+// (or `cur.executescript(...)`, `conn.execute(...)`, etc.). This extractor
+// scans for `CREATE TABLE` SQL embedded in such calls, parses the table name
+// and column definitions from the SQL body, and emits SCOPE.Schema entities:
+//
+//   - one table-level entity per `CREATE TABLE`
+//   - one column-level entity (subtype=column) per column definition
+//
+// This is heuristic (regex over embedded SQL string literals), so the
+// corresponding registry cells are flipped to `partial`, not `full`.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_driver_schema", &DriverSchemaExtractor{})
+}
+
+// DriverSchemaExtractor emits SCOPE.Schema entities for CREATE TABLE
+// statements embedded in raw-driver `cursor.execute(...)` calls.
+type DriverSchemaExtractor struct{}
+
+func (e *DriverSchemaExtractor) Language() string { return "python_driver_schema" }
+
+var (
+	// driverImportRe gates the extractor: the file must import one of the
+	// three supported raw drivers. Without one of these we bail early so we
+	// don't misattribute ORM-generated DDL (SQLAlchemy etc.) to a raw driver.
+	driverImportRe = regexp.MustCompile(
+		`(?m)^\s*(?:import|from)\s+(pymysql|MySQLdb|mysql\.connector|psycopg2|psycopg|asyncpg|sqlite3|aiosqlite)\b`)
+
+	// driverExecuteRe matches a driver execute-style call whose first
+	// argument begins a string literal. We capture the call name to record
+	// provenance and the opening quote so we can read the literal.
+	//   cursor.execute("CREATE TABLE ...")
+	//   cur.executescript('''CREATE TABLE ...''')
+	//   await conn.execute(r"CREATE TABLE ...")
+	driverExecuteRe = regexp.MustCompile(
+		`(?:\.|\b)(execute|executescript|executemany)\s*\(\s*[rbuRBU]*("""|'''|"|')`)
+
+	// createTableRe matches the head of a CREATE TABLE statement inside an
+	// SQL string and captures the (optionally schema-qualified, optionally
+	// quoted) table name.
+	createTableRe = regexp.MustCompile(
+		"(?is)CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?[`\"']?([A-Za-z_][A-Za-z0-9_.]*)[`\"']?\\s*\\(")
+
+	// sqlColumnRe matches a single column definition line inside the
+	// parenthesised body of a CREATE TABLE. Captures the column name and the
+	// type token that follows it.
+	//   id INTEGER PRIMARY KEY
+	//   `name` VARCHAR(255) NOT NULL
+	//   "created_at" TIMESTAMP DEFAULT now()
+	sqlColumnRe = regexp.MustCompile(
+		"(?im)^\\s*[`\"']?([A-Za-z_][A-Za-z0-9_]*)[`\"']?\\s+([A-Za-z][A-Za-z0-9_]*)")
+
+	// sqlConstraintLead flags lines that open a table-level constraint rather
+	// than a column definition; these are skipped.
+	sqlConstraintLead = map[string]bool{
+		"PRIMARY": true, "FOREIGN": true, "UNIQUE": true, "CONSTRAINT": true,
+		"CHECK": true, "KEY": true, "INDEX": true, "FULLTEXT": true, "SPATIAL": true,
+	}
+)
+
+// driverFor maps an import-detected driver token to a stable framework label.
+func driverFrameworks(source string) []string {
+	var fws []string
+	add := func(token, fw string) {
+		if regexp.MustCompile(`(?m)^\s*(?:import|from)\s+` + regexp.QuoteMeta(token) + `\b`).MatchString(source) {
+			fws = append(fws, fw)
+		}
+	}
+	add("pymysql", "mysql")
+	add("MySQLdb", "mysql")
+	add("mysql.connector", "mysql")
+	add("psycopg2", "postgres")
+	add("psycopg", "postgres")
+	add("asyncpg", "postgres")
+	add("sqlite3", "sqlite")
+	add("aiosqlite", "sqlite")
+	return fws
+}
+
+// closingDelim returns the delimiter that terminates a string literal opened
+// with the given opening delimiter.
+func closingDelim(open string) string { return open }
+
+// readStringLiteral returns the contents of a string literal that starts at
+// position open (the index of the first delimiter char) given the opening
+// delimiter. It returns the literal body and the index just past the closing
+// delimiter. If unterminated, end is len(source).
+func readStringLiteral(source string, bodyStart int, delim string) (string, int) {
+	idx := strings.Index(source[bodyStart:], delim)
+	if idx < 0 {
+		return source[bodyStart:], len(source)
+	}
+	return source[bodyStart : bodyStart+idx], bodyStart + idx + len(delim)
+}
+
+// firstFramework picks a deterministic framework when the SQL dialect is
+// ambiguous: prefer the order mysql, postgres, sqlite.
+func firstFramework(fws []string) string {
+	for _, want := range []string{"mysql", "postgres", "sqlite"} {
+		for _, f := range fws {
+			if f == want {
+				return want
+			}
+		}
+	}
+	if len(fws) > 0 {
+		return fws[0]
+	}
+	return ""
+}
+
+func (e *DriverSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_driver_schema")
+	_, span := tracer.Start(ctx, "custom.python_driver_schema")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+
+	// Cheap gates: must import a supported driver and contain CREATE TABLE.
+	if !driverImportRe.MatchString(source) {
+		return nil, nil
+	}
+	if !strings.Contains(strings.ToUpper(source), "CREATE TABLE") {
+		return nil, nil
+	}
+
+	fws := driverFrameworks(source)
+	framework := firstFramework(fws)
+	if framework == "" {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenTables := make(map[string]bool)
+
+	for _, idx := range allMatchesIndex(driverExecuteRe, source) {
+		callName := source[idx[2]:idx[3]]
+		delim := source[idx[4]:idx[5]]
+		bodyStart := idx[5]
+		literal, _ := readStringLiteral(source, bodyStart, closingDelim(delim))
+
+		// Parse every CREATE TABLE inside this literal (executescript may hold
+		// several).
+		for _, ct := range createTableRe.FindAllStringSubmatchIndex(literal, -1) {
+			tableName := literal[ct[2]:ct[3]]
+			// Strip a schema qualifier (public.users -> users) for the name.
+			displayTable := tableName
+			if dot := strings.LastIndex(displayTable, "."); dot >= 0 {
+				displayTable = displayTable[dot+1:]
+			}
+
+			// Line number = line of the execute call + offset of CREATE inside
+			// the literal.
+			tableLine := lineOf(source, idx[0]) + strings.Count(literal[:ct[0]], "\n")
+
+			if !seenTables[displayTable] {
+				seenTables[displayTable] = true
+				out = append(out, entity(displayTable, "SCOPE.Schema", "", file.Path, tableLine,
+					map[string]string{
+						"framework":    framework,
+						"pattern_type": "table",
+						"table_name":   displayTable,
+						"driver_call":  callName,
+						"source":       "raw_sql_ddl",
+					}))
+			}
+
+			// Extract the parenthesised column body.
+			bodyOpen := ct[1] // index just past the "(" captured by createTableRe
+			colBody := balancedParenBody(literal, bodyOpen-1)
+			for _, cm := range sqlColumnRe.FindAllStringSubmatchIndex(colBody, -1) {
+				colName := colBody[cm[2]:cm[3]]
+				colType := colBody[cm[4]:cm[5]]
+				if sqlConstraintLead[strings.ToUpper(colName)] {
+					continue
+				}
+				colLine := tableLine + strings.Count(colBody[:cm[0]], "\n")
+				out = append(out, entity(displayTable+"."+colName, "SCOPE.Schema", "column", file.Path, colLine,
+					map[string]string{
+						"framework":    framework,
+						"pattern_type": "column",
+						"column_type":  strings.ToUpper(colType),
+						"parent_table": displayTable,
+						"source":       "raw_sql_ddl",
+					}))
+			}
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// balancedParenBody returns the text between the parenthesis at openIdx and
+// its matching close paren (exclusive of both). openIdx must point at a "(".
+func balancedParenBody(s string, openIdx int) string {
+	if openIdx < 0 || openIdx >= len(s) || s[openIdx] != '(' {
+		return ""
+	}
+	depth := 0
+	for i := openIdx; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[openIdx+1 : i]
+			}
+		}
+	}
+	return s[openIdx+1:]
+}

--- a/internal/custom/python/driver_schema_test.go
+++ b/internal/custom/python/driver_schema_test.go
@@ -1,0 +1,151 @@
+package python_test
+
+// driver_schema_test.go — proving fixtures for the raw-driver schema
+// extractor (mysql/postgres/sqlite). Dedicated to issue #3189.
+//
+// These tests assert that CREATE TABLE DDL embedded in raw-driver
+// cursor.execute(...) string literals is parsed into SCOPE.Schema table and
+// column entities for each of the three supported drivers.
+
+import "testing"
+
+// findDriverEntity returns the first entity matching name+kind, or nil.
+func findDriverEntity(result []extractResult, name, kind string) *extractResult {
+	for i := range result {
+		if result[i].Name == name && result[i].Kind == kind {
+			return &result[i]
+		}
+	}
+	return nil
+}
+
+// driverColumnNames returns the column entity names belonging to a parent table.
+func driverColumnNames(result []extractResult, parentTable string) map[string]string {
+	cols := make(map[string]string)
+	for _, e := range result {
+		if e.Kind != "SCOPE.Schema" || e.Subtype != "column" {
+			continue
+		}
+		if e.Props["parent_table"] == parentTable {
+			cols[e.Name] = e.Props["column_type"]
+		}
+	}
+	return cols
+}
+
+// ---------------------------------------------------------------------------
+// MySQL (pymysql)
+// ---------------------------------------------------------------------------
+
+func TestDriverSchema_MySQL(t *testing.T) {
+	src := fixtureSchema(t, "driver_schema_mysql.py")
+	ents := extract(t, "python_driver_schema", src)
+
+	users := findDriverEntity(ents, "users", "SCOPE.Schema")
+	if users == nil {
+		t.Fatal("expected users table entity")
+	}
+	if users.Props["framework"] != "mysql" || users.Props["pattern_type"] != "table" {
+		t.Fatalf("users props wrong: %+v", users.Props)
+	}
+	if users.Props["driver_call"] != "execute" {
+		t.Fatalf("expected driver_call=execute, got %q", users.Props["driver_call"])
+	}
+
+	cols := driverColumnNames(ents, "users")
+	for _, want := range []string{"users.id", "users.username", "users.email", "users.created_at"} {
+		if _, ok := cols[want]; !ok {
+			t.Fatalf("expected column %q, got %v", want, cols)
+		}
+	}
+	// Column types are uppercased.
+	if cols["users.username"] != "VARCHAR" {
+		t.Fatalf("expected username VARCHAR, got %q", cols["users.username"])
+	}
+	// Table-level constraint (UNIQUE KEY) must NOT be emitted as a column.
+	if _, leaked := cols["users.UNIQUE"]; leaked {
+		t.Fatal("UNIQUE KEY constraint leaked as a column")
+	}
+
+	if findDriverEntity(ents, "orders", "SCOPE.Schema") == nil {
+		t.Fatal("expected orders table entity")
+	}
+	ocols := driverColumnNames(ents, "orders")
+	if ocols["orders.total"] != "DECIMAL" {
+		t.Fatalf("expected orders.total DECIMAL, got %q", ocols["orders.total"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PostgreSQL (psycopg2)
+// ---------------------------------------------------------------------------
+
+func TestDriverSchema_Postgres(t *testing.T) {
+	src := fixtureSchema(t, "driver_schema_postgres.py")
+	ents := extract(t, "python_driver_schema", src)
+
+	acct := findDriverEntity(ents, "accounts", "SCOPE.Schema")
+	if acct == nil {
+		t.Fatal("expected accounts table entity")
+	}
+	if acct.Props["framework"] != "postgres" {
+		t.Fatalf("expected framework=postgres, got %q", acct.Props["framework"])
+	}
+
+	cols := driverColumnNames(ents, "accounts")
+	for _, want := range []string{"accounts.id", "accounts.owner_name", "accounts.balance", "accounts.opened_at"} {
+		if _, ok := cols[want]; !ok {
+			t.Fatalf("expected column %q, got %v", want, cols)
+		}
+	}
+	if cols["accounts.id"] != "SERIAL" {
+		t.Fatalf("expected id SERIAL, got %q", cols["accounts.id"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SQLite (sqlite3) — executescript with multiple CREATE TABLE statements
+// ---------------------------------------------------------------------------
+
+func TestDriverSchema_SQLite(t *testing.T) {
+	src := fixtureSchema(t, "driver_schema_sqlite.py")
+	ents := extract(t, "python_driver_schema", src)
+
+	notes := findDriverEntity(ents, "notes", "SCOPE.Schema")
+	if notes == nil {
+		t.Fatal("expected notes table entity")
+	}
+	if notes.Props["framework"] != "sqlite" || notes.Props["driver_call"] != "executescript" {
+		t.Fatalf("notes props wrong: %+v", notes.Props)
+	}
+
+	if findDriverEntity(ents, "tags", "SCOPE.Schema") == nil {
+		t.Fatal("expected tags table entity (second CREATE TABLE in executescript)")
+	}
+
+	ncols := driverColumnNames(ents, "notes")
+	for _, want := range []string{"notes.id", "notes.title", "notes.body", "notes.pinned"} {
+		if _, ok := ncols[want]; !ok {
+			t.Fatalf("expected column %q, got %v", want, ncols)
+		}
+	}
+	tcols := driverColumnNames(ents, "tags")
+	if _, ok := tcols["tags.label"]; !ok {
+		t.Fatalf("expected tags.label column, got %v", tcols)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: file without a supported driver import must yield nothing.
+// ---------------------------------------------------------------------------
+
+func TestDriverSchema_NoDriverImport(t *testing.T) {
+	src := `
+from sqlalchemy import create_engine
+engine = create_engine("sqlite://")
+engine.execute("CREATE TABLE x (id INTEGER PRIMARY KEY)")
+`
+	if got := extract(t, "python_driver_schema", src); len(got) != 0 {
+		t.Fatalf("expected no entities without a raw-driver import, got %d", len(got))
+	}
+}

--- a/internal/custom/python/testdata/driver_schema_mysql.py
+++ b/internal/custom/python/testdata/driver_schema_mysql.py
@@ -1,0 +1,22 @@
+import pymysql
+
+conn = pymysql.connect(host="localhost", user="root", db="shop")
+cursor = conn.cursor()
+
+cursor.execute("""
+    CREATE TABLE IF NOT EXISTS users (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        username VARCHAR(150) NOT NULL,
+        email VARCHAR(255) NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE KEY uq_email (email)
+    )
+""")
+
+cursor.execute("""
+    CREATE TABLE orders (
+        id INT PRIMARY KEY,
+        user_id INT NOT NULL,
+        total DECIMAL(10, 2)
+    )
+""")

--- a/internal/custom/python/testdata/driver_schema_postgres.py
+++ b/internal/custom/python/testdata/driver_schema_postgres.py
@@ -1,0 +1,15 @@
+import psycopg2
+
+conn = psycopg2.connect("dbname=shop user=postgres")
+cur = conn.cursor()
+
+cur.execute(
+    """
+    CREATE TABLE IF NOT EXISTS accounts (
+        id SERIAL PRIMARY KEY,
+        owner_name TEXT NOT NULL,
+        balance NUMERIC DEFAULT 0,
+        opened_at TIMESTAMPTZ DEFAULT now()
+    )
+    """
+)

--- a/internal/custom/python/testdata/driver_schema_sqlite.py
+++ b/internal/custom/python/testdata/driver_schema_sqlite.py
@@ -1,0 +1,20 @@
+import sqlite3
+
+conn = sqlite3.connect("app.db")
+cur = conn.cursor()
+
+cur.executescript(
+    """
+    CREATE TABLE notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        body TEXT,
+        pinned INTEGER DEFAULT 0
+    );
+
+    CREATE TABLE tags (
+        id INTEGER PRIMARY KEY,
+        label TEXT NOT NULL
+    );
+    """
+)


### PR DESCRIPTION
## Summary
Implements **issue #3189 (T16)** — a Python raw-driver `schema_extraction` extractor for the MySQL, PostgreSQL, and SQLite drivers. Raw drivers (pymysql, psycopg2/asyncpg, sqlite3) embed schema definitions in SQL string literals passed to `cursor.execute(...)`; no existing extractor scanned these. This adds one.

## What was built
New file `internal/custom/python/driver_schema.go` registering `python_driver_schema`:
- Gated on a supported driver import (`pymysql`/`MySQLdb`/`mysql.connector`, `psycopg2`/`psycopg`/`asyncpg`, `sqlite3`/`aiosqlite`) plus the literal substring `CREATE TABLE`, so ORM-generated DDL (SQLAlchemy etc.) is **not** misattributed to a raw driver.
- Scans `execute` / `executescript` / `executemany` calls whose first arg is a string literal, reads the literal body (single/triple quoted, with `r`/`b`/`u` prefixes), and parses every `CREATE TABLE` inside it.
- Emits one table-level `SCOPE.Schema` entity per table and one `subtype=column` entity per column definition. Strips schema qualifiers (`public.users` → `users`), uppercases column types, and skips table-level constraint lines (`PRIMARY`/`FOREIGN`/`UNIQUE`/`CONSTRAINT`/`CHECK`/`KEY`/`INDEX`/...). Column body is extracted via a balanced-paren scan so nested type parens (`DECIMAL(10,2)`) don't truncate it.

## Fixture proof
Dedicated `internal/custom/python/driver_schema_test.go` (not the shared `extractors_test.go`) with three golden fixtures under `testdata/`:
- `driver_schema_mysql.py` (pymysql) — `users` + `orders` tables; asserts columns, `driver_call=execute`, `DECIMAL`/`VARCHAR` types, and that the `UNIQUE KEY` constraint does **not** leak as a column.
- `driver_schema_postgres.py` (psycopg2) — `accounts`; asserts `framework=postgres`, `SERIAL` PK.
- `driver_schema_sqlite.py` (sqlite3) — two tables in a single `executescript`, proving multi-statement handling and `driver_call=executescript`.
- Negative: a SQLAlchemy file (no raw-driver import) yields zero entities.

## Registry / honesty
Flipped `schema_extraction` from `missing` → **`partial`** on `lang.python.driver.{mysql,postgres,sqlite}` (cite: `internal/custom/python/driver_schema.go`, issue `3189`). `partial` rather than `full` because this is a heuristic regex over embedded SQL string literals — single-literal DDL only; string-concatenated DDL is not stitched. No honesty-NA calls were needed (all three records were genuinely extractable). Coverage docs regenerated and byte-stable.

## Validation
- `go build ./...` — clean
- `go test ./internal/custom/python/... ./internal/extractor/... ./internal/types/... ./tools/coverage/...` — all green (incl. `internal/types` producer-kind validator; `SCOPE.Schema` is already a registered Kind)
- `go run ./tools/coverage validate` — 0 errors
- `go run ./tools/coverage fmt --check` — canonical
- `go run ./tools/coverage gen` — byte-stable (re-run produces no diff)
- `gofmt -l` on touched files — clean

Note: `internal/mcp` (`TestHarness_FixturesCorpus`) and `internal/verify` fail in this environment because they spin up the archigraph daemon and collide with a live daemon on the canonical socket (binary SHA mismatch / "another daemon is running"). These are pre-existing daemon-harness env failures, untouched by this change (it modifies neither package).

Closes #3189

🤖 Generated with [Claude Code](https://claude.com/claude-code)