### PR TITLE
feat(coverage): Go sqlx/pgx/sqlite driver extractor (db: tags + raw SQL)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -52,12 +52,12 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 1/6 | |
 | [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 1/6 | |
 | [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/6 | |
-| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟡 1/6 | |
+| [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟢 4/4 | |
 | [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 1/6 | |
 | [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 1/6 | |
-| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 1/6 | |
+| [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟢 4/4 | |
 | [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 3/8 | |
-| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 2/8 | |
+| [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟢 5/5 | |
 | [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🔴 0/8 | |
 | [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟢 3/3 | |
 | [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟢 7/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -87,10 +87,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 1/6 | |
 | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 1/6 | |
 | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/6 | |
-| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟡 1/6 | |
+| [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟢 4/4 | |
 | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 1/6 | |
 | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 1/6 | |
-| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟡 1/6 | |
+| [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟢 4/4 | |
 | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 3/8 | |
-| [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 2/8 | |
+| [sqlx](../detail/lang.go.orm.sqlx.md) | 🟢 5/5 | |
 | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🔴 0/8 | |

--- a/docs/coverage/detail/lang.go.driver.sqlite.md
+++ b/docs/coverage/detail/lang.go.driver.sqlite.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
+| Lazy loading recognition | — `not_applicable` | — | — | — | — |
+| Relationship extraction | — `not_applicable` | — | — | — | — |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlite_go.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go`<br>`internal/engine/rules/go/orms/sqlite_go.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.go.orm.pgx.md
+++ b/docs/coverage/detail/lang.go.orm.pgx.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
+| Lazy loading recognition | — `not_applicable` | — | — | — | — |
+| Relationship extraction | — `not_applicable` | — | — | — | — |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/pgx.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go`<br>`internal/engine/rules/go/orms/pgx.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.go.orm.sqlx.md
+++ b/docs/coverage/detail/lang.go.orm.sqlx.md
@@ -15,29 +15,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlx.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go`<br>`internal/engine/rules/go/orms/sqlx.yaml` | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
+| Lazy loading recognition | — `not_applicable` | — | — | — | — |
+| Relationship extraction | — `not_applicable` | — | — | — | — |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/sqlx.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go`<br>`internal/engine/rules/go/orms/sqlx.yaml` | — |
 
 ### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/sql_drivers.go`<br>`internal/custom/golang/sql_drivers_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10613,36 +10613,41 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "not_applicable"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/sqlite_go.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go","internal/engine/rules/go/orms/sqlite_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
@@ -13813,36 +13818,41 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "not_applicable"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/pgx.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go","internal/engine/rules/go/orms/pgx.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
@@ -13914,42 +13924,48 @@
         "Models": {
           "model_extraction": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go","internal/engine/rules/go/orms/sqlx.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/sqlx.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go","internal/engine/rules/go/orms/sqlx.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/sql_drivers.go","internal/custom/golang/sql_drivers_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         }
       }

--- a/internal/custom/golang/sql_drivers.go
+++ b/internal/custom/golang/sql_drivers.go
@@ -1,0 +1,307 @@
+package golang
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// sql_drivers.go: struct-tag (`db:`) + raw-SQL extractor for the
+// non-ORM Go SQL access libraries — sqlx, pgx and the sqlite driver.
+//
+// These libraries deliberately have NO object-relational mapping layer:
+// they scan rows into structs by `db:` tag and run hand-written SQL.
+// Consequently the honest coverage shape is:
+//
+//   - Models       — partial. Structs carrying `db:"col"` tags are
+//                    recognised as schemas and their columns enumerated.
+//                    A `db:` tag is a heuristic (it does not prove the
+//                    struct is a table), hence partial rather than full.
+//   - Schema       — partial. Columns come from `db:` tags AND from
+//                    CREATE TABLE statements in SQL string literals.
+//   - Queries      — partial. Exec/Query/QueryRow/Get/Select/NamedExec
+//                    call sites plus their SQL string literal are captured.
+//                    Binding a query to a concrete model from a regex is
+//                    not reliable, so this stays partial.
+//   - Relationships— foreign_key_extraction is partial (FOREIGN KEY clauses
+//                    parsed from CREATE TABLE SQL). association /
+//                    relationship / lazy_loading have no concept in a
+//                    driver with no relation layer → honesty-NA (recorded
+//                    as not_applicable in the registry, no code claim).
+//   - Migrations   — partial. File-based NNN_slug.up/down.sql migrations
+//                    are recognised by filename. (pgx/sqlite drivers ship
+//                    no migration runner of their own; sqlx is commonly
+//                    paired with golang-migrate whose files match here.)
+//
+// The extractor attributes each match to a driver by inspecting the
+// imports actually present in the file, so a file importing only pgx is
+// not tagged sqlx and vice-versa. When no recognised driver import is
+// present the Go branch no-ops (file-based .sql migrations are handled
+// by filename and remain driver-agnostic, tagged "sql").
+
+func init() {
+	extractor.Register("custom_go_sql_drivers", &sqlDriversExtractor{})
+}
+
+type sqlDriversExtractor struct{}
+
+func (e *sqlDriversExtractor) Language() string { return "custom_go_sql_drivers" }
+
+var (
+	// Driver import markers. Presence of any of these in the file gates
+	// the Go-source branch and selects the attributed driver name.
+	reImportSqlx   = regexp.MustCompile(`"github\.com/jmoiron/sqlx"`)
+	reImportPgx    = regexp.MustCompile(`"github\.com/jackc/pgx(?:/v\d+)?(?:/pgxpool)?"`)
+	reImportSqlite = regexp.MustCompile(`"(?:github\.com/mattn/go-sqlite3|modernc\.org/sqlite)"`)
+
+	// A struct field carrying a `db:"column"` tag.
+	//   ID   int    `db:"id"`
+	//   Name string `db:"name"`
+	reDBStruct = regexp.MustCompile(`(?ms)type\s+(\w+)\s+struct\s*\{(.*?)\n\}`)
+	reDBField  = regexp.MustCompile("(?m)^\\s*(\\w+)\\s+([\\w\\.\\[\\]\\*]+)\\s+`[^`]*\\bdb:\"([^\"]*)\"[^`]*`")
+
+	// Query call sites. Captures the verb so query_type can be stamped.
+	reSQLQueryCall = regexp.MustCompile(
+		`(?m)\.(ExecContext|Exec|QueryxContext|QueryRowxContext|QueryRowContext|QueryContext|Queryx|QueryRowx|QueryRow|Query|GetContext|SelectContext|NamedExecContext|NamedQueryContext|NamedExec|NamedQuery|Get|Select)\s*\(`,
+	)
+
+	// SQL string literals: double-quoted or raw back-quoted strings whose
+	// content starts with a SQL DML/DDL keyword (heuristic). Used both to
+	// surface queries and to mine CREATE TABLE schema/FK information.
+	reSQLDoubleQuoted = regexp.MustCompile(
+		"(?is)\"(\\s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE\\s+TABLE|ALTER\\s+TABLE)\\b[^\"]*)\"",
+	)
+	reSQLBackQuoted = regexp.MustCompile(
+		"(?is)`(\\s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE\\s+TABLE|ALTER\\s+TABLE)\\b[^`]*)`",
+	)
+
+	// CREATE TABLE <name> ( ... ) — table name + body for column/FK mining.
+	reCreateTable = regexp.MustCompile(
+		"(?is)CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?[\"`']?([A-Za-z_][A-Za-z0-9_]*)[\"`']?\\s*\\((.*)\\)",
+	)
+	// FOREIGN KEY (col) REFERENCES other(othercol)
+	reForeignKey = regexp.MustCompile(
+		"(?is)FOREIGN\\s+KEY\\s*\\(\\s*[\"`']?([A-Za-z0-9_]+)[\"`']?\\s*\\)\\s*REFERENCES\\s+[\"`']?([A-Za-z0-9_]+)[\"`']?",
+	)
+
+	// File-based migration filename: 000123_add_users.up.sql.
+	reSQLMigrationFile = regexp.MustCompile(
+		`^(\d+)_([A-Za-z0-9_\-]+)\.(up|down)\.sql$`,
+	)
+)
+
+func (e *sqlDriversExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.sql_drivers_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "sql_drivers"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// File-based SQL migrations are recognised by filename regardless of
+	// the source language, so handle them before the Go-only gate.
+	base := filepath.Base(file.Path)
+	if m := reSQLMigrationFile.FindStringSubmatch(base); m != nil {
+		version, slug, direction := m[1], m[2], m[3]
+		ent := makeEntity("migration:"+version+"_"+slug+"."+direction, "SCOPE.Schema", "migration", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "sql", "provenance", "INFERRED_FROM_SQL_MIGRATION_FILE",
+			"migration_version", version, "migration_slug", slug, "migration_direction", direction)
+		add(ent)
+		span.SetAttributes(attribute.Int("entity_count", len(entities)))
+		return entities, nil
+	}
+
+	if file.Language != "go" {
+		return nil, nil
+	}
+
+	driver := detectSQLDriver(src)
+	if driver == "" {
+		// No recognised sqlx/pgx/sqlite import: not our file.
+		return nil, nil
+	}
+
+	// 1. Models / Schema: structs with `db:"col"` field tags.
+	for _, sm := range reDBStruct.FindAllStringSubmatchIndex(src, -1) {
+		structName := src[sm[2]:sm[3]]
+		body := src[sm[4]:sm[5]]
+		structLine := lineOf(src, sm[0])
+		fields := reDBField.FindAllStringSubmatch(body, -1)
+		if len(fields) == 0 {
+			continue
+		}
+		ent := makeEntity(structName, "SCOPE.Schema", "", file.Path, file.Language, structLine)
+		setProps(&ent, "framework", driver, "provenance", "INFERRED_FROM_DB_STRUCT_TAGS")
+		add(ent)
+
+		for _, fm := range fields {
+			fieldName := fm[1]
+			fieldType := fm[2]
+			column := strings.TrimSpace(fm[3])
+			// "-" means "ignore this field"; skip it as a column.
+			if column == "" || column == "-" {
+				continue
+			}
+			// Strip option suffixes such as `db:"id,omitempty"`.
+			if i := strings.IndexByte(column, ','); i >= 0 {
+				column = column[:i]
+			}
+			fieldEnt := makeEntity("field:"+structName+"."+fieldName, "SCOPE.Component", "field", file.Path, file.Language, structLine)
+			setProps(&fieldEnt, "framework", driver, "provenance", "INFERRED_FROM_DB_STRUCT_TAGS",
+				"model_name", structName, "field_name", fieldName, "column_name", column, "go_type", fieldType)
+			add(fieldEnt)
+		}
+	}
+
+	// 2. Schema + foreign keys mined from CREATE TABLE SQL literals.
+	//    Also surfaces queries from SELECT/INSERT/UPDATE/DELETE literals.
+	for _, sqlLit := range collectSQLLiterals(src) {
+		stmt, line := sqlLit.text, sqlLit.line
+		upper := strings.ToUpper(strings.TrimSpace(stmt))
+		switch {
+		case strings.HasPrefix(upper, "CREATE TABLE"):
+			if ct := reCreateTable.FindStringSubmatch(stmt); ct != nil {
+				table := ct[1]
+				tblBody := ct[2]
+				tblEnt := makeEntity("table:"+table, "SCOPE.Schema", "", file.Path, file.Language, line)
+				setProps(&tblEnt, "framework", driver, "provenance", "INFERRED_FROM_CREATE_TABLE",
+					"table_name", table)
+				add(tblEnt)
+				for _, fk := range reForeignKey.FindAllStringSubmatch(tblBody, -1) {
+					col, refTable := fk[1], fk[2]
+					fkEnt := makeEntity("fk:"+table+"."+col, "SCOPE.Component", "relation", file.Path, file.Language, line)
+					setProps(&fkEnt, "framework", driver, "provenance", "INFERRED_FROM_SQL_FOREIGN_KEY",
+						"table_name", table, "foreign_key", col, "references_table", refTable,
+						"relationship", "foreign_key")
+					add(fkEnt)
+				}
+			}
+		default:
+			// SELECT/INSERT/UPDATE/DELETE/ALTER literal => a query.
+			verb := strings.ToLower(strings.Fields(upper)[0])
+			qEnt := makeEntity("sql:"+driver+":"+shortHash(stmt), "SCOPE.Operation", "query", file.Path, file.Language, line)
+			setProps(&qEnt, "framework", driver, "provenance", "INFERRED_FROM_SQL_LITERAL",
+				"query_type", verb, "sql", squashWhitespace(stmt))
+			add(qEnt)
+		}
+	}
+
+	// 3. Queries: Exec/Query/QueryRow/Get/Select/NamedExec call sites.
+	//    Heuristic — captures the verb but cannot bind to a concrete model.
+	for _, m := range reSQLQueryCall.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		ent := makeEntity("call:"+driver+":"+verb+":"+lineToken(src, m[0]), "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", driver, "provenance", "INFERRED_FROM_SQL_CALL",
+			"query_type", "call", "call_verb", verb)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// detectSQLDriver returns the attributed driver name for a Go source file
+// based on the database libraries it imports, or "" when none match.
+// sqlx wins when both sqlx and a bare driver are present, since sqlx is
+// the access layer the developer writes against.
+func detectSQLDriver(src string) string {
+	switch {
+	case reImportSqlx.MatchString(src):
+		return "sqlx"
+	case reImportPgx.MatchString(src):
+		return "pgx"
+	case reImportSqlite.MatchString(src):
+		return "sqlite"
+	default:
+		return ""
+	}
+}
+
+// sqlLiteral is one SQL string literal found in source with its line.
+type sqlLiteral struct {
+	text string
+	line int
+}
+
+// collectSQLLiterals returns SQL string literals (double-quoted and raw
+// back-quoted) whose content begins with a SQL keyword, each paired with
+// its 1-based source line.
+func collectSQLLiterals(src string) []sqlLiteral {
+	var out []sqlLiteral
+	for _, m := range reSQLDoubleQuoted.FindAllStringSubmatchIndex(src, -1) {
+		out = append(out, sqlLiteral{text: src[m[2]:m[3]], line: lineOf(src, m[0])})
+	}
+	for _, m := range reSQLBackQuoted.FindAllStringSubmatchIndex(src, -1) {
+		out = append(out, sqlLiteral{text: src[m[2]:m[3]], line: lineOf(src, m[0])})
+	}
+	return out
+}
+
+// squashWhitespace collapses runs of whitespace (incl. newlines) to single
+// spaces so multi-line SQL literals stamp as a single readable property.
+func squashWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// shortHash returns a short, stable token derived from a string, used to
+// give SQL-literal query entities deterministic, collision-resistant names
+// without embedding the (possibly long, quote-laden) statement in the ID.
+func shortHash(s string) string {
+	const fnvOffset = 2166136261
+	const fnvPrime = 16777619
+	h := uint32(fnvOffset)
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= fnvPrime
+	}
+	const hexDigits = "0123456789abcdef"
+	var b [8]byte
+	for i := 7; i >= 0; i-- {
+		b[i] = hexDigits[h&0xf]
+		h >>= 4
+	}
+	return string(b[:])
+}
+
+// lineToken returns the source line number of offset as a decimal string,
+// used to disambiguate otherwise-identical query-call entity names.
+func lineToken(src string, offset int) string {
+	n := lineOf(src, offset)
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/internal/custom/golang/sql_drivers_test.go
+++ b/internal/custom/golang/sql_drivers_test.go
@@ -1,0 +1,151 @@
+package golang_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+func sqlDriversExtract(t *testing.T, file extreg.FileInput) []entitySummary {
+	t.Helper()
+	e, ok := extreg.Get("custom_go_sql_drivers")
+	if !ok {
+		t.Fatal("custom_go_sql_drivers not registered")
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	out := make([]entitySummary, 0, len(ents))
+	for _, ent := range ents {
+		out = append(out, entitySummary{Kind: ent.Kind, Subtype: ent.Subtype, Name: ent.Name})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// sqlx: Models (db: tags) + Schema columns + queries + FK from CREATE TABLE.
+// ---------------------------------------------------------------------------
+
+func TestSqlxModelsAndQueries(t *testing.T) {
+	ents := sqlDriversExtract(t, fixtureInput(t, "sqlx_models.go", "go"))
+
+	// Models: structs with db: tags are schemas.
+	if !containsEntity(ents, "SCOPE.Schema", "User") {
+		t.Error("expected User schema from db: tags")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "Order") {
+		t.Error("expected Order schema from db: tags")
+	}
+	// Schema columns.
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:User.Name") {
+		t.Error("expected User.Name field component")
+	}
+	// db:"email,omitempty" -> column email (option stripped).
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:User.Email") {
+		t.Error("expected User.Email field component")
+	}
+	// db:"-" must NOT produce a column.
+	if hasSubtype(ents, "SCOPE.Component", "field", "field:User.Skip") {
+		t.Error("did not expect User.Skip column (db:\"-\")")
+	}
+
+	// Queries: at least one SQL-literal-derived query operation.
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected at least one query operation")
+	}
+
+	// CREATE TABLE in a backquoted literal -> table schema + FK relation.
+	if !containsEntity(ents, "SCOPE.Schema", "table:orders") {
+		t.Error("expected orders table schema from CREATE TABLE")
+	}
+	if !hasSubtype(ents, "SCOPE.Component", "relation", "fk:orders.user_id") {
+		t.Error("expected FK relation orders.user_id -> users")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pgx: db: tag model + Exec/Query/QueryRow call-site queries.
+// ---------------------------------------------------------------------------
+
+func TestPgxModelsAndQueries(t *testing.T) {
+	ents := sqlDriversExtract(t, fixtureInput(t, "pgx_queries.go", "go"))
+
+	if !containsEntity(ents, "SCOPE.Schema", "Product") {
+		t.Error("expected Product schema from db: tags")
+	}
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:Product.SKU") {
+		t.Error("expected Product.SKU field component")
+	}
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected query operations for pgx")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sqlite: db: tag model + CREATE TABLE FK + Exec/Query queries.
+// ---------------------------------------------------------------------------
+
+func TestSqliteModelsSchemaAndFK(t *testing.T) {
+	ents := sqlDriversExtract(t, fixtureInput(t, "sqlite_store.go", "go"))
+
+	if !containsEntity(ents, "SCOPE.Schema", "Note") {
+		t.Error("expected Note schema from db: tags")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "table:notes") {
+		t.Error("expected notes table schema from CREATE TABLE")
+	}
+	if !hasSubtype(ents, "SCOPE.Component", "relation", "fk:notes.author_id") {
+		t.Error("expected FK relation notes.author_id -> authors")
+	}
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected query operations for sqlite")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Migrations: file-based NNN_slug.up/down.sql (driver-agnostic, lang=sql).
+// ---------------------------------------------------------------------------
+
+func TestSqlDriverMigrationFiles(t *testing.T) {
+	up := sqlDriversExtract(t, fixtureInput(t, "000123_create_users.up.sql", "sql"))
+	if !hasSubtype(up, "SCOPE.Schema", "migration", "migration:000123_create_users.up") {
+		t.Error("expected up migration schema entity")
+	}
+	down := sqlDriversExtract(t, fixtureInput(t, "000123_create_users.down.sql", "sql"))
+	if !hasSubtype(down, "SCOPE.Schema", "migration", "migration:000123_create_users.down") {
+		t.Error("expected down migration schema entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: a Go file importing no recognised SQL driver yields nothing,
+// proving the import gate and that we never poach gorm/other files.
+// ---------------------------------------------------------------------------
+
+func TestSqlDriverImportGate(t *testing.T) {
+	src := `package x
+
+type Thing struct {
+	ID int ` + "`db:\"id\"`" + `
+}
+
+func run() { _ = "SELECT 1" }
+`
+	file := extreg.FileInput{Path: "no_driver.go", Language: "go", Content: []byte(src)}
+	ents := sqlDriversExtract(t, file)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without a driver import, got %d", len(ents))
+	}
+}
+
+// hasKindSubtype reports whether any entity matches kind+subtype (name-agnostic).
+func hasKindSubtype(ents []entitySummary, kind, subtype string) bool {
+	for _, e := range ents {
+		if e.Kind == kind && e.Subtype == subtype {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/custom/golang/testdata/pgx_queries.go
+++ b/internal/custom/golang/testdata/pgx_queries.go
@@ -1,0 +1,35 @@
+package sample
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Product is scanned via pgx.RowToStructByName; db: tags map columns.
+type Product struct {
+	ID    int     `db:"id"`
+	SKU   string  `db:"sku"`
+	Price float64 `db:"price"`
+}
+
+func listProducts(ctx context.Context, pool *pgxpool.Pool) error {
+	rows, err := pool.Query(ctx, "SELECT id, sku, price FROM products ORDER BY id")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	return nil
+}
+
+func insertProduct(ctx context.Context, conn *pgx.Conn, p Product) error {
+	_, err := conn.Exec(ctx, "INSERT INTO products (sku, price) VALUES ($1, $2)", p.SKU, p.Price)
+	return err
+}
+
+func oneProduct(ctx context.Context, conn *pgx.Conn, id int) (Product, error) {
+	var p Product
+	err := conn.QueryRow(ctx, "SELECT id, sku, price FROM products WHERE id = $1", id).Scan(&p.ID, &p.SKU, &p.Price)
+	return p, err
+}

--- a/internal/custom/golang/testdata/sqlite_store.go
+++ b/internal/custom/golang/testdata/sqlite_store.go
@@ -1,0 +1,33 @@
+package sample
+
+import (
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Note is a row struct backed by the sqlite driver via database/sql.
+type Note struct {
+	ID   int    `db:"id"`
+	Body string `db:"body"`
+}
+
+func initSchema(db *sql.DB) error {
+	_, err := db.Exec(`
+CREATE TABLE IF NOT EXISTS notes (
+    id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    body TEXT NOT NULL,
+    author_id INTEGER,
+    FOREIGN KEY (author_id) REFERENCES authors(id)
+)`)
+	return err
+}
+
+func allNotes(db *sql.DB) (*sql.Rows, error) {
+	return db.Query("SELECT id, body FROM notes")
+}
+
+func addNote(db *sql.DB, body string) error {
+	_, err := db.Exec("INSERT INTO notes (body) VALUES (?)", body)
+	return err
+}

--- a/internal/custom/golang/testdata/sqlx_models.go
+++ b/internal/custom/golang/testdata/sqlx_models.go
@@ -1,0 +1,45 @@
+package sample
+
+import (
+	"github.com/jmoiron/sqlx"
+)
+
+// User is scanned via sqlx StructScan; db: tags map columns.
+type User struct {
+	ID    int    `db:"id"`
+	Name  string `db:"name"`
+	Email string `db:"email,omitempty"`
+	Skip  string `db:"-"`
+}
+
+// Order is another sqlx-mapped row struct.
+type Order struct {
+	ID     int     `db:"order_id"`
+	UserID int     `db:"user_id"`
+	Total  float64 `db:"total"`
+}
+
+func loadUsers(db *sqlx.DB) ([]User, error) {
+	var users []User
+	err := db.Select(&users, "SELECT id, name, email FROM users WHERE active = true")
+	return users, err
+}
+
+func getUser(db *sqlx.DB, id int) (User, error) {
+	var u User
+	err := db.Get(&u, "SELECT id, name, email FROM users WHERE id = $1", id)
+	return u, err
+}
+
+func insertUser(db *sqlx.DB, u User) error {
+	_, err := db.NamedExec("INSERT INTO users (name, email) VALUES (:name, :email)", u)
+	return err
+}
+
+const schemaDDL = `
+CREATE TABLE IF NOT EXISTS orders (
+    order_id INTEGER PRIMARY KEY,
+    user_id  INTEGER NOT NULL,
+    total    REAL,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+)`

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3226,6 +3226,165 @@ records:
           issues_implemented: ["3214"]
           verified_at: "2026-05-30"
 
+  lang.go.orm.sqlx:
+    capabilities:
+      Models:
+        model_extraction:
+          # Structs carrying `db:"col"` field tags are recognised as schemas
+          # (reDBStruct + reDBField). Heuristic — a db tag does not prove the
+          # struct is a table — hence partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract, detectSQLDriver]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+        schema_extraction:
+          # Columns from `db:` tags plus CREATE TABLE statements parsed out of
+          # SQL string literals (reCreateTable).
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract, collectSQLLiterals]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Relationships:
+        foreign_key_extraction:
+          # FOREIGN KEY (col) REFERENCES other(c) clauses mined from CREATE
+          # TABLE literals (reForeignKey). association/relationship/lazy have
+          # no concept in a relation-layerless driver -> not_applicable.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # Exec/Query/QueryRow/Get/Select/NamedExec call sites (reSQLQueryCall)
+          # plus SELECT/INSERT/UPDATE/DELETE string literals. Cannot bind to a
+          # model by regex alone -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Migrations:
+        migration_parsing:
+          # File-based NNN_slug.up/down.sql migrations recognised by filename
+          # (reSQLMigrationFile), as commonly paired with golang-migrate.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
+  lang.go.orm.pgx:
+    capabilities:
+      Models:
+        model_extraction:
+          # Structs with `db:"col"` tags (pgx.RowToStructByName) -> schemas.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract, detectSQLDriver]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+        schema_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract, collectSQLLiterals]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Relationships:
+        foreign_key_extraction:
+          # SQL FOREIGN KEY clauses; relation/association/lazy not_applicable.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # conn.Exec/Query/QueryRow call sites + SQL string literals.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/pgx.yaml
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
+  lang.go.driver.sqlite:
+    capabilities:
+      Models:
+        model_extraction:
+          # Structs with `db:"col"` tags scanned over database/sql + sqlite.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract, detectSQLDriver]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+        schema_extraction:
+          # Columns from db: tags + CREATE TABLE literals.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract, collectSQLLiterals]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Relationships:
+        foreign_key_extraction:
+          # SQL FOREIGN KEY clauses from CREATE TABLE; the driver has no
+          # relation layer so association/relationship/lazy are not_applicable.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # db.Exec/Query/QueryRow call sites + SQL string literals.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/sqlite_go.yaml
+            - file: internal/custom/golang/sql_drivers.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/sql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
   lang.go.framework.net-http:
     capabilities:
       Routing:


### PR DESCRIPTION
**Part of #3214** — Cluster 4 (ORM / Data Access), the **sqlx + pgx + sqlite** slice only. GORM is handled by a separate PR; codegen/schema-driven (ent/sqlc/bun/gen/xo) and the other drivers are out of scope here.

## What

New `internal/custom/golang/sql_drivers.go` — a struct-tag (`db:`) + raw-SQL extractor for the three non-ORM Go SQL access libraries. Registered as `custom_go_sql_drivers` and **import-gated** (`detectSQLDriver`): a file is attributed to exactly one driver (sqlx ≻ pgx ≻ sqlite) and never poaches gorm or driverless files. File-based `.up/.down.sql` migrations are recognised by filename (language-agnostic).

These libraries deliberately have **no ORM relation layer**, so the honest coverage shape leans `partial` (heuristic regex) and `not_applicable` for relation concepts that genuinely don't exist.

## Honest status — driver × capability

| Capability | sqlx | pgx | sqlite |
|---|---|---|---|
| Models / model_extraction | partial | partial | partial |
| Models / schema_extraction | partial | partial | partial |
| Relationships / foreign_key_extraction | partial | partial | partial |
| Relationships / association_extraction | **NA** | **NA** | **NA** |
| Relationships / relationship_extraction | **NA** | **NA** | **NA** |
| Relationships / lazy_loading_recognition | **NA** | **NA** | **NA** |
| Queries / query_attribution | partial | partial | partial |
| Migrations / migration_parsing | partial | **NA** | **NA** |

- **partial** everywhere a fixture proves it but the technique is heuristic regex (db: tags don't *prove* a table; SQL-literal/call-site queries can't be bound to a model by regex).
- **NA** for association/relationship/lazy_loading on all three — relation-layerless drivers. **NA** for migrations on pgx/sqlite — they ship no migration runner; sqlx is `partial` because `.up/.down.sql` (golang-migrate) files are commonly written alongside it and are proven by fixture.

## Scope discipline

Touched only the `orm.sqlx` / `orm.pgx` / `driver.sqlite` registry + capability-map cells, the new extractor, its `_test.go`, and fixtures. **No** gorm / framework / test / build cells changed (verified sqlc record byte-identical).

## Validation (scoped)

- `go build ./internal/... ./tools/coverage/...` clean
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` green (5 new tests incl. import-gate negative + db:"-" exclusion)
- `go run ./tools/coverage validate` exit 0
- `fmt --check` exit 0; `gen` byte-stable (run twice, no diff)
- `gofmt -l` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)