### PR TITLE
feat(coverage): Go chi + gorilla-mux routing extractors (#3212 slice)

### DIFF
--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/chi.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/chi.go`<br>`internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/chi.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/chi.go`<br>`internal/engine/go_routes.go` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gorilla_mux.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/gorilla_mux.go`<br>`internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/gorilla_mux.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/gorilla_mux.go`<br>`internal/engine/go_routes.go` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -11008,13 +11008,13 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/chi.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/chi.go","internal/engine/go_routes.go","internal/engine/rules/go/frameworks/chi.yaml"],
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/chi.go","internal/engine/go_routes.go"],
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
             "status": "missing",
@@ -12299,13 +12299,13 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gorilla_mux.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/gorilla_mux.go","internal/engine/go_routes.go","internal/engine/rules/go/frameworks/gorilla_mux.yaml"],
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/gorilla_mux.go","internal/engine/go_routes.go"],
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
             "status": "missing",

--- a/internal/custom/golang/chi.go
+++ b/internal/custom/golang/chi.go
@@ -1,0 +1,147 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_chi", &chiExtractor{})
+}
+
+type chiExtractor struct{}
+
+func (e *chiExtractor) Language() string { return "custom_go_chi" }
+
+var (
+	reChiRouter = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*chi\.NewRouter\s*\(\s*\)`,
+	)
+	// chi sub-routers: r.Route("/prefix", func(r chi.Router) {...}) and
+	// chi.NewRouter() assigned to a nested var. Route() establishes a path
+	// prefix scope; we capture the prefix as a component.
+	reChiGroup = regexp.MustCompile(
+		`(?m)(\w+)\.Route\s*\(\s*"([^"]+)"`,
+	)
+	// chi uses Title-case verb methods: r.Get/Post/Put/Patch/Delete/...
+	reChiRoute = regexp.MustCompile(
+		`(?m)(\w+)\.(Get|Post|Put|Patch|Delete|Head|Options|Connect|Trace)\s*\(\s*"([^"]+)"`,
+	)
+	// Generic registration: r.Handle("/path", h) / r.HandleFunc("/path", h)
+	reChiHandle = regexp.MustCompile(
+		`(?m)(\w+)\.(Handle|HandleFunc)\s*\(\s*"([^"]+)"`,
+	)
+	// Sub-router mount: r.Mount("/prefix", handler)
+	reChiMount = regexp.MustCompile(
+		`(?m)(\w+)\.Mount\s*\(\s*"([^"]+)"`,
+	)
+	reChiUse = regexp.MustCompile(
+		`(?m)(\w+)\.Use\s*\(\s*((?:[^()]+|\([^)]*\))+?)\s*\)`,
+	)
+)
+
+func (e *chiExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.chi_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "chi"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. chi.NewRouter() -> SCOPE.Service
+	for _, m := range reChiRouter.FindAllStringSubmatchIndex(src, -1) {
+		varName := src[m[2]:m[3]]
+		ent := makeEntity(varName, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "chi", "provenance", "INFERRED_FROM_CHI_ROUTER",
+			"constructor", "chi.NewRouter")
+		add(ent)
+	}
+
+	// 2. r.Route("/prefix", func(r chi.Router){...}) sub-router scope ->
+	//    SCOPE.Component. chi groups are closure-scoped (the prefix is applied
+	//    to the closure's router param, not a returned variable), so we record
+	//    the prefix as a component but leave prefix-joining of nested routes to
+	//    the AST-driven go_routes.go composition pass.
+	for _, m := range reChiGroup.FindAllStringSubmatchIndex(src, -1) {
+		path := src[m[4]:m[5]]
+		ent := makeEntity(path, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "chi", "provenance", "INFERRED_FROM_CHI_ROUTE_GROUP",
+			"group_path", path)
+		add(ent)
+	}
+
+	// 3. HTTP verb routes -> SCOPE.Operation/endpoint
+	for _, m := range reChiRoute.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := src[m[2]:m[3]]
+		method := strings.ToUpper(src[m[4]:m[5]])
+		path := src[m[6]:m[7]]
+		name := method + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "chi", "provenance", "INFERRED_FROM_CHI_ROUTE",
+			"http_method", method, "route_path", path, "router_var", routerVar)
+		add(ent)
+	}
+
+	// 4. r.Handle/HandleFunc("/path", h) -> SCOPE.Operation/endpoint (method-agnostic)
+	for _, m := range reChiHandle.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := src[m[2]:m[3]]
+		path := src[m[6]:m[7]]
+		name := "ANY " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "chi", "provenance", "INFERRED_FROM_CHI_HANDLE",
+			"http_method", "ANY", "route_path", path, "router_var", routerVar)
+		add(ent)
+	}
+
+	// 5. r.Mount("/prefix", handler) sub-router mount -> SCOPE.Component
+	for _, m := range reChiMount.FindAllStringSubmatchIndex(src, -1) {
+		path := src[m[4]:m[5]]
+		ent := makeEntity(path, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "chi", "provenance", "INFERRED_FROM_CHI_MOUNT",
+			"mount_path", path)
+		add(ent)
+	}
+
+	// 6. r.Use(middleware) -> SCOPE.Pattern
+	for _, m := range reChiUse.FindAllStringSubmatchIndex(src, -1) {
+		mwExpr := strings.TrimSpace(src[m[4]:m[5]])
+		ent := makeEntity(mwExpr, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "chi", "provenance", "INFERRED_FROM_CHI_MIDDLEWARE",
+			"pattern_kind", "middleware")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/golang/extractors_test.go
+++ b/internal/custom/golang/extractors_test.go
@@ -192,6 +192,142 @@ func TestFiberNoMatch(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Chi
+// ---------------------------------------------------------------------------
+
+func TestChiRouter(t *testing.T) {
+	src := `r := chi.NewRouter()`
+	ents := extract(t, "custom_go_chi", fi("main.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Service", "r") {
+		t.Error("expected r as chi router service")
+	}
+}
+
+func TestChiRoutes(t *testing.T) {
+	src := `
+r := chi.NewRouter()
+r.Get("/users", listUsers)
+r.Post("/users", createUser)
+r.Delete("/users/{id}", deleteUser)
+`
+	ents := extract(t, "custom_go_chi", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /users") {
+		t.Error("expected GET /users route")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "POST /users") {
+		t.Error("expected POST /users route")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "DELETE /users/{id}") {
+		t.Error("expected DELETE /users/{id} route")
+	}
+}
+
+func TestChiRouteGroup(t *testing.T) {
+	src := `
+r.Route("/api", func(r chi.Router) {
+	r.Get("/health", healthCheck)
+})
+`
+	ents := extract(t, "custom_go_chi", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Component", "/api") {
+		t.Error("expected /api route-group component")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "GET /health") {
+		t.Error("expected GET /health route inside group")
+	}
+}
+
+func TestChiHandleAndMount(t *testing.T) {
+	src := `
+r.HandleFunc("/legacy", legacyHandler)
+r.Mount("/admin", adminRouter)
+`
+	ents := extract(t, "custom_go_chi", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "ANY /legacy") {
+		t.Error("expected ANY /legacy from HandleFunc")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "/admin") {
+		t.Error("expected /admin mount component")
+	}
+}
+
+func TestChiMiddleware(t *testing.T) {
+	src := `r.Use(middleware.Logger)`
+	ents := extract(t, "custom_go_chi", fi("main.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "middleware.Logger") {
+		t.Error("expected middleware.Logger pattern")
+	}
+}
+
+func TestChiNoMatch(t *testing.T) {
+	src := `package main`
+	ents := extract(t, "custom_go_chi", fi("main.go", "go", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gorilla Mux
+// ---------------------------------------------------------------------------
+
+func TestGorillaRouter(t *testing.T) {
+	src := `r := mux.NewRouter()`
+	ents := extract(t, "custom_go_gorilla_mux", fi("main.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Service", "r") {
+		t.Error("expected r as gorilla router service")
+	}
+}
+
+func TestGorillaRoutesWithMethods(t *testing.T) {
+	src := `
+r := mux.NewRouter()
+r.HandleFunc("/users", listUsers).Methods("GET")
+r.HandleFunc("/users", createUser).Methods("POST")
+`
+	ents := extract(t, "custom_go_gorilla_mux", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /users") {
+		t.Error("expected GET /users route")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "POST /users") {
+		t.Error("expected POST /users route")
+	}
+}
+
+func TestGorillaRouteNoMethodsIsAny(t *testing.T) {
+	src := `
+r := mux.NewRouter()
+r.HandleFunc("/health", healthCheck)
+`
+	ents := extract(t, "custom_go_gorilla_mux", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "ANY /health") {
+		t.Error("expected ANY /health for un-method-constrained route")
+	}
+}
+
+func TestGorillaSubrouterPrefix(t *testing.T) {
+	src := `
+api := r.PathPrefix("/api").Subrouter()
+api.HandleFunc("/orders", listOrders).Methods("GET")
+`
+	ents := extract(t, "custom_go_gorilla_mux", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Component", "/api") {
+		t.Error("expected /api subrouter component")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/orders") {
+		t.Error("expected GET /api/orders with subrouter prefix")
+	}
+}
+
+func TestGorillaNoMatch(t *testing.T) {
+	src := `package main`
+	ents := extract(t, "custom_go_gorilla_mux", fi("main.go", "go", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
 // GORM
 // ---------------------------------------------------------------------------
 

--- a/internal/custom/golang/gorilla_mux.go
+++ b/internal/custom/golang/gorilla_mux.go
@@ -1,0 +1,136 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_gorilla_mux", &gorillaMuxExtractor{})
+}
+
+type gorillaMuxExtractor struct{}
+
+func (e *gorillaMuxExtractor) Language() string { return "custom_go_gorilla_mux" }
+
+var (
+	reGorillaRouter = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*mux\.NewRouter\s*\(\s*\)`,
+	)
+	// Subrouter scope: api := r.PathPrefix("/api").Subrouter()
+	reGorillaSubrouter = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*\w+\.PathPrefix\s*\(\s*"([^"]+)"\s*\)\.Subrouter\s*\(\s*\)`,
+	)
+	// Route registration: r.HandleFunc("/path", handler) optionally chained
+	// with .Methods("GET", "POST"). We capture the registration plus the rest
+	// of the line, then scan the tail for a .Methods(...) call to recover the
+	// HTTP verb(s).
+	reGorillaRoute = regexp.MustCompile(
+		`(?m)(\w+)\.(HandleFunc|Handle)\s*\(\s*"([^"]+)"([^\n]*)`,
+	)
+	reGorillaMethods = regexp.MustCompile(`\.Methods\s*\(\s*((?:"[^"]+"\s*,?\s*)+)\)`)
+	reGorillaMethod  = regexp.MustCompile(`"([^"]+)"`)
+	reGorillaUse     = regexp.MustCompile(
+		`(?m)(\w+)\.Use\s*\(\s*((?:[^()]+|\([^)]*\))+?)\s*\)`,
+	)
+)
+
+func (e *gorillaMuxExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.gorilla_mux_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "gorilla-mux"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. mux.NewRouter() -> SCOPE.Service
+	for _, m := range reGorillaRouter.FindAllStringSubmatchIndex(src, -1) {
+		varName := src[m[2]:m[3]]
+		ent := makeEntity(varName, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "gorilla-mux", "provenance", "INFERRED_FROM_GORILLA_ROUTER",
+			"constructor", "mux.NewRouter")
+		add(ent)
+	}
+
+	// 2. PathPrefix(...).Subrouter() -> SCOPE.Component (prefix scope)
+	groupPaths := make(map[string]string)
+	for _, m := range reGorillaSubrouter.FindAllStringSubmatchIndex(src, -1) {
+		varName := src[m[2]:m[3]]
+		path := src[m[4]:m[5]]
+		groupPaths[varName] = path
+		ent := makeEntity(path, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "gorilla-mux", "provenance", "INFERRED_FROM_GORILLA_SUBROUTER",
+			"group_path", path)
+		add(ent)
+	}
+
+	// 3. HandleFunc/Handle routes (+ optional .Methods) -> SCOPE.Operation/endpoint
+	for _, m := range reGorillaRoute.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := src[m[2]:m[3]]
+		path := src[m[6]:m[7]]
+		if gp, ok := groupPaths[routerVar]; ok {
+			path = gp + path
+		}
+		tail := src[m[8]:m[9]]
+		methods := []string{}
+		if mm := reGorillaMethods.FindStringSubmatch(tail); mm != nil {
+			for _, vm := range reGorillaMethod.FindAllStringSubmatch(mm[1], -1) {
+				methods = append(methods, strings.ToUpper(vm[1]))
+			}
+		}
+		if len(methods) == 0 {
+			// No .Methods() chain: gorilla matches any verb for this path.
+			methods = []string{"ANY"}
+		}
+		for _, method := range methods {
+			name := method + " " + path
+			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "gorilla-mux", "provenance", "INFERRED_FROM_GORILLA_ROUTE",
+				"http_method", method, "route_path", path, "router_var", routerVar)
+			add(ent)
+		}
+	}
+
+	// 4. r.Use(middleware) -> SCOPE.Pattern
+	for _, m := range reGorillaUse.FindAllStringSubmatchIndex(src, -1) {
+		mwExpr := strings.TrimSpace(src[m[4]:m[5]])
+		ent := makeEntity(mwExpr, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "gorilla-mux", "provenance", "INFERRED_FROM_GORILLA_MIDDLEWARE",
+			"pattern_kind", "middleware")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/engine/go_routes_test.go
+++ b/internal/engine/go_routes_test.go
@@ -49,6 +49,38 @@ func main() {
 	}
 }
 
+func TestApplyGoRouteComposition_GorillaMuxHandleFunc(t *testing.T) {
+	// gorilla/mux registers via r.HandleFunc("/path", h.Method).Methods(...).
+	// The YAML rule captures only the bare receiver `h`; the AST pass must
+	// rewrite the orphan Controller:h edge to the qualified handler method.
+	src := []byte(`package main
+
+import "github.com/gorilla/mux"
+
+func main() {
+	h := &UsersHandler{}
+	r := mux.NewRouter()
+	r.HandleFunc("/users", h.List).Methods("GET")
+	r.HandleFunc("/users/{id}", h.Get).Methods("GET")
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+		makeRoutesToRel("/users/{id}", "h"),
+	}
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
+	if got[0].ToID != "Controller:UsersHandler.List" {
+		t.Errorf("ToID[0] = %q, want Controller:UsersHandler.List", got[0].ToID)
+	}
+	if got[1].ToID != "Controller:UsersHandler.Get" {
+		t.Errorf("ToID[1] = %q, want Controller:UsersHandler.Get", got[1].ToID)
+	}
+	if got[0].Properties["go_route_binding"] != "method_receiver_resolved" {
+		t.Errorf("go_route_binding[0] = %q, want method_receiver_resolved", got[0].Properties["go_route_binding"])
+	}
+}
+
 func TestApplyGoRouteComposition_ConstructorIdiom(t *testing.T) {
 	// `h := handlers.NewUsersHandler(s)` — cross-package NewT() returns *T.
 	src := []byte(`package main

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -2846,6 +2846,87 @@ records:
           issues_implemented: ["3211"]
           verified_at: "2026-05-30"
 
+  lang.go.framework.chi:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          # chi.go custom extractor: reChiRoute captures r.Get/Post/… (Title-case
+          # methods), reChiHandle covers r.Handle/HandleFunc, reChiMount/reChiGroup
+          # record sub-router prefixes; chi.NewRouter() seeds the router service.
+          # go_routes.go AST pass rewrites bare-receiver ROUTES_TO edges to the
+          # qualified handler method. chi.yaml YAML rules add static patterns.
+          status: full
+          symbols:
+            - file: internal/custom/golang/chi.go
+              functions: [Extract]
+            - file: internal/engine/go_routes.go
+              functions:
+                - applyGoRouteComposition
+                - extractGoHandlerBindings
+                - buildGoVarTypeMap
+                - inferGoExprType
+                - typeNameFromExpr
+            - file: internal/engine/rules/go/frameworks/chi.yaml
+          tests:
+            - file: internal/custom/golang/extractors_test.go
+            - file: internal/engine/go_routes_test.go
+          issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          # go_routes.go resolves the receiver variable in r.Get("/p", h.Method)
+          # to its struct type and rewrites Controller:h → Controller:Type.Method.
+          status: full
+          symbols:
+            - file: internal/custom/golang/chi.go
+              functions: [Extract]
+            - file: internal/engine/go_routes.go
+              functions: [applyGoRouteComposition, extractGoHandlerBindings]
+          tests:
+            - file: internal/custom/golang/extractors_test.go
+            - file: internal/engine/go_routes_test.go
+          issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+
+  lang.go.framework.gorilla-mux:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          # gorilla_mux.go custom extractor: reGorillaRoute captures
+          # r.HandleFunc/Handle("/path", h) with a trailing .Methods("GET",…)
+          # chain (reGorillaMethods) to recover HTTP verbs; reGorillaSubrouter
+          # records PathPrefix(...).Subrouter() prefixes; mux.NewRouter() seeds
+          # the router service. go_routes.go AST pass rewrites bare-receiver
+          # ROUTES_TO edges. gorilla_mux.yaml provides detection markers.
+          status: full
+          symbols:
+            - file: internal/custom/golang/gorilla_mux.go
+              functions: [Extract]
+            - file: internal/engine/go_routes.go
+              functions:
+                - applyGoRouteComposition
+                - extractGoHandlerBindings
+                - buildGoVarTypeMap
+                - inferGoExprType
+                - typeNameFromExpr
+            - file: internal/engine/rules/go/frameworks/gorilla_mux.yaml
+          tests:
+            - file: internal/custom/golang/extractors_test.go
+            - file: internal/engine/go_routes_test.go
+          issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          status: full
+          symbols:
+            - file: internal/custom/golang/gorilla_mux.go
+              functions: [Extract]
+            - file: internal/engine/go_routes.go
+              functions: [applyGoRouteComposition, extractGoHandlerBindings]
+          tests:
+            - file: internal/custom/golang/extractors_test.go
+            - file: internal/engine/go_routes_test.go
+          issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+
   lang.java.framework.spring-webflux:
     capabilities:
       Observability:


### PR DESCRIPTION
**Part of #3212** (Cluster 1 — Routing). This is the **chi + gorilla-mux** slice — the two mux-style frameworks that reuse `internal/engine/go_routes.go`. The cluster stays open for the remaining frameworks (net/http, beego/buffalo/fasthttp/revel/iris, kratos/huma/hertz/go-zero).

## What landed

### Custom Go extractors (modelled on gin.go/echo.go/fiber.go templates)
- **`internal/custom/golang/chi.go`** — `chi.NewRouter()` → Service; Title-case verb routes (`r.Get/Post/Put/Patch/Delete/…`) → Operation/endpoint; `r.Handle`/`r.HandleFunc` → `ANY` endpoint; `r.Mount` and `r.Route("/prefix", …)` sub-router prefixes → Component; `r.Use(...)` middleware → Pattern.
- **`internal/custom/golang/gorilla_mux.go`** — `mux.NewRouter()` → Service; `r.HandleFunc/Handle("/p", h)` with trailing `.Methods("GET", "POST")` verb recovery (multi-verb fan-out; defaults to `ANY` when unconstrained); `PathPrefix("/api").Subrouter()` prefix joining → Component; `r.Use(...)` middleware → Pattern.

Both register via `init()` under the `custom_go_` dispatch prefix and self-gate on Go content, so no dispatch wiring was needed.

### Proving fixtures (honest greening)
- `internal/custom/golang/extractors_test.go` — per-framework route extraction, sub-router/prefix joining, `.Methods` verb recovery, and no-match cases.
- `internal/engine/go_routes_test.go` — new `TestApplyGoRouteComposition_GorillaMuxHandleFunc` proving the shared AST composition rewrites `Controller:h` → `Controller:UsersHandler.Method` for `r.HandleFunc("/p", h.Method).Methods(...)` (chi composite-literal/constructor cases were already covered).

### Registry + capability-map
- `tools/coverage/capability-map.yaml` — new `lang.go.framework.{chi,gorilla-mux}` Routing entries citing the extractor + `go_routes.go` + the YAML rule + both test files.
- `docs/coverage/registry.json` — the 4 cells (`{chi,gorilla-mux}.routing.{endpoint_synthesis,handler_attribution}`, already `full`) now additionally cite the new custom extractors and are re-verified `2026-05-30`.
- `docs/coverage/detail/*.md` regenerated (byte-stable).

## go_routes.go
**Not modified.** It already handles chi/gorilla Title-case verbs and `.Handle`/`.HandleFunc` via `goHTTPVerbs`; only a test was added.

## Validation (scoped, sandboxed — daemon untouched)
- `go build ./internal/... ./tools/coverage/...` ✅
- `go test ./internal/engine/... ./internal/custom/golang/... ./internal/extractors/golang/... ./internal/types/ ./tools/coverage/...` ✅
- `go run ./tools/coverage validate` → 0 errors ✅
- `fmt --check` canonical ✅ · `gen` byte-stable ✅ · `gofmt -l` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)