### PR TITLE
feat(coverage): Go observability + validation for 8 more HTTP frameworks

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -39,21 +39,21 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/2 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/5 | |
 | [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
-| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 5/6 | |
-| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
-| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/6 | |
 | [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/6 | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 3/5 | |
 | [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/6 | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
-| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [Beego](../detail/lang.go.framework.beego.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Echo](../detail/lang.go.framework.echo.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Fiber](../detail/lang.go.framework.fiber.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Gin](../detail/lang.go.framework.gin.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 20/21 | 🟡 5/6 | |
-| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
-| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Huma](../detail/lang.go.framework.huma.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [Iris](../detail/lang.go.framework.iris.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
 | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 1/7 | |
+| [Revel](../detail/lang.go.framework.revel.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/6 | |
 | [chi](../detail/lang.go.framework.chi.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 5/7 | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/6 | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 3/5 | |
 | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/7 | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🔴 0/6 | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 2/3 | — | 🔴 0/4 | 🔴 0/1 | 🟡 6/20 | 🟡 4/6 | |
 
 
 ### Mobile

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | — `not_applicable` | `2026-05-29` | — | — | No struct-tag request binding: fasthttp's RequestCtx exposes raw byte accessors only and Revel binds params positionally via controller-method signatures, so there is no validate:/binding: tag surface to extract. |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | — `not_applicable` | `2026-05-29` | — | — | No struct-tag request binding: fasthttp's RequestCtx exposes raw byte accessors only and Revel binds params positionally via controller-method signatures, so there is no validate:/binding: tag surface to extract. |
 
 ### Middleware
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-29` | 3215 | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
+| Trace extraction | ✅ `full` | `2026-05-29` | — | `internal/custom/golang/observability.go`<br>`internal/custom/golang/observability_test.go` | — |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10717,8 +10717,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -10754,16 +10756,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -10898,8 +10905,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -10935,16 +10944,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -11450,8 +11464,9 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No struct-tag request binding: fasthttp's RequestCtx exposes raw byte accessors only and Revel binds params positionally via controller-method signatures, so there is no validate:/binding: tag surface to extract.",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -11486,16 +11501,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -12420,8 +12440,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -12457,16 +12479,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -12603,8 +12630,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -12640,16 +12669,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -12963,8 +12997,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -13000,16 +13036,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -13320,8 +13361,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/validation.go","internal/custom/golang/validation_test.go"],
+            "issue": "3213",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -13356,16 +13399,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {
@@ -13500,8 +13548,9 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "No struct-tag request binding: fasthttp's RequestCtx exposes raw byte accessors only and Revel binds params positionally via controller-method signatures, so there is no validate:/binding: tag surface to extract.",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
@@ -13537,16 +13586,21 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "issue": "3215",
+            "verified_at": "2026-05-29"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/observability.go","internal/custom/golang/observability_test.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Data": {

--- a/internal/custom/golang/observability.go
+++ b/internal/custom/golang/observability.go
@@ -68,6 +68,14 @@ func (e *observabilityExtractor) Language() string { return "custom_go_observabi
 // the file source, attributes the file to that framework. Markers are the
 // engine constructor + the canonical request-context type for each framework,
 // which are unambiguous and present in any handler/middleware file.
+//
+// The first four (gin/echo/fiber/chi) are the original well-templated set; the
+// remaining eight (beego/iris/hertz/buffalo/gorilla-mux/revel/net-http/
+// fasthttp) extend the same logging/metrics/tracing detection to the rest of
+// the Go HTTP framework family (issue #3215). The markers are reused verbatim
+// from the middleware/auth extender (middleware_auth_extend.go) so a file is
+// attributed to the same framework across every framework-agnostic pass.
+// net-http is placed last because its `http.*` markers are the broadest.
 var obsFrameworkMarkers = []struct {
 	name string
 	re   *regexp.Regexp
@@ -76,11 +84,20 @@ var obsFrameworkMarkers = []struct {
 	{"echo", regexp.MustCompile(`\becho\.(?:New|Echo|Context|HandlerFunc|MiddlewareFunc)\b`)},
 	{"fiber", regexp.MustCompile(`\bfiber\.(?:New|App|Ctx|Handler)\b`)},
 	{"chi", regexp.MustCompile(`\bchi\.(?:NewRouter|Router|Mux)\b`)},
+	{"beego", regexp.MustCompile(`\b(?:beego|web)\.(?:Router|NewNamespace|Run|InsertFilter|AutoRouter)\b`)},
+	{"iris", regexp.MustCompile(`\biris\.(?:New|Default|Application|Context|Party)\b`)},
+	{"hertz", regexp.MustCompile(`\bserver\.(?:Default|New|Hertz)\b|\bapp\.RequestContext\b`)},
+	{"buffalo", regexp.MustCompile(`\bbuffalo\.(?:New|App|Options|Context)\b`)},
+	{"gorilla-mux", regexp.MustCompile(`\bmux\.(?:NewRouter|Router|Vars)\b`)},
+	{"revel", regexp.MustCompile(`\brevel\.(?:Result|Controller|Intercept(?:Func|Method)|BEFORE|AFTER)\b`)},
+	{"fasthttp", regexp.MustCompile(`\bfasthttp\.(?:RequestCtx|RequestHandler|ListenAndServe)\b`)},
+	{"net-http", regexp.MustCompile(`\bhttp\.(?:NewServeMux|HandleFunc|ListenAndServe|ListenAndServeTLS)\b`)},
 }
 
 // detectObsFramework returns the framework the file belongs to, or "" when no
 // recognised framework marker is present. First match wins in declaration
-// order (gin→echo→fiber→chi).
+// order (gin→echo→fiber→chi→beego→iris→hertz→buffalo→gorilla-mux→revel→
+// fasthttp→net-http).
 func detectObsFramework(src string) string {
 	for _, m := range obsFrameworkMarkers {
 		if m.re.MatchString(src) {

--- a/internal/custom/golang/observability_test.go
+++ b/internal/custom/golang/observability_test.go
@@ -143,6 +143,15 @@ func TestObservabilityFixtures(t *testing.T) {
 		{"echo_observability.go", "echo", "zap"},
 		{"fiber_observability.go", "fiber", "slog"},
 		{"chi_observability.go", "chi", "logrus"},
+		// extended frameworks (issue #3215)
+		{"beego_observability.go", "beego", "logrus"},
+		{"iris_observability.go", "iris", "zap"},
+		{"hertz_observability.go", "hertz", "zap"},
+		{"buffalo_observability.go", "buffalo", "logrus"},
+		{"gorilla_mux_observability.go", "gorilla-mux", "zap"},
+		{"revel_observability.go", "revel", "logrus"},
+		{"fasthttp_observability.go", "fasthttp", "zap"},
+		{"nethttp_observability.go", "net-http", "logrus"},
 	}
 	for _, c := range cases {
 		t.Run(c.framework, func(t *testing.T) {

--- a/internal/custom/golang/testdata/beego_observability.go
+++ b/internal/custom/golang/testdata/beego_observability.go
@@ -1,0 +1,41 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/beego/beego/v2/server/web"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+var beegoReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "beego_http_requests_total",
+		Help: "Total HTTP requests.",
+	},
+	[]string{"path"},
+)
+
+// UserController is a beego controller; the package uses web.Router so the
+// observability scanner attributes this file to beego.
+type BeegoUserController struct {
+	web.Controller
+}
+
+func (c *BeegoUserController) Get() {
+	log := logrus.New()
+	log.WithFields(logrus.Fields{"component": "beego"}).Info("get users")
+
+	tracer := otel.Tracer("beego-service")
+	_, span := tracer.Start(context.Background(), "handler.beego.users.list")
+	defer span.End()
+
+	beegoReqCount.WithLabelValues("/users").Inc()
+	c.Ctx.WriteString("ok")
+}
+
+func registerBeego() {
+	web.Router("/users", &BeegoUserController{}, "get:Get")
+	web.Run()
+}

--- a/internal/custom/golang/testdata/beego_validation.go
+++ b/internal/custom/golang/testdata/beego_validation.go
@@ -1,0 +1,28 @@
+package fixtures
+
+import (
+	"github.com/beego/beego/v2/server/web"
+)
+
+// BeegoCreateUserReq is a beego-bound DTO using validate: struct tags.
+type BeegoCreateUserReq struct {
+	Name  string `form:"name" validate:"required,min=2,max=64"`
+	Email string `form:"email" validate:"required,email"`
+}
+
+type BeegoValController struct {
+	web.Controller
+}
+
+func (this *BeegoValController) Post() {
+	var req BeegoCreateUserReq
+	if err := this.ParseForm(&req); err != nil {
+		this.Ctx.WriteString(err.Error())
+		return
+	}
+	this.Ctx.WriteString("created")
+}
+
+func registerBeegoVal() {
+	web.Router("/users", &BeegoValController{}, "post:Post")
+}

--- a/internal/custom/golang/testdata/buffalo_observability.go
+++ b/internal/custom/golang/testdata/buffalo_observability.go
@@ -1,0 +1,33 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+var buffaloReqCount = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "buffalo_inflight_requests",
+		Help: "In-flight requests.",
+	},
+	[]string{"path"},
+)
+
+func newBuffaloApp() *buffalo.App {
+	log := logrus.New()
+	log.WithFields(logrus.Fields{"component": "buffalo"}).Info("starting")
+
+	app := buffalo.New(buffalo.Options{})
+	app.GET("/users", func(c buffalo.Context) error {
+		tracer := otel.Tracer("buffalo-service")
+		_, span := tracer.Start(context.Background(), "handler.buffalo.users.list")
+		defer span.End()
+		buffaloReqCount.WithLabelValues("/users").Inc()
+		return c.Render(200, nil)
+	})
+	return app
+}

--- a/internal/custom/golang/testdata/buffalo_validation.go
+++ b/internal/custom/golang/testdata/buffalo_validation.go
@@ -1,0 +1,22 @@
+package fixtures
+
+import (
+	"github.com/gobuffalo/buffalo"
+)
+
+// BuffaloOrderReq is a buffalo-bound DTO using validate: struct tags.
+type BuffaloOrderReq struct {
+	SKU      string `json:"sku" validate:"required,alphanum"`
+	Quantity int    `json:"quantity" validate:"required,gte=1"`
+}
+
+func setupBuffaloVal() {
+	app := buffalo.New(buffalo.Options{})
+	app.POST("/orders", func(c buffalo.Context) error {
+		var req BuffaloOrderReq
+		if err := c.Bind(&req); err != nil {
+			return c.Render(400, nil)
+		}
+		return c.Render(201, nil)
+	})
+}

--- a/internal/custom/golang/testdata/fasthttp_observability.go
+++ b/internal/custom/golang/testdata/fasthttp_observability.go
@@ -1,0 +1,34 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/valyala/fasthttp"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+)
+
+var fastReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "fasthttp_http_requests_total",
+		Help: "Total HTTP requests.",
+	},
+	[]string{"path"},
+)
+
+func fastHandler(ctx *fasthttp.RequestCtx) {
+	logger, _ := zap.NewProduction()
+	logger.With(zap.String("component", "fasthttp")).Info("handling")
+
+	tracer := otel.Tracer("fasthttp-service")
+	_, span := tracer.Start(context.Background(), "handler.fasthttp.users.list")
+	defer span.End()
+
+	fastReqCount.WithLabelValues(string(ctx.Path())).Inc()
+	ctx.SetStatusCode(200)
+}
+
+func runFast() {
+	_ = fasthttp.ListenAndServe(":8080", fastHandler)
+}

--- a/internal/custom/golang/testdata/gorilla_mux_observability.go
+++ b/internal/custom/golang/testdata/gorilla_mux_observability.go
@@ -1,0 +1,36 @@
+package fixtures
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+)
+
+var muxReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "mux_http_requests_total",
+		Help: "Total HTTP requests.",
+	},
+	[]string{"path"},
+)
+
+func newMuxRouter() *mux.Router {
+	logger, _ := zap.NewProduction()
+	logger.With(zap.String("component", "gorilla-mux")).Info("starting")
+
+	r := mux.NewRouter()
+	r.HandleFunc("/users", func(w http.ResponseWriter, req *http.Request) {
+		tracer := otel.Tracer("mux-service")
+		_, span := tracer.Start(req.Context(), "handler.mux.users.list")
+		defer span.End()
+		muxReqCount.WithLabelValues("/users").Inc()
+		w.WriteHeader(200)
+	})
+	return r
+}
+
+func _muxCtx() context.Context { return context.Background() }

--- a/internal/custom/golang/testdata/gorilla_mux_validation.go
+++ b/internal/custom/golang/testdata/gorilla_mux_validation.go
@@ -1,0 +1,33 @@
+package fixtures
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/gorilla/mux"
+)
+
+// MuxCreateUserReq is a gorilla-mux-handled DTO validated via a
+// validator.New() struct-tag check after a std-lib JSON decode.
+type MuxCreateUserReq struct {
+	Name  string `json:"name" validate:"required,min=2"`
+	Email string `json:"email" validate:"required,email"`
+}
+
+func setupMuxVal() {
+	r := mux.NewRouter()
+	validate := validator.New()
+	r.HandleFunc("/users", func(w http.ResponseWriter, req *http.Request) {
+		var dto MuxCreateUserReq
+		if err := json.NewDecoder(req.Body).Decode(&dto); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		if err := validate.Struct(&dto); err != nil {
+			http.Error(w, err.Error(), 422)
+			return
+		}
+		w.WriteHeader(201)
+	}).Methods("POST")
+}

--- a/internal/custom/golang/testdata/hertz_observability.go
+++ b/internal/custom/golang/testdata/hertz_observability.go
@@ -1,0 +1,33 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+)
+
+var hertzReqCount = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: "hertz_http_requests_total",
+		Help: "Total HTTP requests.",
+	},
+)
+
+func newHertzServer() *server.Hertz {
+	logger, _ := zap.NewProduction()
+	logger.With(zap.String("component", "hertz")).Info("starting")
+
+	h := server.Default()
+	h.GET("/users", func(c context.Context, ctx *app.RequestContext) {
+		tracer := otel.Tracer("hertz-service")
+		_, span := tracer.Start(c, "handler.hertz.users.list")
+		defer span.End()
+		hertzReqCount.Inc()
+		ctx.JSON(200, map[string]any{"ok": true})
+	})
+	return h
+}

--- a/internal/custom/golang/testdata/hertz_validation.go
+++ b/internal/custom/golang/testdata/hertz_validation.go
@@ -1,0 +1,26 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+)
+
+// HertzSignupReq is a hertz-bound DTO using vd/validate: struct tags.
+type HertzSignupReq struct {
+	Email string `json:"email" validate:"required,email"`
+	Age   int    `json:"age" validate:"gte=0,lte=130"`
+}
+
+func setupHertzVal() {
+	h := server.Default()
+	h.POST("/signup", func(c context.Context, ctx *app.RequestContext) {
+		var req HertzSignupReq
+		if err := ctx.BindAndValidate(&req); err != nil {
+			ctx.JSON(400, map[string]any{"error": err.Error()})
+			return
+		}
+		ctx.JSON(201, req)
+	})
+}

--- a/internal/custom/golang/testdata/iris_observability.go
+++ b/internal/custom/golang/testdata/iris_observability.go
@@ -1,0 +1,33 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/kataras/iris/v12"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.uber.org/zap"
+)
+
+var irisReqLatency = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name: "iris_request_duration_seconds",
+		Help: "Request latency.",
+	},
+	[]string{"route"},
+)
+
+func newIrisServer() *iris.Application {
+	logger, _ := zap.NewProduction()
+	logger.With(zap.String("component", "iris")).Info("starting")
+
+	app := iris.New()
+	app.Get("/users", func(ctx iris.Context) {
+		tracer := otel.Tracer("iris-service")
+		_, span := tracer.Start(context.Background(), "handler.iris.users.list")
+		defer span.End()
+		irisReqLatency.WithLabelValues("/users").Observe(0.1)
+		ctx.JSON(iris.Map{"ok": true})
+	})
+	return app
+}

--- a/internal/custom/golang/testdata/iris_validation.go
+++ b/internal/custom/golang/testdata/iris_validation.go
@@ -1,0 +1,23 @@
+package fixtures
+
+import (
+	"github.com/kataras/iris/v12"
+)
+
+// IrisLoginReq is an iris-bound DTO using validate: struct tags.
+type IrisLoginReq struct {
+	Username string `json:"username" validate:"required,alphanum"`
+	Password string `json:"password" validate:"required,min=8"`
+}
+
+func setupIrisVal() {
+	app := iris.New()
+	app.Post("/login", func(ctx iris.Context) {
+		var req IrisLoginReq
+		if err := ctx.ReadJSON(&req); err != nil {
+			ctx.StopWithError(400, err)
+			return
+		}
+		ctx.JSON(req)
+	})
+}

--- a/internal/custom/golang/testdata/nethttp_observability.go
+++ b/internal/custom/golang/testdata/nethttp_observability.go
@@ -1,0 +1,32 @@
+package fixtures
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+var netReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "nethttp_http_requests_total",
+		Help: "Total HTTP requests.",
+	},
+	[]string{"path"},
+)
+
+func newNetHTTPMux() *http.ServeMux {
+	log := logrus.New()
+	log.WithFields(logrus.Fields{"component": "net-http"}).Info("starting")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users", func(w http.ResponseWriter, req *http.Request) {
+		tracer := otel.Tracer("nethttp-service")
+		_, span := tracer.Start(req.Context(), "handler.nethttp.users.list")
+		defer span.End()
+		netReqCount.WithLabelValues("/users").Inc()
+		w.WriteHeader(200)
+	})
+	return mux
+}

--- a/internal/custom/golang/testdata/nethttp_validation.go
+++ b/internal/custom/golang/testdata/nethttp_validation.go
@@ -1,0 +1,32 @@
+package fixtures
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// NetHTTPSignupReq is a net/http-handled DTO validated via a validator.New()
+// struct-tag check after a std-lib JSON decode.
+type NetHTTPSignupReq struct {
+	Username string `json:"username" validate:"required,alphanum"`
+	Password string `json:"password" validate:"required,min=8"`
+}
+
+func setupNetHTTPVal() {
+	mux := http.NewServeMux()
+	validate := validator.New()
+	mux.HandleFunc("/signup", func(w http.ResponseWriter, req *http.Request) {
+		var dto NetHTTPSignupReq
+		if err := json.NewDecoder(req.Body).Decode(&dto); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		if err := validate.Struct(&dto); err != nil {
+			http.Error(w, err.Error(), 422)
+			return
+		}
+		w.WriteHeader(201)
+	})
+}

--- a/internal/custom/golang/testdata/revel_observability.go
+++ b/internal/custom/golang/testdata/revel_observability.go
@@ -1,0 +1,36 @@
+package fixtures
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/revel/revel"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+)
+
+var revelReqCount = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "revel_http_requests_total",
+		Help: "Total HTTP requests.",
+	},
+	[]string{"action"},
+)
+
+// RevelUserController is a revel controller; the package references
+// revel.Controller / revel.Result so the scanner attributes this to revel.
+type RevelUserController struct {
+	*revel.Controller
+}
+
+func (c RevelUserController) List() revel.Result {
+	log := logrus.New()
+	log.WithFields(logrus.Fields{"component": "revel"}).Info("list users")
+
+	tracer := otel.Tracer("revel-service")
+	_, span := tracer.Start(context.Background(), "handler.revel.users.list")
+	defer span.End()
+
+	revelReqCount.WithLabelValues("List").Inc()
+	return c.RenderJSON(map[string]any{"ok": true})
+}

--- a/internal/custom/golang/validation.go
+++ b/internal/custom/golang/validation.go
@@ -59,6 +59,20 @@ func (e *validationExtractor) Language() string { return "custom_go_validation" 
 // valFrameworkMarkers attributes a file to a framework via its canonical engine
 // constructor / request-context type. Same surface observability.go uses, kept
 // file-local to avoid editing shared helpers (contention avoidance).
+//
+// The first four (gin/echo/fiber/chi) are the original well-templated set; the
+// remaining six (beego/iris/hertz/buffalo/gorilla-mux/net-http) extend struct-
+// tag / binding-call validation detection to the rest of the Go HTTP framework
+// family (issue #3213). All ten support go-playground/validator `validate:`
+// struct tags and a request-binding call surface.
+//
+// fasthttp and revel are intentionally absent: neither offers struct-tag
+// request binding (fasthttp's RequestCtx exposes raw byte accessors only;
+// Revel binds params positionally via controller-method signatures, not tags),
+// so there is no validation surface to attribute and their request_validation
+// cell is honestly marked not_applicable rather than fabricated.
+//
+// net-http is placed last because its `http.*` markers are the broadest.
 var valFrameworkMarkers = []struct {
 	name string
 	re   *regexp.Regexp
@@ -67,10 +81,17 @@ var valFrameworkMarkers = []struct {
 	{"echo", regexp.MustCompile(`\becho\.(?:New|Echo|Context|HandlerFunc|MiddlewareFunc)\b`)},
 	{"fiber", regexp.MustCompile(`\bfiber\.(?:New|App|Ctx|Handler)\b`)},
 	{"chi", regexp.MustCompile(`\bchi\.(?:NewRouter|Router|Mux)\b`)},
+	{"beego", regexp.MustCompile(`\b(?:beego|web)\.(?:Router|NewNamespace|Run|InsertFilter|AutoRouter)\b`)},
+	{"iris", regexp.MustCompile(`\biris\.(?:New|Default|Application|Context|Party)\b`)},
+	{"hertz", regexp.MustCompile(`\bserver\.(?:Default|New|Hertz)\b|\bapp\.RequestContext\b`)},
+	{"buffalo", regexp.MustCompile(`\bbuffalo\.(?:New|App|Options|Context)\b`)},
+	{"gorilla-mux", regexp.MustCompile(`\bmux\.(?:NewRouter|Router|Vars)\b`)},
+	{"net-http", regexp.MustCompile(`\bhttp\.(?:NewServeMux|HandleFunc|ListenAndServe|ListenAndServeTLS)\b`)},
 }
 
 // detectValFramework returns the framework a file belongs to, or "" when no
-// recognised marker is present. First match wins (gin→echo→fiber→chi).
+// recognised marker is present. First match wins (gin→echo→fiber→chi→beego→
+// iris→hertz→buffalo→gorilla-mux→net-http).
 func detectValFramework(src string) string {
 	for _, m := range valFrameworkMarkers {
 		if m.re.MatchString(src) {
@@ -178,10 +199,25 @@ var valSignals = []valSignal{
 	{regexp.MustCompile(`\b\w+\.RegisterValidation\s*\(\s*"([^"]+)"`), "validator", "register_validation", 1},
 
 	// binding / parse call sites that trigger validation, per framework.
+	//
+	// gin/echo/fiber/chi (original set):
 	{regexp.MustCompile(`\bc\.(?:ShouldBind\w*|Bind\w*|MustBindWith)\s*\(`), "binding", "bind_call", 0},
 	{regexp.MustCompile(`\bc\.Validate\s*\(`), "binding", "validate_call", 0},
 	{regexp.MustCompile(`\bc\.(?:BodyParser|QueryParser|ParamsParser|ReqHeaderParser)\s*\(`), "binding", "parse_call", 0},
 	{regexp.MustCompile(`\brender\.(?:Bind|DecodeJSON)\s*\(`), "binding", "bind_call", 0},
+
+	// extended frameworks (issue #3213):
+	//   hertz   c.BindAndValidate / c.BindJSON / c.Bind     (covered by c.Bind\w* above; explicit validate form here)
+	//   iris    ctx.ReadJSON / ctx.ReadBody / ctx.ReadForm / ctx.ReadQuery
+	//   beego   this.ParseForm(&dto) controller binding
+	//   buffalo c.Bind(&dto)                                (covered by c.Bind\w* above)
+	//   gorilla-mux / net-http  json.NewDecoder(r.Body).Decode(&dto) — the
+	//           idiomatic std-lib request decode that feeds a validator.New()
+	//           struct-tag check.
+	{regexp.MustCompile(`\b\w+\.BindAndValidate\s*\(`), "binding", "validate_call", 0},
+	{regexp.MustCompile(`\bctx\.Read(?:JSON|Body|Form|Query|XML|MsgPack|YAML|Protobuf)\s*\(`), "binding", "parse_call", 0},
+	{regexp.MustCompile(`\bthis\.ParseForm\s*\(`), "binding", "parse_call", 0},
+	{regexp.MustCompile(`\bjson\.NewDecoder\s*\([^)]*\)\s*\.Decode\s*\(`), "binding", "decode_call", 0},
 }
 
 func (e *validationExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {

--- a/internal/custom/golang/validation_test.go
+++ b/internal/custom/golang/validation_test.go
@@ -186,6 +186,14 @@ func TestValidationFixtures(t *testing.T) {
 		{"echo_validation.go", "echo", "LoginReq", "Password", "validate_call"},
 		{"fiber_validation.go", "fiber", "SignupReq", "Email", "parse_call"},
 		{"chi_validation.go", "chi", "OrderReq", "SKU", "bind_call"},
+		// extended frameworks (issue #3213); fasthttp + revel are
+		// honesty-NA (no struct-tag binding) and intentionally absent.
+		{"beego_validation.go", "beego", "BeegoCreateUserReq", "Email", "parse_call"},
+		{"iris_validation.go", "iris", "IrisLoginReq", "Password", "parse_call"},
+		{"hertz_validation.go", "hertz", "HertzSignupReq", "Email", "validate_call"},
+		{"buffalo_validation.go", "buffalo", "BuffaloOrderReq", "SKU", "bind_call"},
+		{"gorilla_mux_validation.go", "gorilla-mux", "MuxCreateUserReq", "Email", "decode_call"},
+		{"nethttp_validation.go", "net-http", "NetHTTPSignupReq", "Username", "decode_call"},
 	}
 	for _, c := range cases {
 		t.Run(c.framework, func(t *testing.T) {

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3234,6 +3234,61 @@ records:
             - file: internal/custom/golang/middleware_auth_extend_test.go
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) scans gorilla-mux-attributed
+          # files for structured-logger setup (logrus/zap/slog/zerolog) via the
+          # obsSignals table. Heuristic identifier match, no logger→handler data
+          # flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # observability.go detects prometheus/promauto collector declarations
+          # (Counter/Histogram/Gauge/Summary[Vec]) and folds in the Name: opts
+          # literal as metric_name. Heuristic match, no registration proof →
+          # partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # observability.go captures the canonical OTel span lifecycle —
+          # otel.Tracer()/<provider>.Tracer() acquisition plus tracer.Start(ctx,
+          # "name") span starts (span_name recorded). The gorilla-mux_observability.go
+          # fixture proves both halves end-to-end → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans gorilla-mux-attributed files for
+          # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
+          # / RegisterValidation custom validators, and the framework's binding
+          # call sites (e.g. c.Bind*/ctx.Read*/this.ParseForm/json.NewDecoder
+          # .Decode), emitting validation SCOPE.Pattern entities. Heuristic
+          # tag/call match, no rule→call-site data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.buffalo:
     capabilities:
@@ -3273,6 +3328,61 @@ records:
             - file: internal/custom/golang/middleware_auth_extend_test.go
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) scans buffalo-attributed
+          # files for structured-logger setup (logrus/zap/slog/zerolog) via the
+          # obsSignals table. Heuristic identifier match, no logger→handler data
+          # flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # observability.go detects prometheus/promauto collector declarations
+          # (Counter/Histogram/Gauge/Summary[Vec]) and folds in the Name: opts
+          # literal as metric_name. Heuristic match, no registration proof →
+          # partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # observability.go captures the canonical OTel span lifecycle —
+          # otel.Tracer()/<provider>.Tracer() acquisition plus tracer.Start(ctx,
+          # "name") span starts (span_name recorded). The buffalo_observability.go
+          # fixture proves both halves end-to-end → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans buffalo-attributed files for
+          # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
+          # / RegisterValidation custom validators, and the framework's binding
+          # call sites (e.g. c.Bind*/ctx.Read*/this.ParseForm/json.NewDecoder
+          # .Decode), emitting validation SCOPE.Pattern entities. Heuristic
+          # tag/call match, no rule→call-site data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.revel:
     capabilities:
@@ -3309,6 +3419,52 @@ records:
           tests:
             - file: internal/custom/golang/middleware_auth_extend_test.go
           issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) scans revel-attributed
+          # files for structured-logger setup (logrus/zap/slog/zerolog) via the
+          # obsSignals table. Heuristic identifier match, no logger→handler data
+          # flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # observability.go detects prometheus/promauto collector declarations
+          # (Counter/Histogram/Gauge/Summary[Vec]) and folds in the Name: opts
+          # literal as metric_name. Heuristic match, no registration proof →
+          # partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # observability.go captures the canonical OTel span lifecycle —
+          # otel.Tracer()/<provider>.Tracer() acquisition plus tracer.Start(ctx,
+          # "name") span starts (span_name recorded). The revel_observability.go
+          # fixture proves both halves end-to-end → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # Revel binds request params positionally via controller-method signatures, not via validate:/binding: struct tags.
+          # There is no struct-tag binding surface to extract, so the cell is
+          # honestly marked not_applicable rather than fabricated.
+          status: not_applicable
           verified_at: "2026-05-30"
 
   lang.go.framework.fyne:
@@ -4355,6 +4511,53 @@ records:
           status: not_applicable
           notes: "Neo4j is schema-flexible / graph-native; the driver has no migration runner (constraints/indexes are applied via ad-hoc Cypher)."
           issues_implemented: ["3214"]
+  lang.go.framework.fasthttp:
+    capabilities:
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) scans fasthttp-attributed
+          # files (fasthttp.RequestCtx/RequestHandler/ListenAndServe marker) for
+          # structured-logger setup (logrus/zap/slog/zerolog). Heuristic
+          # identifier match, no logger->handler data flow -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # observability.go detects prometheus/promauto collector declarations
+          # in fasthttp files and folds in the Name: opts literal as metric_name.
+          # Heuristic match, no registration proof -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # observability.go captures the canonical OTel span lifecycle
+          # (otel.Tracer()/tracer.Start(ctx, "name")) in fasthttp handlers. The
+          # fasthttp_observability.go fixture proves both halves end-to-end ->
+          # full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # fasthttp's RequestCtx exposes raw byte accessors only (no struct-tag
+          # request binding), so there is no validate:/binding: tag surface to
+          # extract; the cell is honestly marked not_applicable. validation.go
+          # therefore omits fasthttp from its framework-marker table.
+          status: not_applicable
           verified_at: "2026-05-30"
 
   lang.go.framework.net-http:
@@ -4396,6 +4599,61 @@ records:
             - file: internal/custom/golang/extractors_test.go
             - file: internal/engine/go_routes_test.go
           issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) scans net-http-attributed
+          # files for structured-logger setup (logrus/zap/slog/zerolog) via the
+          # obsSignals table. Heuristic identifier match, no logger→handler data
+          # flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # observability.go detects prometheus/promauto collector declarations
+          # (Counter/Histogram/Gauge/Summary[Vec]) and folds in the Name: opts
+          # literal as metric_name. Heuristic match, no registration proof →
+          # partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # observability.go captures the canonical OTel span lifecycle —
+          # otel.Tracer()/<provider>.Tracer() acquisition plus tracer.Start(ctx,
+          # "name") span starts (span_name recorded). The net-http_observability.go
+          # fixture proves both halves end-to-end → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans net-http-attributed files for
+          # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
+          # / RegisterValidation custom validators, and the framework's binding
+          # call sites (e.g. c.Bind*/ctx.Read*/this.ParseForm/json.NewDecoder
+          # .Decode), emitting validation SCOPE.Pattern entities. Heuristic
+          # tag/call match, no rule→call-site data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
   lang.go.framework.beego:
@@ -4466,6 +4724,61 @@ records:
             - file: internal/custom/golang/middleware_auth_extend_test.go
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) scans beego-attributed
+          # files for structured-logger setup (logrus/zap/slog/zerolog) via the
+          # obsSignals table. Heuristic identifier match, no logger→handler data
+          # flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # observability.go detects prometheus/promauto collector declarations
+          # (Counter/Histogram/Gauge/Summary[Vec]) and folds in the Name: opts
+          # literal as metric_name. Heuristic match, no registration proof →
+          # partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # observability.go captures the canonical OTel span lifecycle —
+          # otel.Tracer()/<provider>.Tracer() acquisition plus tracer.Start(ctx,
+          # "name") span starts (span_name recorded). The beego_observability.go
+          # fixture proves both halves end-to-end → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans beego-attributed files for
+          # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
+          # / RegisterValidation custom validators, and the framework's binding
+          # call sites (e.g. c.Bind*/ctx.Read*/this.ParseForm/json.NewDecoder
+          # .Decode), emitting validation SCOPE.Pattern entities. Heuristic
+          # tag/call match, no rule→call-site data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.iris:
     capabilities:
@@ -4531,6 +4844,61 @@ records:
               functions: [classifyAuthMiddleware, emitMiddlewareChain]
           tests:
             - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) scans iris-attributed
+          # files for structured-logger setup (logrus/zap/slog/zerolog) via the
+          # obsSignals table. Heuristic identifier match, no logger→handler data
+          # flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # observability.go detects prometheus/promauto collector declarations
+          # (Counter/Histogram/Gauge/Summary[Vec]) and folds in the Name: opts
+          # literal as metric_name. Heuristic match, no registration proof →
+          # partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # observability.go captures the canonical OTel span lifecycle —
+          # otel.Tracer()/<provider>.Tracer() acquisition plus tracer.Start(ctx,
+          # "name") span starts (span_name recorded). The iris_observability.go
+          # fixture proves both halves end-to-end → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans iris-attributed files for
+          # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
+          # / RegisterValidation custom validators, and the framework's binding
+          # call sites (e.g. c.Bind*/ctx.Read*/this.ParseForm/json.NewDecoder
+          # .Decode), emitting validation SCOPE.Pattern entities. Heuristic
+          # tag/call match, no rule→call-site data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 
@@ -4601,6 +4969,61 @@ records:
               functions: [classifyAuthMiddleware, emitMiddlewareChain]
           tests:
             - file: internal/custom/golang/middleware_auth_extend_test.go
+          issues_implemented: ["3213"]
+          verified_at: "2026-05-30"
+      Observability:
+        log_extraction:
+          # observability.go (custom_go_observability) scans hertz-attributed
+          # files for structured-logger setup (logrus/zap/slog/zerolog) via the
+          # obsSignals table. Heuristic identifier match, no logger→handler data
+          # flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, detectObsFramework]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        metric_extraction:
+          # observability.go detects prometheus/promauto collector declarations
+          # (Counter/Histogram/Gauge/Summary[Vec]) and folds in the Name: opts
+          # literal as metric_name. Heuristic match, no registration proof →
+          # partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract, nearbyPromName]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          issues_implemented: ["3215"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          # observability.go captures the canonical OTel span lifecycle —
+          # otel.Tracer()/<provider>.Tracer() acquisition plus tracer.Start(ctx,
+          # "name") span starts (span_name recorded). The hertz_observability.go
+          # fixture proves both halves end-to-end → full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/observability.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/golang/observability_test.go
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # validation.go (custom_go_validation) scans hertz-attributed files for
+          # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
+          # / RegisterValidation custom validators, and the framework's binding
+          # call sites (e.g. c.Bind*/ctx.Read*/this.ParseForm/json.NewDecoder
+          # .Decode), emitting validation SCOPE.Pattern entities. Heuristic
+          # tag/call match, no rule→call-site data flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/validation.go
+              functions: [Extract, findValidationRules, detectValFramework]
+          tests:
+            - file: internal/custom/golang/validation_test.go
           issues_implemented: ["3213"]
           verified_at: "2026-05-30"
 


### PR DESCRIPTION
## Summary

Extends the framework-agnostic Go **observability** (`observability.go`) and **request-validation** (`validation.go`) scanners beyond the four well-templated frameworks (gin/echo/fiber/chi) to **8 more** Go HTTP frameworks, by adding each framework's engine/context marker to the inference tables. No shared helpers touched (only the file-local marker tables + a few validation binding-call signals).

Frameworks: `beego`, `buffalo`, `fasthttp`, `revel`, `iris`, `hertz`, `net-http`, `gorilla-mux`.

## Per-framework × capability flips

| framework | log_extraction | metric_extraction | trace_extraction | request_validation |
|---|---|---|---|---|
| beego | partial | partial | **full** | partial |
| buffalo | partial | partial | **full** | partial |
| fasthttp | partial | partial | **full** | not_applicable |
| revel | partial | partial | **full** | not_applicable |
| iris | partial | partial | **full** | partial |
| hertz | partial | partial | **full** | partial |
| net-http | partial | partial | **full** | partial |
| gorilla-mux | partial | partial | **full** | partial |

## Honesty

- **trace_extraction = full**: the OTel tracer-acquire + `tracer.Start(ctx, "name")` span lifecycle is canonical and stable; each framework ships a `<fw>_observability.go` fixture proving both halves end-to-end.
- **log/metric = partial**: heuristic logrus/zap/slog/zerolog + prometheus collector match, no logger/metric→handler data flow.
- **request_validation = partial** for the 6 frameworks with a struct-tag / binding-call surface; **not_applicable** for `fasthttp` (RequestCtx exposes raw byte accessors only — no struct-tag binding) and `revel` (positional controller-method param binding, no `validate:`/`binding:` tags). These two are intentionally absent from `validation.go`'s marker table.

## Fixtures / tests

Added per-framework testdata fixtures (8 observability + 6 validation) wired into the existing `TestObservabilityFixtures` / `TestValidationFixtures` table tests. Every non-NA flip is fixture-proven; `full` is used only with a proving fixture.

## Registry / map integrity

- `capability-map.yaml`: the new Observability + Validation cells are documented by extending each framework's **existing** record in place; one **new** `fasthttp` record was created (it had no prior record). Every `lang.go.framework.<fw>:` key appears exactly **once** (gin/echo/fiber/chi/beego/buffalo/fasthttp/revel/iris/hertz/net-http/gorilla-mux all == 1).
- `go run ./tools/coverage validate` exits **0**, no "already defined" / duplicate-key errors.
- `fmt --check` canonical, `gen` byte-stable, `gofmt -l` clean for all touched source/fixtures.
- Scoped tests pass: `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...`.

Part of #3215 and #3213

🤖 Generated with [Claude Code](https://claude.com/claude-code)