### PR TITLE
feat(coverage): extend Go observability + validation detectors to 8 more HTTP frameworks

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -39,21 +39,21 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/2 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/5 | |
 | [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 5/6 | |
-| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
 | [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 3/6 | |
 | [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 3/6 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
 | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 5/6 | |
-| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
 | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
 | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 3/6 | |
 | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 3/6 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/7 | |
 
 
 ### Mobile

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | — `not_applicable` | — | — | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | No built-in request binding/validation surface; fasthttp uses raw RequestCtx and revel uses an imperative c.Validation API (not struct-tag / go-playground validator), so the framework-agnostic validation scanner does not attribute it. |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | — `not_applicable` | — | — | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | No built-in request binding/validation surface; fasthttp uses raw RequestCtx and revel uses an imperative c.Validation API (not struct-tag / go-playground validator), so the framework-agnostic validation scanner does not attribute it. |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3215) | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10692,8 +10692,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -10727,16 +10729,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -10869,8 +10876,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -10904,16 +10913,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -11418,8 +11432,9 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "notes": "No built-in request binding/validation surface; fasthttp uses raw RequestCtx and revel uses an imperative c.Validation API (not struct-tag / go-playground validator), so the framework-agnostic validation scanner does not attribute it."
           }
         },
         "Middleware": {
@@ -11453,16 +11468,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -12373,8 +12393,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -12408,16 +12430,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -12552,8 +12579,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -12587,16 +12616,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -12908,8 +12942,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -12943,16 +12979,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -13262,8 +13303,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -13297,16 +13340,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -13439,8 +13487,9 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "notes": "No built-in request binding/validation surface; fasthttp uses raw RequestCtx and revel uses an imperative c.Validation API (not struct-tag / go-playground validator), so the framework-agnostic validation scanner does not attribute it."
           }
         },
         "Middleware": {
@@ -13474,16 +13523,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {

--- a/internal/custom/golang/observability.go
+++ b/internal/custom/golang/observability.go
@@ -45,12 +45,16 @@ import (
 //
 // Framework attribution: the scanner runs on every Go file (registry key
 // custom_go_observability matches the custom_go_ dispatch prefix). It infers
-// which of gin/echo/fiber/chi the file belongs to from framework-specific
-// engine/context markers and stamps that framework on each emitted entity.
-// A file with no recognised framework marker emits framework="" entities
-// (still useful, but not attributed) — those are skipped for the per-framework
-// cells. Files matching multiple frameworks (rare) attribute to the first
-// match in gin→echo→fiber→chi order.
+// which framework the file belongs to from framework-specific engine/context
+// markers and stamps that framework on each emitted entity. A file with no
+// recognised framework marker emits nothing. Files matching multiple
+// frameworks (rare) attribute to the first marker in declaration order.
+//
+// Recognised frameworks: gin, echo, fiber, chi, beego, buffalo, fasthttp,
+// revel, iris, hertz, gorilla-mux, net-http. The observability lanes are
+// framework-agnostic libraries (logrus/zap/slog/zerolog, prometheus, OTel),
+// so any of these frameworks can carry all three signals; attribution simply
+// stamps which framework's request stack the instrumentation sits in.
 
 func init() {
 	extractor.Register("custom_go_observability", &observabilityExtractor{})
@@ -76,6 +80,23 @@ var obsFrameworkMarkers = []struct {
 	{"echo", regexp.MustCompile(`\becho\.(?:New|Echo|Context|HandlerFunc|MiddlewareFunc)\b`)},
 	{"fiber", regexp.MustCompile(`\bfiber\.(?:New|App|Ctx|Handler)\b`)},
 	{"chi", regexp.MustCompile(`\bchi\.(?:NewRouter|Router|Mux)\b`)},
+
+	// --- extended HTTP frameworks (issues #3215 / #3213) ----------------
+	// Markers are each framework's canonical engine constructor and/or
+	// request-context type, taken from that framework's own routing
+	// extractor so attribution is unambiguous. More-specific frameworks are
+	// listed before the generic net/http marker because a beego/gorilla/
+	// fasthttp file frequently also imports net/http; first match wins, so
+	// net-http is the last fallback (matches only files with no richer
+	// framework marker).
+	{"beego", regexp.MustCompile(`\b(?:beego|web)\.(?:Router|NewNamespace|AutoRouter|Run|Controller|NSRouter)\b|\bbeego\.Controller\b`)},
+	{"buffalo", regexp.MustCompile(`\bbuffalo\.(?:New|App|Context|Options)\b`)},
+	{"fasthttp", regexp.MustCompile(`\bfasthttp\.(?:RequestCtx|ListenAndServe|RequestHandler)\b|\brouter\.New\s*\(\s*\)`)},
+	{"revel", regexp.MustCompile(`\brevel\.(?:Controller|Result|InterceptFunc|InterceptMethod|OnAppStart)\b`)},
+	{"iris", regexp.MustCompile(`\biris\.(?:New|Default|Application)\b`)},
+	{"hertz", regexp.MustCompile(`\bserver\.(?:Default|New)\b|\bapp\.RequestContext\b`)},
+	{"gorilla-mux", regexp.MustCompile(`\bmux\.(?:NewRouter|Router|Vars)\b`)},
+	{"net-http", regexp.MustCompile(`\bhttp\.(?:NewServeMux|HandleFunc|ServeMux)\b`)},
 }
 
 // detectObsFramework returns the framework the file belongs to, or "" when no

--- a/internal/custom/golang/observability_test.go
+++ b/internal/custom/golang/observability_test.go
@@ -143,6 +143,16 @@ func TestObservabilityFixtures(t *testing.T) {
 		{"echo_observability.go", "echo", "zap"},
 		{"fiber_observability.go", "fiber", "slog"},
 		{"chi_observability.go", "chi", "logrus"},
+
+		// extended frameworks (issue #3215)
+		{"beego_observability.go", "beego", "logrus"},
+		{"buffalo_observability.go", "buffalo", "zap"},
+		{"fasthttp_observability.go", "fasthttp", "slog"},
+		{"revel_observability.go", "revel", "logrus"},
+		{"iris_observability.go", "iris", "zap"},
+		{"hertz_observability.go", "hertz", "logrus"},
+		{"gorilla_mux_observability.go", "gorilla-mux", "logrus"},
+		{"nethttp_observability.go", "net-http", "slog"},
 	}
 	for _, c := range cases {
 		t.Run(c.framework, func(t *testing.T) {

--- a/internal/custom/golang/testdata/beego_observability.go
+++ b/internal/custom/golang/testdata/beego_observability.go
@@ -1,0 +1,42 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/beego/beego/v2/server/web"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+var beegoReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "beego_http_requests_total",
+		Help: "Total HTTP requests handled by the beego app.",
+	},
+	[]string{"controller"},
+)
+
+// BeegoUserController is a beego controller embedding web.Controller.
+type BeegoUserController struct {
+	web.Controller
+}
+
+func (c *BeegoUserController) GetAll() {
+	log := logrus.New()
+	log.WithFields(logrus.Fields{"component": "users"}).Info("listing users")
+
+	tracer := otel.Tracer("beego-service")
+	ctx, span := tracer.Start(context.Background(), "controller.users.list")
+	defer span.End()
+
+	beegoReqCount.WithLabelValues("UserController").Inc()
+	_ = ctx
+	c.Data["json"] = map[string]any{"ok": true}
+	c.ServeJSON()
+}
+
+func newBeegoServer() {
+	web.Router("/users", &BeegoUserController{}, "get:GetAll")
+	web.Run()
+}

--- a/internal/custom/golang/testdata/beego_validation.go
+++ b/internal/custom/golang/testdata/beego_validation.go
@@ -1,0 +1,36 @@
+package fixtures
+
+import (
+	"github.com/beego/beego/v2/server/web"
+	"github.com/go-playground/validator/v10"
+)
+
+// BeegoCreateUserReq is a DTO validated via go-playground validate: tags,
+// bound inside a beego controller action.
+type BeegoCreateUserReq struct {
+	Name  string `json:"name" validate:"required,min=2,max=64"`
+	Email string `json:"email" validate:"required,email"`
+	Age   int    `json:"age" validate:"gte=0,lte=130"`
+	Skip  string `json:"-" validate:"-"`
+}
+
+// BeegoUserValidationController embeds web.Controller.
+type BeegoUserValidationController struct {
+	web.Controller
+}
+
+func (c *BeegoUserValidationController) Post() {
+	validate := validator.New()
+	validate.RegisterValidation("is_even", func(fl validator.FieldLevel) bool {
+		return fl.Field().Int()%2 == 0
+	})
+
+	var req BeegoCreateUserReq
+	c.BindJSON(&req)
+	if err := validate.Struct(&req); err != nil {
+		c.Abort("400")
+		return
+	}
+	c.Data["json"] = req
+	c.ServeJSON()
+}

--- a/internal/custom/golang/testdata/buffalo_observability.go
+++ b/internal/custom/golang/testdata/buffalo_observability.go
@@ -1,0 +1,38 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+)
+
+var buffaloReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "buffalo_http_requests_total",
+		Help: "Total HTTP requests handled by the buffalo app.",
+	},
+	[]string{"route"},
+)
+
+func usersList(c buffalo.Context) error {
+	logger, _ := zap.NewProduction()
+	logger = logger.With(zap.String("component", "users"))
+	logger.Info("listing users")
+
+	tracer := otel.Tracer("buffalo-service")
+	ctx, span := tracer.Start(context.Background(), "handler.users.list")
+	defer span.End()
+
+	buffaloReqCount.WithLabelValues("/users").Inc()
+	_ = ctx
+	return c.Render(200, nil)
+}
+
+func newBuffaloServer() *buffalo.App {
+	app := buffalo.New(buffalo.Options{})
+	app.GET("/users", usersList)
+	return app
+}

--- a/internal/custom/golang/testdata/buffalo_validation.go
+++ b/internal/custom/golang/testdata/buffalo_validation.go
@@ -1,0 +1,26 @@
+package fixtures
+
+import (
+	"github.com/gobuffalo/buffalo"
+)
+
+// BuffaloSignupReq is a DTO bound via c.Bind inside a buffalo handler and
+// validated through go-playground validate: tags.
+type BuffaloSignupReq struct {
+	Email    string `json:"email" validate:"required,email"`
+	Password string `json:"password" validate:"required,min=8"`
+}
+
+func buffaloSignup(c buffalo.Context) error {
+	var req BuffaloSignupReq
+	if err := c.Bind(&req); err != nil {
+		return c.Render(400, nil)
+	}
+	return c.Render(201, nil)
+}
+
+func newBuffaloValidationApp() *buffalo.App {
+	app := buffalo.New(buffalo.Options{})
+	app.POST("/signup", buffaloSignup)
+	return app
+}

--- a/internal/custom/golang/testdata/fasthttp_observability.go
+++ b/internal/custom/golang/testdata/fasthttp_observability.go
@@ -1,0 +1,39 @@
+package fixtures
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/fasthttp/router"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/valyala/fasthttp"
+	"go.opentelemetry.io/otel"
+)
+
+var fastReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "fasthttp_http_requests_total",
+		Help: "Total HTTP requests handled by the fasthttp router.",
+	},
+	[]string{"route"},
+)
+
+func fastUsersList(ctx *fasthttp.RequestCtx) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	logger.Info("listing users")
+
+	tracer := otel.Tracer("fasthttp-service")
+	c, span := tracer.Start(context.Background(), "handler.users.list")
+	defer span.End()
+
+	fastReqCount.WithLabelValues("/users").Inc()
+	_ = c
+	ctx.SetStatusCode(fasthttp.StatusOK)
+}
+
+func newFastServer() *router.Router {
+	r := router.New()
+	r.GET("/users", fastUsersList)
+	return r
+}

--- a/internal/custom/golang/testdata/gorilla_mux_observability.go
+++ b/internal/custom/golang/testdata/gorilla_mux_observability.go
@@ -1,0 +1,37 @@
+package fixtures
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+var gorillaReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "gorilla_http_requests_total",
+		Help: "Total HTTP requests handled by the gorilla/mux router.",
+	},
+	[]string{"route"},
+)
+
+func newGorillaServer() *mux.Router {
+	r := mux.NewRouter()
+
+	log := logrus.New()
+	log.WithFields(logrus.Fields{"component": "router"}).Info("starting gorilla")
+
+	r.HandleFunc("/users", func(w http.ResponseWriter, req *http.Request) {
+		tracer := otel.Tracer("gorilla-service")
+		ctx, span := tracer.Start(context.Background(), "handler.users.list")
+		defer span.End()
+
+		gorillaReqCount.WithLabelValues("/users").Inc()
+		_ = ctx
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+	return r
+}

--- a/internal/custom/golang/testdata/gorilla_mux_validation.go
+++ b/internal/custom/golang/testdata/gorilla_mux_validation.go
@@ -1,0 +1,36 @@
+package fixtures
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/gorilla/mux"
+)
+
+// GorillaOrderReq is a DTO decoded from the request body and validated with
+// go-playground validate: tags — gorilla/mux has no built-in binding, so
+// validation is the conventional decode-then-validator.Struct pattern.
+type GorillaOrderReq struct {
+	SKU      string `json:"sku" validate:"required,alphanum"`
+	Quantity int    `json:"quantity" validate:"required,gte=1"`
+}
+
+func newGorillaValidationRouter() *mux.Router {
+	r := mux.NewRouter()
+	validate := validator.New()
+
+	r.HandleFunc("/orders", func(w http.ResponseWriter, req *http.Request) {
+		var body GorillaOrderReq
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if err := validate.Struct(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}).Methods("POST")
+	return r
+}

--- a/internal/custom/golang/testdata/hertz_observability.go
+++ b/internal/custom/golang/testdata/hertz_observability.go
@@ -1,0 +1,37 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+var hertzReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "hertz_http_requests_total",
+		Help: "Total HTTP requests handled by the hertz engine.",
+	},
+	[]string{"route"},
+)
+
+func newHertzServer() {
+	h := server.Default()
+
+	log := logrus.New()
+	log.WithFields(logrus.Fields{"component": "router"}).Info("starting hertz")
+
+	h.GET("/users", func(ctx context.Context, c *app.RequestContext) {
+		tracer := otel.Tracer("hertz-service")
+		spanCtx, span := tracer.Start(ctx, "handler.users.list")
+		defer span.End()
+
+		hertzReqCount.WithLabelValues("/users").Inc()
+		_ = spanCtx
+		c.JSON(200, map[string]any{"ok": true})
+	})
+	h.Spin()
+}

--- a/internal/custom/golang/testdata/hertz_validation.go
+++ b/internal/custom/golang/testdata/hertz_validation.go
@@ -1,0 +1,30 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+)
+
+// HertzCreateUserReq is a DTO bound + validated via hertz's built-in binder
+// (c.Bind / c.BindAndValidate). hertz honours both vd: and binding: tags; the
+// binding: tag is the surface this scanner recognises.
+type HertzCreateUserReq struct {
+	Name  string `json:"name" binding:"required"`
+	Email string `json:"email" binding:"required,email"`
+	Age   int    `json:"age" binding:"gte=0,lte=130"`
+}
+
+func newHertzValidationServer() {
+	h := server.Default()
+	h.POST("/users", func(ctx context.Context, c *app.RequestContext) {
+		var req HertzCreateUserReq
+		if err := c.Bind(&req); err != nil {
+			c.JSON(400, map[string]any{"error": err.Error()})
+			return
+		}
+		c.JSON(201, req)
+	})
+	h.Spin()
+}

--- a/internal/custom/golang/testdata/iris_observability.go
+++ b/internal/custom/golang/testdata/iris_observability.go
@@ -1,0 +1,37 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/kataras/iris/v12"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+)
+
+var irisReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "iris_http_requests_total",
+		Help: "Total HTTP requests handled by the iris app.",
+	},
+	[]string{"route"},
+)
+
+func newIrisServer() *iris.Application {
+	app := iris.New()
+
+	logger, _ := zap.NewProduction()
+	logger = logger.With(zap.String("component", "router"))
+	logger.Info("starting iris")
+
+	app.Get("/users", func(c iris.Context) {
+		tracer := otel.Tracer("iris-service")
+		ctx, span := tracer.Start(context.Background(), "handler.users.list")
+		defer span.End()
+
+		irisReqCount.WithLabelValues("/users").Inc()
+		_ = ctx
+		c.JSON(iris.Map{"ok": true})
+	})
+	return app
+}

--- a/internal/custom/golang/testdata/iris_validation.go
+++ b/internal/custom/golang/testdata/iris_validation.go
@@ -1,0 +1,28 @@
+package fixtures
+
+import (
+	"github.com/go-playground/validator/v10"
+	"github.com/kataras/iris/v12"
+)
+
+// IrisLoginReq is a DTO validated through iris's built-in go-playground
+// validator (app.Validator = validator.New()) using validate: tags.
+type IrisLoginReq struct {
+	Username string `json:"username" validate:"required,alphanum"`
+	Password string `json:"password" validate:"required,min=8"`
+}
+
+func newIrisValidationApp() *iris.Application {
+	app := iris.New()
+	app.Validator = validator.New()
+
+	app.Post("/login", func(c iris.Context) {
+		var req IrisLoginReq
+		if err := c.ReadJSON(&req); err != nil {
+			c.StopWithStatus(400)
+			return
+		}
+		c.JSON(req)
+	})
+	return app
+}

--- a/internal/custom/golang/testdata/nethttp_observability.go
+++ b/internal/custom/golang/testdata/nethttp_observability.go
@@ -1,0 +1,36 @@
+package fixtures
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+)
+
+var netHTTPReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "nethttp_http_requests_total",
+		Help: "Total HTTP requests handled by the net/http ServeMux.",
+	},
+	[]string{"route"},
+)
+
+func newNetHTTPServer() *http.ServeMux {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	logger.Info("starting net/http server")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /users", func(w http.ResponseWriter, r *http.Request) {
+		tracer := otel.Tracer("nethttp-service")
+		ctx, span := tracer.Start(context.Background(), "handler.users.list")
+		defer span.End()
+
+		netHTTPReqCount.WithLabelValues("/users").Inc()
+		_ = ctx
+		w.WriteHeader(http.StatusOK)
+	})
+	return mux
+}

--- a/internal/custom/golang/testdata/nethttp_validation.go
+++ b/internal/custom/golang/testdata/nethttp_validation.go
@@ -1,0 +1,36 @@
+package fixtures
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// NetHTTPCreateUserReq is a DTO decoded from the request body and validated
+// with go-playground validate: tags — the stdlib net/http router has no
+// built-in binding, so validation is the conventional decode-then-validator
+// pattern.
+type NetHTTPCreateUserReq struct {
+	Name  string `json:"name" validate:"required,min=2"`
+	Email string `json:"email" validate:"required,email"`
+}
+
+func newNetHTTPValidationServer() *http.ServeMux {
+	mux := http.NewServeMux()
+	validate := validator.New()
+
+	mux.HandleFunc("POST /users", func(w http.ResponseWriter, r *http.Request) {
+		var req NetHTTPCreateUserReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if err := validate.Struct(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+	return mux
+}

--- a/internal/custom/golang/testdata/revel_observability.go
+++ b/internal/custom/golang/testdata/revel_observability.go
@@ -1,0 +1,40 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/revel/revel"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+var revelReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "revel_http_requests_total",
+		Help: "Total HTTP requests handled by the revel app.",
+	},
+	[]string{"action"},
+)
+
+// RevelApp is a revel controller embedding *revel.Controller.
+type RevelApp struct {
+	*revel.Controller
+}
+
+func (c RevelApp) Index() revel.Result {
+	log := logrus.New()
+	log.WithField("component", "users").Info("index action")
+
+	tracer := otel.Tracer("revel-service")
+	ctx, span := tracer.Start(context.Background(), "action.users.index")
+	defer span.End()
+
+	revelReqCount.WithLabelValues("App.Index").Inc()
+	_ = ctx
+	return c.RenderJSON(map[string]any{"ok": true})
+}
+
+func init() {
+	revel.InterceptMethod(RevelApp.Index, revel.BEFORE)
+}

--- a/internal/custom/golang/validation.go
+++ b/internal/custom/golang/validation.go
@@ -67,6 +67,22 @@ var valFrameworkMarkers = []struct {
 	{"echo", regexp.MustCompile(`\becho\.(?:New|Echo|Context|HandlerFunc|MiddlewareFunc)\b`)},
 	{"fiber", regexp.MustCompile(`\bfiber\.(?:New|App|Ctx|Handler)\b`)},
 	{"chi", regexp.MustCompile(`\bchi\.(?:NewRouter|Router|Mux)\b`)},
+
+	// --- extended HTTP frameworks (issue #3213) -------------------------
+	// Only frameworks with a recognisable request-binding / struct-tag
+	// validation surface are attributed here. fasthttp (raw RequestCtx, no
+	// built-in binding/validation) and revel (imperative c.Validation API,
+	// not struct tags / go-playground validator) are deliberately omitted —
+	// their request_validation cells are honesty-NA, so this scanner must
+	// not attribute generic `validate:` tags to them. Order mirrors
+	// observability.go: specific frameworks before the generic net/http
+	// fallback (first match wins).
+	{"beego", regexp.MustCompile(`\b(?:beego|web)\.(?:Router|NewNamespace|AutoRouter|Run|Controller|NSRouter)\b|\bbeego\.Controller\b`)},
+	{"buffalo", regexp.MustCompile(`\bbuffalo\.(?:New|App|Context|Options)\b`)},
+	{"iris", regexp.MustCompile(`\biris\.(?:New|Default|Application)\b`)},
+	{"hertz", regexp.MustCompile(`\bserver\.(?:Default|New)\b|\bapp\.RequestContext\b`)},
+	{"gorilla-mux", regexp.MustCompile(`\bmux\.(?:NewRouter|Router|Vars)\b`)},
+	{"net-http", regexp.MustCompile(`\bhttp\.(?:NewServeMux|HandleFunc|ServeMux)\b`)},
 }
 
 // detectValFramework returns the framework a file belongs to, or "" when no

--- a/internal/custom/golang/validation_test.go
+++ b/internal/custom/golang/validation_test.go
@@ -186,6 +186,11 @@ func TestValidationFixtures(t *testing.T) {
 		{"echo_validation.go", "echo", "LoginReq", "Password", "validate_call"},
 		{"fiber_validation.go", "fiber", "SignupReq", "Email", "parse_call"},
 		{"chi_validation.go", "chi", "OrderReq", "SKU", "bind_call"},
+
+		// extended frameworks with a recognised binding call site (issue #3213)
+		{"beego_validation.go", "beego", "BeegoCreateUserReq", "Email", "bind_call"},
+		{"buffalo_validation.go", "buffalo", "BuffaloSignupReq", "Email", "bind_call"},
+		{"hertz_validation.go", "hertz", "HertzCreateUserReq", "Email", "bind_call"},
 	}
 	for _, c := range cases {
 		t.Run(c.framework, func(t *testing.T) {
@@ -207,6 +212,57 @@ func TestValidationFixtures(t *testing.T) {
 				if e.Props["framework"] != c.framework {
 					t.Errorf("%s: entity %q framework=%q", c.framework, e.Name, e.Props["framework"])
 				}
+			}
+		})
+	}
+}
+
+// TestValidationFixturesRuleOnly covers extended frameworks whose validation
+// surface is struct-tag rules + a go-playground validator (no framework-native
+// `c.Bind`-style call site this scanner recognises): iris (built-in
+// app.Validator = validator.New()), gorilla-mux and net-http (the conventional
+// decode-then-validator.Struct pattern). These prove the `partial`
+// request_validation flip via rule + validator detection.
+func TestValidationFixturesRuleOnly(t *testing.T) {
+	cases := []struct {
+		fixture, framework, ruleStruct, ruleField string
+	}{
+		{"iris_validation.go", "iris", "IrisLoginReq", "Username"},
+		{"gorilla_mux_validation.go", "gorilla-mux", "GorillaOrderReq", "SKU"},
+		{"nethttp_validation.go", "net-http", "NetHTTPCreateUserReq", "Email"},
+	}
+	for _, c := range cases {
+		t.Run(c.framework, func(t *testing.T) {
+			ents := extractFull(t, "custom_go_validation", fixtureFile(t, c.fixture))
+
+			if findValRule(ents, c.ruleStruct, c.ruleField) == nil {
+				t.Errorf("%s: missing rule %s.%s; got %+v",
+					c.framework, c.ruleStruct, c.ruleField, valEntities(ents))
+			}
+			if findVal(ents, "validator", "validator_new") == nil {
+				t.Errorf("%s: missing validator_new; got %+v", c.framework, valEntities(ents))
+			}
+			for _, e := range valEntities(ents) {
+				if e.Props["framework"] != c.framework {
+					t.Errorf("%s: entity %q framework=%q", c.framework, e.Name, e.Props["framework"])
+				}
+			}
+		})
+	}
+}
+
+// TestValidationNAFrameworks proves the honesty-NA cells: fasthttp (raw
+// RequestCtx, no built-in binding/validation) and revel (imperative
+// c.Validation API, not struct tags) are intentionally not attributed by the
+// validation scanner, so their observability fixtures yield zero validation
+// entities even though they reference the frameworks.
+func TestValidationNAFrameworks(t *testing.T) {
+	for _, fixture := range []string{"fasthttp_observability.go", "revel_observability.go"} {
+		t.Run(fixture, func(t *testing.T) {
+			ents := extractFull(t, "custom_go_validation", fixtureFile(t, fixture))
+			if got := valEntities(ents); len(got) != 0 {
+				t.Fatalf("%s: expected no validation entities (NA framework), got %d: %+v",
+					fixture, len(got), got)
 			}
 		})
 	}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3198,6 +3198,55 @@ records:
             - file: internal/custom/golang/extractors_test.go
             - file: internal/engine/go_routes_test.go
           issues_implemented: ["3212"]
+      Observability:
+        log_extraction:
+          # observability.go infers a gorilla/mux-context file (mux.NewRouter/
+          # Router/Vars) and emits logging SCOPE.Pattern entities for logrus/
+          # zap/slog/zerolog. Heuristic identifier match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # prometheus collector declarations emitted with metric_name.
+          # Heuristic → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # OTel tracer acquire + span start (canonical span lifecycle) → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, obsEntityName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go infers a gorilla/mux-context file and scans validate:
+          # struct-tag rules + validator.New() — gorilla/mux has no built-in
+          # binding, so the conventional decode-then-validator.Struct pattern is
+          # the recognised surface. Heuristic match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
   lang.go.orm.gorm:
     capabilities:
       Models:
@@ -3754,6 +3803,55 @@ records:
             - file: internal/engine/go_routes_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go infers a net/http-context file (http.NewServeMux /
+          # http.HandleFunc / http.ServeMux) and emits logging SCOPE.Pattern
+          # entities for logrus/zap/slog/zerolog. Heuristic identifier match,
+          # and net-http is the generic last-resort marker (specific frameworks
+          # win first) → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # prometheus collector declarations emitted with metric_name → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # OTel tracer acquire + span start (canonical span lifecycle) → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, obsEntityName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go infers a net/http-context file and scans validate:
+          # struct-tag rules + validator.New() — the stdlib router has no
+          # built-in binding, so the conventional decode-then-validator.Struct
+          # pattern is the recognised surface. Heuristic match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.beego:
     capabilities:
@@ -3788,6 +3886,58 @@ records:
             - file: internal/custom/golang/beego_iris_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) infers a beego-context
+          # file (web.Controller / web.Router markers) and emits logging
+          # SCOPE.Pattern entities for logrus/zap/slog/zerolog setup. Heuristic
+          # identifier match, no logger→handler data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # prometheus collector declarations (NewCounter/Histogram/Gauge/
+          # Summary[Vec], promauto forms) emitted with metric_name. Heuristic
+          # declaration match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # OTel tracer acquire (otel.Tracer / x.Tracer("…")) + span start
+          # (tracer.Start(ctx, "name")). The canonical OTel span lifecycle is
+          # the complete public tracing API a handler uses → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, obsEntityName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) infers a beego-context file
+          # and scans go-playground validate: struct-tag rules, validator.New()/
+          # RegisterValidation custom validators, and c.Bind* binding call sites
+          # in controller actions. Heuristic tag/call match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.iris:
     capabilities:
@@ -3821,6 +3971,53 @@ records:
             - file: internal/custom/golang/beego_iris_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go infers an iris-context file (iris.New/Default/
+          # Application) and emits logging SCOPE.Pattern entities for logrus/
+          # zap/slog/zerolog. Heuristic identifier match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # prometheus collector declarations emitted with metric_name.
+          # Heuristic → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # OTel tracer acquire + span start (canonical span lifecycle) → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, obsEntityName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go infers an iris-context file and scans validate:
+          # struct-tag rules + iris's built-in go-playground validator
+          # (app.Validator = validator.New()). Heuristic match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.hertz:
     capabilities:
@@ -3852,6 +4049,53 @@ records:
           tests:
             - file: internal/custom/golang/hertz_huma_test.go
           issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go infers a hertz-context file (server.Default/New,
+          # app.RequestContext) and emits logging SCOPE.Pattern entities for
+          # logrus/zap/slog/zerolog. Heuristic identifier match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # prometheus collector declarations emitted with metric_name.
+          # Heuristic → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # OTel tracer acquire + span start (canonical span lifecycle) → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, obsEntityName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go infers a hertz-context file and scans binding:
+          # struct-tag rules + hertz's built-in binder (c.Bind /
+          # c.BindAndValidate). Heuristic tag/call match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
   lang.go.framework.huma:
@@ -6354,3 +6598,130 @@ records:
         status: partial
         issues_implemented: ["3211"]
         verified_at: "2026-05-30"
+
+  lang.go.framework.buffalo:
+    capabilities:
+      Observability:
+        log_extraction:
+          # observability.go infers a buffalo-context file (buffalo.New/App/
+          # Context) and emits logging SCOPE.Pattern entities for logrus/zap/
+          # slog/zerolog. Heuristic identifier match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # prometheus collector declarations emitted with metric_name → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # OTel tracer acquire + span start (canonical span lifecycle) → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, obsEntityName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go infers a buffalo-context file and scans validate:
+          # struct-tag rules + c.Bind binding call sites in buffalo handlers.
+          # Heuristic tag/call match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+
+  lang.go.framework.fasthttp:
+    capabilities:
+      Observability:
+        log_extraction:
+          # observability.go infers a fasthttp-context file (fasthttp.RequestCtx
+          # / router.New()) and emits logging SCOPE.Pattern entities for logrus/
+          # zap/slog/zerolog. Heuristic identifier match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # prometheus collector declarations emitted with metric_name → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # OTel tracer acquire + span start (canonical span lifecycle) → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, obsEntityName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+      # Validation: request_validation is honesty-NA (raw RequestCtx, no
+      # built-in binding/validation surface) — no mapping entry needed for an
+      # N/A cell.
+
+  lang.go.framework.revel:
+    capabilities:
+      Observability:
+        log_extraction:
+          # observability.go infers a revel-context file (revel.Controller/
+          # Result/Intercept*) and emits logging SCOPE.Pattern entities for
+          # logrus/zap/slog/zerolog. Heuristic identifier match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # prometheus collector declarations emitted with metric_name → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # OTel tracer acquire + span start (canonical span lifecycle) → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, obsEntityName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+      # Validation: request_validation is honesty-NA (revel uses an imperative
+      # c.Validation API, not struct-tag / go-playground validator) — no
+      # mapping entry needed for an N/A cell.


### PR DESCRIPTION
Part of #3215 and #3213.

## What

Extends the framework-agnostic Go observability scanner (`internal/custom/golang/observability.go`) and request-validation scanner (`validation.go`) to attribute their signals to eight more HTTP frameworks: **beego, buffalo, fasthttp, revel, iris, hertz, net-http, gorilla-mux**.

Only the file-local **framework-inference tables** changed — each framework's canonical engine constructor / request-context type was added as a marker (sourced from that framework's own routing extractor). The detection logic itself is untouched:
- observability: logrus/zap/slog/zerolog logger setup, prometheus collectors (`NewCounter/Histogram/Gauge/Summary[Vec]`, promauto), OTel `tracer.Start`/`otel.Tracer`.
- validation: `validate:`/`binding:` struct-tag rules, `validator.New()`/`RegisterValidation`, `c.Bind*`/`render.Bind` binding call sites.

`net-http` is the generic last-resort marker (specific frameworks win first, so a beego/gorilla/fasthttp file that also imports `net/http` still attributes correctly).

## Honesty

| Framework | log_extraction | metric_extraction | trace_extraction | request_validation |
|---|---|---|---|---|
| beego | partial | partial | full | partial |
| buffalo | partial | partial | full | partial |
| fasthttp | partial | partial | full | **N/A** |
| revel | partial | partial | full | **N/A** |
| iris | partial | partial | full | partial |
| hertz | partial | partial | full | partial |
| net-http | partial | partial | full | partial |
| gorilla-mux | partial | partial | full | partial |

- Observability mirrors the existing gin/echo/fiber/chi precedent: logging/metrics are heuristic identifier/declaration matches (`partial`); the OTel tracer-acquire + span-start pair is the complete public tracing API a handler uses (`full`).
- `request_validation` is **honesty-NA** for **fasthttp** (raw `RequestCtx`, no built-in binding/validation) and **revel** (imperative `c.Validation` API, not struct-tag / go-playground validator). Those two are deliberately *not* added to the validation scanner's marker table, and a dedicated test (`TestValidationNAFrameworks`) proves they emit zero validation entities.

## Tests & fixtures

- 8 new observability fixtures + 6 new validation fixtures (the non-NA frameworks) under `internal/custom/golang/testdata/`.
- Extended `TestObservabilityFixtures` (all 8) and `TestValidationFixtures` / new `TestValidationFixturesRuleOnly` + `TestValidationNAFrameworks`.

## Registry / mapping / docs

- Flipped the matching `lang.go.framework.<fw>` Observability + Validation cells via `tools/coverage update`.
- Added `capability-map.yaml` mapping entries for every flipped cell (each key once; NA cells need no entry).
- Regenerated `docs/coverage/*` (byte-stable; `fmt --check` clean).

## Validation run (scoped)

- `go build ./internal/... ./tools/coverage/...`
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` — all pass
- `go run ./tools/coverage validate` — exit 0, no errors, no duplicate keys
- `fmt --check` clean, `gofmt -l` empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)