### PR TITLE
feat(coverage): GWT RPC/RequestFactory data_fetching extractor (#3190)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -161,7 +161,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/8 | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 2/4 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 3/4 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 3/4 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 21/21 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -45,7 +45,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 2/4 | |
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 3/4 | |
 | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 3/4 | |
 
 

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Branch conditions | 🔴 `missing` | — | — | — | — |
-| Data fetching | 🔴 `missing` | — | — | — | — |
+| Data fetching | 🟢 `partial` | `2026-05-30` | 3190 | `internal/custom/java/gwt_rpc.go` | GWT RPC + RequestFactory client-side data fetching: @RemoteServiceRelativePath RPC service interfaces, GWT.create(*.class) proxy-creation sites (linked FETCHES_FROM to the service), AsyncCallback<T> completion sites, RequestFactory/RequestContext interfaces, @ProxyFor EntityProxy/ValueProxy beans, and Request.fire(Receiver) sites. Heuristic regex detection, hence partial. |
 | Prop extraction | — `not_applicable` | — | 3091 | — | GWT compiles Java to client-side JS but uses Java idioms with no React-style concepts; prop_extraction is a React/JSX-paradigm capability that does not apply |
 | State management | — `not_applicable` | — | 3091 | — | GWT compiles Java to client-side JS but uses Java idioms with no React-style concepts; state_management is a React/JSX-paradigm capability that does not apply |
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14896,7 +14896,11 @@
             "status": "missing"
           },
           "data_fetching": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/gwt_rpc.go"],
+            "issue": "3190",
+            "notes": "GWT RPC + RequestFactory client-side data fetching: @RemoteServiceRelativePath RPC service interfaces, GWT.create(*.class) proxy-creation sites (linked FETCHES_FROM to the service), AsyncCallback\u003cT\u003e completion sites, RequestFactory/RequestContext interfaces, @ProxyFor EntityProxy/ValueProxy beans, and Request.fire(Receiver) sites. Heuristic regex detection, hence partial.",
+            "verified_at": "2026-05-30"
           },
           "prop_extraction": {
             "status": "not_applicable",

--- a/internal/custom/java/gwt_rpc.go
+++ b/internal/custom/java/gwt_rpc.go
@@ -1,0 +1,243 @@
+package java
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// GWT RPC / RequestFactory data_fetching custom extractor (#3190).
+//
+// GWT (Google Web Toolkit) compiles Java to client-side JavaScript. Its two
+// canonical client→server data-fetching mechanisms are:
+//
+//   1. GWT-RPC — a service interface annotated with
+//      @RemoteServiceRelativePath("...") plus an async mirror interface; the
+//      client obtains a proxy via GWT.create(MyService.class) and issues calls
+//      that complete through an AsyncCallback<T>.
+//
+//   2. RequestFactory — a RequestFactory subinterface exposing
+//      RequestContext factories; data is fetched by building a Request<T> /
+//      InstanceRequest and invoking .fire(Receiver<T>). Domain objects cross
+//      the wire as EntityProxy / ValueProxy beans.
+//
+// The pre-existing vaadin_gwt.go extractor only records the server-side
+// RemoteServiceServlet taint marker (component/router cells). It does NOT
+// record the client-side data-fetch surface, so the gwt.data_fetching cell
+// was "missing". This file flips it to "partial": it is heuristic regex
+// detection of the well-known RPC / RequestFactory shapes, not a full
+// data-flow proof, hence partial (mirroring Vaadin's data_fetching).
+//
+// Coverage cell delivered (#3190):
+//   - data_fetching → partial  (RPC service ifaces, GWT.create proxies,
+//                               AsyncCallback sites, RequestFactory contexts,
+//                               EntityProxy beans, Request.fire receivers)
+//
+// Entities emitted are SCOPE.Operation / SCOPE.Service / SCOPE.DataModel
+// markers gated to the gwt framework; they never fire on non-GWT sources.
+
+// ─── GWT data-fetching regexps ──────────────────────────────────────────────
+
+var (
+	// @RemoteServiceRelativePath("greet") interface Foo extends RemoteService —
+	// the RPC service-endpoint declaration (client-visible binding path).
+	gwtRemoteServicePathRE = regexp.MustCompile(
+		`(?s)@RemoteServiceRelativePath\s*\(\s*"([^"]*)"\s*\)` +
+			`[^{;]*?interface\s+(\w+)`)
+
+	// GWT.create(MyService.class) — RPC (or RequestFactory) proxy creation site.
+	gwtCreateProxyRE = regexp.MustCompile(
+		`(?m)\bGWT\s*\.\s*create\s*\(\s*(\w+)\s*\.\s*class\s*\)`)
+
+	// new AsyncCallback<Foo>() / AsyncCallback<Foo> cb — RPC async completion.
+	gwtAsyncCallbackRE = regexp.MustCompile(
+		`(?m)\bAsyncCallback\s*<\s*([\w.<>\[\]?, ]*?)\s*>`)
+
+	// interface AppRequestFactory extends RequestFactory — RF root factory.
+	gwtRequestFactoryIfaceRE = regexp.MustCompile(
+		`(?m)interface\s+(\w+)\s+extends\s+(?:[\w.]+\s*,\s*)*RequestFactory\b`)
+
+	// interface FooRequest extends RequestContext — RF request context (the
+	// unit that carries one or more server method invocations).
+	gwtRequestContextIfaceRE = regexp.MustCompile(
+		`(?m)interface\s+(\w+)\s+extends\s+(?:[\w.]+\s*,\s*)*RequestContext\b`)
+
+	// @ProxyFor(Foo.class) / @ProxyForName("...") interface FooProxy
+	// extends EntityProxy|ValueProxy — RF domain proxy bean.
+	gwtProxyForRE = regexp.MustCompile(
+		`(?s)@ProxyFor(?:Name)?\s*\(\s*"?([\w.$]+?)"?(?:\s*\.\s*class)?\s*\)` +
+			`[^{;]*?interface\s+(\w+)`)
+
+	// interface FooProxy extends EntityProxy|ValueProxy (no @ProxyFor) — RF bean.
+	gwtProxyIfaceRE = regexp.MustCompile(
+		`(?m)interface\s+(\w+)\s+extends\s+(?:[\w.]+\s*,\s*)*(?:EntityProxy|ValueProxy)\b`)
+
+	// someRequest.fire(new Receiver<Foo>() ...) / .fire(receiver) — RF fetch site.
+	gwtRequestFireRE = regexp.MustCompile(
+		`(?m)\.\s*fire\s*\(\s*(?:new\s+Receiver\b|[\w.]+\s*\))`)
+)
+
+// ─── ExtractGWTDataFetching ──────────────────────────────────────────────────
+
+// ExtractGWTDataFetching runs the GWT RPC / RequestFactory data_fetching
+// extractor. Delivers partial coverage for: data_fetching.
+//
+// It is gated to language=java and the gwt framework (reusing the
+// gwtFrameworkMatches gate from vaadin_gwt.go) and is a no-op otherwise.
+func ExtractGWTDataFetching(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !gwtFrameworkMatches(ctx.Framework) {
+		return result
+	}
+
+	source := ctx.Source
+	fp := ctx.FilePath
+	seenRefs := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// --- @RemoteServiceRelativePath RPC service interfaces ---
+	for _, m := range gwtRemoteServicePathRE.FindAllStringSubmatchIndex(source, -1) {
+		path := source[m[2]:m[3]]
+		svc := source[m[4]:m[5]]
+		ref := "scope:service:gwt_rpc_service:" + fp + ":" + svc
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: svc, Kind: "SCOPE.Service", Subtype: "rpc_service",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_GWT_RPC_SERVICE", Ref: ref,
+			Properties: map[string]any{
+				"data_fetch_kind": "rpc_service", "relative_path": path,
+				"framework": "gwt",
+			},
+		})
+	}
+
+	// --- GWT.create(Service.class) RPC/RF proxy creation sites ---
+	for _, m := range gwtCreateProxyRE.FindAllStringSubmatchIndex(source, -1) {
+		target := source[m[2]:m[3]]
+		host := findEnclosingClass(source, m[0])
+		if host == "" {
+			host = "unknown"
+		}
+		ref := "scope:operation:gwt_create_proxy:" + fp + ":" + host + ":" + target
+		svcRef := "scope:service:gwt_rpc_service:" + fp + ":" + target
+		if addEntity(&result, seenRefs, SecondaryEntity{
+			Name: host + "::GWT.create(" + target + ")", Kind: "SCOPE.Operation", Subtype: "data_fetch",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_GWT_CREATE_PROXY", Ref: ref,
+			Properties: map[string]any{
+				"data_fetch_kind": "rpc_proxy_create", "service_type": target,
+				"host_class": host, "framework": "gwt",
+			},
+		}) {
+			// Link the proxy-create site to the service interface it targets.
+			addRel(&result, seenRels, Relationship{
+				SourceRef: ref, TargetRef: svcRef, RelationshipType: "FETCHES_FROM",
+				Properties: map[string]string{"service_type": target},
+			})
+		}
+	}
+
+	// --- AsyncCallback<T> RPC completion sites (data_fetching presence) ---
+	for _, m := range gwtAsyncCallbackRE.FindAllStringSubmatchIndex(source, -1) {
+		payload := source[m[2]:m[3]]
+		host := findEnclosingClass(source, m[0])
+		if host == "" {
+			host = "unknown"
+		}
+		ref := "scope:operation:gwt_async_callback:" + fp + ":" + host + ":" + payload
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: host + "::AsyncCallback<" + payload + ">", Kind: "SCOPE.Operation", Subtype: "data_fetch",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_GWT_ASYNC_CALLBACK", Ref: ref,
+			Properties: map[string]any{
+				"data_fetch_kind": "rpc_async_callback", "payload_type": payload,
+				"host_class": host, "framework": "gwt",
+			},
+		})
+	}
+
+	// --- RequestFactory root interfaces ---
+	for _, m := range gwtRequestFactoryIfaceRE.FindAllStringSubmatchIndex(source, -1) {
+		name := source[m[2]:m[3]]
+		ref := "scope:service:gwt_request_factory:" + fp + ":" + name
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Service", Subtype: "request_factory",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_GWT_REQUEST_FACTORY", Ref: ref,
+			Properties: map[string]any{
+				"data_fetch_kind": "request_factory", "framework": "gwt",
+			},
+		})
+	}
+
+	// --- RequestContext interfaces (RF request units) ---
+	for _, m := range gwtRequestContextIfaceRE.FindAllStringSubmatchIndex(source, -1) {
+		name := source[m[2]:m[3]]
+		ref := "scope:service:gwt_request_context:" + fp + ":" + name
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Service", Subtype: "request_context",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_GWT_REQUEST_CONTEXT", Ref: ref,
+			Properties: map[string]any{
+				"data_fetch_kind": "request_context", "framework": "gwt",
+			},
+		})
+	}
+
+	// --- @ProxyFor/@ProxyForName domain proxy beans ---
+	for _, m := range gwtProxyForRE.FindAllStringSubmatchIndex(source, -1) {
+		domain := source[m[2]:m[3]]
+		proxy := source[m[4]:m[5]]
+		ref := "scope:datamodel:gwt_proxy:" + fp + ":" + proxy
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: proxy, Kind: "SCOPE.DataModel", Subtype: "entity_proxy",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_GWT_PROXY", Ref: ref,
+			Properties: map[string]any{
+				"data_fetch_kind": "request_factory_proxy", "domain_type": domain,
+				"framework": "gwt",
+			},
+		})
+	}
+
+	// --- bare proxy interfaces (extends EntityProxy/ValueProxy, no @ProxyFor) ---
+	for _, m := range gwtProxyIfaceRE.FindAllStringSubmatchIndex(source, -1) {
+		proxy := source[m[2]:m[3]]
+		ref := "scope:datamodel:gwt_proxy:" + fp + ":" + proxy
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: proxy, Kind: "SCOPE.DataModel", Subtype: "entity_proxy",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_GWT_PROXY", Ref: ref,
+			Properties: map[string]any{
+				"data_fetch_kind": "request_factory_proxy", "framework": "gwt",
+			},
+		})
+	}
+
+	// --- request.fire(Receiver) RequestFactory fetch sites ---
+	for _, m := range gwtRequestFireRE.FindAllStringSubmatchIndex(source, -1) {
+		host := findEnclosingClass(source, m[0])
+		if host == "" {
+			host = "unknown"
+		}
+		ref := "scope:operation:gwt_request_fire:" + fp + ":" + host + ":" + strconv.Itoa(lineOf(source, m[0]))
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: host + "::Request.fire", Kind: "SCOPE.Operation", Subtype: "data_fetch",
+			SourceFile: fp,
+			LineStart:  lineOf(source, m[0]), LineEnd: lineOf(source, m[0]),
+			Provenance: "INFERRED_FROM_GWT_REQUEST_FIRE", Ref: ref,
+			Properties: map[string]any{
+				"data_fetch_kind": "request_factory_fire", "host_class": host,
+				"framework": "gwt",
+			},
+		})
+	}
+
+	return result
+}

--- a/internal/custom/java/gwt_rpc_test.go
+++ b/internal/custom/java/gwt_rpc_test.go
@@ -1,0 +1,249 @@
+package java
+
+import (
+	"testing"
+)
+
+// ============================================================================
+// Issue #3190: GWT RPC / RequestFactory data_fetching extractor
+//
+// Registry target: lang.java.framework.gwt Data Flow/data_fetching → partial.
+// Cite: internal/custom/java/gwt_rpc.go
+// ============================================================================
+
+func gwtHasProvenance(r PatternResult, prov string) bool {
+	for _, e := range r.Entities {
+		if e.Provenance == prov {
+			return true
+		}
+	}
+	return false
+}
+
+func gwtEntityByProvenance(r PatternResult, prov string) (SecondaryEntity, bool) {
+	for _, e := range r.Entities {
+		if e.Provenance == prov {
+			return e, true
+		}
+	}
+	return SecondaryEntity{}, false
+}
+
+// TestGWTRPC_RemoteServiceRelativePath_Issue3190 proves an RPC service
+// interface annotated with @RemoteServiceRelativePath is recorded as a
+// data_fetching service entity carrying its relative binding path.
+func TestGWTRPC_RemoteServiceRelativePath_Issue3190(t *testing.T) {
+	source := `
+package com.example.client;
+
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+
+@RemoteServiceRelativePath("greet")
+public interface GreetingService extends RemoteService {
+    String greetServer(String name);
+}
+`
+	r := ExtractGWTDataFetching(PatternContext{
+		Source: source, Language: "java", Framework: "gwt",
+		FilePath: "GreetingService.java",
+	})
+
+	e, ok := gwtEntityByProvenance(r, "INFERRED_FROM_GWT_RPC_SERVICE")
+	if !ok {
+		t.Fatalf("[#3190 data_fetching] expected SCOPE.Service from @RemoteServiceRelativePath, got none")
+	}
+	if e.Name != "GreetingService" {
+		t.Errorf("[#3190] expected service name GreetingService, got %q", e.Name)
+	}
+	if e.Properties["relative_path"] != "greet" {
+		t.Errorf("[#3190] expected relative_path=greet, got %v", e.Properties["relative_path"])
+	}
+}
+
+// TestGWTRPC_GWTCreateProxy_Issue3190 proves GWT.create(Service.class) is
+// recorded as a data_fetch proxy-creation operation, linked to the service.
+func TestGWTRPC_GWTCreateProxy_Issue3190(t *testing.T) {
+	source := `
+package com.example.client;
+
+import com.google.gwt.core.client.GWT;
+
+public class GreetingPresenter {
+    private final GreetingServiceAsync svc = GWT.create(GreetingService.class);
+
+    public void load() {
+        svc.greetServer("world", null);
+    }
+}
+`
+	r := ExtractGWTDataFetching(PatternContext{
+		Source: source, Language: "java", Framework: "gwt",
+		FilePath: "GreetingPresenter.java",
+	})
+
+	e, ok := gwtEntityByProvenance(r, "INFERRED_FROM_GWT_CREATE_PROXY")
+	if !ok {
+		t.Fatalf("[#3190 data_fetching] expected proxy-create operation from GWT.create, got none")
+	}
+	if e.Properties["service_type"] != "GreetingService" {
+		t.Errorf("[#3190] expected service_type=GreetingService, got %v", e.Properties["service_type"])
+	}
+	foundRel := false
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "FETCHES_FROM" {
+			foundRel = true
+		}
+	}
+	if !foundRel {
+		t.Errorf("[#3190] expected FETCHES_FROM relationship from proxy-create to service")
+	}
+}
+
+// TestGWTRPC_AsyncCallback_Issue3190 proves an AsyncCallback<T> completion
+// site is recorded as a data_fetch operation carrying its payload type.
+func TestGWTRPC_AsyncCallback_Issue3190(t *testing.T) {
+	source := `
+package com.example.client;
+
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+public class GreetingPresenter {
+    public void load(GreetingServiceAsync svc) {
+        svc.greetServer("world", new AsyncCallback<String>() {
+            public void onSuccess(String result) {}
+            public void onFailure(Throwable caught) {}
+        });
+    }
+}
+`
+	r := ExtractGWTDataFetching(PatternContext{
+		Source: source, Language: "java", Framework: "gwt",
+		FilePath: "GreetingPresenter.java",
+	})
+
+	e, ok := gwtEntityByProvenance(r, "INFERRED_FROM_GWT_ASYNC_CALLBACK")
+	if !ok {
+		t.Fatalf("[#3190 data_fetching] expected AsyncCallback data_fetch op, got none")
+	}
+	if e.Properties["payload_type"] != "String" {
+		t.Errorf("[#3190] expected payload_type=String, got %v", e.Properties["payload_type"])
+	}
+}
+
+// TestGWTRPC_RequestFactory_Issue3190 proves a RequestFactory root interface
+// and its RequestContext are recorded as data_fetching services.
+func TestGWTRPC_RequestFactory_Issue3190(t *testing.T) {
+	source := `
+package com.example.client;
+
+import com.google.web.bindery.requestfactory.shared.RequestFactory;
+import com.google.web.bindery.requestfactory.shared.RequestContext;
+import com.google.web.bindery.requestfactory.shared.Request;
+
+public interface AppRequestFactory extends RequestFactory {
+    EmployeeRequest employeeRequest();
+}
+
+interface EmployeeRequest extends RequestContext {
+    Request<EmployeeProxy> findEmployee(Long id);
+}
+`
+	r := ExtractGWTDataFetching(PatternContext{
+		Source: source, Language: "java", Framework: "gwt",
+		FilePath: "AppRequestFactory.java",
+	})
+
+	if !gwtHasProvenance(r, "INFERRED_FROM_GWT_REQUEST_FACTORY") {
+		t.Errorf("[#3190 data_fetching] expected RequestFactory service entity, got none")
+	}
+	if !gwtHasProvenance(r, "INFERRED_FROM_GWT_REQUEST_CONTEXT") {
+		t.Errorf("[#3190 data_fetching] expected RequestContext service entity, got none")
+	}
+}
+
+// TestGWTRPC_ProxyFor_Issue3190 proves an @ProxyFor EntityProxy bean is
+// recorded as a data_fetching DataModel carrying its domain type.
+func TestGWTRPC_ProxyFor_Issue3190(t *testing.T) {
+	source := `
+package com.example.shared;
+
+import com.google.web.bindery.requestfactory.shared.EntityProxy;
+import com.google.web.bindery.requestfactory.shared.ProxyFor;
+
+@ProxyFor(Employee.class)
+public interface EmployeeProxy extends EntityProxy {
+    String getName();
+    void setName(String name);
+}
+`
+	r := ExtractGWTDataFetching(PatternContext{
+		Source: source, Language: "java", Framework: "gwt",
+		FilePath: "EmployeeProxy.java",
+	})
+
+	e, ok := gwtEntityByProvenance(r, "INFERRED_FROM_GWT_PROXY")
+	if !ok {
+		t.Fatalf("[#3190 data_fetching] expected EntityProxy DataModel, got none")
+	}
+	if e.Name != "EmployeeProxy" {
+		t.Errorf("[#3190] expected proxy name EmployeeProxy, got %q", e.Name)
+	}
+	if e.Properties["domain_type"] != "Employee" {
+		t.Errorf("[#3190] expected domain_type=Employee, got %v", e.Properties["domain_type"])
+	}
+}
+
+// TestGWTRPC_RequestFire_Issue3190 proves request.fire(Receiver) is recorded
+// as a RequestFactory data_fetch site.
+func TestGWTRPC_RequestFire_Issue3190(t *testing.T) {
+	source := `
+package com.example.client;
+
+import com.google.web.bindery.requestfactory.shared.Receiver;
+
+public class EmployeePresenter {
+    public void load(EmployeeRequest req) {
+        req.findEmployee(42L).fire(new Receiver<EmployeeProxy>() {
+            public void onSuccess(EmployeeProxy response) {}
+        });
+    }
+}
+`
+	r := ExtractGWTDataFetching(PatternContext{
+		Source: source, Language: "java", Framework: "gwt",
+		FilePath: "EmployeePresenter.java",
+	})
+
+	if !gwtHasProvenance(r, "INFERRED_FROM_GWT_REQUEST_FIRE") {
+		t.Errorf("[#3190 data_fetching] expected Request.fire data_fetch op, got none")
+	}
+}
+
+// TestGWTRPC_IgnoresNonGWTFramework_Issue3190 proves the framework gate works:
+// the extractor must not fire on a non-GWT framework even with matching syntax.
+func TestGWTRPC_IgnoresNonGWTFramework_Issue3190(t *testing.T) {
+	source := `
+@RemoteServiceRelativePath("greet")
+public interface GreetingService extends RemoteService {}
+`
+	r := ExtractGWTDataFetching(PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot",
+		FilePath: "GreetingService.java",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3190 gate] extractor should not fire on spring_boot framework, got %d entities", len(r.Entities))
+	}
+}
+
+// TestGWTRPC_IgnoresNonJava_Issue3190 proves the language gate works.
+func TestGWTRPC_IgnoresNonJava_Issue3190(t *testing.T) {
+	source := `GWT.create(GreetingService.class)`
+	r := ExtractGWTDataFetching(PatternContext{
+		Source: source, Language: "javascript", Framework: "gwt",
+		FilePath: "x.js",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3190 gate] extractor should not fire on non-java language")
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -2057,6 +2057,19 @@ records:
           issues_implemented: ["2906"]
           verified_at: "2026-05-28"
 
+  lang.java.framework.gwt:
+    capabilities:
+      Data Flow:
+        data_fetching:
+          status: partial
+          symbols:
+            - file: internal/custom/java/gwt_rpc.go
+              functions: [ExtractGWTDataFetching]
+          tests:
+            - file: internal/custom/java/gwt_rpc_test.go
+          issues_implemented: ["3190"]
+          verified_at: "2026-05-30"
+
   lang.java.framework.jakarta-ee:
     capabilities:
       Observability:


### PR DESCRIPTION
## Summary

Implements **#3190** (T17): a GWT `data_fetching` extractor covering both GWT client→server mechanisms.

New file `internal/custom/java/gwt_rpc.go` — `ExtractGWTDataFetching(ctx)`, gated to `language=java` + the `gwt` framework (reusing `gwtFrameworkMatches` from `vaadin_gwt.go`). It records:

- **GWT-RPC**
  - `@RemoteServiceRelativePath("...")` service interfaces → `SCOPE.Service` (carries the relative binding path)
  - `GWT.create(MyService.class)` proxy-creation sites → `SCOPE.Operation`, linked `FETCHES_FROM` to the service interface
  - `AsyncCallback<T>` completion sites → `SCOPE.Operation` (carries payload type)
- **RequestFactory**
  - `extends RequestFactory` root interfaces and `extends RequestContext` request units → `SCOPE.Service`
  - `@ProxyFor(X.class)` / `@ProxyForName` / bare `extends EntityProxy|ValueProxy` beans → `SCOPE.DataModel` (carries domain type)
  - `request.fire(Receiver)` fetch sites → `SCOPE.Operation`

### Why partial (not full)
The pre-existing `vaadin_gwt.go` only recorded the server-side `RemoteServiceServlet` taint marker; the client-side data-fetch surface was unrecorded (`data_fetching` was `missing`). This is heuristic regex detection of the well-known RPC/RequestFactory shapes, not a full data-flow proof, so the honest call is **`partial`** — mirroring how Vaadin's `data_fetching` is recorded.

## Coverage call
- `lang.java.framework.gwt` → `Data Flow/data_fetching`: **missing → partial** (cite `internal/custom/java/gwt_rpc.go`, issue 3190, verified 2026-05-30).
- No cells set to `full` (no golden-graph data-flow proof). No cells flipped to NA.

## Testing / validation
- Dedicated proving tests `internal/custom/java/gwt_rpc_test.go` (one per emission path + language/framework gates).
- `go build ./internal/... ./tools/coverage/...` clean.
- `go test ./internal/custom/java/... ./internal/types/ ./tools/coverage/...` pass.
- `go run ./tools/coverage validate` — 0 errors (pre-existing warnings only; no new `data_fetching` mapping warning).
- `coverage fmt --check` canonical; `coverage gen` byte-stable; `gofmt -l` clean.
- Updated `docs/coverage/registry.json` + `tools/coverage/capability-map.yaml`; regenerated docs.

Closes #3190

🤖 Generated with [Claude Code](https://claude.com/claude-code)