### PR TITLE
feat(coverage): Go buffalo + fasthttp + revel routing extractors (Part of #3212)

### DIFF
--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/buffalo.yaml` | — |
-| Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/buffalo.yaml` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/buffalo.go`<br>`internal/engine/rules/go/frameworks/buffalo.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/buffalo.go`<br>`internal/engine/rules/go/frameworks/buffalo.yaml` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
-| Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/fasthttp.go`<br>`internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/fasthttp.go`<br>`internal/engine/rules/go/frameworks/fasthttp.yaml` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/revel.yaml` | — |
-| Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/revel.yaml` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/revel.go`<br>`internal/engine/rules/go/frameworks/revel.yaml` | — |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/revel.go`<br>`internal/engine/rules/go/frameworks/revel.yaml` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10843,14 +10843,14 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/custom/golang/buffalo.go","internal/engine/rules/go/frameworks/buffalo.yaml"],
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/buffalo.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/custom/golang/buffalo.go","internal/engine/rules/go/frameworks/buffalo.yaml"],
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
             "status": "missing",
@@ -11388,14 +11388,14 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/custom/golang/fasthttp.go","internal/engine/rules/go/frameworks/fasthttp.yaml"],
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/fasthttp.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/custom/golang/fasthttp.go","internal/engine/rules/go/frameworks/fasthttp.yaml"],
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
             "status": "missing",
@@ -13401,14 +13401,14 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/custom/golang/revel.go","internal/engine/rules/go/frameworks/revel.yaml"],
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/revel.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/custom/golang/revel.go","internal/engine/rules/go/frameworks/revel.yaml"],
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
             "status": "missing",

--- a/internal/custom/golang/buffalo.go
+++ b/internal/custom/golang/buffalo.go
@@ -1,0 +1,188 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_buffalo", &buffaloExtractor{})
+}
+
+type buffaloExtractor struct{}
+
+func (e *buffaloExtractor) Language() string { return "custom_go_buffalo" }
+
+var (
+	// app := buffalo.New(opts) / app = buffalo.New(buffalo.Options{...})
+	reBuffaloApp = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*buffalo\.New\s*\(`,
+	)
+	// app.GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS("/path", Handler)
+	reBuffaloRoute = regexp.MustCompile(
+		`(?m)(\w+)\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"\s*,\s*([\w.]+)`,
+	)
+	// app.Resource("/users", UsersResource{}) — RESTful resource expansion.
+	reBuffaloResource = regexp.MustCompile(
+		`(?m)(\w+)\.Resource\s*\(\s*"([^"]+)"\s*,\s*&?([\w.]+)\{?\}?`,
+	)
+	// g := app.Group("/api") — route-prefix group (returns a *buffalo.App).
+	reBuffaloGroup = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*(\w+)\.Group\s*\(\s*"([^"]+)"`,
+	)
+	// app.Mount("/admin", admin.App()) — sub-app mount at a path prefix.
+	reBuffaloMount = regexp.MustCompile(
+		`(?m)(\w+)\.Mount\s*\(\s*"([^"]+)"`,
+	)
+	// app.Use(mw) / app.Middleware.Use(mw) — middleware registration.
+	reBuffaloUse = regexp.MustCompile(
+		`(?m)(\w+)(?:\.Middleware)?\.Use\s*\(\s*([\w.]+)`,
+	)
+)
+
+// buffaloResourceRoutes expands a Buffalo Resource registration into its seven
+// conventional RESTful routes (mirroring buffalo's Resource interface:
+// List/Show/New/Create/Edit/Update/Destroy). path is the resource mount path
+// (e.g. "/users"); the returned slice is (httpMethod, routePath, action) tuples.
+func buffaloResourceRoutes(path string) [][3]string {
+	base := strings.TrimRight(path, "/")
+	return [][3]string{
+		{"GET", base, "List"},
+		{"GET", base + "/new", "New"},
+		{"POST", base, "Create"},
+		{"GET", base + "/{id}", "Show"},
+		{"GET", base + "/{id}/edit", "Edit"},
+		{"PUT", base + "/{id}", "Update"},
+		{"DELETE", base + "/{id}", "Destroy"},
+	}
+}
+
+func (e *buffaloExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.buffalo_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "buffalo"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. buffalo.New(...) application -> SCOPE.Service.
+	for _, m := range reBuffaloApp.FindAllStringSubmatchIndex(src, -1) {
+		varName := submatch(src, m, 2)
+		ent := makeEntity(varName, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "buffalo", "provenance", "INFERRED_FROM_BUFFALO_APP")
+		add(ent)
+	}
+
+	// 2. Group prefixes + Mount prefixes -> SCOPE.Component. Track group var
+	//    prefixes so verb routes on a group resolve their full path.
+	groupPaths := make(map[string]string) // varName -> full prefix
+	for _, m := range reBuffaloGroup.FindAllStringSubmatchIndex(src, -1) {
+		varName := submatch(src, m, 2)
+		parent := submatch(src, m, 4)
+		path := submatch(src, m, 6)
+		if pp, ok := groupPaths[parent]; ok {
+			path = pp + path
+		}
+		groupPaths[varName] = path
+		ent := makeEntity(path, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "buffalo", "provenance", "INFERRED_FROM_BUFFALO_GROUP",
+			"group_path", path)
+		add(ent)
+	}
+	for _, m := range reBuffaloMount.FindAllStringSubmatchIndex(src, -1) {
+		path := submatch(src, m, 4)
+		ent := makeEntity(path, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "buffalo", "provenance", "INFERRED_FROM_BUFFALO_MOUNT",
+			"group_path", path, "is_mount", "true")
+		add(ent)
+	}
+
+	// 3. Verb routes -> SCOPE.Operation/endpoint, with group-prefix resolution
+	//    and handler attribution from the 4th argument.
+	for _, m := range reBuffaloRoute.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := submatch(src, m, 2)
+		method := strings.ToUpper(submatch(src, m, 4))
+		path := submatch(src, m, 6)
+		handler := submatch(src, m, 8)
+		if gp, ok := groupPaths[routerVar]; ok {
+			path = gp + path
+		}
+		name := method + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "buffalo", "provenance", "INFERRED_FROM_BUFFALO_ROUTE",
+			"http_method", method, "route_path", path, "router_var", routerVar)
+		if handler != "" {
+			ent.Properties["handler"] = handler
+		}
+		add(ent)
+	}
+
+	// 4. Resource registrations -> seven conventional RESTful endpoints, each
+	//    attributed to the resource type's conventional action method.
+	for _, m := range reBuffaloResource.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := submatch(src, m, 2)
+		path := submatch(src, m, 4)
+		resource := submatch(src, m, 6)
+		line := lineOf(src, m[0])
+		prefix := ""
+		if gp, ok := groupPaths[routerVar]; ok {
+			prefix = gp
+		}
+		for _, r := range buffaloResourceRoutes(path) {
+			method, routePath, action := r[0], r[1], r[2]
+			fullPath := prefix + routePath
+			name := method + " " + fullPath
+			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, line)
+			setProps(&ent, "framework", "buffalo", "provenance", "INFERRED_FROM_BUFFALO_RESOURCE",
+				"http_method", method, "route_path", fullPath,
+				"resource", resource, "handler", resource+"."+action, "is_resource", "true")
+			add(ent)
+		}
+	}
+
+	// 5. Middleware registration -> SCOPE.Pattern (+ auth classification).
+	for _, m := range reBuffaloUse.FindAllStringSubmatchIndex(src, -1) {
+		mwExpr := submatch(src, m, 4)
+		if mwExpr == "" {
+			continue
+		}
+		ent := makeEntity(mwExpr, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "buffalo", "provenance", "INFERRED_FROM_BUFFALO_MIDDLEWARE",
+			"pattern_kind", "middleware", "middleware_name", mwExpr)
+		if kind := classifyAuthMiddleware(mwExpr); kind != "" {
+			setProps(&ent, "is_auth", "true", "auth_kind", kind)
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/golang/buffalo_fasthttp_revel_test.go
+++ b/internal/custom/golang/buffalo_fasthttp_revel_test.go
@@ -1,0 +1,264 @@
+package golang_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// ---------------------------------------------------------------------------
+// Buffalo
+// ---------------------------------------------------------------------------
+
+func TestBuffaloApp(t *testing.T) {
+	src := `app := buffalo.New(buffalo.Options{})`
+	ents := extract(t, "custom_go_buffalo", fi("app.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Service", "app") {
+		t.Error("expected app as buffalo application service")
+	}
+}
+
+func TestBuffaloVerbRoutes(t *testing.T) {
+	src := `
+app.GET("/", HomeHandler)
+app.POST("/login", LoginHandler)
+`
+	ents := extract(t, "custom_go_buffalo", fi("app.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /") {
+		t.Error("expected GET / route")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "POST /login") {
+		t.Error("expected POST /login route")
+	}
+}
+
+func TestBuffaloGroupPrefix(t *testing.T) {
+	src := `
+api := app.Group("/api/v1")
+api.GET("/health", HealthHandler)
+`
+	ents := extract(t, "custom_go_buffalo", fi("app.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Component", "/api/v1") {
+		t.Error("expected /api/v1 group component")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/v1/health") {
+		t.Error("expected GET /api/v1/health with group prefix resolved")
+	}
+}
+
+func TestBuffaloResource(t *testing.T) {
+	src := `app.Resource("/users", UsersResource{})`
+	ents := extract(t, "custom_go_buffalo", fi("app.go", "go", src))
+	want := []string{
+		"GET /users", "GET /users/new", "POST /users",
+		"GET /users/{id}", "GET /users/{id}/edit",
+		"PUT /users/{id}", "DELETE /users/{id}",
+	}
+	for _, w := range want {
+		if !containsEntity(ents, "SCOPE.Operation", w) {
+			t.Errorf("expected resource route %q", w)
+		}
+	}
+}
+
+func TestBuffaloMount(t *testing.T) {
+	src := `app.Mount("/admin", admin.App())`
+	ents := extract(t, "custom_go_buffalo", fi("app.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Component", "/admin") {
+		t.Error("expected /admin mount component")
+	}
+}
+
+func TestBuffaloMiddleware(t *testing.T) {
+	src := `app.Use(Authorize)`
+	ents := extract(t, "custom_go_buffalo", fi("app.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Authorize") {
+		t.Error("expected Authorize middleware pattern")
+	}
+}
+
+func TestBuffaloFixture(t *testing.T) {
+	f := fixtureInput(t, "buffalo_routes.go", "go")
+	ents := extract(t, "custom_go_buffalo", f)
+	want := []string{
+		"GET /", "POST /login", "GET /api/v1/health",
+		"GET /users", "POST /users", "DELETE /users/{id}",
+	}
+	for _, w := range want {
+		if !containsEntity(ents, "SCOPE.Operation", w) {
+			t.Errorf("fixture: expected operation %q", w)
+		}
+	}
+	if !containsEntity(ents, "SCOPE.Service", "app") {
+		t.Error("fixture: expected app service")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "/admin") {
+		t.Error("fixture: expected /admin mount component")
+	}
+}
+
+func TestBuffaloNoMatch(t *testing.T) {
+	ents := extract(t, "custom_go_buffalo", fi("main.go", "go", `package main`))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fasthttp
+// ---------------------------------------------------------------------------
+
+func TestFasthttpRouter(t *testing.T) {
+	src := `r := router.New()`
+	ents := extract(t, "custom_go_fasthttp", fi("main.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Service", "r") {
+		t.Error("expected r as fasthttp router service")
+	}
+}
+
+func TestFasthttpRoutes(t *testing.T) {
+	src := `
+r := router.New()
+r.GET("/users", listUsers)
+r.POST("/users", createUser)
+`
+	ents := extract(t, "custom_go_fasthttp", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /users") {
+		t.Error("expected GET /users route")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "POST /users") {
+		t.Error("expected POST /users route")
+	}
+}
+
+func TestFasthttpHandleExplicitMethod(t *testing.T) {
+	src := `r.Handle("PUT", "/users/{id}", updateUser)`
+	ents := extract(t, "custom_go_fasthttp", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "PUT /users/{id}") {
+		t.Error("expected PUT /users/{id} from r.Handle")
+	}
+}
+
+func TestFasthttpGroupPrefix(t *testing.T) {
+	src := `
+api := r.Group("/api/v1")
+api.GET("/health", healthCheck)
+`
+	ents := extract(t, "custom_go_fasthttp", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/v1/health") {
+		t.Error("expected GET /api/v1/health with group prefix resolved")
+	}
+}
+
+func TestFasthttpRawHandler(t *testing.T) {
+	src := `func listUsers(ctx *fasthttp.RequestCtx) { ctx.WriteString("ok") }`
+	ents := extract(t, "custom_go_fasthttp", fi("handlers.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "handler:listUsers") {
+		t.Error("expected raw RequestHandler pattern for listUsers")
+	}
+}
+
+func TestFasthttpListen(t *testing.T) {
+	src := `fasthttp.ListenAndServe(":8080", r.Handler)`
+	ents := extract(t, "custom_go_fasthttp", fi("main.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Service", "fasthttp_server:r.Handler") {
+		t.Error("expected fasthttp_server service from ListenAndServe")
+	}
+}
+
+func TestFasthttpFixture(t *testing.T) {
+	f := fixtureInput(t, "fasthttp_routes.go", "go")
+	ents := extract(t, "custom_go_fasthttp", f)
+	want := []string{"GET /users", "POST /users", "PUT /users/{id}", "GET /api/v1/health"}
+	for _, w := range want {
+		if !containsEntity(ents, "SCOPE.Operation", w) {
+			t.Errorf("fixture: expected operation %q", w)
+		}
+	}
+	if !containsEntity(ents, "SCOPE.Service", "r") {
+		t.Error("fixture: expected r router service")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "handler:listUsers") {
+		t.Error("fixture: expected listUsers raw handler pattern")
+	}
+}
+
+func TestFasthttpNoMatch(t *testing.T) {
+	ents := extract(t, "custom_go_fasthttp", fi("main.go", "go", `package main`))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Revel
+// ---------------------------------------------------------------------------
+
+// revelRoutesInput loads the conf/routes fixture under a path containing
+// "conf/routes" so the routes-file detection path is exercised.
+func revelRoutesInput(t *testing.T) extreg.FileInput {
+	t.Helper()
+	p := filepath.Join("testdata", "conf", "routes")
+	content, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read revel routes fixture: %v", err)
+	}
+	return extreg.FileInput{Path: p, Language: "text", Content: content}
+}
+
+func TestRevelRoutesFile(t *testing.T) {
+	ents := extract(t, "custom_go_revel", revelRoutesInput(t))
+	want := []string{
+		"GET /", "GET /login", "POST /users",
+		"GET /users/{id}", "DELETE /users/{id}",
+	}
+	for _, w := range want {
+		if !containsEntity(ents, "SCOPE.Operation", w) {
+			t.Errorf("expected route %q from conf/routes", w)
+		}
+	}
+}
+
+func TestRevelModuleMount(t *testing.T) {
+	ents := extract(t, "custom_go_revel", revelRoutesInput(t))
+	if !containsEntity(ents, "SCOPE.Component", "module:testrunner") {
+		t.Error("expected module:testrunner mount component")
+	}
+}
+
+func TestRevelAutoRouteWildcard(t *testing.T) {
+	ents := extract(t, "custom_go_revel", revelRoutesInput(t))
+	// The wildcard auto-route resolves dynamically; it should still synthesize
+	// an ANY endpoint but not attribute a static handler.
+	if !containsEntity(ents, "SCOPE.Operation", "ANY /{controller}/{action}") {
+		t.Error("expected ANY /{controller}/{action} auto-route")
+	}
+}
+
+func TestRevelControllerActions(t *testing.T) {
+	f := fixtureInput(t, "revel_controller.go", "go")
+	ents := extract(t, "custom_go_revel", f)
+	if !containsEntity(ents, "SCOPE.Pattern", "handler:App.Index") {
+		t.Error("expected App.Index controller-action handler pattern")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "handler:App.Login") {
+		t.Error("expected App.Login controller-action handler pattern")
+	}
+}
+
+func TestRevelInterceptor(t *testing.T) {
+	f := fixtureInput(t, "revel_controller.go", "go")
+	ents := extract(t, "custom_go_revel", f)
+	if !containsEntity(ents, "SCOPE.Pattern", "interceptor:checkUser") {
+		t.Error("expected checkUser interceptor middleware pattern")
+	}
+}
+
+func TestRevelNoMatch(t *testing.T) {
+	ents := extract(t, "custom_go_revel", fi("main.go", "go", `package main`))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/golang/fasthttp.go
+++ b/internal/custom/golang/fasthttp.go
@@ -1,0 +1,165 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_fasthttp", &fasthttpExtractor{})
+}
+
+type fasthttpExtractor struct{}
+
+func (e *fasthttpExtractor) Language() string { return "custom_go_fasthttp" }
+
+var (
+	// r := router.New() — fasthttp/router router constructor.
+	reFastRouterNew = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*router\.New\s*\(\s*\)`,
+	)
+	// r.GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS("/path", handler)
+	reFastRoute = regexp.MustCompile(
+		`(?m)(\w+)\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"([^"]+)"\s*,\s*([\w.]+)`,
+	)
+	// r.Handle("GET", "/path", handler) — explicit-method registration.
+	reFastHandle = regexp.MustCompile(
+		`(?m)(\w+)\.Handle\s*\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,\s*([\w.]+)`,
+	)
+	// g := r.Group("/api") — fasthttp/router group.
+	reFastGroup = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*(\w+)\.Group\s*\(\s*"([^"]+)"`,
+	)
+	// fasthttp.ListenAndServe(addr, handler) — raw-handler server entry.
+	reFastListen = regexp.MustCompile(
+		`(?m)fasthttp\.ListenAndServe(?:TLS)?\s*\(\s*([^,]+),\s*([\w.]+)`,
+	)
+	// func name(ctx *fasthttp.RequestCtx) — raw RequestHandler declaration.
+	reFastHandlerDecl = regexp.MustCompile(
+		`(?m)func\s+(\w+)\s*\(\s*\w+\s+\*fasthttp\.RequestCtx\s*\)`,
+	)
+)
+
+func (e *fasthttpExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.fasthttp_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "fasthttp"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. router.New() -> SCOPE.Service (the fasthttp/router instance).
+	for _, m := range reFastRouterNew.FindAllStringSubmatchIndex(src, -1) {
+		varName := submatch(src, m, 2)
+		ent := makeEntity(varName, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fasthttp", "provenance", "INFERRED_FROM_FASTHTTP_ROUTER")
+		add(ent)
+	}
+
+	// 2. fasthttp.ListenAndServe(addr, handler) -> SCOPE.Service (raw-handler
+	//    server entry; the 2nd arg is the top-level RequestHandler).
+	for _, m := range reFastListen.FindAllStringSubmatchIndex(src, -1) {
+		handler := submatch(src, m, 4)
+		ent := makeEntity("fasthttp_server:"+handler, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fasthttp", "provenance", "INFERRED_FROM_FASTHTTP_LISTEN",
+			"handler", handler)
+		add(ent)
+	}
+
+	// 3. Group prefixes -> SCOPE.Component, tracked for verb-route resolution.
+	groupPaths := make(map[string]string) // varName -> full prefix
+	for _, m := range reFastGroup.FindAllStringSubmatchIndex(src, -1) {
+		varName := submatch(src, m, 2)
+		parent := submatch(src, m, 4)
+		path := submatch(src, m, 6)
+		if pp, ok := groupPaths[parent]; ok {
+			path = pp + path
+		}
+		groupPaths[varName] = path
+		ent := makeEntity(path, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fasthttp", "provenance", "INFERRED_FROM_FASTHTTP_GROUP",
+			"group_path", path)
+		add(ent)
+	}
+
+	// 4. Verb routes -> SCOPE.Operation/endpoint with handler attribution.
+	for _, m := range reFastRoute.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := submatch(src, m, 2)
+		method := strings.ToUpper(submatch(src, m, 4))
+		path := submatch(src, m, 6)
+		handler := submatch(src, m, 8)
+		if gp, ok := groupPaths[routerVar]; ok {
+			path = gp + path
+		}
+		name := method + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fasthttp", "provenance", "INFERRED_FROM_FASTHTTP_ROUTE",
+			"http_method", method, "route_path", path, "router_var", routerVar)
+		if handler != "" {
+			ent.Properties["handler"] = handler
+		}
+		add(ent)
+	}
+
+	// 5. r.Handle("METHOD", "/path", h) -> SCOPE.Operation/endpoint.
+	for _, m := range reFastHandle.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := submatch(src, m, 2)
+		method := strings.ToUpper(submatch(src, m, 4))
+		path := submatch(src, m, 6)
+		handler := submatch(src, m, 8)
+		if gp, ok := groupPaths[routerVar]; ok {
+			path = gp + path
+		}
+		name := method + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fasthttp", "provenance", "INFERRED_FROM_FASTHTTP_HANDLE",
+			"http_method", method, "route_path", path, "router_var", routerVar)
+		if handler != "" {
+			ent.Properties["handler"] = handler
+		}
+		add(ent)
+	}
+
+	// 6. Raw RequestHandler declarations (func(ctx *fasthttp.RequestCtx)) ->
+	//    SCOPE.Pattern. Without a router these handlers are dispatched manually
+	//    (e.g. a switch on string(ctx.Path())), so we cannot synthesize a
+	//    method+path endpoint — we record the handler for attribution only.
+	for _, m := range reFastHandlerDecl.FindAllStringSubmatchIndex(src, -1) {
+		fn := submatch(src, m, 2)
+		ent := makeEntity("handler:"+fn, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fasthttp", "provenance", "INFERRED_FROM_FASTHTTP_HANDLER",
+			"pattern_kind", "request_handler", "handler", fn)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/golang/revel.go
+++ b/internal/custom/golang/revel.go
@@ -1,0 +1,181 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_revel", &revelExtractor{})
+}
+
+type revelExtractor struct{}
+
+func (e *revelExtractor) Language() string { return "custom_go_revel" }
+
+var (
+	// Revel conf/routes line:  METHOD  /path        Controller.Action
+	//   GET    /                      App.Index
+	//   POST   /users/:id             Users.Update
+	//   *      /:controller/:action   :controller.:action   (auto-routing)
+	// Capture groups: 1=verb, 2=path, 3=controller.action.
+	reRevelRoute = regexp.MustCompile(
+		`(?m)^[ \t]*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|WS|\*)\s+(/\S*)\s+([\w.:]+)`,
+	)
+	// module:jobs / module:testrunner mounts in conf/routes.
+	reRevelModule = regexp.MustCompile(
+		`(?m)^[ \t]*module:(\w+)`,
+	)
+	// Revel controller-action method on a struct embedding *revel.Controller:
+	//   func (c App) Index() revel.Result { ... }
+	// Capture groups: 1=receiver type, 2=action method name.
+	reRevelAction = regexp.MustCompile(
+		`(?m)func\s*\(\s*\w+\s+\*?(\w+)\s*\)\s*(\w+)\s*\([^)]*\)\s*revel\.Result`,
+	)
+	// Revel interceptor registration (before/after filters ~ middleware):
+	//   revel.InterceptFunc(checkUser, revel.BEFORE, &App{})
+	//   revel.InterceptMethod(App.checkUser, revel.BEFORE)
+	reRevelIntercept = regexp.MustCompile(
+		`(?m)revel\.Intercept(?:Func|Method)\s*\(\s*([\w.]+)`,
+	)
+)
+
+// isRevelRoutesFile reports whether the file path is a Revel conf/routes file.
+// Revel's routes live at conf/routes (no extension); the indexer may also tag
+// such files with a routes-style basename.
+func isRevelRoutesFile(filePath string) bool {
+	if strings.Contains(filePath, "conf/routes") {
+		return true
+	}
+	base := filePath
+	if i := strings.LastIndex(filePath, "/"); i >= 0 {
+		base = filePath[i+1:]
+	}
+	return base == "routes"
+}
+
+// revelCanonPath converts Revel's :param path segments to {param} form so paths
+// are comparable across extractors (gin/iris/beego use {id}).
+func revelCanonPath(raw string) string {
+	if q := strings.Index(raw, "?"); q >= 0 {
+		raw = raw[:q]
+	}
+	return reRevelColonParam.ReplaceAllString(raw, "{$1}")
+}
+
+var reRevelColonParam = regexp.MustCompile(`:(\w+)`)
+
+func (e *revelExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.revel_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "revel"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	routesFile := isRevelRoutesFile(file.Path)
+
+	// --- conf/routes file: definitive route table (full synthesis). ---
+	if routesFile {
+		for _, m := range reRevelRoute.FindAllStringSubmatchIndex(src, -1) {
+			verb := strings.ToUpper(submatch(src, m, 2))
+			if verb == "*" {
+				verb = "ANY"
+			}
+			path := revelCanonPath(submatch(src, m, 4))
+			action := submatch(src, m, 6)
+			line := lineOf(src, m[0])
+			name := verb + " " + path
+			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, line)
+			setProps(&ent, "framework", "revel", "provenance", "INFERRED_FROM_REVEL_ROUTES",
+				"http_method", verb, "route_path", path, "route_type", "conf_routes")
+			// Attribute the handler unless it is an auto-routing wildcard
+			// (:controller.:action), which resolves dynamically at runtime.
+			if action != "" && !strings.Contains(action, ":") {
+				ent.Properties["handler"] = action
+			} else if strings.Contains(action, ":") {
+				ent.Properties["is_auto"] = "true"
+			}
+			add(ent)
+		}
+
+		// module:<name> mounts -> SCOPE.Component (sub-app route prefixes).
+		for _, m := range reRevelModule.FindAllStringSubmatchIndex(src, -1) {
+			mod := submatch(src, m, 2)
+			ent := makeEntity("module:"+mod, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "revel", "provenance", "INFERRED_FROM_REVEL_MODULE",
+				"module", mod, "is_mount", "true")
+			add(ent)
+		}
+
+		span.SetAttributes(attribute.Int("entity_count", len(entities)))
+		return entities, nil
+	}
+
+	// --- Go controller files: controller-action handler attribution. ---
+	if file.Language != "go" {
+		span.SetAttributes(attribute.Int("entity_count", len(entities)))
+		return entities, nil
+	}
+
+	// Controller-action methods (returning revel.Result) -> SCOPE.Pattern. By
+	// convention Revel maps Controller.Action to a route; without the routes
+	// file we cannot synthesize the method+path, so these are handler patterns
+	// available for attribution against conf/routes entries.
+	for _, m := range reRevelAction.FindAllStringSubmatchIndex(src, -1) {
+		recv := submatch(src, m, 2)
+		action := submatch(src, m, 4)
+		full := recv + "." + action
+		ent := makeEntity("handler:"+full, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "revel", "provenance", "INFERRED_FROM_REVEL_ACTION",
+			"pattern_kind", "controller_action", "handler", full,
+			"controller", recv, "action", action)
+		add(ent)
+	}
+
+	// Interceptors (before/after filters) -> SCOPE.Pattern middleware.
+	for _, m := range reRevelIntercept.FindAllStringSubmatchIndex(src, -1) {
+		fn := submatch(src, m, 2)
+		if fn == "" {
+			continue
+		}
+		ent := makeEntity("interceptor:"+fn, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "revel", "provenance", "INFERRED_FROM_REVEL_INTERCEPT",
+			"pattern_kind", "middleware", "middleware_name", fn)
+		if kind := classifyAuthMiddleware(fn); kind != "" {
+			setProps(&ent, "is_auth", "true", "auth_kind", kind)
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/golang/testdata/buffalo_routes.go
+++ b/internal/custom/golang/testdata/buffalo_routes.go
@@ -1,0 +1,24 @@
+package actions
+
+import "github.com/gobuffalo/buffalo"
+
+// App builds the Buffalo application and registers routes, a group, a mounted
+// sub-app, a RESTful resource, and middleware.
+func App() *buffalo.App {
+	app := buffalo.New(buffalo.Options{})
+
+	app.Use(SetCurrentUser)
+	app.Use(Authorize)
+
+	app.GET("/", HomeHandler)
+	app.POST("/login", LoginHandler)
+
+	api := app.Group("/api/v1")
+	api.GET("/health", HealthHandler)
+
+	app.Resource("/users", UsersResource{})
+
+	app.Mount("/admin", admin.App())
+
+	return app
+}

--- a/internal/custom/golang/testdata/conf/routes
+++ b/internal/custom/golang/testdata/conf/routes
@@ -1,0 +1,13 @@
+# Revel routes configuration
+# Routes are prioritized from top to bottom.
+
+GET     /                                       App.Index
+GET     /login                                  App.Login
+POST    /users                                  Users.Create
+GET     /users/:id                              Users.Show
+DELETE  /users/:id                              Users.Delete
+
+module:testrunner
+
+# Catch-all auto-routing
+*       /:controller/:action                    :controller.:action

--- a/internal/custom/golang/testdata/fasthttp_routes.go
+++ b/internal/custom/golang/testdata/fasthttp_routes.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/fasthttp/router"
+	"github.com/valyala/fasthttp"
+)
+
+// listUsers is a raw fasthttp RequestHandler.
+func listUsers(ctx *fasthttp.RequestCtx) {
+	ctx.WriteString("users")
+}
+
+func main() {
+	r := router.New()
+	r.GET("/users", listUsers)
+	r.POST("/users", createUser)
+	r.Handle("PUT", "/users/{id}", updateUser)
+
+	api := r.Group("/api/v1")
+	api.GET("/health", healthCheck)
+
+	fasthttp.ListenAndServe(":8080", r.Handler)
+}

--- a/internal/custom/golang/testdata/revel_controller.go
+++ b/internal/custom/golang/testdata/revel_controller.go
@@ -1,0 +1,27 @@
+package controllers
+
+import "github.com/revel/revel"
+
+// App is a Revel controller embedding *revel.Controller.
+type App struct {
+	*revel.Controller
+}
+
+// Index renders the home page.
+func (c App) Index() revel.Result {
+	return c.Render()
+}
+
+// Login renders the login page.
+func (c App) Login() revel.Result {
+	return c.Render()
+}
+
+// checkUser is a before-filter interceptor.
+func checkUser(c *revel.Controller) revel.Result {
+	return nil
+}
+
+func init() {
+	revel.InterceptFunc(checkUser, revel.BEFORE, &App{})
+}


### PR DESCRIPTION
Part of #3212 (Cluster 1 — Routing). Adds three new **self-contained** Go custom routing extractors and flips their `Routing.endpoint_synthesis` + `Routing.handler_attribution` cells from `partial` → `full`.

## Frameworks

### buffalo (`internal/custom/golang/buffalo.go`) — full
- `buffalo.New(...)` app → SCOPE.Service
- Verb routes `app.GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS("/path", Handler)` with handler attribution
- `app.Resource("/users", UsersResource{})` → 7 conventional RESTful endpoints (List/New/Create/Show/Edit/Update/Destroy) each attributed to `Resource.Action`
- `app.Group("/api")` prefix resolution (nested) → SCOPE.Component
- `app.Mount("/admin", ...)` sub-app mounts → SCOPE.Component
- `.Use(mw)` / `.Middleware.Use(mw)` middleware (auth-classified via shared catalog)

### fasthttp (`internal/custom/golang/fasthttp.go`) — full
- `router.New()` (fasthttp/router) → SCOPE.Service; verb routes + `.Handle("M","/p",h)` + `.Group` prefix resolution, all with handler attribution
- `fasthttp.ListenAndServe(addr, handler)` raw-handler server entry → SCOPE.Service
- Raw `func h(ctx *fasthttp.RequestCtx)` handler decls → SCOPE.Pattern (manual-dispatch; no method+path synthesizable, recorded for attribution)

### revel (`internal/custom/golang/revel.go`) — full
- `conf/routes` DSL (`METHOD /path Controller.Action`) → full endpoint synthesis + handler attribution; `:param`→`{param}`, `module:<name>` mounts → SCOPE.Component, `*` auto-route wildcards → ANY endpoint flagged `is_auto` (no static handler, resolves at runtime)
- Go controller-action methods returning `revel.Result` → SCOPE.Pattern handler attribution
- `revel.InterceptFunc/InterceptMethod` before/after filters → SCOPE.Pattern middleware (auth-classified)

## Isolation / contention
All new files. Helpers needed beyond the shared read-only set are file-local (`buffaloResourceRoutes`, `revelCanonPath`, `isRevelRoutesFile`). **`helpers.go`, `go_routes.go`, and other framework extractors are untouched.**

## Honesty
All six cells are `full`, each backed by a proving golden fixture (testdata: `buffalo_routes.go`, `fasthttp_routes.go`, `conf/routes`, `revel_controller.go`). Registry edited via `coverage update`; docs regenerated and byte-stable.

## Validation (scoped)
- `go build ./internal/... ./tools/coverage/...` ✅
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` ✅
- `go run ./tools/coverage validate` → exit 0 ✅
- `go run ./tools/coverage fmt --check` → canonical ✅
- `go run ./tools/coverage gen` → byte-stable ✅
- `gofmt -l internal/custom/golang/` → empty ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)