### PR TITLE
feat(coverage): Go fyne + gomobile extractors (Cluster 7, #3218)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -190,7 +190,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 |---|---|---|---|---|---|---|
 | [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/9 | |
 | [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/9 | |
-| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🔴 0/3 | 🔴 0/1 | 🟡 3/21 | 🔴 0/9 | |
+| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🔴 0/3 | 🔴 0/1 | 🟡 3/21 | 🟡 3/4 | |
 | [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
 | [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 13/13 | |
@@ -210,7 +210,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | 🟡 7/10 | 🔴 0/3 | |
 | [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | 🟡 7/10 | 🔴 0/3 | |
 | [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | 🟡 7/10 | 🔴 0/3 | |
-| [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | 🔴 0/10 | 🔴 0/3 | |
+| [go](../by-language/go.md) | [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | 🔴 0/10 | 🟢 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | 🟢 10/10 | ✅ 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | 🟡 7/10 | 🔴 0/3 | |
 | [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | 🟡 7/10 | 🔴 0/3 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -47,14 +47,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🔴 0/3 | 🔴 0/1 | 🟡 3/21 | 🔴 0/9 | |
+| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🔴 0/3 | 🔴 0/1 | 🟡 3/21 | 🟡 3/4 | |
 
 
 ### Desktop
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | 🔴 0/10 | 🔴 0/3 | |
+| [Fyne (desktop GUI)](../detail/lang.go.framework.fyne.md) | 🔴 0/10 | 🟢 1/1 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.go.framework.fyne.md
+++ b/docs/coverage/detail/lang.go.framework.fyne.md
@@ -15,14 +15,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| IPC extraction | 🔴 `missing` | — | — | — | — |
-| Main renderer split | 🔴 `missing` | — | — | — | — |
+| IPC extraction | — `not_applicable` | — | — | — | — |
+| Main renderer split | — `not_applicable` | — | — | — | — |
 
 ### Native
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Native module imports | 🔴 `missing` | — | — | — | — |
+| Native module imports | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3218) | `internal/custom/golang/fyne.go`<br>`internal/custom/golang/fyne_gomobile_test.go` | — |
 
 ### Updates
 

--- a/docs/coverage/detail/lang.go.framework.gomobile.md
+++ b/docs/coverage/detail/lang.go.framework.gomobile.md
@@ -15,34 +15,34 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Context extraction | 🔴 `missing` | — | — | — | — |
+| Context extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3218) | `internal/custom/golang/fyne_gomobile_test.go`<br>`internal/custom/golang/gomobile.go` | — |
 
 ### Navigation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Deep link extraction | 🔴 `missing` | — | — | — | — |
-| Navigation extraction | 🔴 `missing` | — | — | — | — |
-| Screen detection | 🔴 `missing` | — | — | — | — |
+| Deep link extraction | — `not_applicable` | — | — | — | — |
+| Navigation extraction | — `not_applicable` | — | — | — | — |
+| Screen detection | — `not_applicable` | — | — | — | — |
 
 ### Platform
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Platform branching | 🔴 `missing` | — | — | — | — |
+| Platform branching | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3218) | `internal/custom/golang/fyne_gomobile_test.go`<br>`internal/custom/golang/gomobile.go` | — |
 
 ### Native Bridge
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Native module imports | 🔴 `missing` | — | — | — | — |
+| Native module imports | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3218) | `internal/custom/golang/fyne_gomobile_test.go`<br>`internal/custom/golang/gomobile.go` | — |
 
 ### Data Flow
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Branch conditions | 🔴 `missing` | — | — | — | — |
-| State management | 🔴 `missing` | — | — | — | — |
+| State management | — `not_applicable` | — | — | — | — |
 
 ### Type System
 
@@ -56,7 +56,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| State setter emission | 🔴 `missing` | — | — | — | — |
+| State setter emission | — `not_applicable` | — | — | — | — |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -11755,15 +11755,18 @@
       "capabilities": {
         "Process": {
           "ipc_extraction": {
-            "status": "missing"
+            "status": "not_applicable"
           },
           "main_renderer_split": {
-            "status": "missing"
+            "status": "not_applicable"
           }
         },
         "Native": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/fyne.go","internal/custom/golang/fyne_gomobile_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3218",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -12194,28 +12197,37 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/fyne_gomobile_test.go","internal/custom/golang/gomobile.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3218",
+            "verified_at": "2026-05-30"
           }
         },
         "Navigation": {
           "deep_link_extraction": {
-            "status": "missing"
+            "status": "not_applicable"
           },
           "navigation_extraction": {
-            "status": "missing"
+            "status": "not_applicable"
           },
           "screen_detection": {
-            "status": "missing"
+            "status": "not_applicable"
           }
         },
         "Platform": {
           "platform_branching": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/fyne_gomobile_test.go","internal/custom/golang/gomobile.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3218",
+            "verified_at": "2026-05-30"
           }
         },
         "Native Bridge": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/fyne_gomobile_test.go","internal/custom/golang/gomobile.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3218",
+            "verified_at": "2026-05-30"
           }
         },
         "Data Flow": {
@@ -12223,7 +12235,7 @@
             "status": "missing"
           },
           "state_management": {
-            "status": "missing"
+            "status": "not_applicable"
           }
         },
         "Type System": {
@@ -12239,7 +12251,7 @@
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing"
+            "status": "not_applicable"
           }
         },
         "Testing": {

--- a/internal/custom/golang/fyne.go
+++ b/internal/custom/golang/fyne.go
@@ -1,0 +1,189 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// fyne.go — a heuristic extractor for the Fyne desktop-GUI toolkit
+// (fyne.io/fyne/v2), issue #3218 cluster 7 (Desktop & Mobile).
+//
+// Fyne is a single-process, non-HTTP desktop/mobile GUI toolkit. There is no
+// route table, no request/response cycle, and — unlike Electron — no
+// main/renderer process split or IPC channel. The structural surface that IS
+// statically resolvable from source text is the widget/window/event lifecycle:
+//
+//   - app          : the `app.New()` / `app.NewWithID(...)` application root
+//                    → SCOPE.Component (the GUI application object).
+//   - window       : `a.NewWindow("Title")` top-level windows
+//                    → SCOPE.UIComponent (subtype "window").
+//   - widget       : `widget.NewButton(...)`, `widget.NewLabel(...)`, etc.
+//                    construction → SCOPE.UIComponent (subtype "widget").
+//   - event        : event-handler wiring — `btn.OnTapped = ...`,
+//                    `widget.NewButton("x", func(){...})`, `entry.OnChanged`,
+//                    `w.SetOnClosed(...)` → SCOPE.Pattern (pattern_kind=event).
+//   - native_import: the fyne driver/native package imports that back the
+//                    GUI on the host platform → SCOPE.External
+//                    (the desktop `native_module_imports` capability surface).
+//
+// Honesty (registry coverage status, lang.go.framework.fyne):
+//
+//   - Process.ipc_extraction        → not_applicable: Fyne is single-process;
+//                                      there is no IPC channel to extract.
+//   - Process.main_renderer_split   → not_applicable: no main/renderer split
+//                                      (that is an Electron/Tauri concept).
+//   - Native.native_module_imports  → partial: we detect fyne driver/native
+//                                      package imports via a heuristic import
+//                                      match. We do NOT resolve cgo symbols or
+//                                      confirm a platform binding is reached.
+//
+// The widget/window/event entities are graph value (they populate the GUI
+// component tree) but the desktop subcategory has no dedicated capability cell
+// for them, so they do not flip a registry cell on their own.
+//
+// Attribution mirrors observability.go/validation.go: the scanner runs on
+// every Go file and only emits when a Fyne marker is present, stamping
+// framework=fyne on each entity. A file with no Fyne marker emits nothing.
+
+func init() {
+	extractor.Register("custom_go_fyne", &fyneExtractor{})
+}
+
+type fyneExtractor struct{}
+
+func (e *fyneExtractor) Language() string { return "custom_go_fyne" }
+
+var (
+	// reFyneMarker attributes a file to Fyne via an import path or a canonical
+	// package selector. Either the module import or an `app.`/`widget.` use of
+	// the toolkit qualifies.
+	reFyneMarker = regexp.MustCompile(`fyne\.io/fyne`)
+
+	// reFyneApp matches the application-root constructors.
+	//   a := app.New()
+	//   a := app.NewWithID("com.example.app")
+	reFyneApp = regexp.MustCompile(`(?m)(\w+)\s*:?=\s*app\.(New|NewWithID)\s*\(`)
+
+	// reFyneWindow matches top-level window construction.
+	//   w := a.NewWindow("Hello")
+	reFyneWindow = regexp.MustCompile(`(?m)(\w+)\s*:?=\s*\w+\.NewWindow\s*\(\s*"([^"]*)"`)
+
+	// reFyneWidget matches widget constructors: widget.NewButton, widget.NewLabel,
+	// widget.NewEntry, container.NewVBox, etc. Captures the constructor name.
+	reFyneWidget = regexp.MustCompile(`(?m)(?:widget|container|canvas)\.(New\w+)\s*\(`)
+
+	// reFyneEventField matches event-handler field assignments:
+	//   btn.OnTapped = func() { ... }
+	//   entry.OnChanged = handler
+	reFyneEventField = regexp.MustCompile(`(?m)(\w+)\.(On\w+)\s*=`)
+
+	// reFyneEventSetter matches event-handler setter methods:
+	//   w.SetOnClosed(func(){...})
+	//   w.SetCloseIntercept(...)
+	reFyneEventSetter = regexp.MustCompile(`(?m)\w+\.(SetOn\w+|SetCloseIntercept)\s*\(`)
+
+	// reFyneNativeImport matches the fyne driver/native packages that back the
+	// GUI on the host platform — the desktop native_module_imports surface.
+	reFyneNativeImport = regexp.MustCompile(
+		`fyne\.io/fyne(?:/v\d+)?/(driver(?:/[\w/]+)?|internal/driver[\w/]*|app)\b`)
+)
+
+func (e *fyneExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.fyne_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "fyne"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reFyneMarker.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. app.New()/app.NewWithID() — the GUI application root.
+	for _, m := range reFyneApp.FindAllStringSubmatchIndex(src, -1) {
+		varName := submatch(src, m, 2)
+		ctor := submatch(src, m, 4)
+		ent := makeEntity("fyne:app:"+varName, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fyne", "provenance", "INFERRED_FROM_FYNE_APP",
+			"fyne_kind", "app", "constructor", ctor)
+		add(ent)
+	}
+
+	// 2. NewWindow — top-level windows.
+	for _, m := range reFyneWindow.FindAllStringSubmatchIndex(src, -1) {
+		varName := submatch(src, m, 2)
+		title := submatch(src, m, 4)
+		ent := makeEntity("fyne:window:"+varName, "SCOPE.UIComponent", "window", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fyne", "provenance", "INFERRED_FROM_FYNE_WINDOW",
+			"fyne_kind", "window", "window_title", title)
+		add(ent)
+	}
+
+	// 3. widget/container/canvas constructors.
+	for _, m := range reFyneWidget.FindAllStringSubmatchIndex(src, -1) {
+		ctor := submatch(src, m, 2)
+		ent := makeEntity("fyne:widget:"+ctor, "SCOPE.UIComponent", "widget", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fyne", "provenance", "INFERRED_FROM_FYNE_WIDGET",
+			"fyne_kind", "widget", "constructor", ctor)
+		add(ent)
+	}
+
+	// 4. event-handler wiring — field assignments + setter methods.
+	for _, m := range reFyneEventField.FindAllStringSubmatchIndex(src, -1) {
+		recv := submatch(src, m, 2)
+		handler := submatch(src, m, 4)
+		ent := makeEntity("fyne:event:"+recv+"."+handler, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fyne", "provenance", "INFERRED_FROM_FYNE_EVENT",
+			"pattern_kind", "event", "event_name", handler, "receiver", recv)
+		add(ent)
+	}
+	for _, m := range reFyneEventSetter.FindAllStringSubmatchIndex(src, -1) {
+		handler := submatch(src, m, 2)
+		ent := makeEntity("fyne:event:"+handler, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fyne", "provenance", "INFERRED_FROM_FYNE_EVENT",
+			"pattern_kind", "event", "event_name", handler)
+		add(ent)
+	}
+
+	// 5. native driver/app package imports — the native_module_imports surface.
+	for _, m := range reFyneNativeImport.FindAllStringSubmatchIndex(src, -1) {
+		pkg := submatch(src, m, 0)
+		ent := makeEntity("fyne:native:"+pkg, "SCOPE.External", "native_import", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "fyne", "provenance", "INFERRED_FROM_FYNE_NATIVE_IMPORT",
+			"native_kind", "fyne_driver", "import_path", pkg)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/golang/fyne_gomobile_test.go
+++ b/internal/custom/golang/fyne_gomobile_test.go
@@ -1,0 +1,217 @@
+package golang_test
+
+import (
+	"testing"
+)
+
+// Tests for the fyne (desktop GUI) and gomobile (mobile bindings) extractors,
+// issue #3218 cluster 7 (Desktop & Mobile).
+
+// findByName returns the first entity with the given Kind and Name, or nil.
+func findByName(ents []fullEntity, kind, name string) *fullEntity {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// countWhere counts entities matching a predicate on properties.
+func countWhere(ents []fullEntity, pred func(fullEntity) bool) int {
+	n := 0
+	for _, e := range ents {
+		if pred(e) {
+			n++
+		}
+	}
+	return n
+}
+
+// ---------------------------------------------------------------------------
+// fyne
+// ---------------------------------------------------------------------------
+
+func TestFyneNoMarkerNoEmit(t *testing.T) {
+	src := `package main
+func main() {
+	a := app.New()
+	w := a.NewWindow("x")
+	_ = w
+}`
+	// No fyne.io import marker => the app./NewWindow tokens must NOT match.
+	ents := extractFull(t, "custom_go_fyne", fi("main.go", "go", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities without fyne marker, got %d: %+v", len(ents), ents)
+	}
+}
+
+func TestFyneNonGoNoEmit(t *testing.T) {
+	ents := extractFull(t, "custom_go_fyne", fi("main.py", "python", `import "fyne.io/fyne/v2"`))
+	if len(ents) != 0 {
+		t.Fatalf("non-go file should yield nothing, got %d", len(ents))
+	}
+}
+
+func TestFyneAppWindowWidgets(t *testing.T) {
+	ents := extractFull(t, "custom_go_fyne", fixtureFile(t, "fyne_app.go"))
+
+	if e := findByName(ents, "SCOPE.Component", "fyne:app:a"); e == nil {
+		t.Fatalf("expected app component fyne:app:a; got %+v", ents)
+	} else if e.Props["fyne_kind"] != "app" || e.Props["framework"] != "fyne" {
+		t.Fatalf("app props wrong: %+v", e.Props)
+	}
+
+	w := findByName(ents, "SCOPE.UIComponent", "fyne:window:w")
+	if w == nil {
+		t.Fatalf("expected window fyne:window:w")
+	}
+	if w.Props["window_title"] != "Hello Fyne" {
+		t.Fatalf("window title wrong: %q", w.Props["window_title"])
+	}
+
+	// widgets: Label, Entry, Button, and container VBox.
+	for _, ctor := range []string{"NewLabel", "NewEntry", "NewButton", "NewVBox"} {
+		if findByName(ents, "SCOPE.UIComponent", "fyne:widget:"+ctor) == nil {
+			t.Errorf("expected widget fyne:widget:%s", ctor)
+		}
+	}
+}
+
+func TestFyneEventHandlers(t *testing.T) {
+	ents := extractFull(t, "custom_go_fyne", fixtureFile(t, "fyne_app.go"))
+
+	if findByName(ents, "SCOPE.Pattern", "fyne:event:btn.OnTapped") == nil {
+		t.Errorf("expected event fyne:event:btn.OnTapped")
+	}
+	if findByName(ents, "SCOPE.Pattern", "fyne:event:entry.OnChanged") == nil {
+		t.Errorf("expected event fyne:event:entry.OnChanged")
+	}
+	// setter-style handler
+	if findByName(ents, "SCOPE.Pattern", "fyne:event:SetOnClosed") == nil {
+		t.Errorf("expected event fyne:event:SetOnClosed")
+	}
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Props["pattern_kind"] != "event" {
+			t.Errorf("fyne pattern entity has wrong pattern_kind: %+v", e.Props)
+		}
+	}
+}
+
+func TestFyneNativeImport(t *testing.T) {
+	// The fyne_app.go fixture imports fyne.io/fyne/v2/app — a native/driver
+	// package backing the GUI (the native_module_imports surface).
+	ents := extractFull(t, "custom_go_fyne", fixtureFile(t, "fyne_app.go"))
+	n := countWhere(ents, func(e fullEntity) bool {
+		return e.Kind == "SCOPE.External" && e.Props["native_kind"] == "fyne_driver"
+	})
+	if n == 0 {
+		t.Fatalf("expected at least one fyne native import entity; got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gomobile
+// ---------------------------------------------------------------------------
+
+func TestGomobileNoMarkerNoEmit(t *testing.T) {
+	src := `package main
+func main() {
+	app.Main(func(a app.App) {})
+}`
+	ents := extractFull(t, "custom_go_gomobile", fi("main.go", "go", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities without gomobile marker, got %d: %+v", len(ents), ents)
+	}
+}
+
+func TestGomobileNonGoNoEmit(t *testing.T) {
+	ents := extractFull(t, "custom_go_gomobile", fi("main.kt", "kotlin", `import golang.org/x/mobile`))
+	if len(ents) != 0 {
+		t.Fatalf("non-go file should yield nothing, got %d", len(ents))
+	}
+}
+
+func TestGomobileAppRoot(t *testing.T) {
+	ents := extractFull(t, "custom_go_gomobile", fixtureFile(t, "gomobile_app.go"))
+	e := findByName(ents, "SCOPE.Component", "gomobile:app:Main")
+	if e == nil {
+		t.Fatalf("expected gomobile:app:Main component; got %+v", ents)
+	}
+	if e.Props["gomobile_kind"] != "app_root" {
+		t.Fatalf("app root props wrong: %+v", e.Props)
+	}
+}
+
+func TestGomobilePlatformBranching(t *testing.T) {
+	ents := extractFull(t, "custom_go_gomobile", fixtureFile(t, "gomobile_app.go"))
+
+	// modern //go:build android || ios constraint
+	if e := findByName(ents, "SCOPE.Pattern", "gomobile:platform:go_build:android || ios"); e == nil {
+		t.Errorf("expected go_build platform branch; got %+v", ents)
+	} else if e.Props["pattern_kind"] != "platform_branch" {
+		t.Errorf("platform branch props wrong: %+v", e.Props)
+	}
+
+	// runtime.GOOS == "android" guard
+	if findByName(ents, "SCOPE.Pattern", "gomobile:platform:goos_guard:android") == nil {
+		t.Errorf("expected goos_guard platform branch for android")
+	}
+}
+
+func TestGomobilePlatformBranchIgnoresNonMobile(t *testing.T) {
+	src := `//go:build linux
+
+package x
+
+import "golang.org/x/mobile/app"
+
+func f() {
+	if runtime.GOOS == "windows" {
+	}
+}`
+	ents := extractFull(t, "custom_go_gomobile", fi("x.go", "go", src))
+	for _, e := range ents {
+		if e.Props["pattern_kind"] == "platform_branch" {
+			t.Errorf("non-mobile constraint should not emit platform branch: %+v", e)
+		}
+	}
+}
+
+func TestGomobileNativeImports(t *testing.T) {
+	ents := extractFull(t, "custom_go_gomobile", fixtureFile(t, "gomobile_app.go"))
+	n := countWhere(ents, func(e fullEntity) bool {
+		return e.Kind == "SCOPE.External" && e.Props["native_kind"] == "gomobile"
+	})
+	if n < 2 { // app, gl, event/lifecycle
+		t.Fatalf("expected >=2 gomobile native imports, got %d: %+v", n, ents)
+	}
+}
+
+func TestGomobileBoundFuncs(t *testing.T) {
+	ents := extractFull(t, "custom_go_gomobile", fixtureFile(t, "gomobile_bind.go"))
+
+	for _, fn := range []string{"Greet", "Add"} {
+		e := findByName(ents, "SCOPE.External", "gomobile:bound:"+fn)
+		if e == nil {
+			t.Errorf("expected bound func gomobile:bound:%s", fn)
+			continue
+		}
+		if e.Props["native_kind"] != "bound_func" {
+			t.Errorf("bound func props wrong: %+v", e.Props)
+		}
+	}
+	// unexported helper must NOT be a bound func
+	if findByName(ents, "SCOPE.External", "gomobile:bound:helper") != nil {
+		t.Errorf("unexported helper must not be emitted as bound func")
+	}
+}
+
+func TestGomobileBoundFuncsRequireBindImport(t *testing.T) {
+	// gomobile_app.go imports app/gl but NOT bind — exported funcs there must
+	// not be treated as bound FFI symbols.
+	ents := extractFull(t, "custom_go_gomobile", fixtureFile(t, "gomobile_app.go"))
+	if countWhere(ents, func(e fullEntity) bool { return e.Props["native_kind"] == "bound_func" }) != 0 {
+		t.Errorf("non-bind package should not emit bound funcs: %+v", ents)
+	}
+}

--- a/internal/custom/golang/gomobile.go
+++ b/internal/custom/golang/gomobile.go
@@ -1,0 +1,217 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// gomobile.go — a heuristic extractor for gomobile (golang.org/x/mobile),
+// issue #3218 cluster 7 (Desktop & Mobile).
+//
+// gomobile produces mobile apps two ways:
+//
+//   - `gomobile build` of an app package importing golang.org/x/mobile/app —
+//     an event-loop GUI app (app.Main(func(a app.App){...})) running on
+//     Android/iOS; structure + lifecycle live in that event loop.
+//   - `gomobile bind` — Go packages exposed to Java/Kotlin (Android) and
+//     Objective-C/Swift (iOS) as a generated FFI binding. The bound surface is
+//     the exported Go funcs/types reachable from the host Activity/Fragment/
+//     ViewController.
+//
+// Statically resolvable surfaces from source text:
+//
+//   - app_struct  : `app.Main(...)` event-loop entry → SCOPE.Component
+//                    (the mobile app root; the Structure.context_extraction
+//                    surface).
+//   - platform    : build-constraint platform conditionals —
+//                    `//go:build android` / `// +build ios,android` and the
+//                    `runtime.GOOS == "android"` guards → SCOPE.Pattern
+//                    (pattern_kind=platform_branch; the Platform.platform_
+//                    branching surface).
+//   - native      : the gomobile native packages (app/gl/bind/sensor/...) that
+//                    bridge to the host platform → SCOPE.External
+//                    (the Native Bridge.native_module_imports surface).
+//   - bound_func  : exported funcs in a package that imports a gomobile/bind
+//                    surface — the FFI boundary crossed by the generated
+//                    Java/ObjC bindings → SCOPE.External (subtype native_bridge).
+//
+// Honesty (registry coverage status, lang.go.framework.gomobile):
+//
+//   - Structure.context_extraction         → partial: app.Main entry detected;
+//                                             no full component-tree resolution.
+//   - Platform.platform_branching          → partial: build constraints +
+//                                             GOOS guards detected heuristically
+//                                             (no build-tag constraint solving).
+//   - Native Bridge.native_module_imports  → partial: gomobile native package
+//                                             imports detected by import match.
+//   - Navigation.* (navigation/screen/deep_link) → not_applicable: gomobile bind
+//                                             has no Go-side navigation framework;
+//                                             screens/navigation live in the host
+//                                             (Android/iOS) UI layer, not Go.
+//   - Data Flow.state_management            → not_applicable: no Go-side reactive
+//                                             store; state lives host-side.
+//   - Lifecycle.state_setter_emission       → not_applicable: a React/SwiftUI-
+//                                             style state-setter concept that has
+//                                             no gomobile analogue.
+//
+// Attribution mirrors validation.go: emit only when a gomobile marker is
+// present; stamp framework=gomobile on each entity.
+
+func init() {
+	extractor.Register("custom_go_gomobile", &gomobileExtractor{})
+}
+
+type gomobileExtractor struct{}
+
+func (e *gomobileExtractor) Language() string { return "custom_go_gomobile" }
+
+var (
+	// reGomobileMarker attributes a file to gomobile via any x/mobile import.
+	reGomobileMarker = regexp.MustCompile(`golang\.org/x/mobile`)
+
+	// reGomobileAppMain matches the gomobile event-loop entry point.
+	//   app.Main(func(a app.App) { ... })
+	reGomobileAppMain = regexp.MustCompile(`(?m)\bapp\.Main\s*\(`)
+
+	// reGomobileNativeImport matches the gomobile native bridge packages.
+	reGomobileNativeImport = regexp.MustCompile(
+		`golang\.org/x/mobile/(app|gl|bind|exp/[\w/]+|event/[\w/]+|asset|geom|sensor)\b`)
+
+	// reGoBuildConstraint matches the modern `//go:build <expr>` line.
+	reGoBuildConstraint = regexp.MustCompile(`(?m)^//go:build\s+(.+)$`)
+
+	// reGoLegacyBuild matches the legacy `// +build <tags>` line.
+	reGoLegacyBuild = regexp.MustCompile(`(?m)^// \+build\s+(.+)$`)
+
+	// reGOOSGuard matches `runtime.GOOS == "android"` / `!= "ios"` platform
+	// guards in code.
+	reGOOSGuard = regexp.MustCompile(`runtime\.GOOS\s*(?:==|!=)\s*"(\w+)"`)
+
+	// reExportedFunc matches a top-level exported func declaration (the FFI
+	// surface of a `gomobile bind` package). Methods (with a receiver) are
+	// excluded — they are not part of the generated top-level binding.
+	reExportedFunc = regexp.MustCompile(`(?m)^func\s+([A-Z]\w*)\s*\(`)
+)
+
+// mobilePlatformTokens are the GOOS/build tags that name a mobile platform; a
+// build-constraint or GOOS guard mentioning one of these is treated as a
+// platform conditional.
+var mobilePlatformTokens = map[string]bool{
+	"android": true,
+	"ios":     true,
+	"darwin":  true, // iOS builds report darwin
+}
+
+// hasMobilePlatformToken reports whether a build-constraint expression or GOOS
+// value references a mobile platform token.
+func hasMobilePlatformToken(expr string) bool {
+	for _, tok := range regexp.MustCompile(`[\w]+`).FindAllString(strings.ToLower(expr), -1) {
+		if mobilePlatformTokens[tok] {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *gomobileExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.gomobile_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "gomobile"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reGomobileMarker.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. app.Main — the mobile app root (Structure.context_extraction).
+	for _, m := range reGomobileAppMain.FindAllStringSubmatchIndex(src, -1) {
+		ent := makeEntity("gomobile:app:Main", "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "gomobile", "provenance", "INFERRED_FROM_GOMOBILE_APP",
+			"gomobile_kind", "app_root")
+		add(ent)
+	}
+
+	// 2. platform conditionals — build constraints + GOOS guards
+	//    (Platform.platform_branching). Only mobile-platform-bearing ones count.
+	addPlatformBranch := func(form, expr string, line int) {
+		if !hasMobilePlatformToken(expr) {
+			return
+		}
+		expr = strings.TrimSpace(expr)
+		ent := makeEntity("gomobile:platform:"+form+":"+expr, "SCOPE.Pattern", "", file.Path, file.Language, line)
+		setProps(&ent, "framework", "gomobile", "provenance", "INFERRED_FROM_GOMOBILE_PLATFORM",
+			"pattern_kind", "platform_branch", "branch_form", form, "constraint", expr)
+		add(ent)
+	}
+	for _, m := range reGoBuildConstraint.FindAllStringSubmatchIndex(src, -1) {
+		addPlatformBranch("go_build", submatch(src, m, 2), lineOf(src, m[0]))
+	}
+	for _, m := range reGoLegacyBuild.FindAllStringSubmatchIndex(src, -1) {
+		addPlatformBranch("legacy_build", submatch(src, m, 2), lineOf(src, m[0]))
+	}
+	for _, m := range reGOOSGuard.FindAllStringSubmatchIndex(src, -1) {
+		addPlatformBranch("goos_guard", submatch(src, m, 2), lineOf(src, m[0]))
+	}
+
+	// 3. native bridge package imports (Native Bridge.native_module_imports).
+	boundPkg := false
+	for _, m := range reGomobileNativeImport.FindAllStringSubmatchIndex(src, -1) {
+		pkg := submatch(src, m, 0)
+		sub := submatch(src, m, 2)
+		if sub == "bind" {
+			boundPkg = true
+		}
+		ent := makeEntity("gomobile:native:"+pkg, "SCOPE.External", "native_import", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "gomobile", "provenance", "INFERRED_FROM_GOMOBILE_NATIVE_IMPORT",
+			"native_kind", "gomobile", "import_path", pkg)
+		add(ent)
+	}
+
+	// 4. exported funcs in a bind package — the FFI boundary (native_bridge).
+	//    Gated on the bind import so we don't treat every exported func in a
+	//    plain x/mobile/app GUI program as a bound FFI symbol.
+	if boundPkg {
+		for _, m := range reExportedFunc.FindAllStringSubmatchIndex(src, -1) {
+			fn := submatch(src, m, 2)
+			ent := makeEntity("gomobile:bound:"+fn, "SCOPE.External", "native_bridge", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "gomobile", "provenance", "INFERRED_FROM_GOMOBILE_BIND",
+				"native_kind", "bound_func", "func_name", fn)
+			add(ent)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/golang/testdata/fyne_app.go
+++ b/internal/custom/golang/testdata/fyne_app.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+)
+
+func main() {
+	a := app.New()
+	w := a.NewWindow("Hello Fyne")
+
+	label := widget.NewLabel("Welcome")
+	entry := widget.NewEntry()
+	btn := widget.NewButton("Click", func() {
+		label.SetText("clicked")
+	})
+
+	// event-handler wiring
+	btn.OnTapped = func() {
+		label.SetText("tapped")
+	}
+	entry.OnChanged = func(s string) {
+		label.SetText(s)
+	}
+	w.SetOnClosed(func() {
+		// cleanup
+	})
+
+	box := container.NewVBox(label, entry, btn)
+	w.SetContent(box)
+	w.ShowAndRun()
+}

--- a/internal/custom/golang/testdata/gomobile_app.go
+++ b/internal/custom/golang/testdata/gomobile_app.go
@@ -1,0 +1,25 @@
+//go:build android || ios
+
+package main
+
+import (
+	"runtime"
+
+	"golang.org/x/mobile/app"
+	"golang.org/x/mobile/event/lifecycle"
+	"golang.org/x/mobile/gl"
+)
+
+func main() {
+	app.Main(func(a app.App) {
+		for e := range a.Events() {
+			switch e.(type) {
+			case lifecycle.Event:
+				_ = gl.Version
+			}
+		}
+		if runtime.GOOS == "android" {
+			_ = "android-only"
+		}
+	})
+}

--- a/internal/custom/golang/testdata/gomobile_bind.go
+++ b/internal/custom/golang/testdata/gomobile_bind.go
@@ -1,0 +1,22 @@
+// +build android ios
+
+package mylib
+
+import (
+	"golang.org/x/mobile/bind"
+)
+
+var _ = bind.Seq{}
+
+// Greet is exported across the FFI boundary to Java/ObjC.
+func Greet(name string) string {
+	return "Hello, " + name
+}
+
+// Add is another bound function.
+func Add(a, b int) int {
+	return a + b
+}
+
+// helper is unexported and must not be treated as a bound func.
+func helper() {}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3198,6 +3198,69 @@ records:
             - file: internal/custom/golang/extractors_test.go
             - file: internal/engine/go_routes_test.go
           issues_implemented: ["3212"]
+  lang.go.framework.fyne:
+    capabilities:
+      Native:
+        native_module_imports:
+          # fyne.go custom extractor (#3218): reFyneNativeImport matches the
+          # fyne.io/fyne driver/app native packages backing the desktop GUI on
+          # the host platform, emitted as SCOPE.External native_import entities.
+          # Heuristic import match (partial): no cgo symbol resolution. Fyne is
+          # single-process, so Process.ipc_extraction / main_renderer_split are
+          # not_applicable (no Electron-style main/renderer split or IPC).
+          status: partial
+          symbols:
+            - file: internal/custom/golang/fyne.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/fyne_gomobile_test.go
+          issues_implemented: ["3218"]
+          verified_at: "2026-05-30"
+  lang.go.framework.gomobile:
+    capabilities:
+      Structure:
+        context_extraction:
+          # gomobile.go custom extractor (#3218): reGomobileAppMain detects the
+          # app.Main(...) event-loop entry as the mobile app root
+          # (SCOPE.Component). Partial: entry detected, no full component tree.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/gomobile.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/fyne_gomobile_test.go
+          issues_implemented: ["3218"]
+          verified_at: "2026-05-30"
+      Platform:
+        platform_branching:
+          # //go:build and // +build constraints plus runtime.GOOS guards that
+          # name a mobile platform (android/ios/darwin) are emitted as
+          # SCOPE.Pattern platform_branch entities. Partial: heuristic, no
+          # build-tag constraint solving; non-mobile constraints are skipped.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/gomobile.go
+              functions: [Extract, hasMobilePlatformToken]
+          tests:
+            - file: internal/custom/golang/fyne_gomobile_test.go
+          issues_implemented: ["3218"]
+          verified_at: "2026-05-30"
+      Native Bridge:
+        native_module_imports:
+          # golang.org/x/mobile/{app,gl,bind,...} native bridge package imports
+          # become SCOPE.External native_import entities; exported funcs in a
+          # bind package become SCOPE.External native_bridge (FFI) entities.
+          # Partial: heuristic import + exported-func match. Navigation/screen/
+          # deep_link, Data Flow.state_management and Lifecycle.state_setter are
+          # not_applicable — those live host-side (Android/iOS), not in Go.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/gomobile.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/fyne_gomobile_test.go
+          issues_implemented: ["3218"]
+          verified_at: "2026-05-30"
   lang.go.orm.gorm:
     capabilities:
       Models:


### PR DESCRIPTION
## Summary

Implements **Cluster 7 — Desktop & Mobile** (#3218): two new custom Go extractors for the **fyne** desktop GUI toolkit and **gomobile** mobile bindings, plus honest registry + capability-map updates. Both are non-HTTP GUI/mobile toolkits, so a large share of web-oriented capability cells are genuinely **not_applicable**.

New files only — no shared files edited. Both extractors register via `init()` and run on every Go file through the existing `custom_go_` dispatch prefix.

### fyne — `internal/custom/golang/fyne.go`
Detects the widget/window/event lifecycle:
- `app.New()` / `app.NewWithID(...)` app root → `SCOPE.Component`
- `a.NewWindow("title")` → `SCOPE.UIComponent` (window)
- `widget.`/`container.`/`canvas.New*` constructors → `SCOPE.UIComponent` (widget)
- `btn.OnTapped =` / `entry.OnChanged =` / `w.SetOn*(...)` event wiring → `SCOPE.Pattern` (event)
- fyne driver/app native imports → `SCOPE.External` (native_import)

### gomobile — `internal/custom/golang/gomobile.go`
- `app.Main(...)` event-loop entry → `SCOPE.Component` (app root)
- `//go:build` / `// +build` / `runtime.GOOS` guards naming a mobile platform (android/ios/darwin) → `SCOPE.Pattern` (platform_branch)
- `golang.org/x/mobile/{app,gl,bind,...}` imports → `SCOPE.External` (native_import)
- exported funcs in a `bind` package → `SCOPE.External` (native_bridge / FFI)

## Registry classification (honest)

**fyne** (`lang.go.framework.fyne`):
| cell | status |
|---|---|
| Native.native_module_imports | **partial** |
| Process.ipc_extraction | not_applicable |
| Process.main_renderer_split | not_applicable |

`ipc_extraction` / `main_renderer_split` are NA because fyne is single-process — no Electron-style main/renderer split or IPC channel.

**gomobile** (`lang.go.framework.gomobile`):
| cell | status |
|---|---|
| Structure.context_extraction | **partial** |
| Platform.platform_branching | **partial** |
| Native Bridge.native_module_imports | **partial** |
| Navigation.navigation_extraction / screen_detection / deep_link_extraction | not_applicable |
| Data Flow.state_management | not_applicable |
| Lifecycle.state_setter_emission | not_applicable |

Navigation/screens/state are NA because they live host-side (Android/iOS UI layer), not in Go.

**full / partial / NA breakdown:** 0 full · 4 partial · 8 not_applicable (NA expected to be high for GUI/mobile, per the issue).

All partial flips are heuristic (regex/import matching — no cgo, build-tag, or FFI symbol resolution), hence `partial` not `full`, each backed by a dedicated test + fixture and a capability-map entry.

## Validation (scoped)
- `go build ./internal/... ./tools/coverage/...` ✅
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` ✅
- `go run ./tools/coverage validate` → exit 0, 0 errors, no duplicate keys ✅
- `go run ./tools/coverage fmt --check` ✅ · `gofmt -l` empty ✅ · `go vet` ✅
- `go run ./tools/coverage gen` → byte-stable ✅

Closes #3218

🤖 Generated with [Claude Code](https://claude.com/claude-code)