### PR TITLE
feat(coverage): net/http stdlib routing extractor (Part of #3212)

### DIFF
--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/net_http_stdlib.yaml` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/go_routes.go` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/nethttp.go`<br>`internal/engine/go_routes.go`<br>`internal/engine/rules/go/frameworks/net_http_stdlib.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/golang/nethttp.go`<br>`internal/engine/go_routes.go` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -13184,13 +13184,13 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go","internal/engine/rules/go/frameworks/net_http_stdlib.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/nethttp.go","internal/engine/go_routes.go","internal/engine/rules/go/frameworks/net_http_stdlib.yaml"],
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/go_routes.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/nethttp.go","internal/engine/go_routes.go"],
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
             "status": "missing",

--- a/internal/custom/golang/extractors_test.go
+++ b/internal/custom/golang/extractors_test.go
@@ -328,6 +328,78 @@ func TestGorillaNoMatch(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// net/http (stdlib)
+// ---------------------------------------------------------------------------
+
+func TestNetHTTPServeMux(t *testing.T) {
+	src := `mux := http.NewServeMux()`
+	ents := extract(t, "custom_go_nethttp", fi("main.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Service", "mux") {
+		t.Error("expected mux as net/http ServeMux service")
+	}
+}
+
+func TestNetHTTPDefaultMuxRoutes(t *testing.T) {
+	src := `
+http.HandleFunc("/users", listUsers)
+http.Handle("/static", fileServer)
+`
+	ents := extract(t, "custom_go_nethttp", fi("main.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "ANY /users") {
+		t.Error("expected ANY /users from http.HandleFunc")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "ANY /static") {
+		t.Error("expected ANY /static from http.Handle")
+	}
+}
+
+func TestNetHTTPMuxScopedRoutes(t *testing.T) {
+	src := `
+mux := http.NewServeMux()
+mux.HandleFunc("/health", healthCheck)
+mux.Handle("/metrics", promHandler)
+`
+	ents := extract(t, "custom_go_nethttp", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Service", "mux") {
+		t.Error("expected mux service")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "ANY /health") {
+		t.Error("expected ANY /health from mux.HandleFunc")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "ANY /metrics") {
+		t.Error("expected ANY /metrics from mux.Handle")
+	}
+}
+
+func TestNetHTTPMethodPrefixedPatterns(t *testing.T) {
+	// Go 1.22+ method-prefixed patterns.
+	src := `
+mux := http.NewServeMux()
+mux.HandleFunc("GET /users/{id}", getUser)
+mux.HandleFunc("POST /users", createUser)
+mux.HandleFunc("DELETE /users/{id}", deleteUser)
+`
+	ents := extract(t, "custom_go_nethttp", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /users/{id}") {
+		t.Error("expected GET /users/{id} with method token split off")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "POST /users") {
+		t.Error("expected POST /users")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "DELETE /users/{id}") {
+		t.Error("expected DELETE /users/{id}")
+	}
+}
+
+func TestNetHTTPNoMatch(t *testing.T) {
+	src := `package main`
+	ents := extract(t, "custom_go_nethttp", fi("main.go", "go", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
 // GORM
 // ---------------------------------------------------------------------------
 

--- a/internal/custom/golang/nethttp.go
+++ b/internal/custom/golang/nethttp.go
@@ -1,0 +1,141 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_nethttp", &netHTTPExtractor{})
+}
+
+// netHTTPExtractor recovers routes registered against the Go standard-library
+// HTTP router. Three registration surfaces are covered:
+//
+//	http.HandleFunc("/path", fn)       // package-level DefaultServeMux
+//	http.Handle("/path", handler)      // package-level DefaultServeMux
+//	mux := http.NewServeMux()          // explicit mux -> SCOPE.Service
+//	mux.HandleFunc("/path", fn)        // mux-scoped registration
+//	mux.Handle("/path", handler)
+//
+// Since Go 1.22 the stdlib router accepts method-prefixed patterns and host
+// prefixes, e.g. `mux.HandleFunc("GET /users/{id}", h)` or
+// `http.HandleFunc("POST example.com/orders", h)`. We split the leading method
+// token (if it is a recognised HTTP verb) off the pattern so the synthesized
+// endpoint carries the real verb; patterns without a method token default to
+// "ANY" (the stdlib matches any method).
+//
+// Handler-method attribution (rewriting `Controller:<recvVar>` ROUTES_TO edges
+// into `Controller:<Type>.<Method>`) is handled by the shared AST pass in
+// internal/engine/go_routes.go, whose goHTTPVerbs set already includes
+// HandleFunc/Handle — so `mux.HandleFunc("/p", h.List)` resolves for free.
+type netHTTPExtractor struct{}
+
+func (e *netHTTPExtractor) Language() string { return "custom_go_nethttp" }
+
+var (
+	// mux := http.NewServeMux()  /  var mux = http.NewServeMux()
+	reNetHTTPMux = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*http\.NewServeMux\s*\(\s*\)`,
+	)
+	// http.HandleFunc("/p", fn) / http.Handle("/p", h) on DefaultServeMux,
+	// and <mux>.HandleFunc/Handle("/p", …) on an explicit mux. The receiver
+	// capture lets us distinguish the package-level form (receiver == "http")
+	// from a mux variable.
+	reNetHTTPRoute = regexp.MustCompile(
+		`(?m)(\w+)\.(HandleFunc|Handle)\s*\(\s*` + "[\"`]" + `([^"` + "`" + `]+)` + "[\"`]",
+	)
+)
+
+// netHTTPMethodToken splits a Go 1.22+ method-prefixed pattern into (method,
+// rest). Returns ("ANY", pattern) when no recognised leading verb is present.
+// Per the stdlib grammar the method token is followed by a single space:
+// `METHOD [host]/[path]`.
+func netHTTPMethodToken(pattern string) (string, string) {
+	sp := strings.IndexByte(pattern, ' ')
+	if sp <= 0 {
+		return "ANY", pattern
+	}
+	tok := pattern[:sp]
+	rest := strings.TrimSpace(pattern[sp+1:])
+	switch tok {
+	case "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE":
+		return tok, rest
+	}
+	return "ANY", pattern
+}
+
+func (e *netHTTPExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.nethttp_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "net/http"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	// Cheap pre-filter: only do work on files that touch the stdlib router.
+	if !strings.Contains(src, "HandleFunc") && !strings.Contains(src, ".Handle(") &&
+		!strings.Contains(src, "http.NewServeMux") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. http.NewServeMux() -> SCOPE.Service
+	for _, m := range reNetHTTPMux.FindAllStringSubmatchIndex(src, -1) {
+		varName := src[m[2]:m[3]]
+		ent := makeEntity(varName, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "net/http", "provenance", "INFERRED_FROM_NETHTTP_MUX",
+			"constructor", "http.NewServeMux")
+		add(ent)
+	}
+
+	// 2. HandleFunc/Handle registrations -> SCOPE.Operation/endpoint.
+	for _, m := range reNetHTTPRoute.FindAllStringSubmatchIndex(src, -1) {
+		recv := src[m[2]:m[3]]
+		register := src[m[4]:m[5]]
+		pattern := src[m[6]:m[7]]
+		method, path := netHTTPMethodToken(pattern)
+		name := method + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "net/http", "provenance", "INFERRED_FROM_NETHTTP_ROUTE",
+			"http_method", method, "route_path", path, "router_var", recv,
+			"register_func", register)
+		if recv == "http" {
+			ent.Properties["default_serve_mux"] = "true"
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/engine/go_routes.go
+++ b/internal/engine/go_routes.go
@@ -100,6 +100,13 @@ func applyGoRouteComposition(args DetectorPassArgs) DetectorPassResult {
 	rewrite := map[key]string{}
 	for _, b := range bindings {
 		rewrite[key{b.routePath, b.recvVar}] = b.qualified
+		// Go 1.22+ stdlib patterns embed the method in the pattern string
+		// (`"GET /users/{id}"`). The handler arg is keyed by the full pattern,
+		// but the ROUTES_TO edge's path may be the bare route ("/users/{id}").
+		// Register a method-stripped alias so either keying resolves.
+		if stripped := stripGoMethodPrefix(b.routePath); stripped != b.routePath {
+			rewrite[key{stripped, b.recvVar}] = b.qualified
+		}
 	}
 
 	for i, r := range rawRels {
@@ -354,6 +361,23 @@ func inferGoExprType(expr ast.Expr) string {
 		}
 	}
 	return ""
+}
+
+// stripGoMethodPrefix removes a leading Go 1.22+ stdlib method token from a
+// net/http pattern (`"GET /users/{id}"` -> `"/users/{id}"`). Only a recognised
+// HTTP verb followed by a single space is stripped; all other patterns
+// (including third-party-router paths that happen to contain spaces) are
+// returned unchanged.
+func stripGoMethodPrefix(pattern string) string {
+	sp := strings.IndexByte(pattern, ' ')
+	if sp <= 0 {
+		return pattern
+	}
+	switch pattern[:sp] {
+	case "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE":
+		return strings.TrimSpace(pattern[sp+1:])
+	}
+	return pattern
 }
 
 // typeNameFromExpr returns the bare type name from a type expression, peeling

--- a/internal/engine/go_routes_test.go
+++ b/internal/engine/go_routes_test.go
@@ -81,6 +81,39 @@ func main() {
 	}
 }
 
+func TestApplyGoRouteComposition_NetHTTPServeMux(t *testing.T) {
+	// stdlib net/http: mux.HandleFunc("/path", h.Method) — the nethttp custom
+	// extractor synthesizes the endpoint; the shared AST pass resolves the
+	// bare receiver to the qualified handler method (HandleFunc is in
+	// goHTTPVerbs). Covers the Go 1.22+ method-prefixed pattern too.
+	src := []byte(`package main
+
+import "net/http"
+
+func main() {
+	h := &UsersHandler{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users", h.List)
+	mux.HandleFunc("GET /users/{id}", h.Get)
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+		makeRoutesToRel("/users/{id}", "h"),
+	}
+	_res := applyGoRouteComposition(DetectorPassArgs{Lang: "go", Path: "main.go", Content: src, Relationships: rels})
+	_, got := _res.Entities, _res.Relationships
+	if got[0].ToID != "Controller:UsersHandler.List" {
+		t.Errorf("ToID[0] = %q, want Controller:UsersHandler.List", got[0].ToID)
+	}
+	if got[1].ToID != "Controller:UsersHandler.Get" {
+		t.Errorf("ToID[1] = %q, want Controller:UsersHandler.Get", got[1].ToID)
+	}
+	if got[0].Properties["go_route_binding"] != "method_receiver_resolved" {
+		t.Errorf("go_route_binding[0] = %q, want method_receiver_resolved", got[0].Properties["go_route_binding"])
+	}
+}
+
 func TestApplyGoRouteComposition_ConstructorIdiom(t *testing.T) {
 	// `h := handlers.NewUsersHandler(s)` — cross-package NewT() returns *T.
 	src := []byte(`package main

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3103,6 +3103,47 @@ records:
           issues_implemented: ["3214"]
           verified_at: "2026-05-30"
 
+  lang.go.framework.net-http:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          # nethttp.go custom extractor: reNetHTTPRoute captures
+          # http.HandleFunc/Handle("/path", …) on the DefaultServeMux and
+          # <mux>.HandleFunc/Handle on an explicit http.NewServeMux() (seeded as
+          # a SCOPE.Service via reNetHTTPMux). netHTTPMethodToken splits the
+          # Go 1.22+ method-prefixed pattern ("GET /users/{id}") into verb+path;
+          # patterns without a verb default to ANY. net_http_stdlib.yaml
+          # provides import/structural detection markers only.
+          status: full
+          symbols:
+            - file: internal/custom/golang/nethttp.go
+              functions: [Extract, netHTTPMethodToken]
+            - file: internal/engine/rules/go/frameworks/net_http_stdlib.yaml
+          tests:
+            - file: internal/custom/golang/extractors_test.go
+          issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          # go_routes.go AST pass rewrites bare-receiver ROUTES_TO edges
+          # (Controller:h) into the qualified handler method
+          # (Controller:UsersHandler.List). HandleFunc/Handle are in
+          # goHTTPVerbs; stripGoMethodPrefix aliases method-prefixed patterns so
+          # `mux.HandleFunc("GET /p", h.M)` resolves against a "/p" route edge.
+          status: full
+          symbols:
+            - file: internal/custom/golang/nethttp.go
+              functions: [Extract]
+            - file: internal/engine/go_routes.go
+              functions:
+                - applyGoRouteComposition
+                - extractGoHandlerBindings
+                - stripGoMethodPrefix
+          tests:
+            - file: internal/custom/golang/extractors_test.go
+            - file: internal/engine/go_routes_test.go
+          issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+
   lang.java.framework.spring-webflux:
     capabilities:
       Observability:


### PR DESCRIPTION
## Summary

Implements the **net/http stdlib** slice of #3212 (Cluster 1 — Routing): the one framework in the cluster that had **no dedicated route-extraction path**. Its registry cells were already flipped to `full` but cited only `go_routes.go` + `net_http_stdlib.yaml` (a detection-marker-only file with no `routes:` rules) — so bare `http.HandleFunc`/`http.Handle` calls produced no endpoints. This adds the real extractor that backs those flips.

## What's new

**`internal/custom/golang/nethttp.go`** (`custom_go_nethttp`, registered via the `custom_go_` dispatch prefix) — `endpoint_synthesis`:
- `http.HandleFunc("/p", fn)` / `http.Handle("/p", h)` on the package `DefaultServeMux`
- `mux := http.NewServeMux()` → `SCOPE.Service`, plus `mux.HandleFunc`/`mux.Handle`
- Go 1.22+ method-prefixed patterns (`"GET /users/{id}"`) split into verb + path by `netHTTPMethodToken`; patterns with no leading verb default to `ANY` (stdlib matches any method)

**`handler_attribution`** reuses the shared AST pass in `internal/engine/go_routes.go` — `HandleFunc`/`Handle` are already in `goHTTPVerbs`, so `mux.HandleFunc("/p", h.List)` rewrites the bare-receiver `Controller:h` ROUTES_TO edge to `Controller:UsersHandler.List` for free. One tight addition: `stripGoMethodPrefix` registers a method-stripped alias of the binding key so a Go 1.22 method-prefixed pattern still matches a bare-path route edge.

## Tests
- `internal/custom/golang/extractors_test.go`: 5 cases (ServeMux service, DefaultServeMux routes, mux-scoped routes, method-prefixed patterns, no-match)
- `internal/engine/go_routes_test.go`: `TestApplyGoRouteComposition_NetHTTPServeMux` (attribution + method-prefix alias)

## Coverage flips (honest, fixture-proven `full`)
- `lang.go.framework.net-http.Routing.endpoint_synthesis` → **full**
- `lang.go.framework.net-http.Routing.handler_attribution` → **full**

Registry cites now point at `nethttp.go`; `capability-map.yaml` gains the `lang.go.framework.net-http` Routing entries; `docs/coverage/detail/lang.go.framework.net-http.md` regenerated (byte-stable, idempotent).

## Validation (scoped — daemon untouched)
- `go build ./internal/... ./tools/coverage/...` ✅
- `go test ./internal/engine/... ./internal/custom/golang/... ./internal/extractors/golang/... ./internal/types/ ./tools/coverage/...` ✅
- `go run ./tools/coverage validate` → 0 errors ✅ · `fmt --check` canonical ✅ · `gen` byte-stable ✅ · `gofmt -l` clean ✅

Only net-http Routing cells + the nethttp extractor + a tight `go_routes.go` alias were touched (no gorm/orm/test cells).

Part of #3212

🤖 Generated with [Claude Code](https://claude.com/claude-code)