### PR TITLE
coverage(go): gomobile branch_conditions (DataFlow) cell — port branch-condition detection to Go (#3255)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -190,7 +190,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 |---|---|---|---|---|---|---|
 | [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/9 | |
 | [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/9 | |
-| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟡 3/4 | |
+| [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟢 4/4 | |
 | [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
 | [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
 | [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 13/13 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -47,7 +47,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟡 3/4 | |
+| [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟢 4/4 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/lang.go.framework.gomobile.md
+++ b/docs/coverage/detail/lang.go.framework.gomobile.md
@@ -41,7 +41,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Branch conditions | 🔴 `missing` | — | — | — | — |
+| Branch conditions | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/gomobile.go`<br>`internal/custom/golang/gomobile_branch_test.go` | — |
 | State management | — `not_applicable` | — | — | — | — |
 
 ### Type System

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12482,7 +12482,10 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/gomobile.go","internal/custom/golang/gomobile_branch_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "state_management": {
             "status": "not_applicable"

--- a/internal/custom/golang/gomobile.go
+++ b/internal/custom/golang/gomobile.go
@@ -3,6 +3,7 @@ package golang
 import (
 	"context"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -42,6 +43,14 @@ import (
 //   - bound_func  : exported funcs in a package that imports a gomobile/bind
 //                    surface — the FFI boundary crossed by the generated
 //                    Java/ObjC bindings → SCOPE.External (subtype native_bridge).
+//   - branch      : a control-flow site (`if`/`switch`) whose controlling
+//                    expression discriminates on the runtime platform —
+//                    `runtime.GOOS == "android"`, `switch runtime.GOOS { ... }`
+//                    — i.e. a platform branch in mobile-bound code → a
+//                    SCOPE.Operation/branch entity carrying the normalised
+//                    condition + a BRANCHES_ON edge (the Data Flow.branch_
+//                    conditions surface; mirrors the JS/TS branchconditions
+//                    pass, ported to Go's runtime.GOOS idiom). #3255.
 //
 // Honesty (registry coverage status, lang.go.framework.gomobile):
 //
@@ -52,6 +61,10 @@ import (
 //                                             (no build-tag constraint solving).
 //   - Native Bridge.native_module_imports  → partial: gomobile native package
 //                                             imports detected by import match.
+//   - Data Flow.branch_conditions          → partial: runtime.GOOS `if`/`switch`
+//                                             platform branches detected by regex
+//                                             (no AST control-flow graph; nested/
+//                                             aliased GOOS values not resolved).
 //   - Navigation.* (navigation/screen/deep_link) → not_applicable: gomobile bind
 //                                             has no Go-side navigation framework;
 //                                             screens/navigation live in the host
@@ -99,6 +112,24 @@ var (
 	// surface of a `gomobile bind` package). Methods (with a receiver) are
 	// excluded — they are not part of the generated top-level binding.
 	reExportedFunc = regexp.MustCompile(`(?m)^func\s+([A-Z]\w*)\s*\(`)
+
+	// reGOOSSwitch matches a `switch runtime.GOOS {` platform-discriminant
+	// switch. The whole switch is one platform branch site; the individual
+	// `case "android":` arms are captured separately by reGOOSCase.
+	reGOOSSwitch = regexp.MustCompile(`(?m)\bswitch\s+runtime\.GOOS\s*\{`)
+
+	// reGOOSCase matches a `case "<goos>":` arm inside a runtime.GOOS switch.
+	// Used to enumerate the platform arms of a switch into per-platform
+	// branch conditions.
+	reGOOSCase = regexp.MustCompile(`(?m)^\s*case\s+("(?:\w+)"(?:\s*,\s*"\w+")*)\s*:`)
+
+	// reGOOSIf matches an `if`/`else if` controlling expression that compares
+	// runtime.GOOS against a string literal — the canonical Go platform
+	// branch idiom (`if runtime.GOOS == "android" { ... }`). The captured
+	// group is the operator + quoted platform so the condition can be
+	// normalised. Logical compositions (`&& runtime.GOOS == "ios"`) are also
+	// caught because the match floats to the GOOS sub-expression.
+	reGOOSIf = regexp.MustCompile(`runtime\.GOOS\s*(==|!=)\s*"(\w+)"`)
 )
 
 // mobilePlatformTokens are the GOOS/build tags that name a mobile platform; a
@@ -185,6 +216,67 @@ func (e *gomobileExtractor) Extract(ctx context.Context, file extractor.FileInpu
 		addPlatformBranch("goos_guard", submatch(src, m, 2), lineOf(src, m[0]))
 	}
 
+	// 2b. branch conditions — runtime.GOOS `if`/`switch` control-flow sites that
+	//     discriminate on the platform (Data Flow.branch_conditions, #3255).
+	//     Distinct from §2: §2 records the platform constraint as a SCOPE.Pattern
+	//     (the Platform capability); here we record the control-flow *branch* as a
+	//     SCOPE.Operation/branch with a BRANCHES_ON edge, mirroring the JS/TS
+	//     branchconditions pass. Conditions are deduplicated by normalised text.
+	branchSeen := make(map[string]bool)
+	addBranch := func(expr, kind, operator, platform string, line int) {
+		expr = normalizeGoBranchExpr(expr)
+		if expr == "" || branchSeen[expr] {
+			return
+		}
+		branchSeen[expr] = true
+		ent := makeEntity("gomobile:branch:"+expr, "SCOPE.Operation", "branch", file.Path, file.Language, line)
+		setProps(&ent, "framework", "gomobile", "provenance", "INFERRED_FROM_GOMOBILE_BRANCH",
+			"branch_kind", kind, "condition", expr, "discriminant", "runtime.GOOS")
+		if operator != "" {
+			setProps(&ent, "operator", operator)
+		}
+		if platform != "" {
+			setProps(&ent, "platform", platform)
+		}
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "branch:" + expr,
+			Kind: string(types.RelationshipKindBranchesOn),
+			Properties: map[string]string{
+				"line":     strconv.Itoa(line),
+				"operator": operator,
+				"kind":     kind,
+			},
+		})
+		add(ent)
+	}
+	// if / else-if: runtime.GOOS ==/!= "<goos>"
+	for _, m := range reGOOSIf.FindAllStringSubmatchIndex(src, -1) {
+		op := submatch(src, m, 2)
+		plat := submatch(src, m, 4)
+		addBranch("runtime.GOOS"+op+"\""+plat+"\"", "if", op, plat, lineOf(src, m[0]))
+	}
+	// switch runtime.GOOS { case "<goos>": ... } — one branch per case arm so a
+	// multi-platform switch yields a distinct condition per platform.
+	for _, sm := range reGOOSSwitch.FindAllStringIndex(src, -1) {
+		switchLine := lineOf(src, sm[0])
+		body, bodyStart := goosSwitchBody(src, sm[1]-1)
+		if body == "" {
+			continue
+		}
+		for _, cm := range reGOOSCase.FindAllStringSubmatchIndex(body, -1) {
+			labels := submatch(body, cm, 2) // e.g. `"android"` or `"ios", "android"`
+			line := lineOf(src, bodyStart+cm[0])
+			for _, lit := range splitTopLevelArgs(labels) {
+				plat := strings.Trim(lit, `"`)
+				if plat == "" {
+					continue
+				}
+				addBranch("switch runtime.GOOS case \""+plat+"\"", "switch", "case", plat, line)
+			}
+		}
+		_ = switchLine
+	}
+
 	// 3. native bridge package imports (Native Bridge.native_module_imports).
 	boundPkg := false
 	for _, m := range reGomobileNativeImport.FindAllStringSubmatchIndex(src, -1) {
@@ -214,4 +306,46 @@ func (e *gomobileExtractor) Extract(ctx context.Context, file extractor.FileInpu
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// normalizeGoBranchExpr collapses internal whitespace so equivalent platform
+// conditions deduplicate cleanly (mirrors the JS/TS normalizeBranchExpr, but
+// preserves single spaces inside `switch runtime.GOOS case "x"` labels for
+// readability — only runs of whitespace are folded to one space).
+func normalizeGoBranchExpr(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// goosSwitchBody returns the brace-balanced body text of a `switch runtime.GOOS
+// { ... }` statement and the absolute source offset at which the body begins,
+// given the offset of the opening `{`. Quoted strings are skipped so braces
+// inside string literals do not unbalance the scan. Returns ("", 0) when the
+// body is unbalanced/truncated.
+func goosSwitchBody(src string, openBrace int) (string, int) {
+	if openBrace < 0 || openBrace >= len(src) || src[openBrace] != '{' {
+		return "", 0
+	}
+	depth := 0
+	var quote rune
+	for i := openBrace; i < len(src); i++ {
+		r := rune(src[i])
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '"', '\'', '`':
+			quote = r
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[openBrace+1 : i], openBrace + 1
+			}
+		}
+	}
+	return "", 0
 }

--- a/internal/custom/golang/gomobile_branch_test.go
+++ b/internal/custom/golang/gomobile_branch_test.go
@@ -1,0 +1,142 @@
+package golang_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/golang"
+)
+
+// Tests for the gomobile Data Flow.branch_conditions surface (#3255): platform
+// branches expressed via `if runtime.GOOS == ...` and `switch runtime.GOOS`.
+
+// extractBranch returns the raw EntityRecords (including Relationships, which
+// the lighter fullEntity view drops) for the named extractor + fixture.
+func extractBranch(t *testing.T, fixture string) []types.EntityRecord {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join("testdata", fixture))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", fixture, err)
+	}
+	e, ok := extreg.Get("custom_go_gomobile")
+	if !ok {
+		t.Fatal("extractor custom_go_gomobile not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: filepath.Join("testdata", fixture), Language: "go", Content: content,
+	})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+func branchByName(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Operation" && ents[i].Subtype == "branch" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestGomobileBranchIfConditions(t *testing.T) {
+	ents := extractBranch(t, "gomobile_branch.go")
+
+	cases := []struct {
+		name, platform, operator string
+	}{
+		{`gomobile:branch:runtime.GOOS=="android"`, "android", "=="},
+		{`gomobile:branch:runtime.GOOS=="ios"`, "ios", "=="},
+	}
+	for _, c := range cases {
+		e := branchByName(ents, c.name)
+		if e == nil {
+			t.Fatalf("expected branch %q; got %+v", c.name, ents)
+		}
+		if e.Properties["branch_kind"] != "if" {
+			t.Errorf("%s: branch_kind=%q want if", c.name, e.Properties["branch_kind"])
+		}
+		if e.Properties["platform"] != c.platform {
+			t.Errorf("%s: platform=%q want %q", c.name, e.Properties["platform"], c.platform)
+		}
+		if e.Properties["operator"] != c.operator {
+			t.Errorf("%s: operator=%q want %q", c.name, e.Properties["operator"], c.operator)
+		}
+		if e.Properties["framework"] != "gomobile" {
+			t.Errorf("%s: framework=%q", c.name, e.Properties["framework"])
+		}
+		// BRANCHES_ON edge present
+		var found bool
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindBranchesOn) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s: missing BRANCHES_ON edge: %+v", c.name, e.Relationships)
+		}
+	}
+}
+
+func TestGomobileBranchSwitchConditions(t *testing.T) {
+	ents := extractBranch(t, "gomobile_branch.go")
+
+	// switch arms: "android", and the multi-platform "ios","darwin" arm split.
+	for _, plat := range []string{"android", "ios", "darwin"} {
+		name := `gomobile:branch:switch runtime.GOOS case "` + plat + `"`
+		e := branchByName(ents, name)
+		if e == nil {
+			t.Fatalf("expected switch branch for %q; got %+v", plat, ents)
+		}
+		if e.Properties["branch_kind"] != "switch" {
+			t.Errorf("%s: branch_kind=%q want switch", plat, e.Properties["branch_kind"])
+		}
+		if e.Properties["platform"] != plat {
+			t.Errorf("%s: platform=%q", plat, e.Properties["platform"])
+		}
+		if e.Properties["discriminant"] != "runtime.GOOS" {
+			t.Errorf("%s: discriminant=%q", plat, e.Properties["discriminant"])
+		}
+	}
+}
+
+func TestGomobileBranchDedup(t *testing.T) {
+	ents := extractBranch(t, "gomobile_branch.go")
+	// `runtime.GOOS == "android"` appears in both configPath() and guarded();
+	// it must be emitted exactly once.
+	n := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "branch" &&
+			e.Name == `gomobile:branch:runtime.GOOS=="android"` {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 android if-branch (deduped), got %d", n)
+	}
+}
+
+func TestGomobileBranchRequiresMarker(t *testing.T) {
+	// A file with runtime.GOOS branches but NO gomobile import must emit nothing.
+	src := `package p
+import "runtime"
+func f() { if runtime.GOOS == "android" { _ = 1 } }`
+	e, _ := extreg.Get("custom_go_gomobile")
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: "p.go", Language: "go", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ent := range ents {
+		if ent.Subtype == "branch" {
+			t.Fatalf("no gomobile marker => no branch entities, got %+v", ent)
+		}
+	}
+}

--- a/internal/custom/golang/testdata/gomobile_branch.go
+++ b/internal/custom/golang/testdata/gomobile_branch.go
@@ -1,0 +1,54 @@
+//go:build android || ios
+
+// gomobile_branch.go — fixture for the Data Flow.branch_conditions surface
+// (#3255). A gomobile-bound package whose mobile-facing code branches on the
+// runtime platform via both the `if runtime.GOOS == ...` and the
+// `switch runtime.GOOS { ... }` idioms.
+package mobilecfg
+
+import (
+	"runtime"
+
+	"golang.org/x/mobile/app"
+)
+
+// configPath returns a platform-specific config path. It branches on
+// runtime.GOOS with an if / else-if chain — the canonical Go platform branch.
+func configPath() string {
+	if runtime.GOOS == "android" {
+		return "/data/local/cfg"
+	} else if runtime.GOOS == "ios" {
+		return "Documents/cfg"
+	}
+	return "./cfg"
+}
+
+// platformLabel discriminates on runtime.GOOS via a switch, with a
+// multi-platform case arm and a default.
+func platformLabel() string {
+	switch runtime.GOOS {
+	case "android":
+		return "droid"
+	case "ios", "darwin":
+		return "apple"
+	default:
+		return "other"
+	}
+}
+
+// guarded composes runtime.GOOS into a logical condition; the GOOS comparison
+// still floats out as a platform branch.
+func guarded(enabled bool) bool {
+	if enabled && runtime.GOOS == "android" {
+		return true
+	}
+	return false
+}
+
+func main() {
+	app.Main(func(a app.App) {
+		_ = configPath()
+		_ = platformLabel()
+		_ = guarded(true)
+	})
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -3838,6 +3838,23 @@ records:
             - file: internal/custom/golang/fyne_gomobile_test.go
           issues_implemented: ["3218"]
           verified_at: "2026-05-30"
+      Data Flow:
+        branch_conditions:
+          # runtime.GOOS `if`/`switch` control-flow sites are emitted as
+          # SCOPE.Operation/branch entities with a BRANCHES_ON edge — the Go
+          # port of the JS/TS branchconditions pass to the runtime.GOOS idiom
+          # (#3255). Partial: regex over `if runtime.GOOS ==/!= "x"` and
+          # `switch runtime.GOOS { case "x": }` (incl. multi-platform arms),
+          # deduped by normalised condition; no AST control-flow graph and
+          # aliased/indirect GOOS values are not resolved.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/gomobile.go
+              functions: [Extract, normalizeGoBranchExpr, goosSwitchBody]
+          tests:
+            - file: internal/custom/golang/gomobile_branch_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-29"
   lang.go.orm.gorm:
     capabilities:
       Models:


### PR DESCRIPTION
Part of #3255 (Part of #3210). Ports the JS/TS `branchconditions` pass to Go's `runtime.GOOS` platform-branch idiom for the **gomobile** extractor, flipping the last build-gap in the #3255 table: `DataFlow/branch_conditions` for gomobile.

## What
The existing `gomobile.go` already records build constraints / `runtime.GOOS` guards as `SCOPE.Pattern` `platform_branch` entities — that's the **Platform.platform_branching** capability. This PR adds the orthogonal **Data Flow.branch_conditions** surface: the control-flow branch *sites* that discriminate on the runtime platform, mirroring the JS/TS pass (`SCOPE.Operation/branch` + `BRANCHES_ON` edge).

## Detection (heuristic regex → `partial`)
- `if` / `else if runtime.GOOS ==/!= "<goos>"` → one `SCOPE.Operation/branch` per condition (`branch_kind=if`, `operator`, `platform`).
- `switch runtime.GOOS { case "<goos>": … }` → one branch per case arm; multi-platform arms (`case "ios", "darwin":`) split into per-platform conditions via a brace-balanced, string-literal-aware body scan.
- Each branch carries a `BRANCHES_ON` edge and is deduped by normalised condition text.
- Gated on the gomobile import marker; non-gomobile files emit nothing.

Honest `partial`: regex-based, no AST control-flow graph; aliased/indirect GOOS values are not resolved.

## Registry
`lang.go.framework.gomobile` → Data Flow.branch_conditions: **missing → partial** (fixture-proven). `capability-map.yaml` + docs regenerated (`gen` byte-stable).

## Validation
- `go build ./internal/... ./tools/coverage/...` — ok
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` — ok
- `go run ./tools/coverage validate` — **exit 0**
- `fmt --check` — canonical; `gen` byte-stable; own files gofmt-clean
- anti-dup guard: `grep -c "^  lang.go.framework.gomobile:" … == 1`

## Tests
`gomobile_branch_test.go` + `testdata/gomobile_branch.go` cover if / else-if, switch (incl. multi-platform arm split), dedup, the BRANCHES_ON edge, and the no-marker negative case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)