### PR TITLE
feat(coverage): Go mongodb + redis data-access extractors (Part of #3214)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -48,12 +48,12 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 2/8 | |
 | [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🔴 0/8 | |
 | [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟡 1/6 | |
-| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | 🟡 1/6 | |
+| [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | 🟢 2/2 | |
 | [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 1/6 | |
 | [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 1/6 | |
 | [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/6 | |
 | [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟢 4/4 | |
-| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 1/6 | |
+| [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟢 3/3 | |
 | [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 1/6 | |
 | [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟢 4/4 | |
 | [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 3/8 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -83,12 +83,12 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 2/8 | |
 | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🔴 0/8 | |
 | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟡 1/6 | |
-| [go-redis](../detail/lang.go.driver.redis.md) | 🟡 1/6 | |
+| [go-redis](../detail/lang.go.driver.redis.md) | 🟢 2/2 | |
 | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 1/6 | |
 | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 1/6 | |
 | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/6 | |
 | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟢 4/4 | |
-| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟡 1/6 | |
+| [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟢 3/3 | |
 | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 1/6 | |
 | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟢 4/4 | |
 | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟡 3/8 | |

--- a/docs/coverage/detail/lang.go.driver.mongodb.md
+++ b/docs/coverage/detail/lang.go.driver.mongodb.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/mongo_driver.go`<br>`internal/custom/golang/mongo_redis_test.go` | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/mongo_driver.go`<br>`internal/custom/golang/mongo_redis_test.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | — |
+| Foreign key extraction | — `not_applicable` | — | — | — | — |
+| Lazy loading recognition | — `not_applicable` | — | — | — | — |
+| Relationship extraction | — `not_applicable` | — | — | — | — |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/mongo_driver.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/mongo_driver.go`<br>`internal/custom/golang/mongo_redis_test.go`<br>`internal/engine/rules/go/orms/mongo_driver.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.go.driver.redis.md
+++ b/docs/coverage/detail/lang.go.driver.redis.md
@@ -16,22 +16,22 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/mongo_redis_test.go`<br>`internal/custom/golang/redis_driver.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | — |
+| Foreign key extraction | — `not_applicable` | — | — | — | — |
+| Lazy loading recognition | — `not_applicable` | — | — | — | — |
+| Relationship extraction | — `not_applicable` | — | — | — | — |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/go_redis.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | 3214 | `internal/custom/golang/mongo_redis_test.go`<br>`internal/custom/golang/redis_driver.go`<br>`internal/engine/rules/go/orms/go_redis.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10421,36 +10421,38 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "not_applicable"
+            "status": "partial",
+            "cites": ["internal/custom/golang/mongo_driver.go","internal/custom/golang/mongo_redis_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/mongo_driver.go","internal/custom/golang/mongo_redis_test.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/mongo_driver.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/mongo_driver.go","internal/custom/golang/mongo_redis_test.go","internal/engine/rules/go/orms/mongo_driver.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
@@ -10568,33 +10570,32 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/mongo_redis_test.go","internal/custom/golang/redis_driver.go"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable"
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/go_redis.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/mongo_redis_test.go","internal/custom/golang/redis_driver.go","internal/engine/rules/go/orms/go_redis.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {

--- a/internal/custom/golang/mongo_driver.go
+++ b/internal/custom/golang/mongo_driver.go
@@ -1,0 +1,179 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// mongo_driver.go: schema-inference + query-DSL extractor for the official
+// MongoDB Go driver (go.mongodb.org/mongo-driver).
+//
+// MongoDB is schema-less, so the honest coverage shape is:
+//
+//   - Models / Schema — partial. A `client.Database(..).Collection("x")`
+//                    call site is recognised as a SCOPE.Schema collection,
+//                    and Go structs carrying `bson:"field"` tags are
+//                    recognised as document shapes with their fields
+//                    enumerated. A `bson:` tag is a heuristic (it does not
+//                    prove the struct maps to a collection) and a collection
+//                    has no enforced schema, hence partial not full.
+//   - Queries      — partial. Collection method call sites
+//                    (Find/FindOne/InsertOne/InsertMany/UpdateOne/UpdateMany/
+//                    DeleteOne/DeleteMany/Aggregate/CountDocuments/...) are
+//                    captured with the operation verb. Binding a query to a
+//                    concrete collection variable from a regex is not
+//                    reliable, so this stays partial.
+//   - Relationships— honesty-NA. MongoDB has no relational layer; references
+//                    between documents are an application convention, not a
+//                    driver concept. Recorded as not_applicable in the
+//                    registry (no code claim).
+//   - Migrations   — honesty-NA. The driver ships no migration runner and
+//                    collections are created lazily on first write.
+//
+// The extractor gates on the mongo-driver import actually being present in
+// the file, so a file that merely mentions "bson" without the driver is not
+// poached.
+
+func init() {
+	extractor.Register("custom_go_mongo_driver", &mongoDriverExtractor{})
+}
+
+type mongoDriverExtractor struct{}
+
+func (e *mongoDriverExtractor) Language() string { return "custom_go_mongo_driver" }
+
+var (
+	// Import marker for the official MongoDB Go driver. Presence gates the
+	// whole extractor. Matches the mongo package and its bson/options subpkgs.
+	reImportMongo = regexp.MustCompile(`"go\.mongodb\.org/mongo-driver(?:/v\d+)?/(?:mongo|bson)`)
+
+	// .Collection("name") — names a collection => a SCOPE.Schema entity.
+	// Only a string-literal argument is captured (a variable name is not a
+	// stable collection identity).
+	reMongoCollection = regexp.MustCompile(`\.Collection\(\s*"([^"]+)"`)
+
+	// A struct field carrying a `bson:"field"` tag.
+	//   ID   primitive.ObjectID `bson:"_id"`
+	//   Name string             `bson:"name"`
+	reBSONField = regexp.MustCompile("(?m)^\\s*(\\w+)\\s+([\\w\\.\\[\\]\\*]+)\\s+`[^`]*\\bbson:\"([^\"]*)\"[^`]*`")
+
+	// Collection query method call sites. The verb is captured so query_type
+	// can be stamped. Ordered longest-first within alternations is not needed
+	// because Go's regexp is leftmost-longest for alternation? (RE2 is
+	// leftmost, not longest) — each alternative is anchored by the trailing
+	// `(`, so no prefix can shadow a longer verb here.
+	reMongoQueryCall = regexp.MustCompile(
+		`(?m)\.(FindOneAndUpdate|FindOneAndReplace|FindOneAndDelete|InsertMany|InsertOne|UpdateMany|UpdateByID|UpdateOne|ReplaceOne|DeleteMany|DeleteOne|CountDocuments|EstimatedDocumentCount|Distinct|Aggregate|BulkWrite|FindOne|Find)\s*\(`,
+	)
+)
+
+func (e *mongoDriverExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.mongo_driver_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "mongodb"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "go" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reImportMongo.MatchString(src) {
+		// No mongo-driver import: not our file.
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Schema: .Collection("name") call sites => collections.
+	for _, m := range reMongoCollection.FindAllStringSubmatchIndex(src, -1) {
+		coll := src[m[2]:m[3]]
+		ent := makeEntity("collection:"+coll, "SCOPE.Schema", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "mongodb", "provenance", "INFERRED_FROM_MONGO_COLLECTION",
+			"collection_name", coll)
+		add(ent)
+	}
+
+	// 2. Models / Schema: structs with `bson:"field"` field tags.
+	for _, sm := range reDBStruct.FindAllStringSubmatchIndex(src, -1) {
+		structName := src[sm[2]:sm[3]]
+		body := src[sm[4]:sm[5]]
+		structLine := lineOf(src, sm[0])
+		fields := reBSONField.FindAllStringSubmatch(body, -1)
+		if len(fields) == 0 {
+			continue
+		}
+		ent := makeEntity(structName, "SCOPE.Schema", "", file.Path, file.Language, structLine)
+		setProps(&ent, "framework", "mongodb", "provenance", "INFERRED_FROM_BSON_STRUCT_TAGS")
+		add(ent)
+
+		for _, fm := range fields {
+			fieldName := fm[1]
+			fieldType := fm[2]
+			field := strings.TrimSpace(fm[3])
+			// "-" means "omit this field"; skip it.
+			if field == "" || field == "-" {
+				continue
+			}
+			// Strip option suffixes such as `bson:"name,omitempty"`.
+			if i := strings.IndexByte(field, ','); i >= 0 {
+				field = field[:i]
+			}
+			fieldEnt := makeEntity("field:"+structName+"."+fieldName, "SCOPE.Component", "field", file.Path, file.Language, structLine)
+			setProps(&fieldEnt, "framework", "mongodb", "provenance", "INFERRED_FROM_BSON_STRUCT_TAGS",
+				"model_name", structName, "field_name", fieldName, "bson_field", field, "go_type", fieldType)
+			add(fieldEnt)
+		}
+	}
+
+	// 3. Queries: collection method call sites. Heuristic — captures the verb
+	//    but cannot bind to a concrete collection from a regex.
+	for _, m := range reMongoQueryCall.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		ent := makeEntity("mongo:"+verb+":"+lineToken(src, m[0]), "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "mongodb", "provenance", "INFERRED_FROM_MONGO_CALL",
+			"query_type", mongoVerbKind(verb), "call_verb", verb)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// mongoVerbKind classifies a collection method into a coarse CRUD verb so the
+// query_type property is comparable with the SQL-driver extractor's verbs.
+func mongoVerbKind(verb string) string {
+	switch {
+	case strings.HasPrefix(verb, "Insert"):
+		return "insert"
+	case strings.HasPrefix(verb, "Update"), verb == "ReplaceOne", verb == "FindOneAndUpdate", verb == "FindOneAndReplace", verb == "BulkWrite":
+		return "update"
+	case strings.HasPrefix(verb, "Delete"), verb == "FindOneAndDelete":
+		return "delete"
+	default:
+		// Find/FindOne/Aggregate/CountDocuments/Distinct/... are reads.
+		return "select"
+	}
+}

--- a/internal/custom/golang/mongo_redis_test.go
+++ b/internal/custom/golang/mongo_redis_test.go
@@ -1,0 +1,120 @@
+package golang_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+func extractWith(t *testing.T, lang string, file extreg.FileInput) []entitySummary {
+	t.Helper()
+	e, ok := extreg.Get(lang)
+	if !ok {
+		t.Fatalf("%s not registered", lang)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	out := make([]entitySummary, 0, len(ents))
+	for _, ent := range ents {
+		out = append(out, entitySummary{Kind: ent.Kind, Subtype: ent.Subtype, Name: ent.Name})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// mongodb: collection schema + bson struct fields + query DSL verbs.
+// ---------------------------------------------------------------------------
+
+func TestMongoCollectionsModelsAndQueries(t *testing.T) {
+	ents := extractWith(t, "custom_go_mongo_driver", fixtureInput(t, "mongo_store.go", "go"))
+
+	// Schema: .Collection("x") call sites => collections.
+	if !containsEntity(ents, "SCOPE.Schema", "collection:users") {
+		t.Error("expected users collection schema")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "collection:orders") {
+		t.Error("expected orders collection schema")
+	}
+
+	// Models: structs with bson tags are document shapes.
+	if !containsEntity(ents, "SCOPE.Schema", "User") {
+		t.Error("expected User schema from bson tags")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "Order") {
+		t.Error("expected Order schema from bson tags")
+	}
+	// Schema fields.
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:User.Name") {
+		t.Error("expected User.Name field component")
+	}
+	// bson:"email,omitempty" -> field email (option stripped, still emitted).
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:User.Email") {
+		t.Error("expected User.Email field component")
+	}
+	// bson:"-" must NOT produce a field.
+	if hasSubtype(ents, "SCOPE.Component", "field", "field:User.Skip") {
+		t.Error("did not expect User.Skip field (bson:\"-\")")
+	}
+
+	// Queries: at least one query operation from the collection method calls.
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected at least one mongo query operation")
+	}
+}
+
+// A Go file without the mongo-driver import yields nothing (import gate).
+func TestMongoImportGate(t *testing.T) {
+	src := `package x
+
+type Doc struct {
+	ID string ` + "`bson:\"_id\"`" + `
+}
+
+func run() { _ = ".Collection(\"users\")" }
+`
+	file := extreg.FileInput{Path: "no_mongo.go", Language: "go", Content: []byte(src)}
+	ents := extractWith(t, "custom_go_mongo_driver", file)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without mongo import, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// redis: coarse key-pattern keyspaces + command DSL verbs.
+// ---------------------------------------------------------------------------
+
+func TestRedisKeyspacesAndCommands(t *testing.T) {
+	ents := extractWith(t, "custom_go_redis_driver", fixtureInput(t, "redis_cache.go", "go"))
+
+	// Coarse schema: namespaced key patterns => keyspaces by prefix.
+	if !containsEntity(ents, "SCOPE.Schema", "keyspace:user") {
+		t.Error("expected user keyspace from key pattern")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "keyspace:session") {
+		t.Error("expected session keyspace from key pattern")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "keyspace:cache") {
+		t.Error("expected cache keyspace from key pattern")
+	}
+
+	// Queries: command call sites => query operations.
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected at least one redis query operation")
+	}
+}
+
+// A Go file without the go-redis import yields nothing (import gate).
+func TestRedisImportGate(t *testing.T) {
+	src := `package x
+
+func run() { _ = "user:1" }
+`
+	file := extreg.FileInput{Path: "no_redis.go", Language: "go", Content: []byte(src)}
+	ents := extractWith(t, "custom_go_redis_driver", file)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without redis import, got %d", len(ents))
+	}
+}

--- a/internal/custom/golang/redis_driver.go
+++ b/internal/custom/golang/redis_driver.go
@@ -1,0 +1,141 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// redis_driver.go: coarse key-schema + command-DSL extractor for the go-redis
+// client (github.com/redis/go-redis, formerly github.com/go-redis/redis).
+//
+// Redis is a schema-less key/value store, so the honest coverage shape is:
+//
+//   - Models / Schema — partial. Redis has no declared schema, but key naming
+//                    conventions encode a coarse one: a string literal that
+//                    looks like a namespaced key pattern ("user:%d",
+//                    "session:{id}", "cache:user:profile") is surfaced as a
+//                    SCOPE.Schema keyspace whose prefix is the logical "type".
+//                    This is purely heuristic (a key pattern is a convention,
+//                    not an enforced schema), hence partial.
+//   - Queries      — partial. Command call sites (Get/Set/HSet/HGet/LPush/
+//                    SAdd/Incr/Expire/Del/...) are captured with the command
+//                    verb. Binding a command to a concrete key from a regex is
+//                    not reliable, so this stays partial.
+//   - Relationships— honesty-NA. Redis has no relational layer. Recorded as
+//                    not_applicable in the registry (no code claim).
+//   - Migrations   — honesty-NA. Redis has no schema and no migration concept.
+//
+// The extractor gates on the go-redis import actually being present, so a
+// file that merely mentions "redis" without the client is not poached.
+
+func init() {
+	extractor.Register("custom_go_redis_driver", &redisDriverExtractor{})
+}
+
+type redisDriverExtractor struct{}
+
+func (e *redisDriverExtractor) Language() string { return "custom_go_redis_driver" }
+
+var (
+	// Import marker for go-redis (current and legacy import paths).
+	reImportRedis = regexp.MustCompile(`"github\.com/(?:redis/go-redis|go-redis/redis)(?:/v\d+)?(?:/redis)?"`)
+
+	// A namespaced key pattern string literal: one or more ":"-separated
+	// segments where the first segment is a plain identifier. The capture is
+	// the full literal; the logical type is its leading segment.
+	//   "user:%d"  "session:{id}"  "cache:user:profile"
+	reRedisKeyPattern = regexp.MustCompile(`"([A-Za-z_][A-Za-z0-9_]*:[^"]+)"`)
+
+	// go-redis command call sites. The verb is captured so query_type can be
+	// stamped. Covers the common string/hash/list/set/key-mgmt surface.
+	reRedisCommand = regexp.MustCompile(
+		`(?m)\.(GetSet|GetEx|GetDel|Get|SetNX|SetEX|SetXX|Set|MGet|MSet|Append|Incr|IncrBy|Decr|DecrBy|HGetAll|HMGet|HMSet|HGet|HSet|HSetNX|HDel|HExists|LPush|RPush|LPop|RPop|LRange|LLen|SAdd|SRem|SMembers|SIsMember|ZAdd|ZRange|ZScore|ZRem|Expire|ExpireAt|TTL|Persist|Exists|Del|Unlink|Type|Keys|Scan)\s*\(`,
+	)
+)
+
+func (e *redisDriverExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.redis_driver_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "redis"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "go" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reImportRedis.MatchString(src) {
+		// No go-redis import: not our file.
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Coarse schema: namespaced key-pattern literals => keyspaces, keyed by
+	//    the leading prefix segment (the logical "type"). Dedup by prefix so a
+	//    keyspace appears once even when many patterns share it.
+	for _, m := range reRedisKeyPattern.FindAllStringSubmatchIndex(src, -1) {
+		pattern := src[m[2]:m[3]]
+		prefix := pattern[:strings.IndexByte(pattern, ':')]
+		ent := makeEntity("keyspace:"+prefix, "SCOPE.Schema", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "redis", "provenance", "INFERRED_FROM_REDIS_KEY_PATTERN",
+			"keyspace_prefix", prefix, "key_pattern", pattern)
+		add(ent)
+	}
+
+	// 2. Queries: command call sites. Heuristic — captures the command verb
+	//    but cannot bind to a concrete key from a regex.
+	for _, m := range reRedisCommand.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		ent := makeEntity("redis:"+verb+":"+lineToken(src, m[0]), "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "redis", "provenance", "INFERRED_FROM_REDIS_COMMAND",
+			"query_type", redisVerbKind(verb), "call_verb", verb)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// redisVerbKind classifies a go-redis command into a coarse read/write verb so
+// the query_type property is comparable across the data-access extractors.
+func redisVerbKind(verb string) string {
+	switch {
+	case strings.HasPrefix(verb, "Get"), strings.HasPrefix(verb, "MGet"),
+		strings.HasPrefix(verb, "HGet"), strings.HasPrefix(verb, "HMGet"),
+		strings.HasPrefix(verb, "LRange"), strings.HasPrefix(verb, "LLen"),
+		strings.HasPrefix(verb, "LPop"), strings.HasPrefix(verb, "RPop"),
+		strings.HasPrefix(verb, "SMembers"), strings.HasPrefix(verb, "SIsMember"),
+		strings.HasPrefix(verb, "ZRange"), strings.HasPrefix(verb, "ZScore"),
+		strings.HasPrefix(verb, "HExists"), verb == "Exists", verb == "TTL",
+		verb == "Type", verb == "Keys", verb == "Scan", verb == "HGetAll":
+		return "read"
+	case verb == "Del", verb == "Unlink", verb == "HDel", verb == "SRem", verb == "ZRem":
+		return "delete"
+	default:
+		// Set/HSet/LPush/SAdd/ZAdd/Incr/Expire/... are writes.
+		return "write"
+	}
+}

--- a/internal/custom/golang/testdata/mongo_store.go
+++ b/internal/custom/golang/testdata/mongo_store.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// User is a document shape mapped by bson tags.
+type User struct {
+	ID    string `bson:"_id"`
+	Name  string `bson:"name"`
+	Email string `bson:"email,omitempty"`
+	Skip  string `bson:"-"`
+}
+
+// Order is a second document shape.
+type Order struct {
+	ID     string  `bson:"_id"`
+	UserID string  `bson:"user_id"`
+	Total  float64 `bson:"total"`
+}
+
+func usersColl(c *mongo.Client) *mongo.Collection {
+	return c.Database("shop").Collection("users")
+}
+
+func ordersColl(c *mongo.Client) *mongo.Collection {
+	return c.Database("shop").Collection("orders")
+}
+
+func run(ctx context.Context, c *mongo.Client) error {
+	users := usersColl(c)
+	orders := ordersColl(c)
+
+	_, err := users.InsertOne(ctx, User{ID: "1", Name: "Ada"})
+	if err != nil {
+		return err
+	}
+
+	var u User
+	_ = users.FindOne(ctx, bson.M{"name": "Ada"}).Decode(&u)
+
+	cur, err := orders.Find(ctx, bson.M{"user_id": "1"})
+	if err != nil {
+		return err
+	}
+	_ = cur
+
+	_, err = users.UpdateMany(ctx, bson.M{"name": "Ada"}, bson.M{"$set": bson.M{"email": "ada@x.io"}})
+	if err != nil {
+		return err
+	}
+
+	_, err = orders.DeleteOne(ctx, bson.M{"_id": "1"})
+	if err != nil {
+		return err
+	}
+
+	_, err = orders.Aggregate(ctx, mongo.Pipeline{}, options.Aggregate())
+	return err
+}

--- a/internal/custom/golang/testdata/redis_cache.go
+++ b/internal/custom/golang/testdata/redis_cache.go
@@ -1,0 +1,39 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func userKey(id int) string       { return fmt.Sprintf("user:%d", id) }
+func sessionKey(id string) string { return "session:" + id }
+
+func run(ctx context.Context, rdb *redis.Client) error {
+	// Namespaced key patterns => coarse keyspaces.
+	_ = "user:%d"
+	_ = "session:{id}"
+	_ = "cache:user:profile"
+
+	if err := rdb.Set(ctx, userKey(1), "Ada", 0).Err(); err != nil {
+		return err
+	}
+
+	if _, err := rdb.Get(ctx, userKey(1)).Result(); err != nil {
+		return err
+	}
+
+	if err := rdb.HSet(ctx, "session:abc", "uid", "1").Err(); err != nil {
+		return err
+	}
+
+	if _, err := rdb.HGetAll(ctx, sessionKey("abc")).Result(); err != nil {
+		return err
+	}
+
+	rdb.Incr(ctx, "cache:user:profile")
+	rdb.Expire(ctx, userKey(1), 0)
+	rdb.Del(ctx, userKey(1))
+	return nil
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3580,6 +3580,75 @@ records:
           issues_implemented: ["3214"]
           verified_at: "2026-05-30"
 
+  lang.go.driver.mongodb:
+    capabilities:
+      Models:
+        model_extraction:
+          # Structs with `bson:"field"` tags scanned as document shapes.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/mongo_driver.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/mongo_redis_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+        schema_extraction:
+          # client.Database(..).Collection("x") => collection schema +
+          # bson struct fields enumerated as columns.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/mongo_driver.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/mongo_redis_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # Find/FindOne/InsertOne/UpdateMany/DeleteOne/Aggregate/... call
+          # sites; mongoVerbKind stamps a coarse CRUD verb. Relationships +
+          # Migrations are honesty-NA (schema-less, no relation/migration layer).
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/mongo_driver.yaml
+            - file: internal/custom/golang/mongo_driver.go
+              functions: [Extract, mongoVerbKind]
+          tests:
+            - file: internal/custom/golang/mongo_redis_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
+  lang.go.driver.redis:
+    capabilities:
+      Models:
+        schema_extraction:
+          # Namespaced key-pattern literals ("user:%d", "session:{id}") =>
+          # coarse keyspaces keyed by leading prefix segment. model_extraction
+          # stays honesty-NA (key/value store has no model concept).
+          status: partial
+          symbols:
+            - file: internal/custom/golang/redis_driver.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/mongo_redis_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # Get/Set/HSet/HGetAll/Incr/Expire/Del/... command call sites;
+          # redisVerbKind stamps a coarse read/write/delete verb. Relationships
+          # + Migrations are honesty-NA (schema-less, no relation/migration layer).
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/go_redis.yaml
+            - file: internal/custom/golang/redis_driver.go
+              functions: [Extract, redisVerbKind]
+          tests:
+            - file: internal/custom/golang/mongo_redis_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
   lang.go.framework.net-http:
     capabilities:
       Routing:


### PR DESCRIPTION
Part of #3214 (Cluster 4 — ORM/Data Access). Implements the two schema-less Go drivers, each as its own new extractor file with dedicated tests and fixtures. No shared/file-local helpers (`helpers.go`, `gorm.go`, `sql_drivers.go`, `ent.go`, `bun.go`) were edited.

## mongodb — `internal/custom/golang/mongo_driver.go`
- **Schema:** `client.Database(..).Collection("x")` → `SCOPE.Schema` collections; `bson:"field"` struct tags → document shapes + field components (`,omitempty` stripped, `-` skipped).
- **Queries:** `Find/FindOne/InsertOne/InsertMany/UpdateOne/UpdateMany/DeleteOne/DeleteMany/Aggregate/CountDocuments/FindOneAndUpdate/...` call sites; `mongoVerbKind` stamps a coarse CRUD `query_type`.
- **Relationships + Migrations:** honesty-NA (no relational layer; schema-less; no migration runner).

## redis — `internal/custom/golang/redis_driver.go`
- **Schema (coarse):** namespaced key-pattern literals (`"user:%d"`, `"session:{id}"`, `"cache:user:profile"`) → `SCOPE.Schema` keyspaces keyed by leading prefix.
- **Queries:** `Get/Set/HSet/HGetAll/LPush/SAdd/ZAdd/Incr/Expire/Del/...` command call sites; `redisVerbKind` stamps a coarse read/write/delete `query_type`.
- **Relationships + Migrations:** honesty-NA (key/value store; schema-less). `model_extraction` also honesty-NA (no model concept).

Both extractors gate on the real driver import (`go.mongodb.org/mongo-driver`, `github.com/redis/go-redis`) so they never poach other files. Heuristic detection → `partial` (no fixture-proven `full`); previously-`missing` Relationship cells flipped to `not_applicable`. `capability-map.yaml` entries added for every flipped cell (each capability key exactly once).

## Registry status matrix (Part of #3214)
| Capability | mongodb | redis |
|---|---|---|
| Models / model_extraction | partial | NA |
| Models / schema_extraction | partial | partial |
| Relationships / association | NA | NA |
| Relationships / foreign_key | NA | NA |
| Relationships / lazy_loading | NA | NA |
| Relationships / relationship | NA | NA |
| Queries / query_attribution | partial | partial |
| Migrations / migration_parsing | NA | NA |

## Validation (scoped)
- `go build ./internal/... ./tools/coverage/...` — OK
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` — pass
- `go run ./tools/coverage validate` — exit 0, no errors, no duplicate-key errors
- `go run ./tools/coverage fmt --check` — canonical
- `go run ./tools/coverage gen` — byte-stable (idempotent across runs)
- `gofmt -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)