### PR TITLE
feat(coverage): Android platform_branching + native_module_imports extractor (#3188)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -191,8 +191,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/9 | |
 | [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/9 | |
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🔴 0/3 | 🔴 0/1 | 🟡 3/21 | 🔴 0/9 | |
-| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 3/9 | |
-| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 3/9 | |
+| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
+| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
 | [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 13/13 | |
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -60,8 +60,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 3/9 | |
-| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 3/9 | |
+| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
+| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.java.framework.android-jetpack.md
+++ b/docs/coverage/detail/lang.java.framework.android-jetpack.md
@@ -29,13 +29,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Platform branching | 🔴 `missing` | — | — | — | — |
+| Platform branching | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188) |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Native module imports | 🔴 `missing` | — | — | — | — |
+| Native module imports | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188) |
 
 ### Data Flow
 

--- a/docs/coverage/detail/lang.java.framework.android-sdk.md
+++ b/docs/coverage/detail/lang.java.framework.android-sdk.md
@@ -29,13 +29,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Platform branching | 🔴 `missing` | — | — | — | — |
+| Platform branching | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188) |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Native module imports | 🔴 `missing` | — | — | — | — |
+| Native module imports | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188) |
 
 ### Data Flow
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14259,12 +14259,16 @@
         },
         "Platform": {
           "platform_branching": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/android.go"],
+            "notes": "adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188)"
           }
         },
         "Native Bridge": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/android.go"],
+            "notes": "adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188)"
           }
         },
         "Data Flow": {
@@ -14437,12 +14441,16 @@
         },
         "Platform": {
           "platform_branching": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/android.go"],
+            "notes": "adSdkIntBranchRE detects Build.VERSION.SDK_INT API-level comparisons as platform-branch operations owned by the enclosing class (#3188)"
           }
         },
         "Native Bridge": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/android.go"],
+            "notes": "adUsesPermissionRE+adUsesFeatureRE (manifest android.hardware.*) and adHardwareImportRE (import android.hardware.*) emit native-module references (#3188)"
           }
         },
         "Data Flow": {

--- a/internal/custom/java/android.go
+++ b/internal/custom/java/android.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -48,6 +49,23 @@ var (
 			`\s*\(\s*\)[^;]*?\.(?:add|replace)\s*\([^,]*,\s*(?:new\s+)?(\w+)\s*(?:\(\s*\))?`)
 	adViewModelProviderRE = regexp.MustCompile(
 		`(?m)(?:new\s+)?ViewModelProvider\s*\([^)]*\)\s*\.get\s*\(\s*(\w+)\.class\s*\)`)
+	// platform_branching: Build.VERSION.SDK_INT comparisons against an API level.
+	// Captures the comparison operator and the right-hand API-level token
+	// (e.g. Build.VERSION_CODES.O, an int literal, or a constant).
+	adSdkIntBranchRE = regexp.MustCompile(
+		`(?m)Build\.VERSION\.SDK_INT\s*(>=|<=|>|<|==|!=)\s*([A-Za-z0-9_.]+)`)
+	// native_module_imports: <uses-permission android:name="android.hardware.*">
+	// (or android.permission.*) declarations in AndroidManifest.xml.
+	adUsesPermissionRE = regexp.MustCompile(
+		`(?m)<uses-permission\b[^>]*android:name\s*=\s*\"([^\"]+)\"`)
+	// native_module_imports: <uses-feature android:name="android.hardware.*">
+	// declarations in AndroidManifest.xml (hardware/software feature gates).
+	adUsesFeatureRE = regexp.MustCompile(
+		`(?m)<uses-feature\b[^>]*android:name\s*=\s*\"([^\"]+)\"`)
+	// native_module_imports: import android.hardware.* statements in Java source
+	// (Camera, Sensor, fingerprint, usb, etc. — the native-device bridge surface).
+	adHardwareImportRE = regexp.MustCompile(
+		`(?m)^\s*import\s+(android\.hardware\.[A-Za-z0-9_.]+)\s*;`)
 )
 
 func androidFrameworkMatches(fw string) bool {
@@ -248,7 +266,90 @@ func ExtractAndroid(ctx PatternContext) PatternResult {
 		})
 	}
 
+	// platform_branching: Build.VERSION.SDK_INT API-level comparisons.
+	// Each comparison site becomes a branch operation owned by the enclosing
+	// class, mirroring the JS mobile platform_branching capability for Android.
+	for _, m := range adSdkIntBranchRE.FindAllStringSubmatchIndex(source, -1) {
+		op := source[m[2]:m[3]]
+		apiLevel := source[m[4]:m[5]]
+		enclosing := findEnclosingClass(source, m[0])
+		expr := "Build.VERSION.SDK_INT " + op + " " + apiLevel
+		branchRef := "scope:operation:android_platform_branch:" + fp + ":" +
+			expr + ":" + lineToStr(source, m[0])
+		props := map[string]any{
+			"branch_kind": "sdk_int", "operator": op,
+			"api_level": apiLevel, "expression": expr,
+			"framework": "android",
+		}
+		if enclosing != "" {
+			props["enclosing_class"] = enclosing
+		}
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: expr, Kind: "SCOPE.Operation", Subtype: "branch",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_ANDROID_SDK_INT_BRANCH", Ref: branchRef,
+			Properties: props,
+		}) && enclosing != "" {
+			addRel(&result, seenRels, Relationship{
+				SourceRef: resolveRef(enclosing), TargetRef: branchRef,
+				RelationshipType: "OWNS",
+				Properties:       map[string]string{"branch_kind": "platform_sdk_int"},
+			})
+		}
+	}
+
+	// native_module_imports: AndroidManifest <uses-permission> / <uses-feature>
+	// hardware declarations + `import android.hardware.*` statements. These
+	// surface the native-device bridge surface (camera, sensors, usb, biometrics).
+	emitNativeModule := func(name, declKind, prov string, line int) {
+		ref := "scope:reference:android_native_module:" + fp + ":" + name
+		props := map[string]any{
+			"module_name": name, "declaration_kind": declKind,
+			"framework": "android",
+		}
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			props["category"] = name[:i]
+		}
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Reference", Subtype: "native_module",
+			SourceFile: fp, LineStart: line, LineEnd: line,
+			Provenance: prov, Ref: ref, Properties: props,
+		})
+	}
+
+	if isManifest {
+		for _, m := range adUsesPermissionRE.FindAllStringSubmatchIndex(source, -1) {
+			name := source[m[2]:m[3]]
+			if !strings.HasPrefix(name, "android.hardware.") {
+				continue
+			}
+			emitNativeModule(name, "uses-permission",
+				"INFERRED_FROM_ANDROID_USES_PERMISSION", lineOf(source, m[0]))
+		}
+		for _, m := range adUsesFeatureRE.FindAllStringSubmatchIndex(source, -1) {
+			name := source[m[2]:m[3]]
+			if !strings.HasPrefix(name, "android.hardware.") {
+				continue
+			}
+			emitNativeModule(name, "uses-feature",
+				"INFERRED_FROM_ANDROID_USES_FEATURE", lineOf(source, m[0]))
+		}
+	} else {
+		for _, m := range adHardwareImportRE.FindAllStringSubmatchIndex(source, -1) {
+			name := source[m[2]:m[3]]
+			emitNativeModule(name, "import",
+				"INFERRED_FROM_ANDROID_HARDWARE_IMPORT", lineOf(source, m[0]))
+		}
+	}
+
 	return result
+}
+
+// lineToStr returns the 1-indexed line number for offset as a string, for use
+// in synthetic entity refs that must stay unique across like-named branches.
+func lineToStr(source string, offset int) string {
+	return strconv.Itoa(lineOf(source, offset))
 }
 
 func shortClassName(fullName string) string {

--- a/internal/custom/java/android_platform_native_test.go
+++ b/internal/custom/java/android_platform_native_test.go
@@ -1,0 +1,234 @@
+package java
+
+import (
+	"testing"
+)
+
+// ============================================================================
+// Issue #3188: Android platform_branching + native_module_imports extractor
+// ============================================================================
+//
+// These dedicated tests prove the two new capabilities added to android.go:
+//
+//   platform_branching   -> Build.VERSION.SDK_INT API-level comparisons
+//   native_module_imports -> <uses-permission>/<uses-feature> android.hardware.*
+//                            in AndroidManifest.xml + `import android.hardware.*`
+//
+// Registry targets (both flipped to partial):
+//   lang.java.framework.android-sdk     Platform/platform_branching
+//   lang.java.framework.android-sdk     Native Bridge/native_module_imports
+//   lang.java.framework.android-jetpack Platform/platform_branching
+//   lang.java.framework.android-jetpack Native Bridge/native_module_imports
+// Cite: internal/custom/java/android.go
+
+// ----------------------------------------------------------------------------
+// platform_branching: Build.VERSION.SDK_INT comparisons
+// ----------------------------------------------------------------------------
+
+// androidSdkIntFixture is the golden source proving SDK_INT branch detection.
+const androidSdkIntFixture = `package com.example.app;
+
+import android.os.Build;
+import android.app.Activity;
+
+public class FeatureGate extends Activity {
+    public void apply() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundChannel();
+        } else if (Build.VERSION.SDK_INT < 21) {
+            legacyPath();
+        }
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU) {
+            notifyPermission();
+        }
+    }
+}
+`
+
+func TestAndroid_PlatformBranching_SdkInt_Issue3188(t *testing.T) {
+	r := ExtractAndroid(PatternContext{
+		Source:    androidSdkIntFixture,
+		Language:  "java",
+		Framework: "android",
+		FilePath:  "FeatureGate.java",
+	})
+
+	type branch struct{ op, level string }
+	got := make(map[branch]bool)
+	for _, e := range r.Entities {
+		if e.Provenance != "INFERRED_FROM_ANDROID_SDK_INT_BRANCH" {
+			continue
+		}
+		if e.Kind != "SCOPE.Operation" || e.Subtype != "branch" {
+			t.Errorf("[#3188 platform_branching] unexpected kind/subtype %s/%s for %s",
+				e.Kind, e.Subtype, e.Name)
+		}
+		if e.Properties["framework"] != "android" {
+			t.Errorf("[#3188 platform_branching] missing framework=android on %s", e.Name)
+		}
+		got[branch{
+			e.Properties["operator"].(string),
+			e.Properties["api_level"].(string),
+		}] = true
+	}
+
+	want := []branch{
+		{">=", "Build.VERSION_CODES.O"},
+		{"<", "21"},
+		{"==", "Build.VERSION_CODES.TIRAMISU"},
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("[#3188 platform_branching] expected SDK_INT branch %q %q, got %v",
+				w.op, w.level, got)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("[#3188 platform_branching] expected exactly 3 branches, got %d: %v", len(got), got)
+	}
+
+	// Each branch site should be OWNED by the enclosing class.
+	owns := 0
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "OWNS" &&
+			rel.Properties["branch_kind"] == "platform_sdk_int" {
+			owns++
+		}
+	}
+	if owns != 3 {
+		t.Errorf("[#3188 platform_branching] expected 3 OWNS branch edges, got %d", owns)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// native_module_imports: AndroidManifest hardware permissions/features
+// ----------------------------------------------------------------------------
+
+// androidManifestNativeFixture is the golden manifest proving hardware
+// permission + feature detection (and that non-hardware permissions are skipped).
+const androidManifestNativeFixture = `<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.app">
+    <uses-permission android:name="android.hardware.camera" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:name="android.software.leanback" />
+    <application android:label="App">
+        <activity android:name=".MainActivity" />
+    </application>
+</manifest>
+`
+
+func TestAndroid_NativeModuleImports_Manifest_Issue3188(t *testing.T) {
+	r := ExtractAndroid(PatternContext{
+		Source:    androidManifestNativeFixture,
+		Language:  "java",
+		Framework: "android",
+		FilePath:  "app/src/main/AndroidManifest.xml",
+	})
+
+	type nm struct{ name, decl string }
+	got := make(map[nm]bool)
+	for _, e := range r.Entities {
+		switch e.Provenance {
+		case "INFERRED_FROM_ANDROID_USES_PERMISSION",
+			"INFERRED_FROM_ANDROID_USES_FEATURE":
+			if e.Kind != "SCOPE.Reference" || e.Subtype != "native_module" {
+				t.Errorf("[#3188 native_module_imports] unexpected kind/subtype %s/%s for %s",
+					e.Kind, e.Subtype, e.Name)
+			}
+			got[nm{e.Name, e.Properties["declaration_kind"].(string)}] = true
+		}
+	}
+
+	want := []nm{
+		{"android.hardware.camera", "uses-permission"},
+		{"android.hardware.camera.autofocus", "uses-feature"},
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("[#3188 native_module_imports] expected %q (%s), got %v", w.name, w.decl, got)
+		}
+	}
+	// android.permission.INTERNET and android.software.leanback must NOT match.
+	for k := range got {
+		if k.name == "android.permission.INTERNET" || k.name == "android.software.leanback" {
+			t.Errorf("[#3188 native_module_imports] non-hardware decl leaked: %v", k)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("[#3188 native_module_imports] expected exactly 2 hardware decls, got %d: %v", len(got), got)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// native_module_imports: android.hardware.* import statements
+// ----------------------------------------------------------------------------
+
+const androidHardwareImportFixture = `package com.example.app;
+
+import android.hardware.Camera;
+import android.hardware.SensorManager;
+import android.hardware.fingerprint.FingerprintManager;
+import android.os.Build;
+import java.util.List;
+
+public class DeviceProbe {
+}
+`
+
+func TestAndroid_NativeModuleImports_JavaImports_Issue3188(t *testing.T) {
+	r := ExtractAndroid(PatternContext{
+		Source:    androidHardwareImportFixture,
+		Language:  "java",
+		Framework: "android_jetpack",
+		FilePath:  "DeviceProbe.java",
+	})
+
+	got := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance != "INFERRED_FROM_ANDROID_HARDWARE_IMPORT" {
+			continue
+		}
+		if e.Kind != "SCOPE.Reference" || e.Subtype != "native_module" {
+			t.Errorf("[#3188 native_module_imports] unexpected kind/subtype %s/%s for %s",
+				e.Kind, e.Subtype, e.Name)
+		}
+		if e.Properties["declaration_kind"] != "import" {
+			t.Errorf("[#3188 native_module_imports] expected declaration_kind=import for %s", e.Name)
+		}
+		got[e.Name] = true
+	}
+
+	want := []string{
+		"android.hardware.Camera",
+		"android.hardware.SensorManager",
+		"android.hardware.fingerprint.FingerprintManager",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("[#3188 native_module_imports] expected import %q, got %v", w, got)
+		}
+	}
+	// android.os.Build and java.util.List must NOT be treated as native modules.
+	if got["android.os.Build"] || got["java.util.List"] {
+		t.Errorf("[#3188 native_module_imports] non-hardware import leaked: %v", got)
+	}
+	if len(got) != 3 {
+		t.Errorf("[#3188 native_module_imports] expected exactly 3 hardware imports, got %d: %v", len(got), got)
+	}
+}
+
+// TestAndroid_PlatformNative_GateMiss_Issue3188 proves the new scanners stay
+// silent for non-android frameworks (gate respected, no false positives).
+func TestAndroid_PlatformNative_GateMiss_Issue3188(t *testing.T) {
+	r := ExtractAndroid(PatternContext{
+		Source:    androidSdkIntFixture,
+		Language:  "java",
+		Framework: "spring",
+		FilePath:  "FeatureGate.java",
+	})
+	if len(r.Entities) != 0 || len(r.Relationships) != 0 {
+		t.Errorf("[#3188] non-android framework should yield nothing, got %d entities", len(r.Entities))
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -4709,6 +4709,54 @@ records:
             - file: internal/custom/java/extractors_test.go
           issues_implemented: ["3006"]
           verified_at: "2026-05-29"
+  lang.java.framework.android-sdk:
+    capabilities:
+      Platform:
+        platform_branching:
+          status: partial
+          symbols:
+            - file: internal/custom/java/android.go
+              functions: [ExtractAndroid]
+          tests:
+            - file: internal/custom/java/android_platform_native_test.go
+              functions: [TestAndroid_PlatformBranching_SdkInt_Issue3188]
+          issues_implemented: ["3188"]
+          verified_at: "2026-05-30"
+      Native Bridge:
+        native_module_imports:
+          status: partial
+          symbols:
+            - file: internal/custom/java/android.go
+              functions: [ExtractAndroid]
+          tests:
+            - file: internal/custom/java/android_platform_native_test.go
+              functions: [TestAndroid_NativeModuleImports_Manifest_Issue3188, TestAndroid_NativeModuleImports_JavaImports_Issue3188]
+          issues_implemented: ["3188"]
+          verified_at: "2026-05-30"
+  lang.java.framework.android-jetpack:
+    capabilities:
+      Platform:
+        platform_branching:
+          status: partial
+          symbols:
+            - file: internal/custom/java/android.go
+              functions: [ExtractAndroid]
+          tests:
+            - file: internal/custom/java/android_platform_native_test.go
+              functions: [TestAndroid_PlatformBranching_SdkInt_Issue3188]
+          issues_implemented: ["3188"]
+          verified_at: "2026-05-30"
+      Native Bridge:
+        native_module_imports:
+          status: partial
+          symbols:
+            - file: internal/custom/java/android.go
+              functions: [ExtractAndroid]
+          tests:
+            - file: internal/custom/java/android_platform_native_test.go
+              functions: [TestAndroid_NativeModuleImports_Manifest_Issue3188, TestAndroid_NativeModuleImports_JavaImports_Issue3188]
+          issues_implemented: ["3188"]
+          verified_at: "2026-05-30"
   lang.java.framework.vertx:
     capabilities:
       Observability:


### PR DESCRIPTION
## Summary

Implements GitHub issue #3188 — adds two Android capability scanners to the existing Java custom extractor `internal/custom/java/android.go`, flipping `platform_branching` and `native_module_imports` to **partial** on both `lang.java.framework.android-sdk` and `lang.java.framework.android-jetpack`.

### platform_branching
- `adSdkIntBranchRE` matches `Build.VERSION.SDK_INT` comparisons (`>=`, `<=`, `>`, `<`, `==`, `!=`) against an API-level token (`Build.VERSION_CODES.*`, an int literal, or a named constant).
- Each comparison site becomes a `SCOPE.Operation` / `branch` entity (provenance `INFERRED_FROM_ANDROID_SDK_INT_BRANCH`) carrying `operator`, `api_level`, `expression`, and `enclosing_class`, and is linked via an `OWNS` edge from the enclosing class.

### native_module_imports
- `adUsesPermissionRE` + `adUsesFeatureRE` scan `AndroidManifest.xml` for `<uses-permission>` / `<uses-feature>` declarations named `android.hardware.*`.
- `adHardwareImportRE` scans Java source for `import android.hardware.*;` statements.
- Each becomes a `SCOPE.Reference` / `native_module` entity carrying `module_name`, `declaration_kind` (`uses-permission` / `uses-feature` / `import`), and `category`. Non-hardware permissions (`android.permission.*`) and non-hardware imports (`android.os.*`, `java.util.*`) are filtered out.

## Why partial, not full
Both scanners are heuristic regex passes over raw source (no tree-sitter, consistent with the rest of `internal/custom/java/`). They reliably surface the documented branch/native shapes but do not resolve control-flow reachability or transitive native dependencies — `partial` is the honest call. No cells set to `full`; nothing newly `not_applicable`.

## Proof
Dedicated test file `internal/custom/java/android_platform_native_test.go` (not the shared `extractors_test.go`) with golden fixtures:
- `TestAndroid_PlatformBranching_SdkInt_Issue3188` — 3 distinct SDK_INT branches + OWNS edges.
- `TestAndroid_NativeModuleImports_Manifest_Issue3188` — hardware permission + feature detected; `android.permission.INTERNET` and `android.software.leanback` correctly skipped.
- `TestAndroid_NativeModuleImports_JavaImports_Issue3188` — three `android.hardware.*` imports detected; `android.os.Build` / `java.util.List` skipped.
- `TestAndroid_PlatformNative_GateMiss_Issue3188` — silent for non-android frameworks.

## Validation
- `go build ./internal/... ./tools/coverage/...` — clean
- `go test ./internal/custom/java/... ./internal/types/ ./tools/coverage/...` — pass
- `coverage validate` — 0 errors (android cells now have capability-map mapping entries)
- `coverage fmt --check` — canonical
- `coverage gen` — byte-stable; regenerated docs committed
- `gofmt -l` on changed Go files — empty

## Coverage delta
**Cells changed: 4** · improved: **4** · regressed: **0** (all `missing → partial`).

| Record | Group | Capability | Before → After |
|---|---|---|---|
| `lang.java.framework.android-jetpack` | Native Bridge | native_module_imports | missing → partial |
| `lang.java.framework.android-jetpack` | Platform | platform_branching | missing → partial |
| `lang.java.framework.android-sdk` | Native Bridge | native_module_imports | missing → partial |
| `lang.java.framework.android-sdk` | Platform | platform_branching | missing → partial |

**Real-data check:** unit-fixture only.

Closes #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
