### PR TITLE
feat(coverage): Go middleware + auth detection for gin/echo/fiber/chi

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -41,16 +41,16 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🔴 0/6 | |
+| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 1/6 | |
 | [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -28,16 +28,16 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|---|---|---|---|---|
 | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🔴 0/6 | |
+| [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 1/6 | |
 | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/chi.go`<br>`internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/chi.go`<br>`internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/echo.go`<br>`internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/echo.go`<br>`internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/fiber.go`<br>`internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/fiber.go`<br>`internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/gin.go`<br>`internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/gin.go`<br>`internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -11023,7 +11023,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/chi.go","internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -11038,7 +11040,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/chi.go","internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -11200,7 +11204,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/echo.go","internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -11215,7 +11221,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/echo.go","internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -11554,7 +11562,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/fiber.go","internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -11569,7 +11579,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/fiber.go","internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -11795,7 +11807,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/gin.go","internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -11810,7 +11824,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/gin.go","internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {

--- a/internal/custom/golang/chi.go
+++ b/internal/custom/golang/chi.go
@@ -43,9 +43,6 @@ var (
 	reChiMount = regexp.MustCompile(
 		`(?m)(\w+)\.Mount\s*\(\s*"([^"]+)"`,
 	)
-	reChiUse = regexp.MustCompile(
-		`(?m)(\w+)\.Use\s*\(\s*((?:[^()]+|\([^)]*\))+?)\s*\)`,
-	)
 )
 
 func (e *chiExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -133,13 +130,12 @@ func (e *chiExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		add(ent)
 	}
 
-	// 6. r.Use(middleware) -> SCOPE.Pattern
-	for _, m := range reChiUse.FindAllStringSubmatchIndex(src, -1) {
-		mwExpr := strings.TrimSpace(src[m[4]:m[5]])
-		ent := makeEntity(mwExpr, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "chi", "provenance", "INFERRED_FROM_CHI_MIDDLEWARE",
-			"pattern_kind", "middleware")
-		add(ent)
+	// 6. r.Use(middleware, …) -> ordered SCOPE.Pattern middleware (+ auth)
+	for _, uc := range findUseCalls(src) {
+		chain := parseMiddlewareChain(uc.Args)
+		emitMiddlewareChain(add, chain, "chi",
+			"INFERRED_FROM_CHI_MIDDLEWARE", "INFERRED_FROM_CHI_AUTH",
+			file.Path, file.Language, uc.Line)
 	}
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))

--- a/internal/custom/golang/echo.go
+++ b/internal/custom/golang/echo.go
@@ -31,9 +31,6 @@ var (
 	reEchoRoute = regexp.MustCompile(
 		`(?m)(\w+)\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE|Any)\s*\(\s*"([^"]+)"`,
 	)
-	reEchoUse = regexp.MustCompile(
-		`(?m)(\w+)\.Use\s*\(\s*((?:[^()]+|\([^)]*\))+?)\s*\)`,
-	)
 	reEchoBind = regexp.MustCompile(
 		`(?m)c\.(Bind|BindJSON|BindQuery|BindParam|BindBody|BindHeader)\s*\(\s*&?(\w+)`,
 	)
@@ -112,13 +109,12 @@ func (e *echoExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 		add(ent)
 	}
 
-	// 4. .Use(middleware) -> SCOPE.Pattern
-	for _, m := range reEchoUse.FindAllStringSubmatchIndex(src, -1) {
-		mwExpr := strings.TrimSpace(src[m[4]:m[5]])
-		ent := makeEntity(mwExpr, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "echo", "provenance", "INFERRED_FROM_ECHO_MIDDLEWARE",
-			"pattern_kind", "middleware")
-		add(ent)
+	// 4. .Use(middleware, …) -> ordered SCOPE.Pattern middleware (+ auth)
+	for _, uc := range findUseCalls(src) {
+		chain := parseMiddlewareChain(uc.Args)
+		emitMiddlewareChain(add, chain, "echo",
+			"INFERRED_FROM_ECHO_MIDDLEWARE", "INFERRED_FROM_ECHO_AUTH",
+			file.Path, file.Language, uc.Line)
 	}
 
 	// 5. c.Bind* -> SCOPE.Schema

--- a/internal/custom/golang/fiber.go
+++ b/internal/custom/golang/fiber.go
@@ -31,9 +31,6 @@ var (
 	reFiberRoute = regexp.MustCompile(
 		`(?m)(\w+)\.(Get|Post|Put|Delete|Patch|Head|Options|All|Connect|Trace)\s*\(\s*"([^"]+)"`,
 	)
-	reFiberUse = regexp.MustCompile(
-		`(?m)(\w+)\.Use\s*\(\s*((?:[^()]+|\([^)]*\))+?)\s*\)`,
-	)
 	reFiberBind = regexp.MustCompile(
 		`(?m)c\.(BodyParser|QueryParser|ParamsParser|ReqHeaderParser)\s*\(\s*&?(\w+)`,
 	)
@@ -111,13 +108,12 @@ func (e *fiberExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		add(ent)
 	}
 
-	// 4. .Use(middleware) -> SCOPE.Pattern
-	for _, m := range reFiberUse.FindAllStringSubmatchIndex(src, -1) {
-		mwExpr := strings.TrimSpace(src[m[4]:m[5]])
-		ent := makeEntity(mwExpr, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "fiber", "provenance", "INFERRED_FROM_FIBER_MIDDLEWARE",
-			"pattern_kind", "middleware")
-		add(ent)
+	// 4. .Use(middleware, …) -> ordered SCOPE.Pattern middleware (+ auth)
+	for _, uc := range findUseCalls(src) {
+		chain := parseMiddlewareChain(uc.Args)
+		emitMiddlewareChain(add, chain, "fiber",
+			"INFERRED_FROM_FIBER_MIDDLEWARE", "INFERRED_FROM_FIBER_AUTH",
+			file.Path, file.Language, uc.Line)
 	}
 
 	// 5. c.BodyParser etc -> SCOPE.Schema

--- a/internal/custom/golang/gin.go
+++ b/internal/custom/golang/gin.go
@@ -32,9 +32,6 @@ var (
 	reGinRoute = regexp.MustCompile(
 		`(?m)(\w+)\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|Any)\s*\(\s*"([^"]+)"`,
 	)
-	reGinUse = regexp.MustCompile(
-		`(?m)(\w+)\.Use\s*\(\s*((?:[^()]+|\([^)]*\))+?)\s*\)`,
-	)
 	reGinBind = regexp.MustCompile(
 		`(?m)c\.(ShouldBindJSON|BindJSON|ShouldBindQuery|ShouldBind|ShouldBindForm|ShouldBindUri|BindQuery)\s*\(\s*&?(\w+)`,
 	)
@@ -116,13 +113,12 @@ func (e *ginExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		add(ent)
 	}
 
-	// 4. .Use(middleware) -> SCOPE.Pattern
-	for _, m := range reGinUse.FindAllStringSubmatchIndex(src, -1) {
-		mwExpr := strings.TrimSpace(src[m[4]:m[5]])
-		ent := makeEntity(mwExpr, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "gin", "provenance", "INFERRED_FROM_GIN_MIDDLEWARE",
-			"pattern_kind", "middleware")
-		add(ent)
+	// 4. .Use(middleware, …) -> ordered SCOPE.Pattern middleware (+ auth)
+	for _, uc := range findUseCalls(src) {
+		chain := parseMiddlewareChain(uc.Args)
+		emitMiddlewareChain(add, chain, "gin",
+			"INFERRED_FROM_GIN_MIDDLEWARE", "INFERRED_FROM_GIN_AUTH",
+			file.Path, file.Language, uc.Line)
 	}
 
 	// 5. c.ShouldBindJSON etc -> SCOPE.Schema

--- a/internal/custom/golang/helpers.go
+++ b/internal/custom/golang/helpers.go
@@ -3,6 +3,7 @@
 package golang
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -53,5 +54,250 @@ func setProps(e *types.EntityRecord, kv ...string) {
 	}
 	for i := 0; i < len(kv); i += 2 {
 		e.Properties[kv[i]] = kv[i+1]
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared middleware + auth detection (issue #3213)
+//
+// All four well-templated Go HTTP frameworks (gin/echo/fiber/chi) register
+// middleware through a `.Use(...)` call that accepts one or more middleware
+// values, applied left-to-right in registration order. This shared detector
+// parses a single `.Use(...)` argument list into ordered middleware
+// expressions and classifies each against a heuristic auth-pattern catalog.
+//
+// Honesty note: detection is a heuristic substring/identifier match on the
+// middleware expression text — it does NOT perform data-flow analysis to
+// confirm a value actually enforces authentication. It is therefore reported
+// as `partial` coverage in the registry.
+// ---------------------------------------------------------------------------
+
+// middlewareArg is one entry in a `.Use(...)` chain, in registration order.
+type middlewareArg struct {
+	Expr     string // the raw middleware expression, e.g. "jwt.New(cfg)"
+	Name     string // the leading identifier/selector, e.g. "jwt.New"
+	Order    int    // 0-based position within this .Use(...) call
+	AuthKind string // non-empty when classified as auth middleware
+}
+
+// reMiddlewareCallHead extracts the leading identifier/selector of a
+// middleware expression: the part before any "(" call. e.g. "jwt.New(c)" -> "jwt.New".
+var reMiddlewareCallHead = regexp.MustCompile(`^[A-Za-z_][\w.]*`)
+
+// splitTopLevelArgs splits a comma-separated argument list on top-level commas
+// only — commas nested inside (), [], or {} are preserved. Quoted strings are
+// skipped so commas inside string literals do not split arguments.
+func splitTopLevelArgs(argList string) []string {
+	var args []string
+	depth := 0
+	start := 0
+	var quote rune
+	for i, r := range argList {
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '"', '\'', '`':
+			quote = r
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				args = append(args, strings.TrimSpace(argList[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if last := strings.TrimSpace(argList[start:]); last != "" {
+		args = append(args, last)
+	}
+	return args
+}
+
+// parseMiddlewareChain parses the argument text of a single `.Use(...)` call
+// into ordered middleware entries with auth classification applied.
+func parseMiddlewareChain(argList string) []middlewareArg {
+	parts := splitTopLevelArgs(argList)
+	out := make([]middlewareArg, 0, len(parts))
+	order := 0
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		// A bare string/char literal is a path-mount prefix (e.g.
+		// fiber's app.Use("/api", mw)), never a middleware value — skip it
+		// so it neither inflates the order index nor emits a phantom entry.
+		if isStringLiteral(p) {
+			continue
+		}
+		head := reMiddlewareCallHead.FindString(p)
+		if head == "" {
+			head = p
+		}
+		out = append(out, middlewareArg{
+			Expr:     p,
+			Name:     head,
+			Order:    order,
+			AuthKind: classifyAuthMiddleware(p),
+		})
+		order++
+	}
+	return out
+}
+
+// useCall is a single `<recv>.Use(<args>)` invocation located by scanning,
+// with parentheses balanced (so nested calls like JWT([]byte("k")) are
+// captured whole, which the single-level regex form cannot do).
+type useCall struct {
+	Recv string // receiver variable, e.g. "r" / "app"
+	Args string // raw argument text between the outer parens
+	Line int    // 1-based source line of the `.Use(` token
+}
+
+// reUseHead locates the `<ident>.Use(` token; the balanced argument span is
+// then scanned forward from the opening paren.
+var reUseHead = regexp.MustCompile(`(\w+)\.Use\s*\(`)
+
+// findUseCalls returns every balanced `.Use(...)` call in src. Unlike a flat
+// regex, it tracks paren depth (skipping quoted strings) so arbitrarily nested
+// middleware expressions are captured in full.
+func findUseCalls(src string) []useCall {
+	var calls []useCall
+	for _, loc := range reUseHead.FindAllStringSubmatchIndex(src, -1) {
+		recv := src[loc[2]:loc[3]]
+		open := loc[1] - 1 // index of the '(' (reUseHead ends at it)
+		depth := 0
+		var quote rune
+		end := -1
+		for i := open; i < len(src); i++ {
+			r := rune(src[i])
+			if quote != 0 {
+				if r == quote {
+					quote = 0
+				}
+				continue
+			}
+			switch r {
+			case '"', '\'', '`':
+				quote = r
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					end = i
+				}
+			}
+			if end >= 0 {
+				break
+			}
+		}
+		if end < 0 {
+			continue // unbalanced; skip
+		}
+		calls = append(calls, useCall{
+			Recv: recv,
+			Args: strings.TrimSpace(src[open+1 : end]),
+			Line: lineOf(src, loc[0]),
+		})
+	}
+	return calls
+}
+
+// isStringLiteral reports whether expr is a single quoted string or rune
+// literal (no surrounding operators/calls).
+func isStringLiteral(expr string) bool {
+	if len(expr) < 2 {
+		return false
+	}
+	q := expr[0]
+	if q != '"' && q != '\'' && q != '`' {
+		return false
+	}
+	return expr[len(expr)-1] == q
+}
+
+// authPatterns maps a lowercased substring of a middleware expression to a
+// coarse auth kind. Ordered most-specific first so e.g. "jwt" wins over the
+// generic "auth". The catalog covers the common gin/echo/fiber/chi auth
+// middleware surface (framework built-ins + popular community modules).
+var authPatterns = []struct {
+	needle string
+	kind   string
+}{
+	{"jwtware", "jwt"},
+	{"jwt", "jwt"},
+	{"bearer", "jwt"},
+	{"oauth2", "oauth"},
+	{"oauth", "oauth"},
+	{"keyauth", "api_key"},
+	{"apikey", "api_key"},
+	{"api_key", "api_key"},
+	{"basicauth", "basic"},
+	{"basic_auth", "basic"},
+	{"session", "session"},
+	{"casbin", "rbac"},
+	{"rbac", "rbac"},
+	{"authz", "authz"},
+	{"authorize", "authz"},
+	{"requireauth", "auth"},
+	{"authrequired", "auth"},
+	{"authmiddleware", "auth"},
+	{"authenticate", "auth"},
+	{"auth", "auth"},
+}
+
+// classifyAuthMiddleware returns a coarse auth kind for a middleware expression,
+// or "" if it does not look like an auth/authorization middleware. Heuristic:
+// case-insensitive substring match against authPatterns.
+func classifyAuthMiddleware(expr string) string {
+	low := strings.ToLower(expr)
+	for _, p := range authPatterns {
+		if strings.Contains(low, p.needle) {
+			return p.kind
+		}
+	}
+	return ""
+}
+
+// emitMiddlewareChain appends one SCOPE.Pattern entity per middleware in a
+// `.Use(...)` call, preserving registration order via the "mw_order" property,
+// and a dedicated auth SCOPE.Pattern (pattern_kind=auth) for any entry that
+// classifies as auth middleware. The provenance + framework are supplied by
+// the caller so this stays framework-agnostic.
+//
+// add is the caller's dedup-aware appender; line is the source line of the
+// .Use(...) call.
+func emitMiddlewareChain(
+	add func(types.EntityRecord),
+	args []middlewareArg,
+	framework, mwProvenance, authProvenance, filePath, language string,
+	line int,
+) {
+	for _, a := range args {
+		mw := makeEntity(a.Expr, "SCOPE.Pattern", "", filePath, language, line)
+		setProps(&mw, "framework", framework, "provenance", mwProvenance,
+			"pattern_kind", "middleware",
+			"middleware_name", a.Name,
+			"mw_order", strconv.Itoa(a.Order))
+		if a.AuthKind != "" {
+			setProps(&mw, "is_auth", "true", "auth_kind", a.AuthKind)
+		}
+		add(mw)
+
+		if a.AuthKind != "" {
+			au := makeEntity("auth:"+a.Name, "SCOPE.Pattern", "", filePath, language, line)
+			setProps(&au, "framework", framework, "provenance", authProvenance,
+				"pattern_kind", "auth",
+				"auth_kind", a.AuthKind,
+				"middleware_name", a.Name,
+				"middleware_expr", a.Expr)
+			add(au)
+		}
 	}
 }

--- a/internal/custom/golang/middleware_auth_test.go
+++ b/internal/custom/golang/middleware_auth_test.go
@@ -1,0 +1,235 @@
+package golang_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/golang"
+)
+
+// Tests for the shared middleware + auth detector (issue #3213), covering the
+// four well-templated Go frameworks: gin, echo, fiber, chi.
+
+// fullEntity is the test-local view including properties, since middleware
+// ordering + auth classification live in the property bag.
+type fullEntity struct {
+	Kind, Name string
+	Props      map[string]string
+}
+
+func extractFull(t *testing.T, name string, file extreg.FileInput) []fullEntity {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	out := make([]fullEntity, 0, len(ents))
+	for _, ent := range ents {
+		out = append(out, fullEntity{Kind: ent.Kind, Name: ent.Name, Props: ent.Properties})
+	}
+	return out
+}
+
+func findMW(ents []fullEntity, name string) *fullEntity {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Pattern" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func fixtureFile(t *testing.T, name string) extreg.FileInput {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return extreg.FileInput{Path: filepath.Join("testdata", name), Language: "go", Content: content}
+}
+
+// ---------------------------------------------------------------------------
+// Ordering: a multi-arg .Use(...) chain yields one entity per middleware,
+// in registration order, with mw_order 0,1,2,…
+// ---------------------------------------------------------------------------
+
+func TestGinMiddlewareOrdering(t *testing.T) {
+	src := `r.Use(gin.Logger(), gin.Recovery(), cors.Default())`
+	ents := extractFull(t, "custom_go_gin", fi("main.go", "go", src))
+	want := []struct {
+		name, order string
+	}{
+		{"gin.Logger()", "0"},
+		{"gin.Recovery()", "1"},
+		{"cors.Default()", "2"},
+	}
+	for _, w := range want {
+		mw := findMW(ents, w.name)
+		if mw == nil {
+			t.Fatalf("missing middleware %q", w.name)
+		}
+		if mw.Props["pattern_kind"] != "middleware" {
+			t.Errorf("%s: pattern_kind=%q want middleware", w.name, mw.Props["pattern_kind"])
+		}
+		if mw.Props["mw_order"] != w.order {
+			t.Errorf("%s: mw_order=%q want %q", w.name, mw.Props["mw_order"], w.order)
+		}
+	}
+}
+
+func TestChiMiddlewareOrdering(t *testing.T) {
+	src := `r.Use(middleware.RequestID, middleware.Logger, middleware.Recoverer)`
+	ents := extractFull(t, "custom_go_chi", fi("main.go", "go", src))
+	for name, order := range map[string]string{
+		"middleware.RequestID": "0",
+		"middleware.Logger":    "1",
+		"middleware.Recoverer": "2",
+	} {
+		mw := findMW(ents, name)
+		if mw == nil {
+			t.Fatalf("missing middleware %q", name)
+		}
+		if mw.Props["mw_order"] != order {
+			t.Errorf("%s: mw_order=%q want %q", name, mw.Props["mw_order"], order)
+		}
+		if mw.Props["middleware_name"] != name {
+			t.Errorf("%s: middleware_name=%q", name, mw.Props["middleware_name"])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth classification: an auth middleware is flagged is_auth=true with an
+// auth_kind, and a dedicated auth:<name> SCOPE.Pattern (pattern_kind=auth)
+// is also emitted.
+// ---------------------------------------------------------------------------
+
+func TestGinAuthDetection(t *testing.T) {
+	src := `r.Use(authMw.MiddlewareFunc())`
+	ents := extractFull(t, "custom_go_gin", fi("main.go", "go", src))
+	mw := findMW(ents, "authMw.MiddlewareFunc()")
+	if mw == nil {
+		t.Fatal("missing auth middleware entity")
+	}
+	if mw.Props["is_auth"] != "true" || mw.Props["auth_kind"] != "auth" {
+		t.Errorf("expected is_auth/auth_kind, got %+v", mw.Props)
+	}
+	if findMW(ents, "auth:authMw.MiddlewareFunc") == nil {
+		t.Error("expected dedicated auth:authMw.MiddlewareFunc pattern")
+	}
+}
+
+func TestEchoJWTAuthKind(t *testing.T) {
+	src := `e.Use(middleware.JWT([]byte("secret")))`
+	ents := extractFull(t, "custom_go_echo", fi("main.go", "go", src))
+	mw := findMW(ents, `middleware.JWT([]byte("secret"))`)
+	if mw == nil {
+		t.Fatal("missing JWT middleware entity")
+	}
+	if mw.Props["auth_kind"] != "jwt" {
+		t.Errorf("auth_kind=%q want jwt", mw.Props["auth_kind"])
+	}
+}
+
+func TestFiberPathMountSkipsStringLiteral(t *testing.T) {
+	// app.Use("/api", jwtware.New(...)) — the "/api" mount prefix must NOT
+	// become a middleware entity, and the jwtware value must be order 0.
+	src := `app.Use("/api", jwtware.New(jwtware.Config{}))`
+	ents := extractFull(t, "custom_go_fiber", fi("main.go", "go", src))
+	if findMW(ents, `"/api"`) != nil {
+		t.Error("string-literal mount prefix should not be a middleware entity")
+	}
+	mw := findMW(ents, "jwtware.New(jwtware.Config{})")
+	if mw == nil {
+		t.Fatal("missing jwtware middleware entity")
+	}
+	if mw.Props["mw_order"] != "0" {
+		t.Errorf("mw_order=%q want 0 (prefix skipped)", mw.Props["mw_order"])
+	}
+	if mw.Props["auth_kind"] != "jwt" {
+		t.Errorf("auth_kind=%q want jwt", mw.Props["auth_kind"])
+	}
+}
+
+func TestChiAuthDetection(t *testing.T) {
+	src := `r.Use(jwtauth.Authenticator)`
+	ents := extractFull(t, "custom_go_chi", fi("main.go", "go", src))
+	mw := findMW(ents, "jwtauth.Authenticator")
+	if mw == nil {
+		t.Fatal("missing jwtauth.Authenticator entity")
+	}
+	// "jwtauth" classifies as jwt (more specific than the generic "auth").
+	if mw.Props["auth_kind"] != "jwt" {
+		t.Errorf("auth_kind=%q want jwt", mw.Props["auth_kind"])
+	}
+	if findMW(ents, "auth:jwtauth.Authenticator") == nil {
+		t.Error("expected dedicated auth:jwtauth.Authenticator pattern")
+	}
+}
+
+// Non-auth middleware must NOT be flagged.
+func TestNonAuthMiddlewareNotFlagged(t *testing.T) {
+	src := `r.Use(gin.Logger())`
+	ents := extractFull(t, "custom_go_gin", fi("main.go", "go", src))
+	mw := findMW(ents, "gin.Logger()")
+	if mw == nil {
+		t.Fatal("missing gin.Logger() entity")
+	}
+	if mw.Props["is_auth"] == "true" {
+		t.Error("logger middleware wrongly flagged as auth")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fixture-driven end-to-end checks.
+// ---------------------------------------------------------------------------
+
+func TestGinFixtureMiddlewareAuth(t *testing.T) {
+	ents := extractFull(t, "custom_go_gin", fixtureFile(t, "gin_middleware_auth.go"))
+	for _, n := range []string{"gin.Logger()", "gin.Recovery()", "cors.Default()"} {
+		if findMW(ents, n) == nil {
+			t.Errorf("fixture: missing middleware %q", n)
+		}
+	}
+	if findMW(ents, "RequireAuth()") == nil {
+		t.Error("fixture: missing RequireAuth() middleware")
+	}
+}
+
+func TestEchoFixtureAuth(t *testing.T) {
+	ents := extractFull(t, "custom_go_echo", fixtureFile(t, "echo_middleware_auth.go"))
+	jwt := findMW(ents, `middleware.JWT([]byte("secret"))`)
+	if jwt == nil || jwt.Props["auth_kind"] != "jwt" {
+		t.Errorf("fixture: expected echo JWT auth, got %+v", jwt)
+	}
+	basic := findMW(ents, "middleware.BasicAuth(validate)")
+	if basic == nil || basic.Props["auth_kind"] != "basic" {
+		t.Errorf("fixture: expected basic auth, got %+v", basic)
+	}
+}
+
+func TestFiberFixtureAuth(t *testing.T) {
+	ents := extractFull(t, "custom_go_fiber", fixtureFile(t, "fiber_middleware_auth.go"))
+	if findMW(ents, "jwtware.New(jwtware.Config{})") == nil {
+		t.Error("fixture: missing fiber jwtware middleware")
+	}
+}
+
+func TestChiFixtureAuth(t *testing.T) {
+	ents := extractFull(t, "custom_go_chi", fixtureFile(t, "chi_middleware_auth.go"))
+	if findMW(ents, "jwtauth.Verifier(ta)") == nil {
+		t.Error("fixture: missing jwtauth.Verifier")
+	}
+	auth := findMW(ents, "jwtauth.Authenticator")
+	if auth == nil || auth.Props["auth_kind"] == "" {
+		t.Errorf("fixture: expected jwtauth.Authenticator flagged auth, got %+v", auth)
+	}
+}

--- a/internal/custom/golang/testdata/chi_middleware_auth.go
+++ b/internal/custom/golang/testdata/chi_middleware_auth.go
@@ -1,0 +1,18 @@
+package testdata
+
+// Fixture: chi middleware + auth for issue #3213. Uses the chi/middleware
+// built-ins plus a custom Authenticator (jwtauth) auth middleware.
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/jwtauth/v5"
+)
+
+func setupChi(ta *jwtauth.JWTAuth) *chi.Mux {
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID, middleware.Logger, middleware.Recoverer)
+	r.Use(jwtauth.Verifier(ta))
+	r.Use(jwtauth.Authenticator)
+	return r
+}

--- a/internal/custom/golang/testdata/echo_middleware_auth.go
+++ b/internal/custom/golang/testdata/echo_middleware_auth.go
@@ -1,0 +1,19 @@
+package testdata
+
+// Fixture: echo middleware + auth for issue #3213. Mixes built-in middleware
+// with the echo jwt middleware (echojwt / middleware.JWT) and basic auth.
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+func setupEcho() *echo.Echo {
+	e := echo.New()
+	e.Use(middleware.Logger(), middleware.Recover())
+	e.Use(middleware.JWT([]byte("secret")))
+	e.Use(middleware.BasicAuth(validate))
+	return e
+}
+
+func validate(u, p string, c echo.Context) (bool, error) { return true, nil }

--- a/internal/custom/golang/testdata/fiber_middleware_auth.go
+++ b/internal/custom/golang/testdata/fiber_middleware_auth.go
@@ -1,0 +1,19 @@
+package testdata
+
+// Fixture: fiber middleware + auth for issue #3213. Includes a path-mounted
+// .Use("/api", mw) form (the leading string literal must be skipped, not
+// treated as a middleware value) plus the fiber jwtware auth middleware.
+
+import (
+	jwtware "github.com/gofiber/contrib/jwt"
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/logger"
+	"github.com/gofiber/fiber/v2/middleware/recover"
+)
+
+func setupFiber() *fiber.App {
+	app := fiber.New()
+	app.Use(logger.New(), recover.New())
+	app.Use("/api", jwtware.New(jwtware.Config{}))
+	return app
+}

--- a/internal/custom/golang/testdata/gin_middleware_auth.go
+++ b/internal/custom/golang/testdata/gin_middleware_auth.go
@@ -1,0 +1,25 @@
+package testdata
+
+// Fixture: gin middleware + auth registration for issue #3213.
+// Exercises an ordered multi-arg .Use(...) chain plus a dedicated auth
+// middleware (jwt) so the shared detector can prove ordering + auth kind.
+
+import (
+	jwt "github.com/appleboy/gin-jwt/v2"
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+)
+
+func setupGin(authMw *jwt.GinJWTMiddleware) *gin.Engine {
+	r := gin.New()
+	r.Use(gin.Logger(), gin.Recovery(), cors.Default())
+	r.Use(authMw.MiddlewareFunc())
+
+	api := r.Group("/api")
+	api.Use(RequireAuth())
+	api.GET("/profile", profile)
+	return r
+}
+
+func RequireAuth() gin.HandlerFunc { return func(c *gin.Context) {} }
+func profile(c *gin.Context)       {}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -2603,6 +2603,38 @@ records:
           issues_implemented: ["2679"]
           verified_at: "2026-05-28"
 
+      Middleware:
+        middleware_coverage:
+          # gin.go reads balanced .Use(...) chains via findUseCalls and emits one
+          # ordered SCOPE.Pattern (pattern_kind=middleware, mw_order) per
+          # middleware. Heuristic ordering, no data-flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/gin.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [findUseCalls, parseMiddlewareChain, emitMiddlewareChain, splitTopLevelArgs]
+          tests:
+            - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware substring-matches middleware expressions
+          # against an auth-pattern catalog (jwt/oauth/basic/session/rbac/…),
+          # flagging is_auth + auth_kind and emitting an auth: SCOPE.Pattern.
+          # Pattern match only, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/gin.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware, emitMiddlewareChain]
+          tests:
+            - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
       Substrate:
         constant_propagation:
           status: full
@@ -2793,6 +2825,35 @@ records:
           issues_implemented: ["3211"]
           verified_at: "2026-05-30"
 
+      Middleware:
+        middleware_coverage:
+          # echo.go reads balanced .Use(...) chains via findUseCalls and emits
+          # ordered middleware SCOPE.Pattern entities (mw_order). Heuristic → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/echo.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [findUseCalls, parseMiddlewareChain, emitMiddlewareChain, splitTopLevelArgs]
+          tests:
+            - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware flags echo JWT/BasicAuth/etc middleware with
+          # auth_kind + an auth: SCOPE.Pattern. Pattern match only → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/echo.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware, emitMiddlewareChain]
+          tests:
+            - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
       Substrate:
         constant_propagation:
           status: full
@@ -2878,6 +2939,36 @@ records:
           tests:
             - file: internal/custom/golang/extractors_test.go
           issues_implemented: ["3211"]
+          verified_at: "2026-05-30"
+
+      Middleware:
+        middleware_coverage:
+          # fiber.go reads balanced .Use(...) chains via findUseCalls; a leading
+          # string-literal mount prefix (app.Use("/api", mw)) is skipped so it is
+          # not mistaken for a middleware value. Heuristic ordering → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/fiber.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [findUseCalls, parseMiddlewareChain, emitMiddlewareChain, isStringLiteral]
+          tests:
+            - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware flags fiber jwtware/keyauth/basicauth middleware
+          # with auth_kind + an auth: SCOPE.Pattern. Pattern match only → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/fiber.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware, emitMiddlewareChain]
+          tests:
+            - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
       Substrate:
@@ -2970,6 +3061,38 @@ records:
             - file: internal/custom/golang/extractors_test.go
             - file: internal/engine/go_routes_test.go
           issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+
+      Middleware:
+        middleware_coverage:
+          # chi.go reads balanced r.Use(...) chains via findUseCalls and emits
+          # ordered middleware SCOPE.Pattern entities (mw_order). chi commonly
+          # registers each middleware as a bare identifier (middleware.Logger).
+          # Heuristic ordering, no data-flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/chi.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [findUseCalls, parseMiddlewareChain, emitMiddlewareChain, splitTopLevelArgs]
+          tests:
+            - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware flags chi jwtauth.Verifier/Authenticator and
+          # similar auth middleware with auth_kind + an auth: SCOPE.Pattern.
+          # Pattern match only → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/chi.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware, emitMiddlewareChain]
+          tests:
+            - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
   lang.go.framework.gorilla-mux:


### PR DESCRIPTION
## Summary

Implements one slice of #3213 (Cluster 2 — Auth + Middleware + Validation): the **middleware_coverage** and **auth_coverage** capabilities for the four well-templated Go HTTP frameworks **gin, echo, fiber, chi**. Validation + the other 11 frameworks are left for later slices.

A **reusable middleware + auth detector** is added to `internal/custom/golang/helpers.go` and wired into each of the four existing extractors:

- `findUseCalls` — balanced-paren scanner for `.Use(...)` chains. Replaces the old single-level-nesting regex that truncated expressions like `middleware.JWT([]byte("k"))`.
- `splitTopLevelArgs` / `parseMiddlewareChain` — split a chain into **ordered** middleware args (`mw_order` 0,1,2,…), skipping a leading string-literal mount prefix (fiber's `app.Use("/api", mw)`).
- `classifyAuthMiddleware` — heuristic case-insensitive substring match against an auth-pattern catalog (`jwt`/`oauth`/`api_key`/`basic`/`session`/`rbac`/`authz`/`auth`) → `auth_kind`.
- `emitMiddlewareChain` — emits one `SCOPE.Pattern` per middleware (`pattern_kind=middleware`, `middleware_name`, `mw_order`), plus a dedicated `auth:<name>` `SCOPE.Pattern` (`pattern_kind=auth`, `auth_kind`) for any auth middleware, and stamps `is_auth`/`auth_kind` on the middleware entity itself.

## Coverage cells (all `partial`)

| framework | middleware_coverage | auth_coverage |
|---|---|---|
| gin | missing → **partial** | missing → **partial** |
| echo | missing → **partial** | missing → **partial** |
| fiber | missing → **partial** | missing → **partial** |
| chi | missing → **partial** | missing → **partial** |

Honest flips: detection is a heuristic identifier/substring match with no data-flow or enforcement proof, so **all eight cells are `partial`** — none claim `full`. Registry + capability-map symbol/test mappings + regenerated docs are included.

## Tests

`internal/custom/golang/middleware_auth_test.go` (+ 4 fixtures under `testdata/`) covers: multi-arg ordering, JWT/basic/generic auth classification, the fiber path-mount-prefix skip, non-auth non-flagging, and per-framework fixture extraction.

## Validation

- `go build ./internal/... ./tools/coverage/...` ✓
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` ✓
- `go run ./tools/coverage validate` → exit 0, 0 errors ✓
- `go run ./tools/coverage fmt --check` → canonical ✓
- `go run ./tools/coverage gen` → byte-stable (idempotent) ✓
- `gofmt -l internal/custom/golang/` → empty ✓

Scope strictly limited to the `framework.{gin,echo,fiber,chi}.{auth_coverage,middleware_coverage}` cells, those four extractors, and the shared helper. Routing/orm/test cells and other frameworks untouched.

Part of #3213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)