### PR TITLE
feat(coverage): Go hertz + huma routing extractors (Part of #3212)

### DIFF
--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/hertz.yaml` | — |
-| Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/frameworks/hertz.yaml` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/hertz.go`<br>`internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/testdata/hertz_routes.go` | Regex AST extractor: server.Default/New engine, h.GET/POST/... verb routes, nested h.Group prefix resolution, Static mounts; fixture-proven. |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/hertz.go`<br>`internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/testdata/hertz_routes.go` | Trailing-arg handler attribution on each verb route (skips inline middleware); fixture-proven. |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_go_trio.go` | — |
-| Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_go_trio.go` | — |
+| Endpoint synthesis | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/huma.go`<br>`internal/custom/golang/testdata/huma_routes.go`<br>`internal/engine/http_endpoint_go_trio.go` | huma.Register(api, huma.Operation{Method,Path}, handler) -> endpoint. Engine synthesis (go_trio) + dedicated SCOPE-entity extractor; fixture-proven. |
+| Handler attribution | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/hertz_huma_test.go`<br>`internal/custom/golang/huma.go`<br>`internal/custom/golang/testdata/huma_routes.go`<br>`internal/engine/http_endpoint_go_trio.go` | Final huma.Register argument attributed as handler; fixture-proven. |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12516,14 +12516,16 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/custom/golang/hertz.go","internal/custom/golang/hertz_huma_test.go","internal/custom/golang/testdata/hertz_routes.go"],
+            "notes": "Regex AST extractor: server.Default/New engine, h.GET/POST/... verb routes, nested h.Group prefix resolution, Static mounts; fixture-proven.",
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/go/frameworks/hertz.yaml"],
-            "verified_at": "2026-05-28"
+            "status": "full",
+            "cites": ["internal/custom/golang/hertz.go","internal/custom/golang/hertz_huma_test.go","internal/custom/golang/testdata/hertz_routes.go"],
+            "notes": "Trailing-arg handler attribution on each verb route (skips inline middleware); fixture-proven.",
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
             "status": "missing",
@@ -12694,13 +12696,15 @@
         "Routing": {
           "endpoint_synthesis": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_go_trio.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/hertz_huma_test.go","internal/custom/golang/huma.go","internal/custom/golang/testdata/huma_routes.go","internal/engine/http_endpoint_go_trio.go"],
+            "notes": "huma.Register(api, huma.Operation{Method,Path}, handler) -\u003e endpoint. Engine synthesis (go_trio) + dedicated SCOPE-entity extractor; fixture-proven.",
+            "verified_at": "2026-05-29"
           },
           "handler_attribution": {
             "status": "full",
-            "cites": ["internal/engine/http_endpoint_go_trio.go"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/hertz_huma_test.go","internal/custom/golang/huma.go","internal/custom/golang/testdata/huma_routes.go","internal/engine/http_endpoint_go_trio.go"],
+            "notes": "Final huma.Register argument attributed as handler; fixture-proven.",
+            "verified_at": "2026-05-29"
           },
           "route_extraction": {
             "status": "missing",

--- a/internal/custom/golang/hertz.go
+++ b/internal/custom/golang/hertz.go
@@ -1,0 +1,165 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_hertz", &hertzExtractor{})
+}
+
+// hertzExtractor extracts routing structure from CloudWeGo Hertz
+// (github.com/cloudwego/hertz) servers. Hertz exposes a gin-style routing
+// surface: a `*server.Hertz` engine created via `server.Default()` /
+// `server.New(...)`, verb methods `h.GET/POST/...`, route groups via
+// `h.Group("/prefix")`, middleware via `.Use(...)`, and static file mounts
+// via `.Static/.StaticFS/.StaticFile`. Handlers are attributed from the
+// final argument of each verb call.
+type hertzExtractor struct{}
+
+func (e *hertzExtractor) Language() string { return "custom_go_hertz" }
+
+var (
+	// h := server.Default() / h = server.New(opts...) — Hertz engine.
+	reHertzEngine = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*server\.(?:Default|New)\s*\(`,
+	)
+	// g := h.Group("/api") — route-prefix group (returns *route.RouterGroup).
+	reHertzGroup = regexp.MustCompile(
+		`(?m)(\w+)\s*:?=\s*(\w+)\.Group\s*\(\s*"([^"]+)"`,
+	)
+	// h.GET/POST/...("/path", handler) — verb route with handler attribution.
+	// Intermediate middleware args (anything that is not the final identifier)
+	// are skipped via a non-greedy run constrained to a single statement
+	// ([^,()\n] keeps each arg on one line and inside the call), so the final
+	// [\w.]+ binds to the trailing handler identifier.
+	reHertzRoute = regexp.MustCompile(
+		`(?m)(\w+)\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|Any)\s*\(\s*"([^"]+)"\s*,\s*(?:[^\n,]*?,\s*)*?([\w.]+)\s*\)`,
+	)
+	// h.Static("/assets", "./root") / h.StaticFS / h.StaticFile — static mounts.
+	reHertzStatic = regexp.MustCompile(
+		`(?m)(\w+)\.(?:Static|StaticFS|StaticFile)\s*\(\s*"([^"]+)"`,
+	)
+	// h.NoRoute / h.NoMethod error handlers.
+	reHertzNoRoute = regexp.MustCompile(
+		`(?m)(\w+)\.(NoRoute|NoMethod)\s*\(`,
+	)
+)
+
+func (e *hertzExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.hertz_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "hertz"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. server.Default()/server.New() engine -> SCOPE.Service.
+	for _, m := range reHertzEngine.FindAllStringSubmatchIndex(src, -1) {
+		varName := submatch(src, m, 2)
+		ent := makeEntity(varName, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "hertz", "provenance", "INFERRED_FROM_HERTZ_ENGINE")
+		add(ent)
+	}
+
+	// 2. h.Group(...) -> SCOPE.Component, tracking nested group prefixes so
+	//    verb routes registered on a group resolve to their full path.
+	groupPaths := make(map[string]string) // varName -> full prefix
+	for _, m := range reHertzGroup.FindAllStringSubmatchIndex(src, -1) {
+		varName := submatch(src, m, 2)
+		parent := submatch(src, m, 4)
+		path := submatch(src, m, 6)
+		if pp, ok := groupPaths[parent]; ok {
+			path = pp + path
+		}
+		groupPaths[varName] = path
+		ent := makeEntity(path, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "hertz", "provenance", "INFERRED_FROM_HERTZ_GROUP",
+			"group_path", path)
+		add(ent)
+	}
+
+	// 3. Verb routes -> SCOPE.Operation/endpoint with group-prefix resolution
+	//    and handler attribution from the final argument.
+	for _, m := range reHertzRoute.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := submatch(src, m, 2)
+		method := strings.ToUpper(submatch(src, m, 4))
+		path := submatch(src, m, 6)
+		handler := submatch(src, m, 8)
+		if gp, ok := groupPaths[routerVar]; ok {
+			path = gp + path
+		}
+		name := method + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "hertz", "provenance", "INFERRED_FROM_HERTZ_ROUTE",
+			"http_method", method, "route_path", path, "router_var", routerVar)
+		if handler != "" {
+			ent.Properties["handler"] = handler
+		}
+		add(ent)
+	}
+
+	// 4. Static mounts -> SCOPE.Operation/endpoint (GET).
+	for _, m := range reHertzStatic.FindAllStringSubmatchIndex(src, -1) {
+		routerVar := submatch(src, m, 2)
+		path := submatch(src, m, 4)
+		if gp, ok := groupPaths[routerVar]; ok {
+			path = gp + path
+		}
+		name := "GET " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "hertz", "provenance", "INFERRED_FROM_HERTZ_ROUTE",
+			"http_method", "GET", "route_path", path, "is_static", "true")
+		add(ent)
+	}
+
+	// 5. Middleware -> ordered SCOPE.Pattern (+ auth classification), reusing
+	//    the shared balanced .Use(...) parser.
+	for _, uc := range findUseCalls(src) {
+		chain := parseMiddlewareChain(uc.Args)
+		emitMiddlewareChain(add, chain, "hertz",
+			"INFERRED_FROM_HERTZ_MIDDLEWARE", "INFERRED_FROM_HERTZ_AUTH",
+			file.Path, file.Language, uc.Line)
+	}
+
+	// 6. NoRoute/NoMethod error handlers -> SCOPE.Pattern.
+	for _, m := range reHertzNoRoute.FindAllStringSubmatchIndex(src, -1) {
+		handlerKind := submatch(src, m, 4)
+		ent := makeEntity(handlerKind, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "hertz", "provenance", "INFERRED_FROM_HERTZ_ERROR_HANDLER",
+			"handler_kind", handlerKind, "pattern_kind", "error_handler")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/golang/hertz_huma_test.go
+++ b/internal/custom/golang/hertz_huma_test.go
@@ -1,0 +1,225 @@
+package golang_test
+
+import (
+	"testing"
+)
+
+// handlerFor returns the "handler" property of the first entity matching
+// kind+name, or "" if absent. Reuses fullEntity from middleware_auth_test.go.
+func handlerFor(ents []fullEntity, kind, name string) string {
+	for _, e := range ents {
+		if e.Kind == kind && e.Name == name {
+			return e.Props["handler"]
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Hertz (CloudWeGo)
+// ---------------------------------------------------------------------------
+
+func TestHertzEngine(t *testing.T) {
+	ents := extract(t, "custom_go_hertz", fi("main.go", "go", `h := server.Default()`))
+	if !containsEntity(ents, "SCOPE.Service", "h") {
+		t.Error("expected h as hertz engine service")
+	}
+}
+
+func TestHertzEngineNew(t *testing.T) {
+	ents := extract(t, "custom_go_hertz", fi("main.go", "go", `h := server.New(server.WithHostPorts(":8080"))`))
+	if !containsEntity(ents, "SCOPE.Service", "h") {
+		t.Error("expected h from server.New")
+	}
+}
+
+func TestHertzVerbRoutes(t *testing.T) {
+	src := `
+h.GET("/users", listUsers)
+h.POST("/users", createUser)
+h.DELETE("/users/:id", deleteUser)
+`
+	ents := extract(t, "custom_go_hertz", fi("routes.go", "go", src))
+	for _, w := range []string{"GET /users", "POST /users", "DELETE /users/:id"} {
+		if !containsEntity(ents, "SCOPE.Operation", w) {
+			t.Errorf("expected route %q", w)
+		}
+	}
+}
+
+func TestHertzHandlerAttribution(t *testing.T) {
+	src := `h.GET("/users", listUsers)`
+	ents := extractFull(t, "custom_go_hertz", fi("routes.go", "go", src))
+	if got := handlerFor(ents, "SCOPE.Operation", "GET /users"); got != "listUsers" {
+		t.Errorf("expected handler listUsers, got %q", got)
+	}
+}
+
+func TestHertzHandlerAttributionWithMiddleware(t *testing.T) {
+	// Verb call with inline middleware before the final handler argument.
+	src := `h.GET("/users", JWTAuth(), listUsers)`
+	ents := extractFull(t, "custom_go_hertz", fi("routes.go", "go", src))
+	if got := handlerFor(ents, "SCOPE.Operation", "GET /users"); got != "listUsers" {
+		t.Errorf("expected trailing handler listUsers, got %q", got)
+	}
+}
+
+func TestHertzGroupPrefix(t *testing.T) {
+	src := `
+api := h.Group("/api/v1")
+api.GET("/health", healthCheck)
+`
+	ents := extract(t, "custom_go_hertz", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Component", "/api/v1") {
+		t.Error("expected /api/v1 group component")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/v1/health") {
+		t.Error("expected GET /api/v1/health with group prefix resolved")
+	}
+}
+
+func TestHertzNestedGroupPrefix(t *testing.T) {
+	src := `
+api := h.Group("/api/v1")
+admin := api.Group("/admin")
+admin.GET("/stats", adminStats)
+`
+	ents := extract(t, "custom_go_hertz", fi("routes.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/v1/admin/stats") {
+		t.Error("expected nested group prefix resolution")
+	}
+}
+
+func TestHertzStatic(t *testing.T) {
+	ents := extract(t, "custom_go_hertz", fi("main.go", "go", `h.Static("/assets", "./static")`))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /assets") {
+		t.Error("expected GET /assets static mount")
+	}
+}
+
+func TestHertzMiddleware(t *testing.T) {
+	ents := extract(t, "custom_go_hertz", fi("main.go", "go", `h.Use(RecoveryMiddleware)`))
+	if !containsEntity(ents, "SCOPE.Pattern", "RecoveryMiddleware") {
+		t.Error("expected RecoveryMiddleware pattern")
+	}
+}
+
+func TestHertzNoRoute(t *testing.T) {
+	ents := extract(t, "custom_go_hertz", fi("main.go", "go", `h.NoRoute(notFound)`))
+	if !containsEntity(ents, "SCOPE.Pattern", "NoRoute") {
+		t.Error("expected NoRoute error-handler pattern")
+	}
+}
+
+func TestHertzFixture(t *testing.T) {
+	f := fixtureInput(t, "hertz_routes.go", "go")
+	ents := extractFull(t, "custom_go_hertz", f)
+	wantHandlers := map[string]string{
+		"GET /":                    "indexHandler",
+		"POST /login":              "loginHandler",
+		"GET /api/v1/users":        "listUsers",
+		"POST /api/v1/users":       "createUser",
+		"DELETE /api/v1/users/:id": "deleteUser",
+		"GET /api/v1/admin/stats":  "adminStats",
+	}
+	for op, h := range wantHandlers {
+		if got := handlerFor(ents, "SCOPE.Operation", op); got != h {
+			t.Errorf("fixture: %q expected handler %q, got %q", op, h, got)
+		}
+	}
+	summaries := summaries(ents)
+	if !containsEntity(summaries, "SCOPE.Service", "h") {
+		t.Error("fixture: expected h engine service")
+	}
+	if !containsEntity(summaries, "SCOPE.Operation", "GET /assets") {
+		t.Error("fixture: expected static mount")
+	}
+}
+
+func TestHertzNoMatch(t *testing.T) {
+	ents := extract(t, "custom_go_hertz", fi("main.go", "go", `package main`))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Huma (OpenAPI-first)
+// ---------------------------------------------------------------------------
+
+func TestHumaStringVerb(t *testing.T) {
+	src := `
+import "github.com/danielgtaylor/huma/v2"
+huma.Register(api, huma.Operation{Method: "POST", Path: "/users"}, createUser)
+`
+	ents := extract(t, "custom_go_huma", fi("router.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "POST /users") {
+		t.Error("expected POST /users from string-literal verb")
+	}
+}
+
+func TestHumaConstantVerb(t *testing.T) {
+	src := `
+import "github.com/danielgtaylor/huma/v2"
+huma.Register(api, huma.Operation{Method: http.MethodGet, Path: "/users/{id}"}, getUser)
+`
+	ents := extract(t, "custom_go_huma", fi("router.go", "go", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /users/{id}") {
+		t.Error("expected GET /users/{id} from http.MethodGet constant")
+	}
+}
+
+func TestHumaHandlerAttribution(t *testing.T) {
+	src := `
+import "github.com/danielgtaylor/huma/v2"
+huma.Register(api, huma.Operation{Method: "GET", Path: "/users/{id}"}, getUser)
+`
+	ents := extractFull(t, "custom_go_huma", fi("router.go", "go", src))
+	if got := handlerFor(ents, "SCOPE.Operation", "GET /users/{id}"); got != "getUser" {
+		t.Errorf("expected handler getUser, got %q", got)
+	}
+}
+
+func TestHumaIncompleteOperationSkipped(t *testing.T) {
+	// Missing Path -> would fail at huma runtime too; emit nothing.
+	src := `
+import "github.com/danielgtaylor/huma/v2"
+huma.Register(api, huma.Operation{Method: "GET"}, getUser)
+`
+	ents := extract(t, "custom_go_huma", fi("router.go", "go", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for incomplete Operation, got %d", len(ents))
+	}
+}
+
+func TestHumaFixture(t *testing.T) {
+	f := fixtureInput(t, "huma_routes.go", "go")
+	ents := extractFull(t, "custom_go_huma", f)
+	wantHandlers := map[string]string{
+		"GET /users/{id}":    "getUser",
+		"POST /users":        "createUser",
+		"DELETE /users/{id}": "deleteUser",
+	}
+	for op, h := range wantHandlers {
+		if got := handlerFor(ents, "SCOPE.Operation", op); got != h {
+			t.Errorf("fixture: %q expected handler %q, got %q", op, h, got)
+		}
+	}
+}
+
+func TestHumaNoMatch(t *testing.T) {
+	ents := extract(t, "custom_go_huma", fi("main.go", "go", `package main`))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// summaries projects full entities down to the kind/name shape consumed by the
+// shared containsEntity helper.
+func summaries(ents []fullEntity) []entitySummary {
+	out := make([]entitySummary, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, entitySummary{Kind: e.Kind, Name: e.Name})
+	}
+	return out
+}

--- a/internal/custom/golang/huma.go
+++ b/internal/custom/golang/huma.go
@@ -1,0 +1,154 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_go_huma", &humaExtractor{})
+}
+
+// humaExtractor extracts routing structure from Huma
+// (github.com/danielgtaylor/huma) servers. Huma is OpenAPI-first: routes are
+// declared by registering an Operation against an API value —
+//
+//	huma.Register(api, huma.Operation{Method: "GET", Path: "/users/{id}"}, handler)
+//
+// The Method + Path fields of the Operation literal yield an endpoint, and the
+// final argument of huma.Register is the handler (handler attribution). Both
+// v1 (danielgtaylor/huma) and v2 (danielgtaylor/huma/v2) share the same
+// huma.Register entry point and Operation struct shape.
+type humaExtractor struct{}
+
+func (e *humaExtractor) Language() string { return "custom_go_huma" }
+
+var (
+	// huma.Register( — start token; the balanced argument span is scanned
+	// forward so the Operation struct literal (with its own braces/commas)
+	// is captured whole.
+	reHumaRegisterHead = regexp.MustCompile(`huma\s*\.\s*Register\s*\(`)
+	// Method field of an Operation literal: Method: http.MethodGet | "POST".
+	reHumaMethodField = regexp.MustCompile(
+		`Method\s*:\s*(?:http\.Method(\w+)|"([A-Za-z]+)")`,
+	)
+	// Path field of an Operation literal: Path: "/users/{id}".
+	reHumaPathField = regexp.MustCompile(`Path\s*:\s*"([^"]+)"`)
+)
+
+// humaVerb resolves the HTTP verb from a Method-field match, normalising both
+// the http.Method<Verb> constant form and the bare string-literal form.
+func humaVerb(src string, m []int) string {
+	if v := submatch(src, m, 2); v != "" { // http.MethodGet -> GET
+		return strings.ToUpper(v)
+	}
+	if v := submatch(src, m, 4); v != "" { // "POST"
+		return strings.ToUpper(v)
+	}
+	return ""
+}
+
+func (e *humaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.huma_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "huma"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !strings.Contains(src, "danielgtaylor/huma") && !strings.Contains(src, "huma.Register") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, loc := range reHumaRegisterHead.FindAllStringIndex(src, -1) {
+		open := loc[1] - 1 // index of the '(' that reHumaRegisterHead ends at
+		args, end := balancedArgs(src, open)
+		if end < 0 {
+			continue // unbalanced; skip
+		}
+		parts := splitTopLevelArgs(args)
+		if len(parts) < 3 {
+			continue // need (api, Operation{...}, handler)
+		}
+		opLit := parts[1]
+		handler := strings.TrimSpace(parts[len(parts)-1])
+
+		verb := humaVerb(opLit, reHumaMethodField.FindStringSubmatchIndex(opLit))
+		pathM := reHumaPathField.FindStringSubmatch(opLit)
+		if verb == "" || pathM == nil {
+			continue // incomplete Operation — would fail at huma runtime too
+		}
+		path := pathM[1]
+		line := lineOf(src, loc[0])
+
+		name := verb + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, line)
+		setProps(&ent, "framework", "huma", "provenance", "INFERRED_FROM_HUMA_OPERATION",
+			"http_method", verb, "route_path", path)
+		if handler != "" {
+			ent.Properties["handler"] = handler
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// balancedArgs returns the argument text between the paren at index open and
+// its matching close paren, plus the index of that close paren. Quoted strings
+// are skipped so parens inside string literals do not affect the depth count.
+// Returns ("", -1) when the parens are unbalanced.
+func balancedArgs(src string, open int) (string, int) {
+	depth := 0
+	var quote rune
+	for i := open; i < len(src); i++ {
+		r := rune(src[i])
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '"', '\'', '`':
+			quote = r
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(src[open+1 : i]), i
+			}
+		}
+	}
+	return "", -1
+}

--- a/internal/custom/golang/testdata/hertz_routes.go
+++ b/internal/custom/golang/testdata/hertz_routes.go
@@ -1,0 +1,43 @@
+// Hertz routing fixture (CloudWeGo). Exercises engine creation, verb routes,
+// nested route groups with prefix resolution, middleware, static mounts, and a
+// NoRoute error handler — covering endpoint synthesis + handler attribution.
+package hertzfixture
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+)
+
+func register() {
+	h := server.Default()
+
+	h.Use(RecoveryMiddleware)
+
+	h.GET("/", indexHandler)
+	h.POST("/login", loginHandler)
+
+	api := h.Group("/api/v1")
+	api.Use(JWTAuth())
+	api.GET("/users", listUsers)
+	api.POST("/users", createUser)
+	api.DELETE("/users/:id", deleteUser)
+
+	admin := api.Group("/admin")
+	admin.GET("/stats", adminStats)
+
+	h.Static("/assets", "./static")
+
+	h.NoRoute(notFoundHandler)
+
+	h.Spin()
+}
+
+func indexHandler(ctx context.Context, c *app.RequestContext)    {}
+func loginHandler(ctx context.Context, c *app.RequestContext)    {}
+func listUsers(ctx context.Context, c *app.RequestContext)       {}
+func createUser(ctx context.Context, c *app.RequestContext)      {}
+func deleteUser(ctx context.Context, c *app.RequestContext)      {}
+func adminStats(ctx context.Context, c *app.RequestContext)      {}
+func notFoundHandler(ctx context.Context, c *app.RequestContext) {}

--- a/internal/custom/golang/testdata/huma_routes.go
+++ b/internal/custom/golang/testdata/huma_routes.go
@@ -1,0 +1,66 @@
+// Huma routing fixture (OpenAPI-first). huma.Register binds an Operation
+// (carrying Method + Path) to a handler passed as the final argument —
+// covering endpoint synthesis + handler attribution. Exercises both the
+// http.Method* constant form and the bare string-literal verb form.
+package humafixture
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type GetUserInput struct {
+	ID string `path:"id"`
+}
+
+type GetUserOutput struct {
+	Body struct {
+		ID string `json:"id"`
+	}
+}
+
+type CreateUserInput struct {
+	Body struct {
+		Name string `json:"name"`
+	}
+}
+
+type CreateUserOutput struct {
+	Body struct {
+		ID string `json:"id"`
+	}
+}
+
+func register(api huma.API) {
+	huma.Register(api, huma.Operation{
+		Method:  http.MethodGet,
+		Path:    "/users/{id}",
+		Summary: "Get user by id",
+	}, getUser)
+
+	huma.Register(api, huma.Operation{
+		Method:  "POST",
+		Path:    "/users",
+		Summary: "Create user",
+	}, createUser)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "deleteUser",
+		Method:      http.MethodDelete,
+		Path:        "/users/{id}",
+	}, deleteUser)
+}
+
+func getUser(ctx context.Context, in *GetUserInput) (*GetUserOutput, error) {
+	return &GetUserOutput{}, nil
+}
+
+func createUser(ctx context.Context, in *CreateUserInput) (*CreateUserOutput, error) {
+	return &CreateUserOutput{}, nil
+}
+
+func deleteUser(ctx context.Context, in *GetUserInput) (*struct{}, error) {
+	return nil, nil
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3493,6 +3493,72 @@ records:
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
 
+  lang.go.framework.hertz:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          # hertz.go custom extractor (CloudWeGo): reHertzEngine seeds the
+          # *server.Hertz service from server.Default()/server.New(); reHertzRoute
+          # captures h.GET/POST/… verb methods; reHertzGroup records h.Group
+          # prefixes (nested prefixes resolved transitively); reHertzStatic emits
+          # Static/StaticFS/StaticFile mounts as GET endpoints. hertz.yaml provides
+          # detection markers only.
+          status: full
+          symbols:
+            - file: internal/custom/golang/hertz.go
+              functions: [Extract]
+            - file: internal/engine/rules/go/frameworks/hertz.yaml
+          tests:
+            - file: internal/custom/golang/hertz_huma_test.go
+          issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          # hertz.go binds the trailing identifier/selector argument of each verb
+          # call as the endpoint handler, skipping any inline middleware args.
+          # Heuristic regex resolution, fixture-proven.
+          status: full
+          symbols:
+            - file: internal/custom/golang/hertz.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/hertz_huma_test.go
+          issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+
+  lang.go.framework.huma:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          # huma is OpenAPI-first: routes are declared via huma.Register(api,
+          # huma.Operation{Method, Path, …}, handler). The shared go_trio engine
+          # synthesizes http_endpoint definitions; huma.go adds a dedicated
+          # SCOPE-entity extractor that scans balanced huma.Register(...) calls,
+          # parses the Operation literal's Method (http.Method* const or string
+          # literal) + Path, and emits an endpoint per registration.
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_go_trio.go
+              functions: [synthesizeHuma, humaVerbFromBody]
+            - file: internal/custom/golang/huma.go
+              functions: [Extract, humaVerb, balancedArgs]
+          tests:
+            - file: internal/custom/golang/hertz_huma_test.go
+          issues_implemented: ["2686", "3212"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          # The final argument of huma.Register is the handler; both the engine
+          # synthesis pass and huma.go attribute it to the synthesized endpoint.
+          status: full
+          symbols:
+            - file: internal/engine/http_endpoint_go_trio.go
+              functions: [synthesizeHuma]
+            - file: internal/custom/golang/huma.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/hertz_huma_test.go
+          issues_implemented: ["2686", "3212"]
+          verified_at: "2026-05-30"
+
   lang.java.framework.spring-webflux:
     capabilities:
       Observability:


### PR DESCRIPTION
Part of #3212 — Cluster 1 Routing slice: the **hertz** + **huma** frameworks, each as its own new Go custom extractor. Capabilities: **endpoint_synthesis + handler_attribution**.

## What landed

### `internal/custom/golang/hertz.go` (new)
CloudWeGo Hertz, gin-style routing surface:
- `server.Default()` / `server.New(...)` engine → `SCOPE.Service`
- `h.GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS/Any("/path", ..., handler)` verb routes → `SCOPE.Operation/endpoint`, with **trailing-argument handler attribution** (skips inline middleware args)
- `h.Group("/prefix")` route groups → `SCOPE.Component`, with **nested prefix resolution**
- `Static/StaticFS/StaticFile` mounts → GET endpoints
- `.Use(...)` middleware via the shared balanced-paren detector (+ auth classification)
- `NoRoute/NoMethod` error handlers → `SCOPE.Pattern`

### `internal/custom/golang/huma.go` (new)
Huma (OpenAPI-first). Scans balanced `huma.Register(api, huma.Operation{Method, Path, ...}, handler)` calls:
- resolves the verb from `http.Method*` constants **or** bare string literals
- emits an endpoint per registration and attributes the **final argument** as handler
- skips incomplete Operations (missing Method/Path) — they would fail at huma runtime too
- v1 + v2 both supported

This complements the existing `go_trio` engine synthesis (#2686) with a dedicated per-framework SCOPE-entity path, matching the gin/echo/fiber custom-extractor model.

## Isolation / contention
- New files only. `helpers.go`, `go_routes.go`, and other extractors untouched.
- Dispatch is automatic via the `custom_go_` registry prefix (`init()` registration).
- `framework.{hertz,huma}.routing` capability-map cells added as their own entries (no duplicate keys).

## Honesty
- **hertz: `partial` → `full`** for both endpoint_synthesis and handler_attribution — proven by golden fixture `testdata/hertz_routes.go` (engine, verb routes, nested groups, static, error handler) with per-endpoint handler assertions.
- **huma: stays `full`** (already full via the engine, #2686); the new extractor is added as an additional cite, proven by golden fixture `testdata/huma_routes.go` (both verb forms + handler attribution).

## Validation (scoped)
- `go build ./internal/... ./tools/coverage/...` — clean
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` — pass
- `go vet ./internal/custom/golang/...` — clean
- `go run ./tools/coverage validate` — exit 0 (pre-existing warnings only)
- `go run ./tools/coverage fmt --check` — canonical
- `go run ./tools/coverage gen` — byte-stable
- `gofmt -l` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)