### PR TITLE
feat(coverage): Alembic schema_extraction extractor (op.create_table/add_column/create_index)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -112,7 +112,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 1/6 | |
 | [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 1/6 | |
 | [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/6 | |
-| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 1/2 | |
+| [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟢 2/2 | |
 | [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟢 6/6 | |
 | [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |
 | [python](../by-language/python.md) | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟢 6/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -88,7 +88,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 1/2 | |
+| [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟢 2/2 | |
 | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟢 6/6 | |
 | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |
 | [MongoEngine](../detail/lang.python.orm.mongoengine.md) | 🟢 6/6 | |

--- a/docs/coverage/detail/lang.python.orm.alembic.md
+++ b/docs/coverage/detail/lang.python.orm.alembic.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3192 | `internal/custom/python/alembic_schema.go`<br>`internal/custom/python/alembic_schema_test.go`<br>`internal/custom/python/testdata/alembic_schema.py` | alembic_schema.go scans Alembic migrations (gated on `from alembic import op`) for op.create_table / op.add_column / op.create_index and emits SCOPE.Schema table, column, and index entities. Heuristic regex over migration source (not a full Python parse), distinct from and non-overlapping with driver_schema.go (#3189); partial because dropped/altered columns, server_default/constraint metadata, and op.alter_column type changes are not modeled. |
 
 ### Relationships
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -38482,8 +38482,11 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/python/alembic_schema.go","internal/custom/python/alembic_schema_test.go","internal/custom/python/testdata/alembic_schema.py"],
+            "issue": "3192",
+            "notes": "alembic_schema.go scans Alembic migrations (gated on `from alembic import op`) for op.create_table / op.add_column / op.create_index and emits SCOPE.Schema table, column, and index entities. Heuristic regex over migration source (not a full Python parse), distinct from and non-overlapping with driver_schema.go (#3189); partial because dropped/altered columns, server_default/constraint metadata, and op.alter_column type changes are not modeled.",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {

--- a/internal/custom/python/alembic_schema.go
+++ b/internal/custom/python/alembic_schema.go
@@ -1,0 +1,201 @@
+package python
+
+// alembic_schema.go — schema extraction for Alembic migration operations.
+//
+// Issue #3192 — Alembic schema_extraction extractor
+// (op.create_table / op.add_column / op.create_index).
+//
+// Pattern: Alembic migration files (under a versions/ directory) express
+// schema mutations imperatively through the `op` migration-operations proxy
+// rather than as ORM model classes. The schema is therefore not visible to
+// the SQLAlchemy class-body scanner (sqlalchemy.go) nor to the raw-SQL-literal
+// scanner (driver_schema.go, #3189). This extractor scans for the three
+// structural Alembic operations and emits SCOPE.Schema entities:
+//
+//   - op.create_table("users", sa.Column("id", sa.Integer), ...)
+//       -> one table entity ("users") + one column entity per sa.Column(...)
+//   - op.add_column("users", sa.Column("email", sa.String))
+//       -> one column entity ("users.email") attributed to its parent table
+//   - op.create_index("ix_users_email", "users", ["email"])
+//       -> one index entity ("users.ix_users_email")
+//
+// This is heuristic (regex over the migration source, not a full Python
+// parse), so the registry cell is flipped to `partial`, not `full`. It is
+// deliberately distinct from and non-overlapping with driver_schema.go: that
+// extractor only fires on raw-driver imports + embedded CREATE TABLE SQL,
+// whereas this one only fires on the Alembic `op.` operations proxy and never
+// parses SQL string literals.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_alembic_schema", &AlembicSchemaExtractor{})
+}
+
+// AlembicSchemaExtractor emits SCOPE.Schema entities for the structural
+// Alembic migration operations (create_table / add_column / create_index).
+type AlembicSchemaExtractor struct{}
+
+func (e *AlembicSchemaExtractor) Language() string { return "python_alembic_schema" }
+
+var (
+	// alembicGateRe gates the extractor: the file must look like an Alembic
+	// migration. Alembic-generated migrations import the operations proxy as
+	// `from alembic import op` and almost always carry a `revision = "..."`
+	// module variable. Requiring the `op` import keeps us from misfiring on
+	// arbitrary modules that happen to define an `op` local.
+	alembicGateRe = regexp.MustCompile(
+		`(?m)^\s*from\s+alembic\s+import\s+[^\n]*\bop\b`)
+
+	// alembicCreateTableRe matches the head of an op.create_table call and
+	// captures the (string-literal) table name.
+	//   op.create_table("users", ...)
+	//   op.create_table('orders', ...)
+	alembicCreateTableRe = regexp.MustCompile(
+		`(?:\bop|\.)\.?create_table\s*\(\s*[rbuRBU]*["']([A-Za-z_][A-Za-z0-9_]*)["']`)
+
+	// alembicAddColumnRe matches an op.add_column call, capturing the target
+	// table name. The column itself is parsed from the sa.Column(...) argument
+	// that follows.
+	//   op.add_column("users", sa.Column("email", sa.String()))
+	alembicAddColumnRe = regexp.MustCompile(
+		`(?:\bop|\.)\.?add_column\s*\(\s*[rbuRBU]*["']([A-Za-z_][A-Za-z0-9_]*)["']`)
+
+	// alembicCreateIndexRe matches an op.create_index call, capturing the
+	// index name and the table it targets.
+	//   op.create_index("ix_users_email", "users", ["email"])
+	//   op.create_index(op.f("ix_users_email"), "users", ["email"])
+	alembicCreateIndexRe = regexp.MustCompile(
+		`(?:\bop|\.)\.?create_index\s*\(\s*(?:op\.f\s*\(\s*)?[rbuRBU]*["']([A-Za-z_][A-Za-z0-9_]*)["']\s*\)?\s*,\s*[rbuRBU]*["']([A-Za-z_][A-Za-z0-9_]*)["']`)
+
+	// alembicColumnRe matches an `sa.Column("name", <type>...)` definition and
+	// captures the column name and the leading type token. The type may be a
+	// dotted reference (sa.Integer, sa.String, postgresql.JSONB) — we capture
+	// the final identifier as the column type.
+	//   sa.Column("id", sa.Integer(), primary_key=True)
+	//   sa.Column('email', sa.String(255), nullable=False)
+	alembicColumnRe = regexp.MustCompile(
+		`(?:sa\.)?[Cc]olumn\s*\(\s*[rbuRBU]*["']([A-Za-z_][A-Za-z0-9_]*)["']\s*,\s*(?:[A-Za-z_][A-Za-z0-9_]*\.)*([A-Za-z_][A-Za-z0-9_]*)`)
+)
+
+func (e *AlembicSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_alembic_schema")
+	_, span := tracer.Start(ctx, "custom.python_alembic_schema")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	source := string(file.Content)
+
+	// Cheap gate: must be an Alembic migration (imports the `op` proxy).
+	if !alembicGateRe.MatchString(source) {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seenTables := make(map[string]bool)
+	seenCols := make(map[string]bool)
+	seenIdx := make(map[string]bool)
+
+	emitTable := func(name string, line int) {
+		if seenTables[name] {
+			return
+		}
+		seenTables[name] = true
+		out = append(out, entity(name, "SCOPE.Schema", "", file.Path, line,
+			map[string]string{
+				"framework":    "alembic",
+				"pattern_type": "table",
+				"table_name":   name,
+				"source":       "alembic_migration",
+			}))
+	}
+
+	emitColumn := func(table, col, colType string, line int) {
+		key := table + "." + col
+		if seenCols[key] {
+			return
+		}
+		seenCols[key] = true
+		out = append(out, entity(key, "SCOPE.Schema", "column", file.Path, line,
+			map[string]string{
+				"framework":    "alembic",
+				"pattern_type": "column",
+				"column_type":  colType,
+				"parent_table": table,
+				"source":       "alembic_migration",
+			}))
+	}
+
+	// --- op.create_table("name", sa.Column(...), ...) ---------------------
+	for _, ct := range allMatchesIndex(alembicCreateTableRe, source) {
+		table := source[ct[2]:ct[3]]
+		tableLine := lineOf(source, ct[0])
+		emitTable(table, tableLine)
+
+		// The column definitions live inside the create_table(...) argument
+		// list. Read the balanced parenthesised body starting at the "(" that
+		// opens the call (the last "(" before the table-name literal).
+		openIdx := strings.LastIndex(source[:ct[3]], "(")
+		body := balancedParenBody(source, openIdx)
+		for _, cm := range alembicColumnRe.FindAllStringSubmatchIndex(body, -1) {
+			col := body[cm[2]:cm[3]]
+			colType := body[cm[4]:cm[5]]
+			colLine := tableLine + strings.Count(body[:cm[0]], "\n")
+			emitColumn(table, col, colType, colLine)
+		}
+	}
+
+	// --- op.add_column("name", sa.Column(...)) ----------------------------
+	for _, ac := range allMatchesIndex(alembicAddColumnRe, source) {
+		table := source[ac[2]:ac[3]]
+		addLine := lineOf(source, ac[0])
+		// add_column targets an existing table; record it as a (table) entity
+		// so the column has a parent, but it is a column-level operation.
+		emitTable(table, addLine)
+
+		openIdx := strings.LastIndex(source[:ac[3]], "(")
+		body := balancedParenBody(source, openIdx)
+		if cm := alembicColumnRe.FindStringSubmatchIndex(body); cm != nil {
+			col := body[cm[2]:cm[3]]
+			colType := body[cm[4]:cm[5]]
+			colLine := addLine + strings.Count(body[:cm[0]], "\n")
+			emitColumn(table, col, colType, colLine)
+		}
+	}
+
+	// --- op.create_index("ix_name", "table", [...]) -----------------------
+	for _, ix := range allMatchesIndex(alembicCreateIndexRe, source) {
+		idxName := source[ix[2]:ix[3]]
+		table := source[ix[4]:ix[5]]
+		idxLine := lineOf(source, ix[0])
+		key := table + "." + idxName
+		if seenIdx[key] {
+			continue
+		}
+		seenIdx[key] = true
+		out = append(out, entity(key, "SCOPE.Schema", "index", file.Path, idxLine,
+			map[string]string{
+				"framework":    "alembic",
+				"pattern_type": "index",
+				"index_name":   idxName,
+				"parent_table": table,
+				"source":       "alembic_migration",
+			}))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/python/alembic_schema_test.go
+++ b/internal/custom/python/alembic_schema_test.go
@@ -1,0 +1,130 @@
+package python_test
+
+// alembic_schema_test.go — proving fixtures for the Alembic schema extractor.
+// Dedicated to issue #3192.
+//
+// These tests assert that the structural Alembic migration operations
+// (op.create_table / op.add_column / op.create_index) are parsed into
+// SCOPE.Schema table, column, and index entities.
+
+import "testing"
+
+// findAlembicEntity returns the first entity matching name+kind, or nil.
+func findAlembicEntity(result []extractResult, name, kind string) *extractResult {
+	for i := range result {
+		if result[i].Name == name && result[i].Kind == kind {
+			return &result[i]
+		}
+	}
+	return nil
+}
+
+// alembicColumnNames returns the column entity names (-> type) for a parent table.
+func alembicColumnNames(result []extractResult, parentTable string) map[string]string {
+	cols := make(map[string]string)
+	for _, e := range result {
+		if e.Kind != "SCOPE.Schema" || e.Subtype != "column" {
+			continue
+		}
+		if e.Props["parent_table"] == parentTable {
+			cols[e.Name] = e.Props["column_type"]
+		}
+	}
+	return cols
+}
+
+func TestAlembicSchema_CreateTable(t *testing.T) {
+	src := fixtureSchema(t, "alembic_schema.py")
+	ents := extract(t, "python_alembic_schema", src)
+
+	users := findAlembicEntity(ents, "users", "SCOPE.Schema")
+	if users == nil {
+		t.Fatal("expected users table entity")
+	}
+	if users.Subtype != "" {
+		t.Fatalf("expected table subtype empty, got %q", users.Subtype)
+	}
+	if users.Props["framework"] != "alembic" || users.Props["pattern_type"] != "table" {
+		t.Fatalf("users props wrong: %+v", users.Props)
+	}
+	if users.Props["source"] != "alembic_migration" {
+		t.Fatalf("expected source=alembic_migration, got %q", users.Props["source"])
+	}
+
+	if findAlembicEntity(ents, "orders", "SCOPE.Schema") == nil {
+		t.Fatal("expected orders table entity")
+	}
+
+	cols := alembicColumnNames(ents, "users")
+	for _, want := range []string{"users.id", "users.username", "users.email", "users.created_at"} {
+		if _, ok := cols[want]; !ok {
+			t.Fatalf("expected column %q, got %v", want, cols)
+		}
+	}
+	// Type token is the final identifier of the sa.<Type>() argument.
+	if cols["users.username"] != "String" {
+		t.Fatalf("expected users.username String, got %q", cols["users.username"])
+	}
+	if cols["users.id"] != "Integer" {
+		t.Fatalf("expected users.id Integer, got %q", cols["users.id"])
+	}
+	// PrimaryKeyConstraint / UniqueConstraint must NOT leak as columns.
+	if _, leaked := cols["users.PrimaryKeyConstraint"]; leaked {
+		t.Fatal("PrimaryKeyConstraint leaked as a column")
+	}
+
+	ocols := alembicColumnNames(ents, "orders")
+	if ocols["orders.total"] != "Numeric" {
+		t.Fatalf("expected orders.total Numeric, got %q", ocols["orders.total"])
+	}
+	// Dialect-qualified type (postgresql.JSONB) captures the final identifier.
+	if ocols["orders.metadata"] != "JSONB" {
+		t.Fatalf("expected orders.metadata JSONB, got %q", ocols["orders.metadata"])
+	}
+}
+
+func TestAlembicSchema_AddColumn(t *testing.T) {
+	src := fixtureSchema(t, "alembic_schema.py")
+	ents := extract(t, "python_alembic_schema", src)
+
+	cols := alembicColumnNames(ents, "users")
+	if cols["users.is_active"] != "Boolean" {
+		t.Fatalf("expected users.is_active Boolean from add_column, got %q (cols=%v)", cols["users.is_active"], cols)
+	}
+}
+
+func TestAlembicSchema_CreateIndex(t *testing.T) {
+	src := fixtureSchema(t, "alembic_schema.py")
+	ents := extract(t, "python_alembic_schema", src)
+
+	// Plain string index name.
+	ix := findAlembicEntity(ents, "users.ix_users_email", "SCOPE.Schema")
+	if ix == nil {
+		t.Fatal("expected users.ix_users_email index entity")
+	}
+	if ix.Subtype != "index" || ix.Props["parent_table"] != "users" {
+		t.Fatalf("index props wrong: subtype=%q props=%+v", ix.Subtype, ix.Props)
+	}
+	if ix.Props["index_name"] != "ix_users_email" {
+		t.Fatalf("expected index_name=ix_users_email, got %q", ix.Props["index_name"])
+	}
+
+	// op.f("...") wrapped index name.
+	if findAlembicEntity(ents, "orders.ix_orders_user_id", "SCOPE.Schema") == nil {
+		t.Fatal("expected orders.ix_orders_user_id index entity (op.f wrapped)")
+	}
+}
+
+// Negative: a non-Alembic module that happens to call create_table on some
+// local `op` object must yield nothing (no `from alembic import op`).
+func TestAlembicSchema_NotAlembic(t *testing.T) {
+	src := `
+import sqlalchemy as sa
+
+op = something_else()
+op.create_table("ghost", sa.Column("id", sa.Integer()))
+`
+	if got := extract(t, "python_alembic_schema", src); len(got) != 0 {
+		t.Fatalf("expected no entities for non-Alembic module, got %d: %+v", len(got), got)
+	}
+}

--- a/internal/custom/python/testdata/alembic_schema.py
+++ b/internal/custom/python/testdata/alembic_schema.py
@@ -1,0 +1,48 @@
+"""create users and orders
+
+Revision ID: a1b2c3d4e5f6
+Revises: 0f1e2d3c4b5a
+Create Date: 2026-05-29 12:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "a1b2c3d4e5f6"
+down_revision = "0f1e2d3c4b5a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("username", sa.String(length=100), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_table(
+        "orders",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id")),
+        sa.Column("total", sa.Numeric(10, 2), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Mutate an existing table.
+    op.add_column("users", sa.Column("is_active", sa.Boolean(), server_default="true"))
+
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+    op.create_index(op.f("ix_orders_user_id"), "orders", ["user_id"])
+
+
+def downgrade():
+    op.drop_index("ix_orders_user_id", table_name="orders")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_column("users", "is_active")
+    op.drop_table("orders")
+    op.drop_table("users")

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3930,6 +3930,24 @@ records:
           issues_implemented: ["2986"]
           verified_at: "2026-05-29"
 
+  lang.python.orm.alembic:
+    capabilities:
+      Models:
+        schema_extraction:
+          # op.create_table / op.add_column / op.create_index in Alembic
+          # migrations emitted as SCOPE.Schema table/column/index entities;
+          # gated on `from alembic import op`. Heuristic regex, distinct from
+          # driver_schema.go (#3189). Issue #3192.
+          status: partial
+          symbols:
+            - file: internal/custom/python/alembic_schema.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/python/alembic_schema_test.go
+            - file: internal/custom/python/testdata/alembic_schema.py
+          issues_implemented: ["3192"]
+          verified_at: "2026-05-30"
+
   lang.python.orm.sqlalchemy:
     capabilities:
       Relationships:


### PR DESCRIPTION
## Summary

Implements **#3192** — an Alembic `schema_extraction` extractor for `lang.python.orm.alembic`.

Alembic migrations express schema mutations imperatively via the `op` operations proxy rather than as ORM model classes, so they were invisible to both the SQLAlchemy class-body scanner (`sqlalchemy.go`) and the raw-SQL-literal scanner (`driver_schema.go`, #3189). New `internal/custom/python/alembic_schema.go` scans for the three structural operations and emits `SCOPE.Schema` entities:

- `op.create_table("t", sa.Column(...), ...)` → one **table** entity + one **column** entity per `sa.Column(...)`
- `op.add_column("t", sa.Column(...))` → a **column** entity attributed to its parent table
- `op.create_index("ix", "t", [...])` → an **index** entity (also handles the `op.f("ix")` wrapper)

Column type tokens capture the final identifier of the type argument (`sa.Integer()` → `Integer`, `postgresql.JSONB()` → `JSONB`). Table-level constraints (`PrimaryKeyConstraint` / `UniqueConstraint` / `ForeignKey`) do **not** leak as columns.

### Isolation from #3189
Deliberately distinct and non-overlapping with `driver_schema.go`: this extractor is gated on `from alembic import op` and only walks the `op.` operations proxy — it never parses raw SQL string literals, and `driver_schema.go` never fires on Alembic migrations (it requires a raw-driver import + embedded `CREATE TABLE` SQL).

## Coverage call
- `lang.python.orm.alembic` / **Models.schema_extraction**: `missing` → **`partial`**.
  - **partial, not full**: heuristic regex over migration source (not a full Python parse); dropped/altered columns, `server_default`/constraint metadata, and `op.alter_column` type changes are not modeled. No other honesty calls changed.

## Tests / fixtures
- Dedicated `alembic_schema_test.go` (create_table, add_column, create_index incl. `op.f(...)`, and a negative non-Alembic case).
- Proving fixture `testdata/alembic_schema.py` (realistic two-table migration with constraints, dialect type, add_column, two indexes, and a downgrade).
- `capability-map.yaml` entry added for `lang.python.orm.alembic` Models/schema_extraction.

## Validation
- `go build ./internal/... ./tools/coverage/...` — clean
- `go test ./internal/custom/python/... ./internal/types/ ./tools/coverage/...` — pass
- `coverage validate` — **0 errors** (only pre-existing warnings)
- `coverage fmt --check` — canonical
- `coverage gen` — **byte-stable** (regenerated docs committed)
- `gofmt -l` on new files — clean

Closes #3192

🤖 Generated with [Claude Code](https://claude.com/claude-code)