### PR TITLE
feat(coverage): Go validation extractor for gin/echo/fiber/chi

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -41,16 +41,16 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
-| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 4/6 | |
+| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 5/6 | |
 | [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
+| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -28,16 +28,16 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|---|---|---|---|---|
 | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
-| [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
-| [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 4/6 | |
+| [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
+| [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
+| [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 5/6 | |
 | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
+| [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
 | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -11047,8 +11047,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -11231,8 +11233,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -11592,8 +11596,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -11840,8 +11846,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {

--- a/internal/custom/golang/testdata/chi_validation.go
+++ b/internal/custom/golang/testdata/chi_validation.go
@@ -1,0 +1,34 @@
+package fixtures
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/go-playground/validator/v10"
+)
+
+// OrderReq is a chi-bound DTO using validate: struct tags, decoded via render.
+type OrderReq struct {
+	SKU   string `json:"sku" validate:"required,alphanum"`
+	Qty   int    `json:"qty" validate:"required,gt=0"`
+	Notes string `json:"notes" validate:"max=200"`
+}
+
+func setupChi() {
+	r := chi.NewRouter()
+	validate := validator.New()
+
+	r.Post("/orders", func(w http.ResponseWriter, req *http.Request) {
+		var body OrderReq
+		if err := render.DecodeJSON(req.Body, &body); err != nil {
+			render.Status(req, http.StatusBadRequest)
+			return
+		}
+		if err := validate.Struct(&body); err != nil {
+			render.Status(req, http.StatusBadRequest)
+			return
+		}
+		render.JSON(w, req, body)
+	})
+}

--- a/internal/custom/golang/testdata/echo_validation.go
+++ b/internal/custom/golang/testdata/echo_validation.go
@@ -1,0 +1,32 @@
+package fixtures
+
+import (
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+)
+
+// LoginReq is an echo-bound DTO using validate: struct tags (go-playground).
+type LoginReq struct {
+	Username string `json:"username" validate:"required,alphanum"`
+	Password string `json:"password" validate:"required,min=8"`
+}
+
+type echoValidator struct{ v *validator.Validate }
+
+func (ev *echoValidator) Validate(i interface{}) error { return ev.v.Struct(i) }
+
+func setupEcho() {
+	e := echo.New()
+	e.Validator = &echoValidator{v: validator.New()}
+
+	e.POST("/login", func(c echo.Context) error {
+		var req LoginReq
+		if err := c.Bind(&req); err != nil {
+			return err
+		}
+		if err := c.Validate(&req); err != nil {
+			return err
+		}
+		return c.JSON(200, req)
+	})
+}

--- a/internal/custom/golang/testdata/fiber_validation.go
+++ b/internal/custom/golang/testdata/fiber_validation.go
@@ -1,0 +1,28 @@
+package fixtures
+
+import (
+	"github.com/go-playground/validator/v10"
+	"github.com/gofiber/fiber/v2"
+)
+
+// SignupReq is a fiber-bound DTO using validate: struct tags.
+type SignupReq struct {
+	Email string `json:"email" validate:"required,email"`
+	Phone string `json:"phone" validate:"required,e164"`
+}
+
+func setupFiber() {
+	app := fiber.New()
+	validate := validator.New()
+
+	app.Post("/signup", func(c *fiber.Ctx) error {
+		var req SignupReq
+		if err := c.BodyParser(&req); err != nil {
+			return err
+		}
+		if err := validate.Struct(&req); err != nil {
+			return err
+		}
+		return c.JSON(req)
+	})
+}

--- a/internal/custom/golang/testdata/gin_validation.go
+++ b/internal/custom/golang/testdata/gin_validation.go
@@ -1,0 +1,32 @@
+package fixtures
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+)
+
+// CreateUserReq is a gin-bound DTO using binding: struct tags.
+type CreateUserReq struct {
+	Name  string `json:"name" binding:"required,min=2,max=64"`
+	Email string `json:"email" binding:"required,email"`
+	Age   int    `json:"age" binding:"gte=0,lte=130"`
+	Skip  string `json:"-" binding:"-"`
+}
+
+func setup() {
+	r := gin.Default()
+
+	validate := validator.New()
+	validate.RegisterValidation("is_even", func(fl validator.FieldLevel) bool {
+		return fl.Field().Int()%2 == 0
+	})
+
+	r.POST("/users", func(c *gin.Context) {
+		var req CreateUserReq
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(201, req)
+	})
+}

--- a/internal/custom/golang/validation.go
+++ b/internal/custom/golang/validation.go
@@ -1,0 +1,267 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// validation.go — a framework-agnostic request-validation scanner for the four
+// well-templated Go HTTP frameworks (gin/echo/fiber/chi), issue #3213 cluster 2
+// (the validation capability; middleware + auth already landed in helpers.go).
+//
+// It detects three validation surfaces that the per-framework routing and
+// middleware extractors do not model:
+//
+//   - rule        : struct-field validation rules declared via `validate:"..."`
+//                   or `binding:"..."` field tags on bound request DTOs. Each
+//                   distinct (struct, field, rule-set) yields one entity.
+//   - validator   : custom validator registration —
+//                   `validator.New()` instances and
+//                   `<v>.RegisterValidation("name", ...)` calls.
+//   - binding      : request-binding call sites that trigger validation —
+//                   gin   c.ShouldBind*/c.Bind* / c.MustBindWith,
+//                   echo  c.Bind / c.Validate,
+//                   fiber c.BodyParser / c.QueryParser / c.ParamsParser,
+//                   chi   render.Bind / render.DecodeJSON.
+//
+// Honesty (registry coverage status):
+//
+// Detection is a heuristic regex/identifier match on source text. It does NOT
+// resolve imports, confirm the validator is wired into a request handler, or
+// link a `validate:` tag to the binding call site that enforces it. It is
+// therefore reported `partial` for gin/echo/fiber/chi: a tag/call match proves
+// the validation surface is present, not that every rule is enforced. There is
+// no genuinely-N/A framework in this set (all four support struct-tag
+// validation), so no honesty-NA cell is emitted here.
+//
+// Framework attribution mirrors observability.go: the scanner runs on every Go
+// file (registry key custom_go_validation matches the custom_go_ dispatch
+// prefix) and infers gin/echo/fiber/chi from framework-specific engine/context
+// markers, stamping that framework on each emitted entity. A file with no
+// recognised framework marker emits nothing.
+
+func init() {
+	extractor.Register("custom_go_validation", &validationExtractor{})
+}
+
+type validationExtractor struct{}
+
+func (e *validationExtractor) Language() string { return "custom_go_validation" }
+
+// valFrameworkMarkers attributes a file to a framework via its canonical engine
+// constructor / request-context type. Same surface observability.go uses, kept
+// file-local to avoid editing shared helpers (contention avoidance).
+var valFrameworkMarkers = []struct {
+	name string
+	re   *regexp.Regexp
+}{
+	{"gin", regexp.MustCompile(`\bgin\.(?:Default|New|Engine|Context|HandlerFunc)\b`)},
+	{"echo", regexp.MustCompile(`\becho\.(?:New|Echo|Context|HandlerFunc|MiddlewareFunc)\b`)},
+	{"fiber", regexp.MustCompile(`\bfiber\.(?:New|App|Ctx|Handler)\b`)},
+	{"chi", regexp.MustCompile(`\bchi\.(?:NewRouter|Router|Mux)\b`)},
+}
+
+// detectValFramework returns the framework a file belongs to, or "" when no
+// recognised marker is present. First match wins (gin→echo→fiber→chi).
+func detectValFramework(src string) string {
+	for _, m := range valFrameworkMarkers {
+		if m.re.MatchString(src) {
+			return m.name
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Struct-tag validation rules
+// ---------------------------------------------------------------------------
+
+// reGoStructHead locates a `type <Name> struct {` opening so field tags can be
+// attributed to the enclosing struct.
+var reGoStructHead = regexp.MustCompile(`type\s+(\w+)\s+struct\s*\{`)
+
+// reGoValidatedField matches a struct field line carrying a `validate:"..."` or
+// `binding:"..."` tag, capturing the field name and the rule string. The field
+// name is the first identifier on the line; binding/validate tags live in the
+// backtick-quoted tag literal.
+//
+//	Name string `json:"name" binding:"required,min=2"`
+//	Age  int    `validate:"gte=0,lte=130"`
+var reGoValidatedField = regexp.MustCompile(
+	"(?m)^\\s*(\\w+)\\s+[^`\\n]*`[^`]*\\b(?:binding|validate):\"([^\"]+)\"[^`]*`")
+
+// reGoTagKind extracts which tag key (binding|validate) carried the rules, used
+// for the rule_source property. binding is gin's spelling; validate is the
+// go-playground/validator spelling used by echo/fiber/chi.
+var reGoTagKind = regexp.MustCompile(`\b(binding|validate):"`)
+
+// validationRule is one (struct, field) pair carrying validation rules.
+type validationRule struct {
+	Struct string
+	Field  string
+	Rules  string
+	Source string // "binding" | "validate"
+	Line   int
+}
+
+// findValidationRules scans struct definitions for fields carrying binding/
+// validate tags. Fields are attributed to the most recently opened struct by
+// source offset. "-" rule strings (explicit skip) are ignored.
+func findValidationRules(src string) []validationRule {
+	// Index struct heads by offset so each field can find its enclosing struct.
+	type head struct {
+		name string
+		off  int
+	}
+	var heads []head
+	for _, m := range reGoStructHead.FindAllStringSubmatchIndex(src, -1) {
+		heads = append(heads, head{name: src[m[2]:m[3]], off: m[0]})
+	}
+	structAt := func(off int) string {
+		name := ""
+		for _, h := range heads {
+			if h.off <= off {
+				name = h.name
+			} else {
+				break
+			}
+		}
+		return name
+	}
+
+	var rules []validationRule
+	for _, m := range reGoValidatedField.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		ruleSet := src[m[4]:m[5]]
+		if ruleSet == "" || ruleSet == "-" {
+			continue
+		}
+		source := "validate"
+		if k := reGoTagKind.FindStringSubmatch(src[m[0]:m[1]]); k != nil {
+			source = k[1]
+		}
+		rules = append(rules, validationRule{
+			Struct: structAt(m[0]),
+			Field:  field,
+			Rules:  ruleSet,
+			Source: source,
+			Line:   lineOf(src, m[0]),
+		})
+	}
+	return rules
+}
+
+// ---------------------------------------------------------------------------
+// Custom validators + binding call sites
+// ---------------------------------------------------------------------------
+
+// valSignal is a non-tag validation construct detected by a single regex.
+type valSignal struct {
+	re      *regexp.Regexp
+	kind    string // pattern sub-kind: validator | binding
+	subtype string // finer detail: validator_new | register_validation | bind_call
+	// nameGroup is the submatch whose text names the entity (0 = whole match).
+	nameGroup int
+}
+
+var valSignals = []valSignal{
+	// custom validators
+	{regexp.MustCompile(`\bvalidator\.New\s*\(`), "validator", "validator_new", 0},
+	{regexp.MustCompile(`\b\w+\.RegisterValidation\s*\(\s*"([^"]+)"`), "validator", "register_validation", 1},
+
+	// binding / parse call sites that trigger validation, per framework.
+	{regexp.MustCompile(`\bc\.(?:ShouldBind\w*|Bind\w*|MustBindWith)\s*\(`), "binding", "bind_call", 0},
+	{regexp.MustCompile(`\bc\.Validate\s*\(`), "binding", "validate_call", 0},
+	{regexp.MustCompile(`\bc\.(?:BodyParser|QueryParser|ParamsParser|ReqHeaderParser)\s*\(`), "binding", "parse_call", 0},
+	{regexp.MustCompile(`\brender\.(?:Bind|DecodeJSON)\s*\(`), "binding", "bind_call", 0},
+}
+
+func (e *validationExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.validation_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	framework := detectValFramework(src)
+	if framework == "" {
+		span.SetAttributes(attribute.String("framework", ""))
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	prov := func(detail string) string {
+		return "INFERRED_FROM_" + strings.ToUpper(framework) + "_" + strings.ToUpper(detail)
+	}
+
+	// 1. struct-tag validation rules
+	for _, r := range findValidationRules(src) {
+		name := "validation:rule:" + r.Struct + "." + r.Field
+		ent := makeEntity(name, "SCOPE.Pattern", "", file.Path, file.Language, r.Line)
+		setProps(&ent, "framework", framework,
+			"provenance", prov("VALIDATION"),
+			"pattern_kind", "validation",
+			"validation_kind", "rule",
+			"struct_name", r.Struct,
+			"field_name", r.Field,
+			"rules", r.Rules,
+			"rule_source", r.Source)
+		add(ent)
+	}
+
+	// 2. custom validators + binding call sites
+	for _, sig := range valSignals {
+		for _, m := range sig.re.FindAllStringSubmatchIndex(src, -1) {
+			detail := submatch(src, m, sig.nameGroup*2)
+			if detail == "" {
+				detail = strings.TrimSpace(src[m[0]:m[1]])
+			}
+			name := "validation:" + sig.kind + ":" + sig.subtype + ":" + detail
+			ent := makeEntity(name, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", framework,
+				"provenance", prov("VALIDATION"),
+				"pattern_kind", "validation",
+				"validation_kind", sig.kind,
+				"validation_subtype", sig.subtype)
+			if sig.subtype == "register_validation" {
+				setProps(&ent, "tag", detail)
+			}
+			add(ent)
+		}
+	}
+
+	span.SetAttributes(
+		attribute.String("framework", framework),
+		attribute.Int("entity_count", len(entities)),
+	)
+	return entities, nil
+}

--- a/internal/custom/golang/validation_test.go
+++ b/internal/custom/golang/validation_test.go
@@ -1,0 +1,213 @@
+package golang_test
+
+import (
+	"testing"
+)
+
+// Tests for the framework-agnostic request-validation scanner (issue #3213,
+// cluster 2 validation capability): struct-tag rules, custom validators, and
+// binding call sites within gin/echo/fiber/chi context.
+
+// findVal returns the first SCOPE.Pattern validation entity matching the given
+// validation_kind (and, when non-empty, validation_subtype), or nil.
+func findVal(ents []fullEntity, kind, subtype string) *fullEntity {
+	for i := range ents {
+		if ents[i].Kind != "SCOPE.Pattern" {
+			continue
+		}
+		p := ents[i].Props
+		if p["pattern_kind"] != "validation" || p["validation_kind"] != kind {
+			continue
+		}
+		if subtype != "" && p["validation_subtype"] != subtype {
+			continue
+		}
+		return &ents[i]
+	}
+	return nil
+}
+
+func valEntities(ents []fullEntity) []fullEntity {
+	var out []fullEntity
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Props["pattern_kind"] == "validation" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func findValRule(ents []fullEntity, structName, field string) *fullEntity {
+	for i := range ents {
+		p := ents[i].Props
+		if p["pattern_kind"] == "validation" && p["validation_kind"] == "rule" &&
+			p["struct_name"] == structName && p["field_name"] == field {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Framework attribution: no recognised framework marker => no emit.
+// ---------------------------------------------------------------------------
+
+func TestValidationNoFrameworkNoEmit(t *testing.T) {
+	src := `package x
+type Req struct {
+	Name string ` + "`" + `validate:"required"` + "`" + `
+}`
+	ents := extractFull(t, "custom_go_validation", fi("main.go", "go", src))
+	if got := valEntities(ents); len(got) != 0 {
+		t.Fatalf("expected no validation entities without a framework marker, got %d: %+v", len(got), got)
+	}
+}
+
+func TestValidationNonGoNoEmit(t *testing.T) {
+	src := `r := gin.Default()`
+	ents := extractFull(t, "custom_go_validation", fi("main.py", "python", src))
+	if len(ents) != 0 {
+		t.Fatalf("non-go file should yield nothing, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Struct-tag rule detection: binding: (gin) and validate: (others).
+// ---------------------------------------------------------------------------
+
+func TestValidationBindingTagRule(t *testing.T) {
+	src := "r := gin.Default()\n" +
+		"type Req struct {\n" +
+		"\tName string `json:\"name\" binding:\"required,min=2\"`\n" +
+		"\tSkip string `json:\"-\" binding:\"-\"`\n" +
+		"}\n"
+	ents := extractFull(t, "custom_go_validation", fi("main.go", "go", src))
+	r := findValRule(ents, "Req", "Name")
+	if r == nil {
+		t.Fatalf("missing rule for Req.Name; got %+v", valEntities(ents))
+	}
+	if r.Props["rules"] != "required,min=2" {
+		t.Errorf("rules=%q want required,min=2", r.Props["rules"])
+	}
+	if r.Props["rule_source"] != "binding" {
+		t.Errorf("rule_source=%q want binding", r.Props["rule_source"])
+	}
+	// the "-" skip tag must not produce a rule entity.
+	if findValRule(ents, "Req", "Skip") != nil {
+		t.Errorf("explicit skip tag (binding:\"-\") should not emit a rule")
+	}
+}
+
+func TestValidationValidateTagRule(t *testing.T) {
+	src := "e := echo.New()\n" +
+		"type Login struct {\n" +
+		"\tUsername string `validate:\"required,alphanum\"`\n" +
+		"}\n"
+	ents := extractFull(t, "custom_go_validation", fi("main.go", "go", src))
+	r := findValRule(ents, "Login", "Username")
+	if r == nil {
+		t.Fatalf("missing rule for Login.Username; got %+v", valEntities(ents))
+	}
+	if r.Props["rule_source"] != "validate" {
+		t.Errorf("rule_source=%q want validate", r.Props["rule_source"])
+	}
+	if r.Props["framework"] != "echo" {
+		t.Errorf("framework=%q want echo", r.Props["framework"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Custom validators.
+// ---------------------------------------------------------------------------
+
+func TestValidationCustomValidator(t *testing.T) {
+	src := "r := gin.Default()\n" +
+		"v := validator.New()\n" +
+		"v.RegisterValidation(\"is_even\", fn)\n"
+	ents := extractFull(t, "custom_go_validation", fi("main.go", "go", src))
+	if findVal(ents, "validator", "validator_new") == nil {
+		t.Errorf("missing validator_new; got %+v", valEntities(ents))
+	}
+	reg := findVal(ents, "validator", "register_validation")
+	if reg == nil {
+		t.Fatalf("missing register_validation; got %+v", valEntities(ents))
+	}
+	if reg.Props["tag"] != "is_even" {
+		t.Errorf("tag=%q want is_even", reg.Props["tag"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Binding call sites, per framework dialect.
+// ---------------------------------------------------------------------------
+
+func TestValidationBindingCallSites(t *testing.T) {
+	cases := []struct {
+		name, src, subtype string
+	}{
+		{"gin_shouldbind", "r := gin.Default()\nc.ShouldBindJSON(&req)", "bind_call"},
+		{"echo_validate", "e := echo.New()\nc.Validate(&req)", "validate_call"},
+		{"fiber_bodyparser", "app := fiber.New()\nc.BodyParser(&req)", "parse_call"},
+		{"chi_render", "r := chi.NewRouter()\nrender.DecodeJSON(req.Body, &b)", "bind_call"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ents := extractFull(t, "custom_go_validation", fi("main.go", "go", c.src))
+			if findVal(ents, "binding", c.subtype) == nil {
+				t.Fatalf("missing binding/%s; got %+v", c.subtype, valEntities(ents))
+			}
+		})
+	}
+}
+
+func TestValidationProvenance(t *testing.T) {
+	src := "r := gin.Default()\nv := validator.New()"
+	ents := extractFull(t, "custom_go_validation", fi("main.go", "go", src))
+	v := findVal(ents, "validator", "validator_new")
+	if v == nil {
+		t.Fatal("missing validator_new")
+	}
+	if v.Props["provenance"] != "INFERRED_FROM_GIN_VALIDATION" {
+		t.Errorf("provenance=%q want INFERRED_FROM_GIN_VALIDATION", v.Props["provenance"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fixture-driven end-to-end checks: each framework fixture carries struct-tag
+// rules + a binding call site (+ gin a custom validator). These prove the
+// general gin/echo/fiber/chi validation surface.
+// ---------------------------------------------------------------------------
+
+func TestValidationFixtures(t *testing.T) {
+	cases := []struct {
+		fixture, framework, ruleStruct, ruleField, bindSubtype string
+	}{
+		{"gin_validation.go", "gin", "CreateUserReq", "Email", "bind_call"},
+		{"echo_validation.go", "echo", "LoginReq", "Password", "validate_call"},
+		{"fiber_validation.go", "fiber", "SignupReq", "Email", "parse_call"},
+		{"chi_validation.go", "chi", "OrderReq", "SKU", "bind_call"},
+	}
+	for _, c := range cases {
+		t.Run(c.framework, func(t *testing.T) {
+			ents := extractFull(t, "custom_go_validation", fixtureFile(t, c.fixture))
+
+			// a struct-tag rule on the expected field.
+			if findValRule(ents, c.ruleStruct, c.ruleField) == nil {
+				t.Errorf("%s: missing rule %s.%s; got %+v",
+					c.framework, c.ruleStruct, c.ruleField, valEntities(ents))
+			}
+
+			// a binding call site (framework's dialect).
+			if findVal(ents, "binding", c.bindSubtype) == nil {
+				t.Errorf("%s: missing binding/%s", c.framework, c.bindSubtype)
+			}
+
+			// every emitted entity must be attributed to this framework.
+			for _, e := range valEntities(ents) {
+				if e.Props["framework"] != c.framework {
+					t.Errorf("%s: entity %q framework=%q", c.framework, e.Name, e.Props["framework"])
+				}
+			}
+		})
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -2635,6 +2635,23 @@ records:
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans gin-context files for
+          # `binding:"..."` struct-tag rules on bound DTOs, validator.New()/
+          # RegisterValidation custom validators, and c.ShouldBind*/Bind*
+          # binding call sites, emitting validation SCOPE.Pattern entities
+          # (validation_kind=rule|validator|binding). Heuristic tag/call match,
+          # no rule→call-site data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
       Substrate:
         constant_propagation:
           status: full
@@ -2854,6 +2871,22 @@ records:
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans echo-context files for
+          # `validate:"..."` struct-tag rules (go-playground), validator.New()/
+          # RegisterValidation custom validators, and c.Bind/c.Validate binding
+          # call sites, emitting validation SCOPE.Pattern entities. Heuristic
+          # tag/call match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
       Substrate:
         constant_propagation:
           status: full
@@ -2968,6 +3001,22 @@ records:
               functions: [classifyAuthMiddleware, emitMiddlewareChain]
           tests:
             - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans fiber-context files for
+          # `validate:"..."` struct-tag rules (go-playground), validator.New()/
+          # RegisterValidation custom validators, and c.BodyParser/QueryParser/
+          # ParamsParser binding call sites, emitting validation SCOPE.Pattern
+          # entities. Heuristic tag/call match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
@@ -3092,6 +3141,22 @@ records:
               functions: [classifyAuthMiddleware, emitMiddlewareChain]
           tests:
             - file: internal/custom/golang/middleware_auth_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans chi-context files for
+          # `validate:"..."` struct-tag rules (go-playground), validator.New()/
+          # RegisterValidation custom validators, and render.Bind/render.DecodeJSON
+          # binding call sites, emitting validation SCOPE.Pattern entities.
+          # Heuristic tag/call match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 


### PR DESCRIPTION
Part of #3213 (Cluster 2 — Auth + Middleware + Validation). Implements the **validation** capability for the four well-templated Go HTTP frameworks (middleware + auth already landed in `helpers.go`).

## What
A framework-agnostic request-validation scanner — `internal/custom/golang/validation.go`, registered as `custom_go_validation` — mirroring the existing `observability.go` pattern (runs on every Go file, infers the framework from canonical engine/context markers, stamps it on every emitted entity, emits nothing when no gin/echo/fiber/chi marker is present).

It detects three validation surfaces and emits a `SCOPE.Pattern` per finding (`pattern_kind=validation`, `validation_kind=rule|validator|binding`):

- **struct-tag rules** — `binding:"..."` (gin) / `validate:"..."` (go-playground) field tags on bound DTOs, attributed to the enclosing `type … struct` and field; explicit `-` skip tags ignored. Props: `struct_name`, `field_name`, `rules`, `rule_source`.
- **custom validators** — `validator.New()` and `<v>.RegisterValidation("name", …)` (tag captured).
- **binding call sites** — gin `c.ShouldBind*`/`Bind*`/`MustBindWith`, echo `c.Bind`/`c.Validate`, fiber `c.BodyParser`/`QueryParser`/`ParamsParser`, chi `render.Bind`/`render.DecodeJSON`.

## Honesty
Detection is heuristic regex/tag matching with **no** rule→call-site data flow and no import resolution, so all four `Validation.request_validation` cells flip to **`partial`** (a fixture proves the surface is present, not that every rule is enforced). No honesty-NA cell — all four frameworks support struct-tag validation.

| framework | request_validation |
|---|---|
| gin | partial |
| echo | partial |
| fiber | partial |
| chi | partial |

## Contention safety
All logic is file-local in `validation.go` (+ `validation_test.go` + four per-framework fixtures). `helpers.go`, `go_routes.go`, and the existing gin/echo/fiber/chi extractors are **untouched**. Capmap gains four `Validation.request_validation` cells as their own entries (no duplicate keys); docs regenerated byte-stable.

## Validation (scoped)
- `go build ./internal/... ./tools/coverage/...` ✅
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` ✅
- `go run ./tools/coverage validate` → exit 0, no new warnings ✅
- `fmt --check` ✅ · `gen` byte-stable ✅ · `gofmt -l` clean on touched files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)