### PR TITLE
feat(coverage): Go auth+middleware for 6 more HTTP frameworks (#3213)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -39,21 +39,21 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/2 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/5 | |
 | [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 5/6 | |
-| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/6 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 5/6 | |
-| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
 | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/6 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/6 | |
 
 
 ### Mobile

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | — `not_applicable` | — | — | — | fasthttp / fasthttp-router has no middleware-registration primitive; middleware is manual RequestHandler wrapping with no .Use() chain to extract. |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | — `not_applicable` | — | — | — | fasthttp / fasthttp-router has no middleware-registration primitive; middleware is manual RequestHandler wrapping with no .Use() chain to extract. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | — `not_applicable` | — | — | — | net/http has no middleware-registration primitive; middleware is manual handler wrapping (func(http.Handler) http.Handler) with no .Use() chain to extract. |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | — `not_applicable` | — | — | — | net/http has no middleware-registration primitive; middleware is manual handler wrapping (func(http.Handler) http.Handler) with no .Use() chain to extract. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/helpers.go`<br>`internal/custom/golang/middleware_auth_extend.go`<br>`internal/custom/golang/middleware_auth_extend_test.go` | — |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10683,7 +10683,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -10698,7 +10700,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -10860,7 +10864,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -10875,7 +10881,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -11409,7 +11417,8 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "fasthttp / fasthttp-router has no middleware-registration primitive; middleware is manual RequestHandler wrapping with no .Use() chain to extract."
           }
         },
         "Validation": {
@@ -11424,7 +11433,8 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "fasthttp / fasthttp-router has no middleware-registration primitive; middleware is manual RequestHandler wrapping with no .Use() chain to extract."
           }
         },
         "Type System": {
@@ -12376,7 +12386,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -12391,7 +12403,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -12555,7 +12569,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -12570,7 +12586,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -12911,7 +12929,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -12926,7 +12946,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -13265,7 +13287,8 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "net/http has no middleware-registration primitive; middleware is manual handler wrapping (func(http.Handler) http.Handler) with no .Use() chain to extract."
           }
         },
         "Validation": {
@@ -13280,7 +13303,8 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "net/http has no middleware-registration primitive; middleware is manual handler wrapping (func(http.Handler) http.Handler) with no .Use() chain to extract."
           }
         },
         "Type System": {
@@ -13442,7 +13466,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -13457,7 +13483,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/helpers.go","internal/custom/golang/middleware_auth_extend.go","internal/custom/golang/middleware_auth_extend_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {

--- a/internal/custom/golang/helpers.go
+++ b/internal/custom/golang/helpers.go
@@ -160,8 +160,11 @@ type useCall struct {
 }
 
 // reUseHead locates the `<ident>.Use(` token; the balanced argument span is
-// then scanned forward from the opening paren.
-var reUseHead = regexp.MustCompile(`(\w+)\.Use\s*\(`)
+// then scanned forward from the opening paren. The optional Router/Global
+// suffix covers Iris's `.UseRouter(...)` / `.UseGlobal(...)` middleware
+// registration variants (gin/echo/fiber/chi/hertz/buffalo/gorilla-mux use the
+// bare `.Use(...)` form, which the optional group still matches).
+var reUseHead = regexp.MustCompile(`(\w+)\.Use(?:Router|Global)?\s*\(`)
 
 // findUseCalls returns every balanced `.Use(...)` call in src. Unlike a flat
 // regex, it tracks paren depth (skipping quoted strings) so arbitrarily nested

--- a/internal/custom/golang/middleware_auth_extend.go
+++ b/internal/custom/golang/middleware_auth_extend.go
@@ -1,0 +1,256 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// middleware_auth_extend.go — a framework-agnostic middleware + auth scanner
+// (issue #3213, cluster 2) that extends the shared `.Use(...)` detector
+// (helpers.go) beyond the four well-templated frameworks (gin/echo/fiber/chi,
+// which call the helpers from their own extractors) to the remaining Go HTTP
+// frameworks that register middleware/filters/interceptors:
+//
+//   - buffalo     : app.Use(mw) / app.Middleware.Use(mw)        (.Use chain)
+//   - iris        : app.Use(mw) / .UseRouter / .UseGlobal       (.Use chain)
+//   - hertz       : h.Use(mw)                                    (.Use chain)
+//   - gorilla-mux : r.Use(mw)                                    (.Use chain)
+//   - beego       : web/beego.InsertFilter("/p", pos, FilterFn)  (filter API)
+//   - revel       : revel.InterceptFunc/Method(fn, revel.BEFORE) (interceptors)
+//
+// Each emitted entity is a SCOPE.Pattern (pattern_kind=middleware), with a
+// dedicated auth SCOPE.Pattern (pattern_kind=auth) for any expression that
+// classifies as auth middleware via the shared classifyAuthMiddleware catalog
+// (jwt/oauth/basic/session/rbac/api_key/…). All emission funnels through the
+// shared helpers (parseMiddlewareChain/emitMiddlewareChain for .Use chains;
+// classifyAuthMiddleware for filter/interceptor expressions) so the property
+// shape is identical across every framework.
+//
+// Honesty (registry coverage status):
+//
+//	partial — for every framework above. Detection is a heuristic regex /
+//	substring match on source text. It does NOT perform import-resolution or
+//	data-flow analysis to confirm a value actually enforces authentication, and
+//	it does not bind the middleware to a specific route. The auth classifier is
+//	a substring match on the expression.
+//
+//	not_applicable — for raw net/http and fasthttp. Neither the Go standard
+//	library router (net/http) nor fasthttp / fasthttp/router exposes a
+//	first-class middleware-registration primitive: middleware in both is plain
+//	manual handler wrapping (`func(next http.Handler) http.Handler` /
+//	`func(h fasthttp.RequestHandler) fasthttp.RequestHandler`) with no
+//	`.Use(...)`-style chain to extract. There is therefore no
+//	registration-surface to catalog, and we honestly mark those cells NA rather
+//	than fabricate one. (Auth in those frameworks is likewise inline checks in
+//	handlers, not a registered middleware.)
+//
+// Framework attribution: the scanner runs on every Go file (registry key
+// custom_go_middleware_auth matches the custom_go_ dispatch prefix). It infers
+// the framework from framework-specific engine/context markers and stamps it
+// on each emitted entity. A file with no recognised marker emits nothing.
+// gin/echo/fiber/chi are intentionally NOT handled here — their own extractors
+// already call the shared helpers — so we never double-emit for them.
+
+func init() {
+	extractor.Register("custom_go_middleware_auth", &middlewareAuthExtractor{})
+}
+
+type middlewareAuthExtractor struct{}
+
+func (e *middlewareAuthExtractor) Language() string { return "custom_go_middleware_auth" }
+
+// mwExtendFramework is one framework this agnostic pass attributes + scans.
+// mode selects the registration-surface parser:
+//
+//	"use"        — balanced .Use(...) chain (shared helpers)
+//	"insertfilter" — beego web/beego.InsertFilter("/p", pos, fn)
+//	"intercept"  — revel.InterceptFunc/Method(fn, …)
+type mwExtendFramework struct {
+	name   string
+	marker *regexp.Regexp
+	mode   string
+}
+
+// mwExtendFrameworks lists the frameworks handled by this pass, in priority
+// order. The marker is a framework-specific engine/context construct that is
+// unambiguous and present in any router/handler file. First match wins, so the
+// list is ordered to avoid cross-framework confusion (hertz before buffalo
+// etc. is irrelevant because the markers are disjoint).
+//
+// gin/echo/fiber/chi are deliberately absent (their own extractors emit
+// middleware/auth). net/http and fasthttp are absent because they have no
+// middleware-registration primitive (see file-level honesty note → NA cells).
+var mwExtendFrameworks = []mwExtendFramework{
+	{"buffalo", regexp.MustCompile(`\bbuffalo\.(?:New|App|Options|Context)\b`), "use"},
+	{"iris", regexp.MustCompile(`\biris\.(?:New|Default|Application|Context|Party)\b`), "use"},
+	{"hertz", regexp.MustCompile(`\bserver\.(?:Default|New|Hertz)\b|\bapp\.RequestContext\b`), "use"},
+	{"gorilla-mux", regexp.MustCompile(`\bmux\.(?:NewRouter|Router|Vars)\b`), "use"},
+	{"beego", regexp.MustCompile(`\b(?:beego|web)\.(?:Router|NewNamespace|Run|InsertFilter|AutoRouter)\b`), "insertfilter"},
+	{"revel", regexp.MustCompile(`\brevel\.(?:Result|Controller|Intercept(?:Func|Method)|BEFORE|AFTER)\b`), "intercept"},
+}
+
+// detectMWExtendFramework returns the framework + scan mode the file belongs
+// to, or ("","") when no recognised marker is present.
+func detectMWExtendFramework(src string) (string, string) {
+	for _, f := range mwExtendFrameworks {
+		if f.marker.MatchString(src) {
+			return f.name, f.mode
+		}
+	}
+	return "", ""
+}
+
+// reBeegoInsertFilter matches Beego's filter-registration API:
+//
+//	web.InsertFilter("/api/*", web.BeforeRouter, AuthFilter)
+//	beego.InsertFilter("/*", beego.BeforeExec, JWTFilter, web.WithReturnOnOutput(true))
+//
+// Capture groups: 1=path pattern, 2=position const (e.g. BeforeRouter),
+// 3=filter function expression.
+var reBeegoInsertFilter = regexp.MustCompile(
+	`(?:beego|web)\.InsertFilter\s*\(\s*"([^"]*)"\s*,\s*([\w.]+)\s*,\s*([\w.]+)`,
+)
+
+// reRevelExtendIntercept matches Revel interceptor registration:
+//
+//	revel.InterceptFunc(checkUser, revel.BEFORE, &App{})
+//	revel.InterceptMethod(App.checkUser, revel.BEFORE)
+//
+// Capture group 1 is the interceptor function/method expression.
+var reRevelExtendIntercept = regexp.MustCompile(
+	`revel\.Intercept(?:Func|Method)\s*\(\s*([\w.]+)`,
+)
+
+func (e *middlewareAuthExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.middleware_auth_extend_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	framework, mode := detectMWExtendFramework(src)
+	if framework == "" {
+		span.SetAttributes(attribute.String("framework", ""))
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	mwProv := "INFERRED_FROM_" + provToken(framework) + "_MIDDLEWARE"
+	authProv := "INFERRED_FROM_" + provToken(framework) + "_AUTH"
+
+	switch mode {
+	case "use":
+		// Balanced .Use(...) chains via the shared helpers — one ordered
+		// SCOPE.Pattern per middleware + a dedicated auth pattern for any
+		// entry that classifies as auth.
+		for _, uc := range findUseCalls(src) {
+			chain := parseMiddlewareChain(uc.Args)
+			emitMiddlewareChain(add, chain, framework, mwProv, authProv,
+				file.Path, file.Language, uc.Line)
+		}
+
+	case "insertfilter":
+		// Beego filter API: the 3rd argument is the filter function; the
+		// filter position (e.g. BeforeRouter) is recorded for ordering context.
+		for _, m := range reBeegoInsertFilter.FindAllStringSubmatchIndex(src, -1) {
+			pathPat := submatch(src, m, 2)
+			position := submatch(src, m, 4)
+			filterFn := submatch(src, m, 6)
+			if filterFn == "" {
+				continue
+			}
+			emitFilterMiddleware(add, framework, mwProv, authProv,
+				filterFn, file.Path, file.Language, lineOf(src, m[0]),
+				"filter_position", position, "filter_path", pathPat)
+		}
+
+	case "intercept":
+		// Revel interceptors (before/after filters ~ middleware).
+		for _, m := range reRevelExtendIntercept.FindAllStringSubmatchIndex(src, -1) {
+			fn := submatch(src, m, 2)
+			if fn == "" {
+				continue
+			}
+			emitFilterMiddleware(add, framework, mwProv, authProv,
+				fn, file.Path, file.Language, lineOf(src, m[0]),
+				"middleware_form", "interceptor")
+		}
+	}
+
+	span.SetAttributes(
+		attribute.String("framework", framework),
+		attribute.Int("entity_count", len(entities)),
+	)
+	return entities, nil
+}
+
+// emitFilterMiddleware emits a single non-.Use middleware registration (a beego
+// filter or a revel interceptor) as a SCOPE.Pattern (pattern_kind=middleware),
+// plus a dedicated auth SCOPE.Pattern when the expression classifies as auth.
+// It mirrors emitMiddlewareChain's property shape (minus mw_order, which is
+// undefined for these single-registration APIs). extraProps are appended as
+// key/value pairs onto the middleware entity.
+func emitFilterMiddleware(
+	add func(types.EntityRecord),
+	framework, mwProvenance, authProvenance, expr, filePath, language string,
+	line int,
+	extraProps ...string,
+) {
+	head := reMiddlewareCallHead.FindString(expr)
+	if head == "" {
+		head = expr
+	}
+	authKind := classifyAuthMiddleware(expr)
+
+	mw := makeEntity(expr, "SCOPE.Pattern", "", filePath, language, line)
+	setProps(&mw, "framework", framework, "provenance", mwProvenance,
+		"pattern_kind", "middleware", "middleware_name", head)
+	if len(extraProps) > 0 {
+		setProps(&mw, extraProps...)
+	}
+	if authKind != "" {
+		setProps(&mw, "is_auth", "true", "auth_kind", authKind)
+	}
+	add(mw)
+
+	if authKind != "" {
+		au := makeEntity("auth:"+head, "SCOPE.Pattern", "", filePath, language, line)
+		setProps(&au, "framework", framework, "provenance", authProvenance,
+			"pattern_kind", "auth", "auth_kind", authKind,
+			"middleware_name", head, "middleware_expr", expr)
+		add(au)
+	}
+}
+
+// provToken normalises a framework name into the UPPER_SNAKE token used in the
+// INFERRED_FROM_* provenance tags (e.g. "gorilla-mux" -> "GORILLA_MUX").
+func provToken(framework string) string {
+	r := strings.NewReplacer("-", "_", "/", "_", ".", "_")
+	return strings.ToUpper(r.Replace(framework))
+}

--- a/internal/custom/golang/middleware_auth_extend_test.go
+++ b/internal/custom/golang/middleware_auth_extend_test.go
@@ -1,0 +1,189 @@
+package golang_test
+
+import (
+	"testing"
+)
+
+// Tests for the framework-agnostic middleware + auth extender
+// (custom_go_middleware_auth, issue #3213): buffalo / iris / hertz /
+// gorilla-mux (.Use chains), beego (InsertFilter), revel (interceptors).
+//
+// Reuses fullEntity / findMW / extractFull / fixtureFile / fi from
+// middleware_auth_test.go (same package).
+
+const mwExtendKey = "custom_go_middleware_auth"
+
+// findAuth finds the dedicated auth SCOPE.Pattern by its auth:<name> name.
+func findAuth(ents []fullEntity, name string) *fullEntity {
+	return findMW(ents, name)
+}
+
+// ---------------------------------------------------------------------------
+// .Use-chain frameworks
+// ---------------------------------------------------------------------------
+
+func TestBuffaloMiddlewareAuthExtend(t *testing.T) {
+	src := `app.Use(csrf.New)
+app.Use(RequestLogger)
+app.Middleware.Use(JWTAuth)
+var _ = buffalo.New`
+	ents := extractFull(t, mwExtendKey, fi("app.go", "go", src))
+	for _, n := range []string{"csrf.New", "RequestLogger", "JWTAuth"} {
+		if findMW(ents, n) == nil {
+			t.Fatalf("missing middleware %q", n)
+		}
+	}
+	jwt := findMW(ents, "JWTAuth")
+	if jwt.Props["framework"] != "buffalo" {
+		t.Errorf("framework=%q want buffalo", jwt.Props["framework"])
+	}
+	if jwt.Props["auth_kind"] != "jwt" {
+		t.Errorf("auth_kind=%q want jwt", jwt.Props["auth_kind"])
+	}
+	if findAuth(ents, "auth:JWTAuth") == nil {
+		t.Error("missing dedicated auth:JWTAuth pattern")
+	}
+}
+
+func TestIrisMiddlewareAuthExtend(t *testing.T) {
+	ents := extractFull(t, mwExtendKey, fixtureFile(t, "iris_middleware_auth.go"))
+	log := findMW(ents, "logger.New()")
+	if log == nil || log.Props["framework"] != "iris" {
+		t.Fatalf("missing iris logger middleware, got %+v", log)
+	}
+	if log.Props["is_auth"] == "true" {
+		t.Error("logger wrongly flagged auth")
+	}
+	jwt := findMW(ents, "jwt.New(jwtConfig).VerifyMiddleware()")
+	if jwt == nil || jwt.Props["auth_kind"] != "jwt" {
+		t.Errorf("expected iris jwt auth, got %+v", jwt)
+	}
+	if findMW(ents, "BasicAuth()") == nil {
+		t.Error("missing UseGlobal BasicAuth() middleware")
+	}
+}
+
+func TestHertzMiddlewareAuthExtend(t *testing.T) {
+	ents := extractFull(t, mwExtendKey, fixtureFile(t, "hertz_middleware_auth.go"))
+	// Ordered chain: RecoveryMiddleware() order 0, AccessLog() order 1.
+	rec := findMW(ents, "RecoveryMiddleware()")
+	if rec == nil || rec.Props["mw_order"] != "0" {
+		t.Errorf("RecoveryMiddleware order, got %+v", rec)
+	}
+	acc := findMW(ents, "AccessLog()")
+	if acc == nil || acc.Props["mw_order"] != "1" {
+		t.Errorf("AccessLog order, got %+v", acc)
+	}
+	auth := findMW(ents, "authMw.MiddlewareFunc()")
+	if auth == nil || auth.Props["auth_kind"] != "auth" {
+		t.Errorf("expected hertz auth middleware, got %+v", auth)
+	}
+	if auth.Props["framework"] != "hertz" {
+		t.Errorf("framework=%q want hertz", auth.Props["framework"])
+	}
+}
+
+func TestGorillaMuxMiddlewareAuthExtend(t *testing.T) {
+	ents := extractFull(t, mwExtendKey, fixtureFile(t, "gorilla_mux_middleware_auth.go"))
+	logmw := findMW(ents, "LoggingMiddleware")
+	if logmw == nil || logmw.Props["framework"] != "gorilla-mux" {
+		t.Fatalf("missing gorilla LoggingMiddleware, got %+v", logmw)
+	}
+	if logmw.Props["mw_order"] != "0" {
+		t.Errorf("LoggingMiddleware order=%q want 0", logmw.Props["mw_order"])
+	}
+	auth := findMW(ents, "JWTAuthMiddleware")
+	if auth == nil || auth.Props["auth_kind"] != "jwt" {
+		t.Errorf("expected gorilla jwt auth, got %+v", auth)
+	}
+	if findAuth(ents, "auth:JWTAuthMiddleware") == nil {
+		t.Error("missing auth:JWTAuthMiddleware pattern")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// beego InsertFilter API
+// ---------------------------------------------------------------------------
+
+func TestBeegoInsertFilterMiddlewareAuth(t *testing.T) {
+	ents := extractFull(t, mwExtendKey, fixtureFile(t, "beego_middleware_auth.go"))
+	logf := findMW(ents, "LoggingFilter")
+	if logf == nil || logf.Props["framework"] != "beego" {
+		t.Fatalf("missing beego LoggingFilter, got %+v", logf)
+	}
+	if logf.Props["pattern_kind"] != "middleware" {
+		t.Errorf("pattern_kind=%q want middleware", logf.Props["pattern_kind"])
+	}
+	if logf.Props["filter_position"] != "web.BeforeRouter" {
+		t.Errorf("filter_position=%q", logf.Props["filter_position"])
+	}
+	if logf.Props["filter_path"] != "/api/*" {
+		t.Errorf("filter_path=%q want /api/*", logf.Props["filter_path"])
+	}
+	auth := findMW(ents, "JWTAuthFilter")
+	if auth == nil || auth.Props["auth_kind"] != "jwt" {
+		t.Errorf("expected beego jwt auth filter, got %+v", auth)
+	}
+	if findAuth(ents, "auth:JWTAuthFilter") == nil {
+		t.Error("missing auth:JWTAuthFilter pattern")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// revel interceptors
+// ---------------------------------------------------------------------------
+
+func TestRevelInterceptMiddlewareAuth(t *testing.T) {
+	ents := extractFull(t, mwExtendKey, fixtureFile(t, "revel_middleware_auth.go"))
+	logmw := findMW(ents, "RequestLogger")
+	if logmw == nil || logmw.Props["framework"] != "revel" {
+		t.Fatalf("missing revel RequestLogger interceptor, got %+v", logmw)
+	}
+	if logmw.Props["middleware_form"] != "interceptor" {
+		t.Errorf("middleware_form=%q want interceptor", logmw.Props["middleware_form"])
+	}
+	auth := findMW(ents, "App.checkAuthUser")
+	if auth == nil || auth.Props["auth_kind"] != "auth" {
+		t.Errorf("expected revel auth interceptor, got %+v", auth)
+	}
+	if findAuth(ents, "auth:App.checkAuthUser") == nil {
+		t.Error("missing auth:App.checkAuthUser pattern")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NA frameworks: net/http + fasthttp have no middleware-registration surface;
+// the extender must emit nothing for them (no .Use / filter / interceptor).
+// ---------------------------------------------------------------------------
+
+func TestNetHTTPNoMiddlewareEmitted(t *testing.T) {
+	src := `mux := http.NewServeMux()
+mux.HandleFunc("GET /users", listUsers)`
+	ents := extractFull(t, mwExtendKey, fi("main.go", "go", src))
+	for _, e := range ents {
+		if e.Props["pattern_kind"] == "middleware" || e.Props["pattern_kind"] == "auth" {
+			t.Errorf("net/http should emit no middleware/auth, got %q", e.Name)
+		}
+	}
+}
+
+func TestFasthttpNoMiddlewareEmitted(t *testing.T) {
+	src := `r := router.New()
+r.GET("/", Index)
+fasthttp.ListenAndServe(":8080", r.Handler)`
+	ents := extractFull(t, mwExtendKey, fi("main.go", "go", src))
+	for _, e := range ents {
+		if e.Props["pattern_kind"] == "middleware" || e.Props["pattern_kind"] == "auth" {
+			t.Errorf("fasthttp should emit no middleware/auth, got %q", e.Name)
+		}
+	}
+}
+
+// Files with no recognised framework marker emit nothing.
+func TestMiddlewareAuthExtendNoFrameworkNoEmit(t *testing.T) {
+	src := `func main() { fmt.Println("hi") }`
+	ents := extractFull(t, mwExtendKey, fi("main.go", "go", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for unattributed file, got %d", len(ents))
+	}
+}

--- a/internal/custom/golang/testdata/beego_middleware_auth.go
+++ b/internal/custom/golang/testdata/beego_middleware_auth.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/beego/beego/v2/server/web"
+)
+
+func init() {
+	web.InsertFilter("/api/*", web.BeforeRouter, LoggingFilter)
+	web.InsertFilter("/api/*", web.BeforeExec, JWTAuthFilter)
+}
+
+func main() {
+	web.Run()
+}

--- a/internal/custom/golang/testdata/buffalo_middleware_auth.go
+++ b/internal/custom/golang/testdata/buffalo_middleware_auth.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/mw-csrf"
+)
+
+func App() *buffalo.App {
+	app := buffalo.New(buffalo.Options{})
+	app.Use(csrf.New)
+	app.Use(RequestLogger)
+	app.Middleware.Use(JWTAuth)
+	return app
+}

--- a/internal/custom/golang/testdata/gorilla_mux_middleware_auth.go
+++ b/internal/custom/golang/testdata/gorilla_mux_middleware_auth.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	r := mux.NewRouter()
+	r.Use(LoggingMiddleware)
+	r.Use(JWTAuthMiddleware)
+	http.ListenAndServe(":8080", r)
+}

--- a/internal/custom/golang/testdata/hertz_middleware_auth.go
+++ b/internal/custom/golang/testdata/hertz_middleware_auth.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/hertz-contrib/jwt"
+)
+
+func main() {
+	h := server.Default()
+	h.Use(RecoveryMiddleware(), AccessLog())
+	authMw, _ := jwt.New(jwtMiddleware)
+	h.Use(authMw.MiddlewareFunc())
+	h.Spin()
+}

--- a/internal/custom/golang/testdata/iris_middleware_auth.go
+++ b/internal/custom/golang/testdata/iris_middleware_auth.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/kataras/iris/v12"
+	"github.com/kataras/iris/v12/middleware/jwt"
+	"github.com/kataras/iris/v12/middleware/logger"
+)
+
+func main() {
+	app := iris.New()
+	app.Use(logger.New())
+	app.UseRouter(jwt.New(jwtConfig).VerifyMiddleware())
+	v1 := app.Party("/v1")
+	v1.UseGlobal(BasicAuth())
+	app.Listen(":8080")
+}

--- a/internal/custom/golang/testdata/revel_middleware_auth.go
+++ b/internal/custom/golang/testdata/revel_middleware_auth.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"github.com/revel/revel"
+)
+
+func init() {
+	revel.InterceptFunc(RequestLogger, revel.BEFORE, revel.ALL_CONTROLLERS)
+	revel.InterceptMethod(App.checkAuthUser, revel.BEFORE)
+}
+
+type App struct {
+	*revel.Controller
+}
+
+func (c App) checkAuthUser() revel.Result {
+	return nil
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3198,6 +3198,119 @@ records:
             - file: internal/custom/golang/extractors_test.go
             - file: internal/engine/go_routes_test.go
           issues_implemented: ["3212"]
+      Middleware:
+        middleware_coverage:
+          # gorilla_mux.go already records r.Use(...) middleware;
+          # middleware_auth_extend.go (custom_go_middleware_auth) extends this
+          # via the framework-agnostic pass, reading balanced r.Use(...) chains
+          # with the shared findUseCalls/parseMiddlewareChain helpers and
+          # emitting ordered SCOPE.Pattern (mw_order) middleware. Heuristic
+          # ordering, no data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/gorilla_mux.go
+              functions: [Extract]
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract, detectMWExtendFramework]
+            - file: internal/custom/golang/helpers.go
+              functions: [findUseCalls, parseMiddlewareChain, emitMiddlewareChain, splitTopLevelArgs]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware substring-matches each gorilla-mux r.Use
+          # middleware expression against the shared auth-pattern catalog,
+          # flagging is_auth + auth_kind and emitting a dedicated auth:
+          # SCOPE.Pattern. Pattern match only, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware, emitMiddlewareChain]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
+  lang.go.framework.buffalo:
+    capabilities:
+      Middleware:
+        middleware_coverage:
+          # buffalo.go already records app.Use / app.Middleware.Use middleware;
+          # middleware_auth_extend.go (custom_go_middleware_auth) provides the
+          # framework-agnostic coverage, reading balanced .Use(...) chains via
+          # the shared findUseCalls/parseMiddlewareChain helpers and emitting
+          # ordered SCOPE.Pattern (mw_order) middleware. Heuristic ordering,
+          # no data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/buffalo.go
+              functions: [Extract]
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract, detectMWExtendFramework]
+            - file: internal/custom/golang/helpers.go
+              functions: [findUseCalls, parseMiddlewareChain, emitMiddlewareChain, splitTopLevelArgs]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware substring-matches each buffalo .Use
+          # middleware expression against the shared auth-pattern catalog,
+          # flagging is_auth + auth_kind and emitting a dedicated auth:
+          # SCOPE.Pattern. Pattern match only, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware, emitMiddlewareChain]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
+  lang.go.framework.revel:
+    capabilities:
+      Middleware:
+        middleware_coverage:
+          # middleware_auth_extend.go (custom_go_middleware_auth) scans
+          # revel-attributed files for interceptor registration
+          # revel.InterceptFunc/InterceptMethod(fn, revel.BEFORE/AFTER) via
+          # reRevelExtendIntercept, emitting one SCOPE.Pattern
+          # (pattern_kind=middleware, middleware_form=interceptor) per
+          # interceptor. Heuristic regex match, no data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract, detectMWExtendFramework, emitFilterMiddleware]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware substring-matches each revel interceptor
+          # function/method expression against the shared auth-pattern catalog,
+          # flagging is_auth + auth_kind and emitting a dedicated auth:
+          # SCOPE.Pattern. Pattern match only, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract, emitFilterMiddleware]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
   lang.go.framework.fyne:
     capabilities:
       Native:
@@ -3851,6 +3964,41 @@ records:
             - file: internal/custom/golang/beego_iris_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # middleware_auth_extend.go (custom_go_middleware_auth) scans
+          # beego-attributed files for the filter-registration API
+          # web/beego.InsertFilter("/p", BeforeRouter, FilterFn) via
+          # reBeegoInsertFilter, emitting one SCOPE.Pattern
+          # (pattern_kind=middleware) per filter with filter_position +
+          # filter_path props. Heuristic regex match, no data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract, detectMWExtendFramework, emitFilterMiddleware]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware substring-matches each beego InsertFilter
+          # function expression against the shared auth-pattern catalog
+          # (jwt/oauth/basic/session/rbac/api_key/…), flagging is_auth +
+          # auth_kind and emitting a dedicated auth: SCOPE.Pattern. Pattern
+          # match only, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract, emitFilterMiddleware]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.iris:
     capabilities:
@@ -3884,6 +4032,40 @@ records:
             - file: internal/custom/golang/beego_iris_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # middleware_auth_extend.go (custom_go_middleware_auth) scans
+          # iris-attributed files for app.Use / .UseRouter / .UseGlobal
+          # middleware chains via the shared findUseCalls/parseMiddlewareChain
+          # helpers (reUseHead's optional Router/Global suffix covers the iris
+          # variants), emitting one ordered SCOPE.Pattern (mw_order) per
+          # middleware. Heuristic ordering, no data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract, detectMWExtendFramework]
+            - file: internal/custom/golang/helpers.go
+              functions: [findUseCalls, parseMiddlewareChain, emitMiddlewareChain, splitTopLevelArgs]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware substring-matches each iris middleware
+          # expression against the shared auth-pattern catalog, flagging
+          # is_auth + auth_kind and emitting a dedicated auth: SCOPE.Pattern.
+          # Pattern match only, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware, emitMiddlewareChain]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.hertz:
     capabilities:
@@ -3915,6 +4097,44 @@ records:
           tests:
             - file: internal/custom/golang/hertz_huma_test.go
           issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # hertz.go already reads balanced h.Use(...) chains via the shared
+          # findUseCalls/parseMiddlewareChain helpers, emitting ordered
+          # SCOPE.Pattern (mw_order) middleware; middleware_auth_extend.go
+          # (custom_go_middleware_auth) provides the same coverage via the
+          # framework-agnostic pass for hertz-attributed files. Heuristic
+          # ordering, no data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/hertz.go
+              functions: [Extract]
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract, detectMWExtendFramework]
+            - file: internal/custom/golang/helpers.go
+              functions: [findUseCalls, parseMiddlewareChain, emitMiddlewareChain, splitTopLevelArgs]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # classifyAuthMiddleware substring-matches each hertz .Use middleware
+          # expression against the shared auth-pattern catalog, flagging
+          # is_auth + auth_kind and emitting a dedicated auth: SCOPE.Pattern.
+          # Pattern match only, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/hertz.go
+              functions: [Extract]
+            - file: internal/custom/golang/middleware_auth_extend.go
+              functions: [Extract]
+            - file: internal/custom/golang/helpers.go
+              functions: [classifyAuthMiddleware, emitMiddlewareChain]
+          tests:
+            - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
   lang.go.framework.huma:


### PR DESCRIPTION
## Summary

Extends the shared Go middleware/auth detection (the gin/echo/fiber/chi helpers in `internal/custom/golang/helpers.go`) to the remaining HTTP frameworks, via a **new framework-agnostic pass** — `internal/custom/golang/middleware_auth_extend.go` (extractor key `custom_go_middleware_auth`) — that reuses the existing helpers rather than editing each per-framework extractor (mirrors the `observability.go` model).

The pass infers the framework from engine/context markers and scans the per-framework registration surface:

| Framework | Registration surface | Mechanism |
|---|---|---|
| buffalo / iris / hertz / gorilla-mux | `.Use(...)` chains | shared `findUseCalls` / `parseMiddlewareChain` / `emitMiddlewareChain` |
| beego | `web/beego.InsertFilter("/p", pos, FilterFn)` | `reBeegoInsertFilter` → `emitFilterMiddleware` |
| revel | `revel.InterceptFunc/InterceptMethod(fn, revel.BEFORE/AFTER)` | `reRevelExtendIntercept` → `emitFilterMiddleware` |

Each match emits a `SCOPE.Pattern` (`pattern_kind=middleware`) plus a dedicated auth `SCOPE.Pattern` whenever `classifyAuthMiddleware` flags it. `reUseHead` in `helpers.go` was broadened to also match Iris's `.UseRouter` / `.UseGlobal` (additive; bare `.Use(` still matches, so gin/echo/fiber/chi/hertz/buffalo/gorilla-mux are unaffected).

## Honesty / coverage flips

All detection is heuristic source-text matching with no data-flow or enforcement proof → **partial**.

| Framework | auth_coverage | middleware_coverage |
|---|---|---|
| beego | partial | partial |
| buffalo | partial | partial |
| iris | partial | partial |
| hertz | partial | partial |
| gorilla-mux | partial | partial |
| revel | partial | partial |
| **net-http** | **not_applicable** | **not_applicable** |
| **fasthttp** | **not_applicable** | **not_applicable** |

`net/http` and `fasthttp` are **honestly NA**: neither exposes a middleware-registration primitive — middleware in both is manual handler wrapping (`func(http.Handler) http.Handler` / RequestHandler wrapping) with no `.Use(...)` chain to extract. Negative tests assert the pass emits nothing for them.

## Tests / fixtures

- `middleware_auth_extend_test.go`: per-framework assertions (ordering, auth classification, beego filter props, revel interceptor form) + negative net/http & fasthttp tests + no-framework no-emit.
- Per-framework fixtures under `testdata/*_middleware_auth.go` for the 6 partial flips.

## capability-map.yaml

Added Middleware + Auth mapping entries for all 12 flipped cells (new `buffalo` / `revel` records; extended `beego` / `iris` / `hertz` / `gorilla-mux`), one entry per key.

## Validation (scoped)

- `go build ./internal/... ./tools/coverage/...` ✅
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/... ./internal/extractors/` ✅
- `go run ./tools/coverage validate` → exit 0, no duplicate keys ✅
- `go run ./tools/coverage fmt --check` → canonical ✅
- `go run ./tools/coverage gen` → byte-stable, docs committed ✅
- `gofmt -l` clean on all touched files ✅

Part of #3213

🤖 Generated with [Claude Code](https://claude.com/claude-code)