### PR TITLE
feat(coverage): Struts dto_extraction extractor (ActionForm detection) — #3191

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -123,7 +123,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
 | [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 5/7 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 6/7 | |
 | [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
 | [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -27,7 +27,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 5/7 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 6/7 | |
 | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
 | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | 3191 | `internal/custom/java/struts_dto_test.go`<br>`internal/custom/java/struts_routes.go`<br>`testdata/fixtures/sources/java/struts/StrutsDtoFixture.java` | Detects Struts 1 ActionForm subclasses (incl. Validator/Dyna variants) and Struts 2 action field-binding (ActionSupport/Action/ModelDriven). Emits SCOPE.Schema DTO entities, SCOPE.Field bound fields from public OGNL setters (skipping framework plumbing), BINDS_INPUT relationships, and BINDS_MODEL for ModelDriven<T>. Heuristic regex over setters / extends-clauses, hence partial |
 | Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -17988,8 +17988,11 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/struts_dto_test.go","internal/custom/java/struts_routes.go","testdata/fixtures/sources/java/struts/StrutsDtoFixture.java"],
+            "issue": "3191",
+            "notes": "Detects Struts 1 ActionForm subclasses (incl. Validator/Dyna variants) and Struts 2 action field-binding (ActionSupport/Action/ModelDriven). Emits SCOPE.Schema DTO entities, SCOPE.Field bound fields from public OGNL setters (skipping framework plumbing), BINDS_INPUT relationships, and BINDS_MODEL for ModelDriven\u003cT\u003e. Heuristic regex over setters / extends-clauses, hence partial",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "missing",

--- a/internal/custom/java/struts_dto_test.go
+++ b/internal/custom/java/struts_dto_test.go
@@ -1,0 +1,301 @@
+package java
+
+import (
+	"os"
+	"testing"
+)
+
+// ============================================================================
+// Issue #3191: Struts dto_extraction extractor (ActionForm + Struts 2 binding)
+//
+// Registry target: lang.java.framework.struts Validation/dto_extraction → partial
+// Cite: internal/custom/java/struts_routes.go
+//       internal/custom/java/struts_dto_test.go
+//       testdata/fixtures/sources/java/struts/StrutsDtoFixture.java
+// ============================================================================
+
+func strutsDTOCtx(source, file string) PatternContext {
+	return PatternContext{
+		Source:    source,
+		Language:  "java",
+		Framework: "struts",
+		FilePath:  file,
+	}
+}
+
+// schemaNames returns the names of SCOPE.Schema entities with the given
+// provenance.
+func strutsSchemaNamesByProvenance(r PatternResult, provenance string) []string {
+	var out []string
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Schema" && e.Provenance == provenance {
+			out = append(out, e.Name)
+		}
+	}
+	return out
+}
+
+func strutsHasEntity(r PatternResult, kind, name string) bool {
+	for _, e := range r.Entities {
+		if e.Kind == kind && e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func strutsHasRel(r PatternResult, src, tgt, typ string) bool {
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == typ && rel.SourceRef == src && rel.TargetRef == tgt {
+			return true
+		}
+	}
+	return false
+}
+
+// ----------------------------------------------------------------------------
+// Struts 1: ActionForm subclass detection
+// ----------------------------------------------------------------------------
+
+// TestStruts_DTO_ActionForm_Issue3191 proves that `extends ActionForm`
+// subclasses are emitted as SCOPE.Schema DTO entities with their bound fields.
+func TestStruts_DTO_ActionForm_Issue3191(t *testing.T) {
+	source := `
+package com.example;
+
+import org.apache.struts.action.ActionForm;
+
+public class RegisterForm extends ActionForm {
+    private String username;
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public void setEmail(String email) { }
+}
+`
+	r := ExtractStruts(strutsDTOCtx(source, "RegisterForm.java"))
+
+	if !strutsHasEntity(r, "SCOPE.Schema", "RegisterForm") {
+		t.Fatalf("[#3191 dto_extraction] expected SCOPE.Schema DTO for RegisterForm; got %+v", r.Entities)
+	}
+
+	// Bound fields: username + email.
+	gotFields := map[string]bool{}
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Field" {
+			gotFields[e.Properties["field_name"].(string)] = true
+		}
+	}
+	for _, want := range []string{"username", "email"} {
+		if !gotFields[want] {
+			t.Errorf("[#3191 dto_extraction] expected bound field %q, got %v", want, gotFields)
+		}
+	}
+
+	// BINDS_INPUT relationships present.
+	var binds int
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "BINDS_INPUT" {
+			binds++
+		}
+	}
+	if binds < 2 {
+		t.Errorf("[#3191 dto_extraction] expected >=2 BINDS_INPUT rels; got %d", binds)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Struts 2: ActionSupport field-binding (OGNL setters)
+// ----------------------------------------------------------------------------
+
+// TestStruts_DTO_ActionSupportBinding_Issue3191 proves that an ActionSupport
+// subclass with public setters is treated as a request-binding DTO.
+func TestStruts_DTO_ActionSupportBinding_Issue3191(t *testing.T) {
+	source := `
+package com.example;
+
+import com.opensymphony.xwork2.ActionSupport;
+
+public class SearchAction extends ActionSupport {
+    private String query;
+    public void setQuery(String query) { this.query = query; }
+    public void setLimit(int limit) { }
+}
+`
+	r := ExtractStruts(strutsDTOCtx(source, "SearchAction.java"))
+
+	if !strutsHasEntity(r, "SCOPE.Schema", "SearchAction") {
+		t.Fatalf("[#3191 dto_extraction] expected SCOPE.Schema DTO for SearchAction; got %+v", r.Entities)
+	}
+	form := ""
+	for _, e := range r.Entities {
+		if e.Name == "SearchAction" && e.Kind == "SCOPE.Schema" {
+			form = e.Properties["form_kind"].(string)
+		}
+	}
+	if form != "ActionSupport" {
+		t.Errorf("[#3191 dto_extraction] expected form_kind=ActionSupport; got %q", form)
+	}
+
+	gotFields := map[string]bool{}
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Field" {
+			gotFields[e.Properties["field_name"].(string)] = true
+		}
+	}
+	for _, want := range []string{"query", "limit"} {
+		if !gotFields[want] {
+			t.Errorf("[#3191 dto_extraction] expected bound field %q, got %v", want, gotFields)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Struts 2: framework-plumbing setters are not bound DTO fields
+// ----------------------------------------------------------------------------
+
+// TestStruts_DTO_SkipPlumbingSetters_Issue3191 proves that
+// setServletRequest/setSession-style plumbing setters are not surfaced as
+// bound DTO fields.
+func TestStruts_DTO_SkipPlumbingSetters_Issue3191(t *testing.T) {
+	source := `
+import com.opensymphony.xwork2.ActionSupport;
+
+public class CartAction extends ActionSupport {
+    public void setItem(String item) { }
+    public void setServletRequest(Object r) { }
+    public void setSession(java.util.Map s) { }
+}
+`
+	r := ExtractStruts(strutsDTOCtx(source, "CartAction.java"))
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Field" {
+			name := e.Properties["field_name"].(string)
+			if name == "servletRequest" || name == "session" {
+				t.Errorf("[#3191 dto_extraction] plumbing setter %q must not be a bound field", name)
+			}
+		}
+	}
+	if !strutsHasEntity(r, "SCOPE.Field", "CartAction.item") {
+		t.Errorf("[#3191 dto_extraction] expected real field CartAction.item bound")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Struts 2: ModelDriven<T> exposes a separate domain model
+// ----------------------------------------------------------------------------
+
+// TestStruts_DTO_ModelDriven_Issue3191 proves that ModelDriven<T> surfaces the
+// model type T as its own DTO and links the action via BINDS_MODEL.
+func TestStruts_DTO_ModelDriven_Issue3191(t *testing.T) {
+	source := `
+import com.opensymphony.xwork2.ActionSupport;
+import com.opensymphony.xwork2.ModelDriven;
+
+public class AccountAction extends ActionSupport implements ModelDriven<Account> {
+    private final Account account = new Account();
+    public Account getModel() { return account; }
+}
+`
+	r := ExtractStruts(strutsDTOCtx(source, "AccountAction.java"))
+
+	if !strutsHasEntity(r, "SCOPE.Schema", "Account") {
+		t.Fatalf("[#3191 dto_extraction] expected SCOPE.Schema DTO for ModelDriven model Account; got %+v", r.Entities)
+	}
+	actionRef := "scope:schema:struts_dto:AccountAction.java:AccountAction"
+	modelRef := "scope:schema:struts_dto:AccountAction.java:Account"
+	if !strutsHasRel(r, actionRef, modelRef, "BINDS_MODEL") {
+		t.Errorf("[#3191 dto_extraction] expected BINDS_MODEL %s -> %s; rels=%+v", actionRef, modelRef, r.Relationships)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Gating: extractor must not fire for non-struts frameworks
+// ----------------------------------------------------------------------------
+
+func TestStruts_DTO_Gating_Issue3191(t *testing.T) {
+	source := `public class FooForm extends ActionForm { public void setX(String x) {} }`
+	r := ExtractStruts(PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot", FilePath: "FooForm.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3191 gating] extractor must not fire for framework=spring_boot; got %+v", r.Entities)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Golden fixture integration test
+// ----------------------------------------------------------------------------
+
+// TestStruts_DTO_FixtureFile_Issue3191 loads the committed golden fixture and
+// asserts the full set of DTO extractions, proving dto_extraction → partial.
+func TestStruts_DTO_FixtureFile_Issue3191(t *testing.T) {
+	data, err := os.ReadFile("../../../testdata/fixtures/sources/java/struts/StrutsDtoFixture.java")
+	if err != nil {
+		t.Fatalf("[#3191 fixture] cannot read fixture: %v", err)
+	}
+	r := ExtractStruts(strutsDTOCtx(string(data), "StrutsDtoFixture.java"))
+
+	// 1. Struts 1 ActionForm subclasses.
+	actionForms := strutsSchemaNamesByProvenance(r, "INFERRED_FROM_STRUTS_ACTIONFORM")
+	for _, want := range []string{"UserForm", "LoginForm"} {
+		found := false
+		for _, n := range actionForms {
+			if n == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("[#3191 fixture] missing ActionForm DTO %q; got %v", want, actionForms)
+		}
+	}
+
+	// 2. Struts 2 action binding DTOs.
+	if !strutsHasEntity(r, "SCOPE.Schema", "OrderAction") {
+		t.Errorf("[#3191 fixture] expected ActionSupport DTO OrderAction; got %v", actionForms)
+	}
+
+	// 3. ModelDriven model surfaced + linked.
+	modelDriven := strutsSchemaNamesByProvenance(r, "INFERRED_FROM_STRUTS_MODELDRIVEN")
+	foundProduct := false
+	for _, n := range modelDriven {
+		if n == "Product" {
+			foundProduct = true
+		}
+	}
+	if !foundProduct {
+		t.Errorf("[#3191 fixture] expected ModelDriven model Product; got %v", modelDriven)
+	}
+	productActionRef := "scope:schema:struts_dto:StrutsDtoFixture.java:ProductAction"
+	productRef := "scope:schema:struts_dto:StrutsDtoFixture.java:Product"
+	if !strutsHasRel(r, productActionRef, productRef, "BINDS_MODEL") {
+		t.Errorf("[#3191 fixture] expected BINDS_MODEL ProductAction -> Product")
+	}
+
+	// 4. Bound fields from UserForm (incl. type capture) but NOT plumbing.
+	wantFields := map[string]string{"username": "String", "email": "String", "age": "int"}
+	gotTypes := map[string]string{}
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Field" && e.Properties["dto"] == "UserForm" {
+			gotTypes[e.Properties["field_name"].(string)] = e.Properties["field_type"].(string)
+		}
+	}
+	for f, typ := range wantFields {
+		if gotTypes[f] != typ {
+			t.Errorf("[#3191 fixture] UserForm.%s expected type %q; got %q (all=%v)", f, typ, gotTypes[f], gotTypes)
+		}
+	}
+	if _, bad := gotTypes["servletRequest"]; bad {
+		t.Errorf("[#3191 fixture] UserForm must not bind plumbing setServletRequest")
+	}
+
+	// 5. BINDS_INPUT relationships present overall.
+	var binds int
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "BINDS_INPUT" {
+			binds++
+		}
+	}
+	if binds == 0 {
+		t.Errorf("[#3191 fixture] expected >=1 BINDS_INPUT relationship; got 0")
+	}
+}

--- a/internal/custom/java/struts_routes.go
+++ b/internal/custom/java/struts_routes.go
@@ -38,10 +38,25 @@ import (
 // Transactions are C (not_applicable): Struts has no transaction management;
 // projects use Spring @Transactional or JTA outside the framework.
 //
+// DTO extraction (#3191): Struts binds request parameters to action state in
+// two ways:
+//   1. Struts 1 — ActionForm subclasses (and Validator/Dyna variants) act as
+//      the form-backing DTO; their getter/setter properties are the bound
+//      request fields.
+//   2. Struts 2 — action classes (ActionSupport subclasses, Action /
+//      ModelDriven implementors) bind request params directly onto public
+//      setters via OGNL. ModelDriven<T> exposes a separate domain model T.
+// We emit a SCOPE.Schema DTO entity for each backing type and BINDS_INPUT
+// relationships from the action handler. This is heuristic (regex over public
+// setters / `extends ActionForm`), so the cell is `partial`.
+//
 // Coverage cells delivered (#3089):
 //   - Routing:    route_extraction                → partial
 //   - Auth:       auth_coverage                   → partial
 //   - Middleware: middleware_coverage              → partial
+//
+// Coverage cells delivered (#3191):
+//   - Validation: dto_extraction                  → partial
 //   - DI:         di_binding_extraction, di_injection_point, di_scope_resolution → not_applicable
 //   - AOP:        advice_attribution, aspect_extraction, pointcut_resolution     → not_applicable
 //   - Transactions: transaction_boundary_extraction, transaction_propagation,
@@ -50,12 +65,12 @@ import (
 // strutsFrameworks is the set of framework identifiers that activate the Struts
 // extractor.
 var strutsFrameworks = map[string]bool{
-	"struts":         true,
-	"struts2":        true,
-	"struts-2":       true,
-	"apache_struts":  true,
-	"apache-struts":  true,
-	"struts_2":       true,
+	"struts":        true,
+	"struts2":       true,
+	"struts-2":      true,
+	"apache_struts": true,
+	"apache-struts": true,
+	"struts_2":      true,
 }
 
 var (
@@ -106,7 +121,51 @@ var (
 	// @Namespace("/prefix") — package-level namespace annotation.
 	strutsNamespaceRE = regexp.MustCompile(
 		`@Namespace\s*\(\s*"([^"]+)"`)
+
+	// ── DTO extraction (#3191) ───────────────────────────────────────────────
+
+	// Struts 1 ActionForm subclass: `class FooForm extends ActionForm` and the
+	// common Struts/Validator/Dyna variants. Capture group 1: class name,
+	// group 2: the base class actually extended (for provenance/properties).
+	strutsActionFormRE = regexp.MustCompile(
+		`(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)\s+extends\s+` +
+			`(ActionForm|ValidatorForm|ValidatorActionForm|DynaActionForm|DynaValidatorForm)\b`)
+
+	// Struts 2 action base class: `class FooAction extends ActionSupport`
+	// (also bare implementors of the Action interface / ModelDriven).
+	// Capture group 1: class name, group 2: base/interface.
+	strutsActionClassRE = regexp.MustCompile(
+		`(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)\s+` +
+			`(?:extends\s+(ActionSupport)\b|` +
+			`(?:[\w<>, ]+\s+)?implements\s+[^{]*\b(ModelDriven|Action)\b)`)
+
+	// Public setter method — the OGNL field-binding surface for Struts 2
+	// actions. Capture group 1: property name (after `set`), group 2: param type.
+	strutsSetterRE = regexp.MustCompile(
+		`(?m)public\s+void\s+set([A-Z]\w*)\s*\(\s*([\w.<>\[\], ]+?)\s+\w+\s*\)`)
+
+	// ModelDriven<T>.getModel() return type — the bound domain model.
+	// Capture group 1: the model type.
+	strutsModelDrivenRE = regexp.MustCompile(
+		`implements\s+[^{]*\bModelDriven\s*<\s*([\w.]+)\s*>`)
 )
+
+// strutsDTOSkipProps lists setter property names that are framework plumbing
+// rather than bound request fields, so they are not surfaced as DTO fields.
+var strutsDTOSkipProps = map[string]bool{
+	"servletRequest":  true,
+	"servletResponse": true,
+	"session":         true,
+	"application":     true,
+	"request":         true,
+	"response":        true,
+	"parameters":      true,
+	"servletContext":  true,
+	"pageContext":     true,
+	"actionErrors":    true,
+	"actionMessages":  true,
+	"fieldErrors":     true,
+}
 
 // strutsXMLAction represents a parsed <action> element from struts.xml.
 type strutsXMLAction struct {
@@ -157,6 +216,8 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 		if !strings.Contains(ctx.Source, "struts2") &&
 			!strings.Contains(ctx.Source, "Struts") &&
 			!strings.Contains(ctx.Source, "ActionSupport") &&
+			!strings.Contains(ctx.Source, "ActionForm") &&
+			!strings.Contains(ctx.Source, "ModelDriven") &&
 			!strings.Contains(ctx.Source, "opensymphony") &&
 			!strings.Contains(ctx.Source, "@Action") &&
 			!strings.Contains(ctx.Source, "Interceptor") {
@@ -259,14 +320,14 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 					Provenance: "INFERRED_FROM_STRUTS_XML_ACTION",
 					Ref:        ref,
 					Properties: map[string]any{
-						"http_verb":      "ANY",
-						"path":           fullPath,
-						"framework":      "struts",
-						"route_type":     "xml_config",
-						"action_class":   action.Class,
-						"action_method":  method,
-						"package_name":   pkg.Name,
-						"namespace":      ns,
+						"http_verb":     "ANY",
+						"path":          fullPath,
+						"framework":     "struts",
+						"route_type":    "xml_config",
+						"action_class":  action.Class,
+						"action_method": method,
+						"package_name":  pkg.Name,
+						"namespace":     ns,
 					},
 				}
 				addEntity(&result, seen, e)
@@ -384,6 +445,12 @@ func ExtractStruts(ctx PatternContext) PatternResult {
 	}
 
 	// -------------------------------------------------------------------------
+	// DTO extraction (#3191): ActionForm (Struts 1) + action field-binding
+	// (Struts 2). Emits SCOPE.Schema DTO entities and BINDS_INPUT relationships.
+	// -------------------------------------------------------------------------
+	extractStrutsDTO(ctx, &result, seen, seenRels)
+
+	// -------------------------------------------------------------------------
 	// Auth: JAAS / Spring Security markers
 	// -------------------------------------------------------------------------
 	if strutsJAASLoginContextRE.MatchString(ctx.Source) {
@@ -455,4 +522,162 @@ func joinStrutsPath(namespace, path string) string {
 		return p
 	}
 	return ns + p
+}
+
+// extractStrutsDTO detects form-backing DTO types and request-binding fields
+// for both Struts 1 (ActionForm) and Struts 2 (ActionSupport / Action /
+// ModelDriven) and records them on result.
+//
+// Emitted records:
+//   - SCOPE.Schema DTO entity per ActionForm subclass / action class that
+//     binds request parameters (provenance INFERRED_FROM_STRUTS_*).
+//   - BINDS_INPUT relationship from the DTO entity to each bound field
+//     (the OGNL/getter-setter property surface).
+//   - For ModelDriven<T>: a SCOPE.Schema entity for the model type T plus a
+//     BINDS_MODEL relationship from the action to the model.
+func extractStrutsDTO(
+	ctx PatternContext,
+	result *PatternResult,
+	seen map[string]bool,
+	seenRels map[relKey]bool,
+) {
+	src := ctx.Source
+	fp := ctx.FilePath
+
+	// Collect the public-setter-bound field properties for the file once.
+	// Each entry maps the setter offset to its (property, type).
+	type setterProp struct {
+		prop   string
+		typ    string
+		offset int
+	}
+	var setters []setterProp
+	for _, m := range strutsSetterRE.FindAllStringSubmatchIndex(src, -1) {
+		prop := src[m[2]:m[3]]
+		typ := strings.TrimSpace(src[m[4]:m[5]])
+		// Lower-case the leading character to get the bean property name.
+		lcProp := strings.ToLower(prop[:1]) + prop[1:]
+		if strutsDTOSkipProps[lcProp] {
+			continue
+		}
+		setters = append(setters, setterProp{prop: lcProp, typ: typ, offset: m[0]})
+	}
+
+	// emitDTO records a DTO Schema entity + its bound fields. base describes the
+	// detected backing-type kind for provenance/properties.
+	emitDTO := func(className string, classOffset int, formKind, provenance string) {
+		dtoRef := fmt.Sprintf("scope:schema:struts_dto:%s:%s", fp, className)
+		addEntity(result, seen, SecondaryEntity{
+			Name:       className,
+			Kind:       "SCOPE.Schema",
+			SourceFile: fp,
+			LineStart:  lineOf(src, classOffset),
+			Provenance: provenance,
+			Ref:        dtoRef,
+			Properties: map[string]any{
+				"kind":      "dto",
+				"framework": "struts",
+				"form_kind": formKind,
+			},
+		})
+
+		// Bind the public setters that belong to this class (the next class
+		// declaration after classOffset bounds the field set).
+		nextClass := len(src)
+		for _, m := range classDeclRE.FindAllStringSubmatchIndex(src, -1) {
+			if m[0] > classOffset && m[0] < nextClass {
+				nextClass = m[0]
+			}
+		}
+		for _, s := range setters {
+			if s.offset <= classOffset || s.offset >= nextClass {
+				continue
+			}
+			fieldRef := fmt.Sprintf("scope:field:struts_dto:%s:%s:%s", fp, className, s.prop)
+			addEntity(result, seen, SecondaryEntity{
+				Name:       className + "." + s.prop,
+				Kind:       "SCOPE.Field",
+				SourceFile: fp,
+				LineStart:  lineOf(src, s.offset),
+				Provenance: "INFERRED_FROM_STRUTS_FIELD_BINDING",
+				Ref:        fieldRef,
+				Properties: map[string]any{
+					"framework":  "struts",
+					"field_name": s.prop,
+					"field_type": s.typ,
+					"dto":        className,
+				},
+			})
+			addRel(result, seenRels, Relationship{
+				SourceRef:        dtoRef,
+				TargetRef:        fieldRef,
+				RelationshipType: "BINDS_INPUT",
+				Properties: map[string]string{
+					"framework": "struts",
+					"via":       "ognl_setter",
+				},
+			})
+		}
+	}
+
+	// Struts 1: ActionForm subclasses (and Validator/Dyna variants).
+	for _, m := range strutsActionFormRE.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		base := src[m[4]:m[5]]
+		emitDTO(className, m[0], base, "INFERRED_FROM_STRUTS_ACTIONFORM")
+	}
+
+	// Struts 2: ActionSupport / Action / ModelDriven implementors.
+	for _, m := range strutsActionClassRE.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		// Determine the base/interface that matched (group 2 = ActionSupport,
+		// group 3 = ModelDriven/Action).
+		formKind := "action"
+		if m[4] >= 0 {
+			formKind = src[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			formKind = src[m[6]:m[7]]
+		}
+		emitDTO(className, m[0], formKind, "INFERRED_FROM_STRUTS_ACTION_BINDING")
+	}
+
+	// ModelDriven<T>: surface the domain model type as its own DTO and link it.
+	for _, m := range strutsModelDrivenRE.FindAllStringSubmatchIndex(src, -1) {
+		modelType := src[m[2]:m[3]]
+		// Use the simple class name for the DTO entity.
+		if dot := strings.LastIndex(modelType, "."); dot >= 0 {
+			modelType = modelType[dot+1:]
+		}
+		if modelType == "" {
+			continue
+		}
+		modelRef := fmt.Sprintf("scope:schema:struts_dto:%s:%s", fp, modelType)
+		addEntity(result, seen, SecondaryEntity{
+			Name:       modelType,
+			Kind:       "SCOPE.Schema",
+			SourceFile: fp,
+			LineStart:  lineOf(src, m[0]),
+			Provenance: "INFERRED_FROM_STRUTS_MODELDRIVEN",
+			Ref:        modelRef,
+			Properties: map[string]any{
+				"kind":      "dto",
+				"framework": "struts",
+				"form_kind": "model_driven",
+			},
+		})
+		// Link the enclosing action class to the model it drives.
+		action := findEnclosingClass(src, m[0])
+		if action != "" {
+			actionRef := fmt.Sprintf("scope:schema:struts_dto:%s:%s", fp, action)
+			addRel(result, seenRels, Relationship{
+				SourceRef:        actionRef,
+				TargetRef:        modelRef,
+				RelationshipType: "BINDS_MODEL",
+				Properties: map[string]string{
+					"framework": "struts",
+					"via":       "model_driven",
+				},
+			})
+		}
+	}
 }

--- a/testdata/fixtures/sources/java/struts/StrutsDtoFixture.java
+++ b/testdata/fixtures/sources/java/struts/StrutsDtoFixture.java
@@ -1,0 +1,59 @@
+package com.example.struts;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.validator.ValidatorForm;
+import org.apache.struts2.convention.annotation.Action;
+import com.opensymphony.xwork2.ActionSupport;
+import com.opensymphony.xwork2.ModelDriven;
+
+// ── Struts 1: classic ActionForm subclass ───────────────────────────────────
+// The form is the request-backing DTO; its setters are the bound fields.
+public class UserForm extends ActionForm {
+    private String username;
+    private String email;
+    private int age;
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public int getAge() { return age; }
+    public void setAge(int age) { this.age = age; }
+
+    // Framework plumbing — must NOT be treated as a bound DTO field.
+    public void setServletRequest(javax.servlet.http.HttpServletRequest request) { }
+}
+
+// ── Struts 1: ValidatorForm variant ─────────────────────────────────────────
+class LoginForm extends ValidatorForm {
+    private String password;
+    public void setPassword(String password) { this.password = password; }
+}
+
+// ── Struts 2: ActionSupport with OGNL field binding ─────────────────────────
+class OrderAction extends ActionSupport {
+    private String orderId;
+    private double amount;
+
+    @Action(value = "/orders/place")
+    public String place() { return SUCCESS; }
+
+    public void setOrderId(String orderId) { this.orderId = orderId; }
+    public void setAmount(double amount) { this.amount = amount; }
+}
+
+// ── Struts 2: ModelDriven exposes a separate domain model ────────────────────
+class ProductAction extends ActionSupport implements ModelDriven<Product> {
+    private final Product product = new Product();
+
+    public Product getModel() { return product; }
+
+    public void setCategory(String category) { }
+}
+
+class Product {
+    private String sku;
+    public void setSku(String sku) { this.sku = sku; }
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -4289,6 +4289,17 @@ records:
           verified_at: "2026-05-29"
   lang.java.framework.struts:
     capabilities:
+      Validation:
+        dto_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/java/struts_routes.go
+              functions: [ExtractStruts, extractStrutsDTO]
+          tests:
+            - file: internal/custom/java/struts_dto_test.go
+              functions: [TestStruts_DTO_ActionForm_Issue3191, TestStruts_DTO_ActionSupportBinding_Issue3191, TestStruts_DTO_ModelDriven_Issue3191, TestStruts_DTO_FixtureFile_Issue3191]
+          issues_implemented: ["3191"]
+          verified_at: "2026-05-30"
       Observability:
         log_extraction:
           status: partial


### PR DESCRIPTION
## Summary

Implements the Struts `dto_extraction` extractor for the `lang.java.framework.struts` Validation cell, flipping it **missing → partial**.

Apache Struts binds request parameters to action state in two ways, both now detected in `internal/custom/java/struts_routes.go` (`extractStrutsDTO`):

- **Struts 1 — ActionForm subclasses**: `class X extends ActionForm` and the common `ValidatorForm`, `ValidatorActionForm`, `DynaActionForm`, `DynaValidatorForm` variants. The form is the request-backing DTO.
- **Struts 2 — action field binding (OGNL)**: `ActionSupport` subclasses and `Action` / `ModelDriven` implementors bind request params onto public setters. Framework-plumbing setters (`setServletRequest`, `setSession`, `setApplication`, …) are skipped.
- **ModelDriven&lt;T&gt;**: the domain model `T` is surfaced as its own DTO and linked to its action via `BINDS_MODEL`.

### Emitted records
- `SCOPE.Schema` DTO entity per backing type (provenance `INFERRED_FROM_STRUTS_ACTIONFORM` / `INFERRED_FROM_STRUTS_ACTION_BINDING` / `INFERRED_FROM_STRUTS_MODELDRIVEN`).
- `SCOPE.Field` bound-field entity per OGNL setter (with `field_type`).
- `BINDS_INPUT` (DTO → field) and `BINDS_MODEL` (action → model) relationships.

## Tests
Dedicated `internal/custom/java/struts_dto_test.go` (NOT the shared `extractors_test.go`) with a committed golden fixture `testdata/fixtures/sources/java/struts/StrutsDtoFixture.java`:
- ActionForm detection + bound fields
- ActionSupport OGNL binding + `form_kind`
- plumbing-setter skip
- ModelDriven model + `BINDS_MODEL`
- framework gating (no fire for `spring_boot`)
- full golden-fixture integration assertion (types, ModelDriven, plumbing exclusion)

## Docs
- `docs/coverage/registry.json` — struts `dto_extraction` → `partial` (canonical, `fmt --check` clean).
- `tools/coverage/capability-map.yaml` — added the struts `Validation/dto_extraction` mapping entry (symbols + tests + issue).
- Generated docs regenerated via `coverage gen` (byte-stable).

## Coverage delta
**Cells changed: 1** · improved: **1** · regressed: **0**

| Record | Group | Capability | Before → After |
|---|---|---|---|
| `lang.java.framework.struts` | Validation | dto_extraction | missing → **partial** |

- **What changed / benefits:** Struts action forms / action-bound fields and ModelDriven domain models are now graph entities, so DTO/schema queries return Struts request shapes that were previously invisible.
- **How proven:** Dedicated `_test.go` + committed golden fixture exercising every detection path; full integration test asserts entity set, field types, relationships, and plumbing exclusion.
- **Caveats:** Left as **partial** — heuristic regex over `extends`-clauses and public setters; no tree-sitter type resolution, no cross-file resolution of `ModelDriven<T>` to T's own fields, no XML `<form-bean>` (struts-config.xml) parsing.
- **Limits / not covered:** Struts 1 `struts-config.xml` form-bean declarations and validation.xml rules are out of scope (would belong to `request_validation`, still `missing`).
- **Real-data check:** Unit-fixture only (isolated worktree; live graph not touched).

## Validation
- `go build ./...` ✅
- `go test ./internal/custom/java/ ./internal/types/ ./tools/coverage/...` ✅
- `coverage validate` 0 errors ✅ · `coverage fmt --check` ✅ · `coverage gen` byte-stable ✅
- `gofmt -l` clean on changed files ✅

_(The `internal/verify` fixtures-corpus harness fails only because it tries to spin up a daemon and is blocked by an already-running daemon on the canonical socket — environmental, unrelated to this change.)_

Closes #3191

🤖 Generated with [Claude Code](https://claude.com/claude-code)