### PR TITLE
feat(coverage): Go NoSQL driver extractors — gocql/dynamodb/elasticsearch/neo4j

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -42,19 +42,19 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [elixir](../by-language/elixir.md) | [ecto_sqlite3](../detail/lang.elixir.orm.ecto-sqlite3.md) | 🟡 2/8 | |
 | [elixir](../by-language/elixir.md) | [elasticsearch-elixir](../detail/lang.elixir.driver.elastic.md) | 🟡 1/6 | |
 | [elixir](../by-language/elixir.md) | [mongodb (Elixir driver)](../detail/lang.elixir.driver.mongodb.md) | 🟡 1/6 | |
-| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟡 1/6 | |
+| [go](../by-language/go.md) | [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟢 3/3 | |
 | [go](../by-language/go.md) | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 2/8 | |
 | [go](../by-language/go.md) | [GORM](../detail/lang.go.orm.gorm.md) | 🟢 8/8 | |
 | [go](../by-language/go.md) | [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 2/8 | |
 | [go](../by-language/go.md) | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🟢 3/3 | |
-| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟡 1/6 | |
+| [go](../by-language/go.md) | [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟢 4/4 | |
 | [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | 🟢 2/2 | |
 | [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 1/6 | |
-| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 1/6 | |
+| [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟢 2/2 | |
 | [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/6 | |
 | [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟢 4/4 | |
 | [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟢 3/3 | |
-| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 1/6 | |
+| [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟢 3/3 | |
 | [go](../by-language/go.md) | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟢 4/4 | |
 | [go](../by-language/go.md) | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟢 4/4 | |
 | [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟢 5/5 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -77,19 +77,19 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟡 1/6 | |
+| [AWS SDK DynamoDB (Go)](../detail/lang.go.driver.dynamodb.md) | 🟢 3/3 | |
 | [Bun (uptrace)](../detail/lang.go.orm.bun.md) | 🟡 2/8 | |
 | [GORM](../detail/lang.go.orm.gorm.md) | 🟢 8/8 | |
 | [ent (Facebook)](../detail/lang.go.orm.ent.md) | 🟡 2/8 | |
 | [gen (gentleman / GORM gen)](../detail/lang.go.orm.gen.md) | 🟢 3/3 | |
-| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟡 1/6 | |
+| [go-elasticsearch](../detail/lang.go.driver.elastic.md) | 🟢 4/4 | |
 | [go-redis](../detail/lang.go.driver.redis.md) | 🟢 2/2 | |
 | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟡 1/6 | |
-| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟡 1/6 | |
+| [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟢 2/2 | |
 | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/6 | |
 | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟢 4/4 | |
 | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟢 3/3 | |
-| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟡 1/6 | |
+| [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟢 3/3 | |
 | [pgx (PostgreSQL driver)](../detail/lang.go.orm.pgx.md) | 🟢 4/4 | |
 | [sqlc (codegen)](../detail/lang.go.orm.sqlc.md) | 🟢 4/4 | |
 | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟢 5/5 | |

--- a/docs/coverage/detail/lang.go.driver.cassandra.md
+++ b/docs/coverage/detail/lang.go.driver.cassandra.md
@@ -16,22 +16,22 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/gocql.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/cassandra_go.yaml` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | NoSQL/graph driver: no ORM association metadata. |
+| Foreign key extraction | — `not_applicable` | — | — | — | No foreign-key concept in this driver. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | No lazy/eager loading; queries are explicit. |
+| Relationship extraction | — `not_applicable` | — | — | — | Cassandra is a wide-column store with no foreign keys or joins. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/cassandra_go.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/gocql.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/cassandra_go.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.go.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.go.driver.dynamodb.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/dynamodb.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/dynamodb_go.yaml` | — |
+| Schema extraction | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/dynamodb.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/dynamodb_go.yaml` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | NoSQL/graph driver: no ORM association metadata. |
+| Foreign key extraction | — `not_applicable` | — | — | — | No foreign-key concept in this driver. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | No lazy/eager loading; queries are explicit. |
+| Relationship extraction | — `not_applicable` | — | — | — | DynamoDB has no foreign keys or joins; GSIs/LSIs are access-path indexes. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/dynamodb_go.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/dynamodb.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/dynamodb_go.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.go.driver.elastic.md
+++ b/docs/coverage/detail/lang.go.driver.elastic.md
@@ -15,29 +15,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/elasticsearch.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
+| Schema extraction | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/elasticsearch.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | NoSQL/graph driver: no ORM association metadata. |
+| Foreign key extraction | — `not_applicable` | — | — | — | No foreign-key concept in this driver. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | No lazy/eager loading; queries are explicit. |
+| Relationship extraction | — `not_applicable` | — | — | — | Elasticsearch is a document store; join/nested types are denormalisation, not relations. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/elasticsearch.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
 
 ### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | — `not_applicable` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/elasticsearch.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/elasticsearch_go.yaml` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.go.driver.neo4j.md
+++ b/docs/coverage/detail/lang.go.driver.neo4j.md
@@ -16,22 +16,22 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/neo4j.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/neo4j.yaml` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | NoSQL/graph driver: no ORM association metadata. |
+| Foreign key extraction | — `not_applicable` | — | — | — | No foreign-key concept in this driver. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | No lazy/eager loading; queries are explicit. |
+| Relationship extraction | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/neo4j.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/neo4j.yaml` | — |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/go/orms/neo4j.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3214 | `internal/custom/golang/neo4j.go`<br>`internal/custom/golang/nosql_drivers_test.go`<br>`internal/engine/rules/go/orms/neo4j.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10280,33 +10280,36 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/gocql.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/cassandra_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "NoSQL/graph driver: no ORM association metadata."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No foreign-key concept in this driver."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No lazy/eager loading; queries are explicit."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Cassandra is a wide-column store with no foreign keys or joins."
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/cassandra_go.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/gocql.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/cassandra_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -10325,36 +10328,42 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "not_applicable"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dynamodb.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/dynamodb_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dynamodb.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/dynamodb_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "NoSQL/graph driver: no ORM association metadata."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No foreign-key concept in this driver."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No lazy/eager loading; queries are explicit."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "DynamoDB has no foreign keys or joins; GSIs/LSIs are access-path indexes."
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/dynamodb_go.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/dynamodb.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/dynamodb_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -10373,41 +10382,50 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "not_applicable"
+            "status": "partial",
+            "cites": ["internal/custom/golang/elasticsearch.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/elasticsearch_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/elasticsearch.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/elasticsearch_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "NoSQL/graph driver: no ORM association metadata."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No foreign-key concept in this driver."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No lazy/eager loading; queries are explicit."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Elasticsearch is a document store; join/nested types are denormalisation, not relations."
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/elasticsearch_go.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/elasticsearch.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/elasticsearch_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "not_applicable"
+            "status": "partial",
+            "cites": ["internal/custom/golang/elasticsearch.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/elasticsearch_go.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         }
       }
@@ -10522,33 +10540,38 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/neo4j.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/neo4j.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "NoSQL/graph driver: no ORM association metadata."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No foreign-key concept in this driver."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No lazy/eager loading; queries are explicit."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/neo4j.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/neo4j.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Queries": {
           "query_attribution": {
             "status": "partial",
-            "cites": ["internal/engine/rules/go/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "cites": ["internal/custom/golang/neo4j.go","internal/custom/golang/nosql_drivers_test.go","internal/engine/rules/go/orms/neo4j.yaml"],
+            "issue": "3214",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {

--- a/internal/custom/golang/dynamodb.go
+++ b/internal/custom/golang/dynamodb.go
@@ -1,0 +1,167 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// dynamodb.go: item-shape + query-DSL extractor for the AWS DynamoDB Go SDK
+// (aws-sdk-go-v2/service/dynamodb, and the v1 aws-sdk-go path).
+//
+// DynamoDB is schema-less at the attribute level (only the key schema is
+// declared), so the honest coverage shape is:
+//
+//   - Models / Schema — partial. Go structs carrying `dynamodbav:"attr"` tags
+//                    are recognised as item shapes with their attributes
+//                    enumerated, and `TableName: aws.String("x")` /
+//                    `TableName: "x"` literals name SCOPE.Schema tables. A
+//                    `dynamodbav` tag is a marshalling hint (it does not prove
+//                    the struct maps to a table) and an item has no enforced
+//                    schema beyond the key, hence partial.
+//   - Queries      — partial. Client method call sites (GetItem/PutItem/Query/
+//                    Scan/UpdateItem/DeleteItem/BatchGetItem/BatchWriteItem/
+//                    TransactWriteItems/...) are captured with the operation
+//                    verb. Binding a call to a concrete table from a regex is
+//                    not reliable, so this stays partial.
+//   - Relationships— honesty-NA. DynamoDB has no foreign keys or joins. GSIs /
+//                    LSIs are access-path indexes, not relations, and are not
+//                    modelled as relationships here. Recorded not_applicable.
+//   - Migrations   — honesty-NA. The SDK ships no migration runner; tables are
+//                    created via CreateTable/IaC out-of-band.
+//
+// The extractor gates on the dynamodb SDK import actually being present, so a
+// file that merely mentions "dynamodbav" without the SDK is not poached.
+
+func init() {
+	extractor.Register("custom_go_dynamodb", &dynamoExtractor{})
+}
+
+type dynamoExtractor struct{}
+
+func (e *dynamoExtractor) Language() string { return "custom_go_dynamodb" }
+
+var (
+	// Import marker for the DynamoDB SDK (v2 and v1 service paths).
+	reImportDynamo = regexp.MustCompile(`"github\.com/aws/aws-sdk-go(?:-v2)?/(?:service|aws)/dynamodb`)
+
+	// A struct field carrying a `dynamodbav:"attr"` tag.
+	//   ID   string `dynamodbav:"id"`
+	//   Name string `dynamodbav:"name,omitempty"`
+	reDynamoavField = regexp.MustCompile("(?m)^\\s*(\\w+)\\s+([\\w\\.\\[\\]\\*]+)\\s+`[^`]*\\bdynamodbav:\"([^\"]*)\"[^`]*`")
+
+	// TableName: aws.String("x") / TableName: "x" => names a table.
+	reDynamoTableName = regexp.MustCompile(`TableName:\s*(?:aws\.String\(\s*)?"([^"]+)"`)
+
+	// Client method call sites. Verb captured for query_type stamping.
+	reDynamoQueryCall = regexp.MustCompile(
+		`(?m)\.(BatchGetItem|BatchWriteItem|TransactGetItems|TransactWriteItems|GetItem|PutItem|UpdateItem|DeleteItem|Query|Scan)\s*\(`,
+	)
+)
+
+func (e *dynamoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.dynamodb_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "dynamodb"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "go" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reImportDynamo.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Schema: TableName: "x" literals => tables.
+	for _, m := range reDynamoTableName.FindAllStringSubmatchIndex(src, -1) {
+		table := src[m[2]:m[3]]
+		ent := makeEntity("table:"+table, "SCOPE.Schema", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "dynamodb", "provenance", "INFERRED_FROM_DYNAMODB_TABLE",
+			"table_name", table)
+		add(ent)
+	}
+
+	// 2. Models / Schema: structs with `dynamodbav:"attr"` field tags.
+	for _, sm := range reDBStruct.FindAllStringSubmatchIndex(src, -1) {
+		structName := src[sm[2]:sm[3]]
+		body := src[sm[4]:sm[5]]
+		structLine := lineOf(src, sm[0])
+		fields := reDynamoavField.FindAllStringSubmatch(body, -1)
+		if len(fields) == 0 {
+			continue
+		}
+		ent := makeEntity(structName, "SCOPE.Schema", "", file.Path, file.Language, structLine)
+		setProps(&ent, "framework", "dynamodb", "provenance", "INFERRED_FROM_DYNAMODB_ITEM_STRUCT")
+		add(ent)
+
+		for _, fm := range fields {
+			fieldName := fm[1]
+			fieldType := fm[2]
+			attr := strings.TrimSpace(fm[3])
+			if attr == "" || attr == "-" {
+				continue
+			}
+			if i := strings.IndexByte(attr, ','); i >= 0 {
+				attr = attr[:i]
+			}
+			fieldEnt := makeEntity("field:"+structName+"."+fieldName, "SCOPE.Component", "field", file.Path, file.Language, structLine)
+			setProps(&fieldEnt, "framework", "dynamodb", "provenance", "INFERRED_FROM_DYNAMODB_ITEM_STRUCT",
+				"model_name", structName, "field_name", fieldName, "dynamodb_attr", attr, "go_type", fieldType)
+			add(fieldEnt)
+		}
+	}
+
+	// 3. Queries: client method call sites.
+	for _, m := range reDynamoQueryCall.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		ent := makeEntity("dynamo:"+verb+":"+itoa(lineOf(src, m[0])), "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "dynamodb", "provenance", "INFERRED_FROM_DYNAMODB_QUERY",
+			"query_type", dynamoVerbKind(verb), "call_verb", verb)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// dynamoVerbKind classifies a DynamoDB client method into a coarse CRUD verb so
+// query_type is comparable across the data-access extractors.
+func dynamoVerbKind(verb string) string {
+	switch verb {
+	case "GetItem", "BatchGetItem", "Query", "Scan", "TransactGetItems":
+		return "select"
+	case "PutItem", "BatchWriteItem":
+		return "insert"
+	case "UpdateItem", "TransactWriteItems":
+		return "update"
+	case "DeleteItem":
+		return "delete"
+	default:
+		return "query"
+	}
+}

--- a/internal/custom/golang/elasticsearch.go
+++ b/internal/custom/golang/elasticsearch.go
@@ -1,0 +1,185 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// elasticsearch.go: index-mapping + query-DSL extractor for the two common Go
+// Elasticsearch clients: the official go-elasticsearch
+// (github.com/elastic/go-elasticsearch) and olivere/elastic.
+//
+// Elasticsearch indexes are schema-ful via mappings, but mappings are usually
+// applied as JSON DSL rather than declared in Go types, so the honest coverage
+// shape is:
+//
+//   - Models / Schema — partial. Index names are recovered from
+//                    `Index("name")` / `Index: "name"` / `Indices("name")`
+//                    call sites and surfaced as SCOPE.Schema indices, and Go
+//                    structs carrying `json:"field"` tags adjacent to the
+//                    client are treated as document shapes (a heuristic — a
+//                    json tag does not prove the struct is an ES document).
+//                    Hence partial.
+//   - Queries      — partial. Request-builder / DSL call sites (Search/Index/
+//                    Get/Update/Delete/Bulk/Count/Msearch/...) are captured
+//                    with the operation verb. Binding a query to a concrete
+//                    index from a regex is not reliable, so this stays partial.
+//   - Migrations   — partial. `CreateIndex("name")` /
+//                    `indices.Create(...)` call sites are index-creation
+//                    operations: the closest analogue to a migration ES has.
+//                    There is no ordered/versioned migration runner, so this is
+//                    partial, not full.
+//   - Relationships— honesty-NA. Elasticsearch is a document store; join/nested
+//                    types are denormalisation, not relations. Recorded
+//                    not_applicable.
+//
+// The extractor gates on an ES client import actually being present.
+
+func init() {
+	extractor.Register("custom_go_elasticsearch", &elasticExtractor{})
+}
+
+type elasticExtractor struct{}
+
+func (e *elasticExtractor) Language() string { return "custom_go_elasticsearch" }
+
+var (
+	// Import marker for the two common Go ES clients.
+	reImportElastic = regexp.MustCompile(`"github\.com/(?:elastic/go-elasticsearch(?:/v\d+)?|olivere/elastic(?:/v\d+)?)`)
+
+	// Index identification: Index("name") / Indices("name") / Index: "name".
+	reESIndexCall = regexp.MustCompile(`\b(?:Index|Indices)\s*[(:]\s*"([^"]+)"`)
+
+	// Index-creation (the migration analogue): CreateIndex("name") or
+	// indices.Create / .Create("name") on an index API. The index name, when a
+	// string literal, is captured.
+	reESCreateIndex = regexp.MustCompile(`\b(?:CreateIndex|(?:[Ii]ndices\.)?Create)\(\s*"([^"]+)"`)
+
+	// A struct field carrying a `json:"field"` tag (ES documents are marshalled
+	// as JSON). Heuristic document-shape detection.
+	reESJSONField = regexp.MustCompile("(?m)^\\s*(\\w+)\\s+([\\w\\.\\[\\]\\*]+)\\s+`[^`]*\\bjson:\"([^\"]*)\"[^`]*`")
+
+	// Query/operation call sites on an ES client or request builder.
+	reESQueryCall = regexp.MustCompile(
+		`(?m)\.(MultiSearch|Msearch|SearchScroll|Search|IndexDoc|Index|Bulk|MultiGet|Mget|Get|Update|Delete|Count|Scroll|Reindex)\s*\(`,
+	)
+)
+
+func (e *elasticExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.elasticsearch_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "elasticsearch"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "go" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reImportElastic.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Schema: index name call sites => indices.
+	for _, m := range reESIndexCall.FindAllStringSubmatchIndex(src, -1) {
+		idx := src[m[2]:m[3]]
+		ent := makeEntity("index:"+idx, "SCOPE.Schema", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "elasticsearch", "provenance", "INFERRED_FROM_ES_INDEX",
+			"index_name", idx)
+		add(ent)
+	}
+
+	// 2. Models / Schema: structs with `json:"field"` field tags => document
+	//    shapes (heuristic).
+	for _, sm := range reDBStruct.FindAllStringSubmatchIndex(src, -1) {
+		structName := src[sm[2]:sm[3]]
+		body := src[sm[4]:sm[5]]
+		structLine := lineOf(src, sm[0])
+		fields := reESJSONField.FindAllStringSubmatch(body, -1)
+		if len(fields) == 0 {
+			continue
+		}
+		ent := makeEntity(structName, "SCOPE.Schema", "", file.Path, file.Language, structLine)
+		setProps(&ent, "framework", "elasticsearch", "provenance", "INFERRED_FROM_ES_DOC_STRUCT")
+		add(ent)
+
+		for _, fm := range fields {
+			fieldName := fm[1]
+			fieldType := fm[2]
+			field := strings.TrimSpace(fm[3])
+			if field == "" || field == "-" {
+				continue
+			}
+			if i := strings.IndexByte(field, ','); i >= 0 {
+				field = field[:i]
+			}
+			fieldEnt := makeEntity("field:"+structName+"."+fieldName, "SCOPE.Component", "field", file.Path, file.Language, structLine)
+			setProps(&fieldEnt, "framework", "elasticsearch", "provenance", "INFERRED_FROM_ES_DOC_STRUCT",
+				"model_name", structName, "field_name", fieldName, "es_field", field, "go_type", fieldType)
+			add(fieldEnt)
+		}
+	}
+
+	// 3. Migrations (partial): index-creation call sites.
+	for _, m := range reESCreateIndex.FindAllStringSubmatchIndex(src, -1) {
+		idx := src[m[2]:m[3]]
+		ent := makeEntity("create_index:"+idx, "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "elasticsearch", "provenance", "INFERRED_FROM_ES_CREATE_INDEX",
+			"index_name", idx, "migration_kind", "index_creation")
+		add(ent)
+	}
+
+	// 4. Queries: client / request-builder call sites.
+	for _, m := range reESQueryCall.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		ent := makeEntity("es:"+verb+":"+itoa(lineOf(src, m[0])), "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "elasticsearch", "provenance", "INFERRED_FROM_ES_QUERY",
+			"query_type", esVerbKind(verb), "call_verb", verb)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// esVerbKind classifies an ES client/builder method into a coarse CRUD verb so
+// query_type is comparable across the data-access extractors.
+func esVerbKind(verb string) string {
+	switch verb {
+	case "Search", "SearchScroll", "MultiSearch", "Msearch", "Get", "MultiGet",
+		"Mget", "Count", "Scroll":
+		return "select"
+	case "Index", "IndexDoc", "Bulk", "Reindex":
+		return "insert"
+	case "Update":
+		return "update"
+	case "Delete":
+		return "delete"
+	default:
+		return "query"
+	}
+}

--- a/internal/custom/golang/gocql.go
+++ b/internal/custom/golang/gocql.go
@@ -1,0 +1,197 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// gocql.go: CQL-schema + query-DSL extractor for the gocql Cassandra driver
+// (github.com/gocql/gocql, and the gocqlx query-builder layered on top).
+//
+// Cassandra is schema-ful (CQL has CREATE TABLE), so the honest coverage shape
+// differs from the truly schema-less key/value stores:
+//
+//   - Models / Schema — partial. A `CREATE TABLE [keyspace.]name (...)` literal
+//                    embedded in a Go string is parsed into a SCOPE.Schema
+//                    table with its column names enumerated as SCOPE.Component
+//                    fields. The schema is real CQL, but it is recovered from a
+//                    string literal by regex (not a CQL parser, and DDL may
+//                    live in external .cql files the Go extractor never sees),
+//                    so this is partial not full.
+//   - Queries      — partial. `session.Query("...")` / `.Bind(...)` /
+//                    gocqlx `qb.Select(...)` call sites are captured with a
+//                    coarse CRUD verb sniffed from the leading CQL keyword.
+//                    The query text is often built dynamically, so binding a
+//                    call to a concrete table from a regex is unreliable.
+//   - Relationships— honesty-NA. Cassandra is a wide-column store with no
+//                    foreign keys or joins; references are a denormalisation
+//                    convention, not a driver concept. Recorded not_applicable.
+//   - Migrations   — honesty-NA. gocql ships no migration runner; schema
+//                    evolution is applied out-of-band (cqlsh / external tools).
+//
+// The extractor gates on the gocql import actually being present, so a file
+// that merely mentions "cassandra" or contains CQL-looking strings without the
+// driver is not poached.
+
+func init() {
+	extractor.Register("custom_go_gocql", &gocqlExtractor{})
+}
+
+type gocqlExtractor struct{}
+
+func (e *gocqlExtractor) Language() string { return "custom_go_gocql" }
+
+var (
+	// Import marker for gocql (and gocqlx, the query-builder layer).
+	reImportGocql = regexp.MustCompile(`"github\.com/(?:gocql/gocql|scylladb/gocqlx(?:/v\d+)?)"`)
+
+	// CREATE TABLE [IF NOT EXISTS] [keyspace.]name ( ... ) inside a Go string
+	// literal. The table name (last dotted segment) and the parenthesised column
+	// body are captured. Case-insensitive; spans newlines.
+	reCQLCreateTable = regexp.MustCompile(`(?is)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w.]*)\s*\((.*?)\)`)
+
+	// A column definition line inside a CREATE TABLE body: a leading identifier
+	// followed by a type token. PRIMARY KEY clauses and bare "PRIMARY"/"KEY"
+	// tokens are filtered out by gocqlIsColumnLine.
+	reCQLColumn = regexp.MustCompile(`(?im)^\s*([A-Za-z_]\w*)\s+([A-Za-z_][\w<>, ]*?)\s*[,)]?\s*$`)
+
+	// session.Query("CQL ...") / gocqlx qb.Select/Insert/Update/Delete call
+	// sites. Only the Query("…") string-literal form yields a CQL verb; the
+	// builder forms are captured by their leading verb method.
+	reGocqlQueryString = regexp.MustCompile(`(?s)\.Query\(\s*` + "`" + `([^` + "`" + `]*)` + "`" + `|\.Query\(\s*"((?:[^"\\]|\\.)*)"`)
+
+	// gocqlx query-builder entry points: qb.Select("t") / qb.Insert("t") / ...
+	reGocqlxBuilder = regexp.MustCompile(`\bqb\.(Select|Insert|Update|Delete)\(`)
+)
+
+func (e *gocqlExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.gocql_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "cassandra"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "go" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reImportGocql.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Schema: CREATE TABLE literals => tables + enumerated columns.
+	for _, m := range reCQLCreateTable.FindAllStringSubmatchIndex(src, -1) {
+		qualified := src[m[2]:m[3]]
+		body := src[m[4]:m[5]]
+		// Logical table name = last dotted segment (strip keyspace prefix).
+		table := qualified
+		if i := strings.LastIndexByte(table, '.'); i >= 0 {
+			table = table[i+1:]
+		}
+		line := lineOf(src, m[0])
+		ent := makeEntity("table:"+table, "SCOPE.Schema", "", file.Path, file.Language, line)
+		setProps(&ent, "framework", "cassandra", "provenance", "INFERRED_FROM_CQL_CREATE_TABLE",
+			"table_name", table, "cql_table", qualified)
+		add(ent)
+
+		for _, cm := range reCQLColumn.FindAllStringSubmatch(body, -1) {
+			col := cm[1]
+			colType := strings.TrimSpace(cm[2])
+			if !gocqlIsColumnLine(col, colType) {
+				continue
+			}
+			fieldEnt := makeEntity("field:"+table+"."+col, "SCOPE.Component", "field", file.Path, file.Language, line)
+			setProps(&fieldEnt, "framework", "cassandra", "provenance", "INFERRED_FROM_CQL_CREATE_TABLE",
+				"model_name", table, "field_name", col, "cql_type", colType)
+			add(fieldEnt)
+		}
+	}
+
+	// 2. Queries: session.Query("CQL") string literals.
+	for _, m := range reGocqlQueryString.FindAllStringSubmatchIndex(src, -1) {
+		cql := submatch(src, m, 2) // backtick form
+		if cql == "" {
+			cql = submatch(src, m, 4) // double-quote form
+		}
+		verb := gocqlVerbKind(cql)
+		ent := makeEntity("cql:"+verb+":"+itoa(lineOf(src, m[0])), "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cassandra", "provenance", "INFERRED_FROM_CASSANDRA_CQL",
+			"query_type", verb)
+		add(ent)
+	}
+
+	// 3. Queries: gocqlx query-builder entry points.
+	for _, m := range reGocqlxBuilder.FindAllStringSubmatchIndex(src, -1) {
+		verb := strings.ToLower(src[m[2]:m[3]])
+		ent := makeEntity("cqlx:"+verb+":"+itoa(lineOf(src, m[0])), "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cassandra", "provenance", "INFERRED_FROM_CASSANDRA_CQL",
+			"query_type", verb, "builder", "gocqlx")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// gocqlIsColumnLine filters non-column lines (PRIMARY KEY clauses, empty type)
+// out of a CREATE TABLE body so only real column definitions become fields.
+func gocqlIsColumnLine(col, colType string) bool {
+	if col == "" || colType == "" {
+		return false
+	}
+	up := strings.ToUpper(col)
+	if up == "PRIMARY" || up == "KEY" || up == "WITH" {
+		return false
+	}
+	// "PRIMARY KEY (...)" defined inline starts with PRIMARY; the type token of a
+	// real column never begins with the PRIMARY/KEY keywords.
+	upType := strings.ToUpper(colType)
+	if strings.HasPrefix(upType, "KEY") {
+		return false
+	}
+	return true
+}
+
+// gocqlVerbKind sniffs a coarse CRUD verb from the leading keyword of a CQL
+// statement so query_type is comparable with the other data-access extractors.
+func gocqlVerbKind(cql string) string {
+	t := strings.ToLower(strings.TrimSpace(cql))
+	switch {
+	case strings.HasPrefix(t, "select"):
+		return "select"
+	case strings.HasPrefix(t, "insert"):
+		return "insert"
+	case strings.HasPrefix(t, "update"):
+		return "update"
+	case strings.HasPrefix(t, "delete"):
+		return "delete"
+	case strings.HasPrefix(t, "create"), strings.HasPrefix(t, "alter"), strings.HasPrefix(t, "drop"):
+		return "ddl"
+	default:
+		return "query"
+	}
+}

--- a/internal/custom/golang/neo4j.go
+++ b/internal/custom/golang/neo4j.go
@@ -1,0 +1,190 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// neo4j.go: Cypher-DSL extractor for the official Neo4j Go driver
+// (github.com/neo4j/neo4j-go-driver, v4 and v5).
+//
+// Neo4j is the one driver in this slice where relationships are first-class:
+// they are declared inline in the Cypher query text. The honest coverage shape:
+//
+//   - Models / Schema — partial. Node labels in Cypher patterns ((n:Person),
+//                    (:Movie)) are surfaced as SCOPE.Schema nodes. Labels are a
+//                    soft schema (a node may carry any labels at runtime) and
+//                    are recovered from a query string by regex, hence partial.
+//   - Relationships— partial. Relationship types in Cypher patterns
+//                    (-[:ACTED_IN]->, -[r:KNOWS]-) are surfaced as
+//                    SCOPE.Schema entities with subtype "relationship" (there
+//                    is no dedicated SCOPE.Relation kind). This is the
+//                    first-class graph case — but the endpoints of the relation
+//                    are not always statically resolvable from the query text,
+//                    so the relation type is recorded without proven endpoint
+//                    binding: partial.
+//   - Queries      — partial. `session.Run("CYPHER")` / `ExecuteQuery(...,
+//                    "CYPHER")` / `tx.Run("CYPHER")` call sites are captured
+//                    with a coarse verb sniffed from the leading Cypher clause.
+//                    Dynamically-built query strings are not fully recoverable,
+//                    so partial.
+//   - Migrations   — honesty-NA. Neo4j is schema-flexible / graph-native; there
+//                    is no migration runner in the driver (constraints/indexes
+//                    are applied via ad-hoc Cypher). Recorded not_applicable.
+//
+// The extractor gates on the neo4j-go-driver import actually being present.
+
+func init() {
+	extractor.Register("custom_go_neo4j", &neo4jExtractor{})
+}
+
+type neo4jExtractor struct{}
+
+func (e *neo4jExtractor) Language() string { return "custom_go_neo4j" }
+
+var (
+	// Import marker for the official Neo4j Go driver (v4 and v5).
+	reImportNeo4j = regexp.MustCompile(`"github\.com/neo4j/neo4j-go-driver(?:/v\d+)?/neo4j`)
+
+	// Cypher query strings passed to session.Run / tx.Run / ExecuteQuery. Both
+	// backtick and double-quoted literals are captured.
+	reNeo4jRun = regexp.MustCompile(
+		"(?s)\\.(?:Run|ExecuteQuery)\\([^`\"]*`([^`]*)`|\\.(?:Run|ExecuteQuery)\\([^\"]*\"((?:[^\"\\\\]|\\\\.)*)\"",
+	)
+
+	// A node label inside a Cypher pattern: (var:Label) or (:Label). Captures
+	// the first label; chained labels (:A:B) capture A (the primary label).
+	reCypherLabel = regexp.MustCompile(`\([A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|\(\s*:\s*([A-Za-z_]\w*)`)
+
+	// A relationship type inside a Cypher pattern: -[:TYPE]-> / -[r:TYPE]-.
+	reCypherRelType = regexp.MustCompile(`-\[\s*[A-Za-z_]\w*?\s*:\s*([A-Za-z_]\w*)|-\[\s*:\s*([A-Za-z_]\w*)`)
+)
+
+func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.neo4j_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "neo4j"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if file.Language != "go" || len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !reImportNeo4j.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, m := range reNeo4jRun.FindAllStringSubmatchIndex(src, -1) {
+		cypher := submatch(src, m, 2) // backtick form
+		if cypher == "" {
+			cypher = submatch(src, m, 4) // double-quote form
+		}
+		line := lineOf(src, m[0])
+
+		// Query operation, verb sniffed from the leading Cypher clause.
+		verb := neo4jVerbKind(cypher)
+		q := makeEntity("cypher:"+verb+":"+itoa(line), "SCOPE.Operation", "query", file.Path, file.Language, line)
+		setProps(&q, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+			"query_type", verb)
+		add(q)
+
+		// Schema: node labels in the Cypher pattern.
+		for _, lm := range reCypherLabel.FindAllStringSubmatch(cypher, -1) {
+			label := lm[1]
+			if label == "" {
+				label = lm[2]
+			}
+			if label == "" {
+				continue
+			}
+			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, file.Language, line)
+			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"node_label", label)
+			add(n)
+		}
+
+		// Relationships: relationship types in the Cypher pattern (first-class).
+		for _, rm := range reCypherRelType.FindAllStringSubmatch(cypher, -1) {
+			relType := rm[1]
+			if relType == "" {
+				relType = rm[2]
+			}
+			if relType == "" {
+				continue
+			}
+			r := makeEntity("rel:"+relType, "SCOPE.Schema", "relationship", file.Path, file.Language, line)
+			setProps(&r, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
+				"rel_type", relType)
+			add(r)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// neo4jVerbKind sniffs a coarse verb from the leading Cypher clause so
+// query_type is comparable across the data-access extractors.
+func neo4jVerbKind(cypher string) string {
+	// Find the first non-space keyword.
+	i := 0
+	for i < len(cypher) && (cypher[i] == ' ' || cypher[i] == '\t' || cypher[i] == '\n' || cypher[i] == '\r') {
+		i++
+	}
+	j := i
+	for j < len(cypher) {
+		c := cypher[j]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			j++
+			continue
+		}
+		break
+	}
+	switch upperCypher(cypher[i:j]) {
+	case "MATCH", "RETURN", "WITH", "UNWIND", "CALL":
+		return "read"
+	case "CREATE", "MERGE":
+		return "create"
+	case "SET":
+		return "update"
+	case "DELETE", "REMOVE", "DETACH":
+		return "delete"
+	default:
+		return "query"
+	}
+}
+
+// upperCypher upper-cases an ASCII keyword without allocating via strings.
+func upperCypher(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 'a' - 'A'
+		}
+	}
+	return string(b)
+}

--- a/internal/custom/golang/nosql_drivers_test.go
+++ b/internal/custom/golang/nosql_drivers_test.go
@@ -1,0 +1,192 @@
+package golang_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// ---------------------------------------------------------------------------
+// gocql (Cassandra): CQL CREATE TABLE schema + columns + Query() verbs.
+// ---------------------------------------------------------------------------
+
+func TestGocqlSchemaAndQueries(t *testing.T) {
+	ents := extractWith(t, "custom_go_gocql", fixtureInput(t, "gocql_store.go", "go"))
+
+	// Schema: CREATE TABLE literals => tables (keyspace prefix stripped).
+	if !containsEntity(ents, "SCOPE.Schema", "table:users") {
+		t.Error("expected users table schema from CREATE TABLE")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "table:orders") {
+		t.Error("expected orders table schema from CREATE TABLE")
+	}
+
+	// Columns enumerated as fields; PRIMARY KEY clause not a field.
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:users.name") {
+		t.Error("expected users.name field component")
+	}
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:users.email") {
+		t.Error("expected users.email field component")
+	}
+	if hasSubtype(ents, "SCOPE.Component", "field", "field:users.PRIMARY") {
+		t.Error("did not expect a PRIMARY KEY pseudo-field")
+	}
+
+	// Queries: at least one CQL query operation.
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected at least one gocql query operation")
+	}
+}
+
+func TestGocqlImportGate(t *testing.T) {
+	src := `package x
+
+const ddl = "CREATE TABLE users (id uuid, PRIMARY KEY (id))"
+`
+	file := extreg.FileInput{Path: "no_gocql.go", Language: "go", Content: []byte(src)}
+	ents := extractWith(t, "custom_go_gocql", file)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without gocql import, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// dynamodb: dynamodbav item structs + TableName tables + client verbs.
+// ---------------------------------------------------------------------------
+
+func TestDynamoModelsTablesAndQueries(t *testing.T) {
+	ents := extractWith(t, "custom_go_dynamodb", fixtureInput(t, "dynamodb_store.go", "go"))
+
+	// Models: structs with dynamodbav tags are item shapes.
+	if !containsEntity(ents, "SCOPE.Schema", "User") {
+		t.Error("expected User item schema from dynamodbav tags")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "Order") {
+		t.Error("expected Order item schema from dynamodbav tags")
+	}
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:User.Email") {
+		t.Error("expected User.Email field component")
+	}
+	// dynamodbav:"-" must NOT produce a field.
+	if hasSubtype(ents, "SCOPE.Component", "field", "field:User.Skip") {
+		t.Error("did not expect User.Skip field (dynamodbav:\"-\")")
+	}
+
+	// Schema: TableName literals => tables.
+	if !containsEntity(ents, "SCOPE.Schema", "table:users") {
+		t.Error("expected users table from TableName")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "table:orders") {
+		t.Error("expected orders table from TableName")
+	}
+
+	// Queries.
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected at least one dynamodb query operation")
+	}
+}
+
+func TestDynamoImportGate(t *testing.T) {
+	src := `package x
+
+type Doc struct {
+	ID string ` + "`dynamodbav:\"id\"`" + `
+}
+`
+	file := extreg.FileInput{Path: "no_dynamo.go", Language: "go", Content: []byte(src)}
+	ents := extractWith(t, "custom_go_dynamodb", file)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without dynamodb import, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// elasticsearch: index schema + json doc structs + create-index migration +
+// query verbs.
+// ---------------------------------------------------------------------------
+
+func TestElasticIndicesModelsMigrationsAndQueries(t *testing.T) {
+	ents := extractWith(t, "custom_go_elasticsearch", fixtureInput(t, "elasticsearch_store.go", "go"))
+
+	// Schema: index name call sites => indices.
+	if !containsEntity(ents, "SCOPE.Schema", "index:products") {
+		t.Error("expected products index schema")
+	}
+
+	// Models: json-tagged struct => document shape.
+	if !containsEntity(ents, "SCOPE.Schema", "Product") {
+		t.Error("expected Product doc schema from json tags")
+	}
+	if !hasSubtype(ents, "SCOPE.Component", "field", "field:Product.Name") {
+		t.Error("expected Product.Name field component")
+	}
+
+	// Migrations (partial): index-creation operation.
+	if !hasKindSubtype(ents, "SCOPE.Operation", "migration") {
+		t.Error("expected an index-creation migration operation")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "create_index:products") {
+		t.Error("expected create_index:products migration")
+	}
+
+	// Queries.
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected at least one elasticsearch query operation")
+	}
+}
+
+func TestElasticImportGate(t *testing.T) {
+	src := `package x
+
+type Doc struct {
+	ID string ` + "`json:\"id\"`" + `
+}
+`
+	file := extreg.FileInput{Path: "no_es.go", Language: "go", Content: []byte(src)}
+	ents := extractWith(t, "custom_go_elasticsearch", file)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without elasticsearch import, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// neo4j: Cypher node labels (schema) + relationship types (relationships,
+// first-class) + query verbs.
+// ---------------------------------------------------------------------------
+
+func TestNeo4jSchemaRelationshipsAndQueries(t *testing.T) {
+	ents := extractWith(t, "custom_go_neo4j", fixtureInput(t, "neo4j_store.go", "go"))
+
+	// Schema: node labels in Cypher patterns => nodes.
+	if !containsEntity(ents, "SCOPE.Schema", "node:Person") {
+		t.Error("expected Person node schema")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "node:Movie") {
+		t.Error("expected Movie node schema")
+	}
+
+	// Relationships: relationship types => SCOPE.Schema subtype=relationship.
+	if !hasSubtype(ents, "SCOPE.Schema", "relationship", "rel:ACTED_IN") {
+		t.Error("expected ACTED_IN relationship")
+	}
+	if !hasSubtype(ents, "SCOPE.Schema", "relationship", "rel:KNOWS") {
+		t.Error("expected KNOWS relationship")
+	}
+
+	// Queries.
+	if !hasKindSubtype(ents, "SCOPE.Operation", "query") {
+		t.Error("expected at least one neo4j query operation")
+	}
+}
+
+func TestNeo4jImportGate(t *testing.T) {
+	src := `package x
+
+const q = "MATCH (p:Person)-[:KNOWS]->(o) RETURN p"
+`
+	file := extreg.FileInput{Path: "no_neo4j.go", Language: "go", Content: []byte(src)}
+	ents := extractWith(t, "custom_go_neo4j", file)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without neo4j import, got %d", len(ents))
+	}
+}

--- a/internal/custom/golang/testdata/dynamodb_store.go
+++ b/internal/custom/golang/testdata/dynamodb_store.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+// User is a DynamoDB item shape mapped by dynamodbav tags.
+type User struct {
+	ID    string `dynamodbav:"id"`
+	Name  string `dynamodbav:"name"`
+	Email string `dynamodbav:"email,omitempty"`
+	Skip  string `dynamodbav:"-"`
+}
+
+// Order is a second item shape.
+type Order struct {
+	ID     string  `dynamodbav:"id"`
+	UserID string  `dynamodbav:"user_id"`
+	Total  float64 `dynamodbav:"total"`
+}
+
+func run(ctx context.Context, c *dynamodb.Client) error {
+	_, err := c.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("users"),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = c.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String("users"),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Query(ctx, &dynamodb.QueryInput{
+		TableName: aws.String("orders"),
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = c.UpdateItem(ctx, &dynamodb.UpdateItemInput{TableName: aws.String("users")})
+	if err != nil {
+		return err
+	}
+
+	_, err = c.DeleteItem(ctx, &dynamodb.DeleteItemInput{TableName: aws.String("orders")})
+	return err
+}

--- a/internal/custom/golang/testdata/elasticsearch_store.go
+++ b/internal/custom/golang/testdata/elasticsearch_store.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"github.com/elastic/go-elasticsearch/v8"
+)
+
+// Product is a document shape marshalled to JSON for indexing.
+type Product struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Price float64 `json:"price,omitempty"`
+	Skip  string  `json:"-"`
+}
+
+func run(es *elasticsearch.Client) error {
+	// Index-creation: the migration analogue.
+	if _, err := es.Indices.Create("products"); err != nil {
+		return err
+	}
+
+	// Search the products index.
+	if _, err := es.Search(
+		es.Search.WithIndex("products"),
+	); err != nil {
+		return err
+	}
+
+	// Index a document.
+	if _, err := es.Index("products", nil); err != nil {
+		return err
+	}
+
+	if _, err := es.Get("products", "1"); err != nil {
+		return err
+	}
+
+	if _, err := es.Delete("products", "1"); err != nil {
+		return err
+	}
+
+	_, err := es.Count(es.Count.WithIndex("products"))
+	return err
+}

--- a/internal/custom/golang/testdata/gocql_store.go
+++ b/internal/custom/golang/testdata/gocql_store.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"github.com/gocql/gocql"
+)
+
+const createUsers = `
+CREATE TABLE IF NOT EXISTS shop.users (
+	id uuid,
+	name text,
+	email text,
+	created_at timestamp,
+	PRIMARY KEY (id)
+)`
+
+const createOrders = `
+CREATE TABLE orders (
+	id uuid,
+	user_id uuid,
+	total decimal,
+	PRIMARY KEY (id, user_id)
+)`
+
+func run(session *gocql.Session) error {
+	if err := session.Query(`SELECT id, name FROM users WHERE id = ?`, "1").Exec(); err != nil {
+		return err
+	}
+	if err := session.Query("INSERT INTO users (id, name) VALUES (?, ?)", "1", "Ada").Exec(); err != nil {
+		return err
+	}
+	if err := session.Query(`UPDATE users SET name = ? WHERE id = ?`, "Bob", "1").Exec(); err != nil {
+		return err
+	}
+	return session.Query(`DELETE FROM orders WHERE id = ?`, "1").Exec()
+}

--- a/internal/custom/golang/testdata/neo4j_store.go
+++ b/internal/custom/golang/testdata/neo4j_store.go
@@ -1,0 +1,34 @@
+package store
+
+import (
+	"context"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+func run(ctx context.Context, session neo4j.SessionWithContext) error {
+	// Read with node label + relationship type.
+	if _, err := session.Run(ctx,
+		`MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m`,
+		nil); err != nil {
+		return err
+	}
+
+	// Create a node.
+	if _, err := session.Run(ctx,
+		`CREATE (p:Person {name: $name}) RETURN p`,
+		map[string]any{"name": "Ada"}); err != nil {
+		return err
+	}
+
+	// Merge a relationship.
+	if _, err := session.Run(ctx,
+		`MATCH (a:Person), (b:Person) MERGE (a)-[r:KNOWS]->(b) RETURN r`,
+		nil); err != nil {
+		return err
+	}
+
+	// Delete.
+	_, err := session.Run(ctx, `MATCH (p:Person {name: $name}) DETACH DELETE p`, nil)
+	return err
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -4035,6 +4035,215 @@ records:
           issues_implemented: ["3214"]
           verified_at: "2026-05-30"
 
+  lang.go.driver.cassandra:
+    capabilities:
+      Models:
+        schema_extraction:
+          # CQL `CREATE TABLE [keyspace.]name (...)` literals embedded in Go
+          # strings => SCOPE.Schema tables with columns enumerated as fields
+          # (reCQLCreateTable + reCQLColumn). Recovered by regex from string
+          # literals, not a CQL parser, hence partial.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/cassandra_go.yaml
+            - file: internal/custom/golang/gocql.go
+              functions: [Extract, gocqlIsColumnLine]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # session.Query("CQL") string literals + gocqlx qb.Select/Insert/...
+          # builder call sites; gocqlVerbKind stamps a coarse CRUD verb from the
+          # leading CQL keyword.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/cassandra_go.yaml
+            - file: internal/custom/golang/gocql.go
+              functions: [Extract, gocqlVerbKind]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Relationships:
+        relationship_extraction:
+          status: not_applicable
+          notes: "Cassandra is a wide-column store with no foreign keys or joins; references are a denormalisation convention, not a driver concept."
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Migrations:
+        migration_parsing:
+          status: not_applicable
+          notes: "gocql ships no migration runner; CQL schema evolution is applied out-of-band (cqlsh / external tools)."
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
+  lang.go.driver.dynamodb:
+    capabilities:
+      Models:
+        model_extraction:
+          # Structs with `dynamodbav:"attr"` tags scanned as item shapes.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/dynamodb_go.yaml
+            - file: internal/custom/golang/dynamodb.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+        schema_extraction:
+          # `TableName: aws.String("x")` / `TableName: "x"` literals => tables;
+          # dynamodbav item attributes enumerated as columns.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/dynamodb_go.yaml
+            - file: internal/custom/golang/dynamodb.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # GetItem/PutItem/Query/Scan/UpdateItem/DeleteItem/BatchGetItem/...
+          # client call sites; dynamoVerbKind stamps a coarse CRUD verb.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/dynamodb_go.yaml
+            - file: internal/custom/golang/dynamodb.go
+              functions: [Extract, dynamoVerbKind]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Relationships:
+        relationship_extraction:
+          status: not_applicable
+          notes: "DynamoDB has no foreign keys or joins; GSIs/LSIs are access-path indexes, not relations."
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Migrations:
+        migration_parsing:
+          status: not_applicable
+          notes: "Schema-less; the SDK has no migration runner — tables are created via CreateTable/IaC out-of-band."
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
+  lang.go.driver.elastic:
+    capabilities:
+      Models:
+        model_extraction:
+          # Structs with `json:"field"` tags adjacent to the ES client treated
+          # as document shapes (heuristic — a json tag does not prove the struct
+          # is an ES document).
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/elasticsearch_go.yaml
+            - file: internal/custom/golang/elasticsearch.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+        schema_extraction:
+          # Index("name") / Index: "name" / Indices("name") call sites =>
+          # SCOPE.Schema indices.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/elasticsearch_go.yaml
+            - file: internal/custom/golang/elasticsearch.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # Search/Index/Get/Update/Delete/Bulk/Count/Msearch/... request-builder
+          # call sites; esVerbKind stamps a coarse CRUD verb.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/elasticsearch_go.yaml
+            - file: internal/custom/golang/elasticsearch.go
+              functions: [Extract, esVerbKind]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Migrations:
+        migration_parsing:
+          # CreateIndex("name") / indices.Create(...) call sites are the index-
+          # creation analogue of a migration. No ordered/versioned migration
+          # runner exists, so partial.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/elasticsearch_go.yaml
+            - file: internal/custom/golang/elasticsearch.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Relationships:
+        relationship_extraction:
+          status: not_applicable
+          notes: "Elasticsearch is a document store; join/nested types are denormalisation, not relations."
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
+  lang.go.driver.neo4j:
+    capabilities:
+      Models:
+        schema_extraction:
+          # Node labels in Cypher patterns ((n:Person), (:Movie)) => SCOPE.Schema
+          # nodes (reCypherLabel). Labels are a soft schema recovered from query
+          # strings by regex, hence partial.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/neo4j.yaml
+            - file: internal/custom/golang/neo4j.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Relationships:
+        relationship_extraction:
+          # Relationship types in Cypher patterns (-[:ACTED_IN]->, -[r:KNOWS]-)
+          # => SCOPE.Schema subtype=relationship (reCypherRelType). The one driver
+          # in this slice where relationships are first-class. Endpoints are not
+          # always statically resolvable from the query text, so partial.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/neo4j.yaml
+            - file: internal/custom/golang/neo4j.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # session.Run("CYPHER") / tx.Run / ExecuteQuery call sites;
+          # neo4jVerbKind stamps a coarse verb from the leading Cypher clause.
+          status: partial
+          symbols:
+            - file: internal/engine/rules/go/orms/neo4j.yaml
+            - file: internal/custom/golang/neo4j.go
+              functions: [Extract, neo4jVerbKind]
+          tests:
+            - file: internal/custom/golang/nosql_drivers_test.go
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+      Migrations:
+        migration_parsing:
+          status: not_applicable
+          notes: "Neo4j is schema-flexible / graph-native; the driver has no migration runner (constraints/indexes are applied via ad-hoc Cypher)."
+          issues_implemented: ["3214"]
+          verified_at: "2026-05-30"
+
   lang.go.framework.net-http:
     capabilities:
       Routing:


### PR DESCRIPTION
Part of #3214. Final ORM-driver slice: four new file-local Go custom extractors for the NoSQL data-access drivers. Each gates on its driver import being present (no false positives from look-alike string literals), with a dedicated `_test.go` + per-driver fixtures including an import-gate test.

## Extractors (all new files; no shared-file edits)
- `internal/custom/golang/gocql.go` — Cassandra (`github.com/gocql/gocql`, gocqlx). CQL `CREATE TABLE` literals → `SCOPE.Schema` tables + enumerated columns; `session.Query("CQL")` + `qb.Select/Insert/...` → `SCOPE.Operation/query` with coarse CRUD verb (`gocqlVerbKind`).
- `internal/custom/golang/dynamodb.go` — AWS DynamoDB SDK (v1 + v2). `dynamodbav`-tagged item structs → models + fields; `TableName:` literals → tables; `GetItem/PutItem/Query/Scan/UpdateItem/DeleteItem/Batch*/Transact*` → queries (`dynamoVerbKind`).
- `internal/custom/golang/elasticsearch.go` — go-elasticsearch + olivere/elastic. `Index(...)/Indices(...)` → indices; `json`-tagged doc structs → document shapes; `Search/Index/Get/Update/Delete/Bulk/Count/...` → queries; `CreateIndex/indices.Create` → **partial Migrations** (index-creation analogue).
- `internal/custom/golang/neo4j.go` — neo4j-go-driver v4/v5. `session.Run/ExecuteQuery` Cypher strings → queries; node labels → `SCOPE.Schema` nodes; relationship types → `SCOPE.Schema` subtype=`relationship` (the one driver where relationships are first-class; partial — endpoints not statically bound).

## Honesty
All flips are `partial` (heuristic regex over string literals / struct tags) or `not_applicable`. **No `full`** — none of these can be proven exhaustive from regex. Schema-less / graph-native drivers record Relationships + Migrations as `not_applicable` (DynamoDB GSIs are access-paths not relations; Cassandra/Neo4j have no migration runner). Elasticsearch Migrations are `partial` (index creation only, no versioned runner).

## Per-driver × capability
| Driver | Models | Relationships | Queries | Migrations |
|---|---|---|---|---|
| gocql (Cassandra) | partial (schema) | NA | partial | NA |
| dynamodb | partial (model+schema) | NA | partial | NA |
| elasticsearch | partial (model+schema) | NA | partial | **partial** |
| neo4j | partial (schema) | **partial** | partial | NA |

(Relational-ORM-only sub-features — association/foreign_key/lazy_loading — set `not_applicable` across all four.)

## Validation (scoped)
- `go build ./internal/... ./tools/coverage/...` ✓
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` ✓
- `go run ./tools/coverage validate` exit 0, no duplicate keys ✓
- `coverage fmt --check` canonical ✓ · `gen` byte-stable ✓ · `gofmt -l` clean on all new files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)