### PR TITLE
feat(coverage): Dramatiq task_routing extractor (queue_name routing)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -240,5 +240,5 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | Language | Name | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
 | [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | 🟢 1/1 | 🟢 21/21 | ✅ 6/6 | |
-| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | 🟢 1/1 | 🟢 21/21 | 🟡 4/5 | |
+| [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
 | [python](../by-language/python.md) | [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-language/python.md
+++ b/docs/coverage/by-language/python.md
@@ -57,7 +57,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|
 | [Celery (task queue)](../detail/lang.python.framework.celery.md) | 🟢 1/1 | 🟢 21/21 | ✅ 6/6 | |
-| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | 🟢 1/1 | 🟢 21/21 | 🟡 4/5 | |
+| [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
 | [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 

--- a/docs/coverage/detail/lang.python.framework.dramatiq.md
+++ b/docs/coverage/detail/lang.python.framework.dramatiq.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Task extraction | 🟢 `partial` | `2026-05-28` | — | `internal/custom/python/dramatiq.go`<br>`internal/engine/rules/python/frameworks/dramatiq.yaml` | — |
-| Task routing | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/2983) | — | — |
+| Task routing | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3193) | `internal/custom/python/dramatiq.go`<br>`internal/custom/python/dramatiq_routing_test.go` | queue->actor routing extracted from @dramatiq.actor(queue_name=...) decorators and actor.send_with_options(queue_name=...) dispatch overrides. Partial because broker-level routing middleware (broker.add_middleware) and dynamic/computed queue names are not modelled. |
 
 ### Schedule
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -35279,8 +35279,11 @@
             "verified_at": "2026-05-28"
           },
           "task_routing": {
-            "status": "missing",
-            "issue": "https://github.com/cajasmota/archigraph/issues/2983"
+            "status": "partial",
+            "cites": ["internal/custom/python/dramatiq.go","internal/custom/python/dramatiq_routing_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3193",
+            "notes": "queue-\u003eactor routing extracted from @dramatiq.actor(queue_name=...) decorators and actor.send_with_options(queue_name=...) dispatch overrides. Partial because broker-level routing middleware (broker.add_middleware) and dynamic/computed queue names are not modelled.",
+            "verified_at": "2026-05-30"
           }
         },
         "Schedule": {

--- a/internal/custom/python/dramatiq.go
+++ b/internal/custom/python/dramatiq.go
@@ -51,6 +51,18 @@ var (
 	// Retry policy: max_retries=N inside @dramatiq.actor(...) decorator args.
 	dmActorMaxRetriesRe = regexp.MustCompile(
 		`@dramatiq\.actor\s*\([^)]*max_retries\s*=\s*(\d+)`)
+
+	// Routing — queue_name on the @dramatiq.actor(...) decorator, paired with
+	// the actor function it decorates. Captures (1) queue name, (2) func name.
+	// Issue #3193 (task_routing).
+	dmActorQueueNameRe = regexp.MustCompile(
+		`(?m)@dramatiq\.actor\s*\([^)]*queue_name\s*=\s*["']([^"']+)["'][^)]*\)\s*\n(?:\s*#[^\n]*\n)*\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+	// Routing — explicit queue override at dispatch:
+	// actor.send_with_options(queue_name="..."). Captures (1) actor ref,
+	// (2) queue name. Issue #3193 (task_routing).
+	dmSendQueueNameRe = regexp.MustCompile(
+		`(?m)(\w+)\.send_with_options\s*\((?:[^()]|\([^()]*\))*?queue_name\s*=\s*["']([^"']+)["']`)
 )
 
 func (e *dramatiqExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -136,6 +148,42 @@ func (e *dramatiqExtractor) Extract(ctx context.Context, file extractor.FileInpu
 				"pattern_type": "retry_policy",
 				"max_retries":  maxRetries,
 				"provenance":   "INFERRED_FROM_DRAMATIQ_ACTOR_MAX_RETRIES",
+			}))
+	}
+
+	// 6. Routing: queue_name on @dramatiq.actor(...) decorator — maps a queue
+	//    to the actor that consumes it. Issue #3193 (task_routing).
+	for _, m := range dmActorQueueNameRe.FindAllStringSubmatchIndex(source, -1) {
+		queueName := source[m[2]:m[3]]
+		funcName := source[m[4]:m[5]]
+		line := lineOf(source, m[0])
+		out = append(out, entity(funcName, "SCOPE.Pattern", "task_routing", file.Path, line,
+			map[string]string{
+				"framework":    "dramatiq",
+				"pattern_type": "actor_queue",
+				"queue_name":   queueName,
+				"actor":        funcName,
+				"task_id":      "task:dramatiq:" + funcName,
+				"edge_kind":    "ROUTES_TO",
+				"provenance":   "INFERRED_FROM_DRAMATIQ_ACTOR_QUEUE_NAME",
+			}))
+	}
+
+	// 7. Routing: explicit queue override at dispatch via
+	//    actor.send_with_options(queue_name="..."). Issue #3193 (task_routing).
+	for _, m := range dmSendQueueNameRe.FindAllStringSubmatchIndex(source, -1) {
+		actorRef := source[m[2]:m[3]]
+		queueName := source[m[4]:m[5]]
+		line := lineOf(source, m[0])
+		out = append(out, entity(actorRef+".send_with_options", "SCOPE.Pattern", "task_routing", file.Path, line,
+			map[string]string{
+				"framework":    "dramatiq",
+				"pattern_type": "send_queue_override",
+				"queue_name":   queueName,
+				"actor_ref":    actorRef,
+				"task_id":      "task:dramatiq:" + actorRef,
+				"edge_kind":    "ROUTES_TO",
+				"provenance":   "INFERRED_FROM_DRAMATIQ_SEND_WITH_OPTIONS_QUEUE_NAME",
 			}))
 	}
 

--- a/internal/custom/python/dramatiq_routing_test.go
+++ b/internal/custom/python/dramatiq_routing_test.go
@@ -1,0 +1,140 @@
+package python_test
+
+// dramatiq_routing_test.go — proving fixtures for the dramatiq task_routing
+// extractor. Dedicated to issue #3193.
+//
+// Covers queue->actor routing via:
+//   - @dramatiq.actor(queue_name="...") decorator routing
+//   - actor.send_with_options(queue_name="...") explicit dispatch override
+//
+// Kept distinct from broker_binding_test.go (#3074, broker/retry) and the
+// celery/rq task-routing tests so the task_routing capability is proved on its
+// own fixture.
+
+import "testing"
+
+// findRouting returns the first task_routing entity matching name, or nil.
+func findRouting(result []extractResult, name string) *extractResult {
+	for i := range result {
+		if result[i].Subtype == "task_routing" && result[i].Name == name {
+			return &result[i]
+		}
+	}
+	return nil
+}
+
+// ============================================================================
+// Golden fixture — full queue->actor routing surface
+// ============================================================================
+
+func TestDramatiq_TaskRouting_GoldenFixture(t *testing.T) {
+	src := fixtureSchema(t, "dramatiq_task_routing.py")
+	ents := extract(t, "python_dramatiq", src)
+
+	// Decorator routing: @dramatiq.actor(queue_name="emails") def send_email
+	emails := findRouting(ents, "send_email")
+	if emails == nil {
+		t.Fatal("expected task_routing entity for send_email (queue_name=emails)")
+	}
+	if emails.Props["framework"] != "dramatiq" {
+		t.Errorf("framework: got %q", emails.Props["framework"])
+	}
+	if emails.Props["pattern_type"] != "actor_queue" {
+		t.Errorf("pattern_type: got %q", emails.Props["pattern_type"])
+	}
+	if emails.Props["queue_name"] != "emails" {
+		t.Errorf("queue_name: got %q want emails", emails.Props["queue_name"])
+	}
+	if emails.Props["actor"] != "send_email" {
+		t.Errorf("actor: got %q", emails.Props["actor"])
+	}
+	if emails.Props["edge_kind"] != "ROUTES_TO" {
+		t.Errorf("edge_kind: got %q", emails.Props["edge_kind"])
+	}
+	if emails.Kind != "SCOPE.Pattern" {
+		t.Errorf("kind: got %q", emails.Kind)
+	}
+
+	// Decorator routing on a second actor (order of decorator args differs).
+	reports := findRouting(ents, "generate_report")
+	if reports == nil {
+		t.Fatal("expected task_routing entity for generate_report (queue_name=reports)")
+	}
+	if reports.Props["queue_name"] != "reports" || reports.Props["pattern_type"] != "actor_queue" {
+		t.Errorf("generate_report routing props wrong: %+v", reports.Props)
+	}
+
+	// Explicit dispatch override:
+	// generate_report.send_with_options(queue_name="reports_priority")
+	override := findRouting(ents, "generate_report.send_with_options")
+	if override == nil {
+		t.Fatal("expected task_routing entity for send_with_options queue override")
+	}
+	if override.Props["pattern_type"] != "send_queue_override" {
+		t.Errorf("override pattern_type: got %q", override.Props["pattern_type"])
+	}
+	if override.Props["queue_name"] != "reports_priority" {
+		t.Errorf("override queue_name: got %q want reports_priority", override.Props["queue_name"])
+	}
+	if override.Props["actor_ref"] != "generate_report" {
+		t.Errorf("override actor_ref: got %q", override.Props["actor_ref"])
+	}
+
+	// Negative: a bare @dramatiq.actor with no queue_name must NOT emit a
+	// task_routing marker.
+	if r := findRouting(ents, "default_queue_task"); r != nil {
+		t.Errorf("unexpected task_routing entity for bare actor: %+v", r.Props)
+	}
+}
+
+// ============================================================================
+// Focused unit cases
+// ============================================================================
+
+func TestDramatiq_TaskRouting_DecoratorQueueName(t *testing.T) {
+	src := `import dramatiq
+
+@dramatiq.actor(queue_name="billing")
+def charge_card(amount):
+    pass
+`
+	ents := extract(t, "python_dramatiq", src)
+	r := findRouting(ents, "charge_card")
+	if r == nil {
+		t.Fatal("expected task_routing for charge_card")
+	}
+	if r.Props["queue_name"] != "billing" {
+		t.Errorf("queue_name: got %q want billing", r.Props["queue_name"])
+	}
+}
+
+func TestDramatiq_TaskRouting_SendWithOptionsOverride(t *testing.T) {
+	src := `email_task.send_with_options(args=("x",), queue_name="urgent")
+`
+	ents := extract(t, "python_dramatiq", src)
+	r := findRouting(ents, "email_task.send_with_options")
+	if r == nil {
+		t.Fatal("expected task_routing for send_with_options override")
+	}
+	if r.Props["queue_name"] != "urgent" || r.Props["actor_ref"] != "email_task" {
+		t.Errorf("override props wrong: %+v", r.Props)
+	}
+}
+
+func TestDramatiq_TaskRouting_NoQueueNameNoMarker(t *testing.T) {
+	src := `import dramatiq
+
+@dramatiq.actor(max_retries=2)
+def plain_task():
+    pass
+
+plain_task.send()
+plain_task.send_with_options(args=(1,))
+`
+	ents := extract(t, "python_dramatiq", src)
+	for _, e := range ents {
+		if e.Subtype == "task_routing" {
+			t.Errorf("unexpected task_routing entity when no queue_name present: %+v", e.Props)
+		}
+	}
+}

--- a/internal/custom/python/testdata/dramatiq_task_routing.py
+++ b/internal/custom/python/testdata/dramatiq_task_routing.py
@@ -1,0 +1,34 @@
+"""Golden fixture for the dramatiq task_routing extractor (issue #3193).
+
+Exercises queue->actor routing via:
+  - @dramatiq.actor(queue_name="...") decorator routing
+  - actor.send_with_options(queue_name="...") explicit dispatch override
+"""
+import dramatiq
+from dramatiq.brokers.rabbitmq import RabbitmqBroker
+
+rabbitmq_broker = RabbitmqBroker(url="amqp://localhost")
+dramatiq.set_broker(rabbitmq_broker)
+
+
+@dramatiq.actor(queue_name="emails", max_retries=3)
+def send_email(recipient):
+    pass
+
+
+@dramatiq.actor(queue_name="reports")
+def generate_report(report_id):
+    pass
+
+
+@dramatiq.actor
+def default_queue_task():
+    # No queue_name -> routed to the implicit "default" queue, not a routing marker.
+    pass
+
+
+def dispatch():
+    # Producer using the actor's declared queue.
+    send_email.send("user@example.com")
+    # Explicit per-message queue override.
+    generate_report.send_with_options(args=(42,), queue_name="reports_priority")

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -5111,6 +5111,22 @@ records:
           issues_implemented: ["2989"]
           verified_at: "2026-05-29"
 
+  lang.python.framework.dramatiq:
+    capabilities:
+      Tasks:
+        task_routing:
+          # #3193: queue->actor routing from @dramatiq.actor(queue_name=...)
+          # decorators and actor.send_with_options(queue_name=...) overrides.
+          status: partial
+          symbols:
+            - file: internal/custom/python/dramatiq.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/python/dramatiq_routing_test.go
+              functions: [TestDramatiq_TaskRouting_GoldenFixture, TestDramatiq_TaskRouting_DecoratorQueueName, TestDramatiq_TaskRouting_SendWithOptionsOverride, TestDramatiq_TaskRouting_NoQueueNameNoMarker]
+          issues_implemented: ["3193"]
+          verified_at: "2026-05-30"
+
   lang.jsts.orm.knex:
     capabilities:
       Models:


### PR DESCRIPTION
## Summary

Implements **issue #3193** — the Dramatiq `task_routing` extractor. Extends `internal/custom/python/dramatiq.go` to extract queue→actor routing, flipping `task_routing` on `lang.python.framework.dramatiq` from `missing` to **`partial`**.

## What's extracted

- **Decorator routing** — `@dramatiq.actor(queue_name="...")` emits a `task_routing` marker (`pattern_type=actor_queue`) mapping the declared queue to the actor it decorates. Robust to decorator-arg ordering (`max_retries` before/after `queue_name`).
- **Dispatch override** — `actor.send_with_options(queue_name="...")` emits a `task_routing` marker (`pattern_type=send_queue_override`) capturing the per-message queue override and the actor ref. The regex tolerates intervening `args=(...)` tuples.

Both emit `SCOPE.Pattern` entities with `edge_kind=ROUTES_TO`, `framework=dramatiq`, and provenance props. A bare `@dramatiq.actor` (no `queue_name`) emits **no** routing marker.

Kept distinct from the existing `task_extraction` (actor/send) and `broker_binding`/`retry_policy` (#3074) emitters in the same file.

## Honesty call

**`partial`** — the proving golden fixture exercises both the decorator and dispatch-override paths, but broker-level routing middleware (`broker.add_middleware(...)`) and dynamic/computed queue names are not modelled. (`task_extraction` stays `partial`; broker/retry unchanged; `result_backend_binding` remains honest-NA — dramatiq has no result-backend concept.)

## Tests

Dedicated `internal/custom/python/dramatiq_routing_test.go`:
- `TestDramatiq_TaskRouting_GoldenFixture` — full surface over `testdata/dramatiq_task_routing.py` (two decorator-routed actors, one dispatch override, one bare actor as negative).
- Focused: decorator `queue_name`, `send_with_options` override, and a no-`queue_name`/no-marker negative case.

## Validation (scoped)

- `go build ./internal/... ./tools/coverage/...` — clean
- `go test ./internal/custom/python/... ./internal/types/ ./tools/coverage/...` — pass
- `go run ./tools/coverage validate` — **0 errors**
- `coverage fmt --check` — canonical
- `coverage gen` — byte-stable (ran twice, no drift)
- `gofmt -l` on changed Go files — empty

Registry + `capability-map.yaml` updated (new `lang.python.framework.dramatiq` mapping record); generated docs regenerated.

Closes #3193

🤖 Generated with [Claude Code](https://claude.com/claude-code)