### PR TITLE
coverage(go): auth+middleware+request_validation for kratos/go-zero/huma (#3255)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -46,13 +46,13 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟡 5/6 | |
 | [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
+| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
+| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/6 | |
 | [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/5 | |
-| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
+| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -33,13 +33,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Gin](../detail/lang.go.framework.gin.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟡 5/6 | |
 | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
+| [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [Iris](../detail/lang.go.framework.iris.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
+| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/6 | |
 | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/5 | |
-| [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
+| [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/6 | |
 
 

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -23,20 +23,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/go_zero.go`<br>`internal/custom/golang/testdata/go_zero_server.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/go_zero.go`<br>`internal/custom/golang/testdata/go_zero_server.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/go_zero.go`<br>`internal/custom/golang/testdata/go_zero_server.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -23,20 +23,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/huma.go`<br>`internal/custom/golang/testdata/huma_security.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/huma.go`<br>`internal/custom/golang/testdata/huma_security.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/huma.go`<br>`internal/custom/golang/testdata/huma_security.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -23,20 +23,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/kratos.go`<br>`internal/custom/golang/testdata/kratos_server.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/kratos.go`<br>`internal/custom/golang/testdata/kratos_request.pb.validate.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/codegen_authmwval_test.go`<br>`internal/custom/golang/kratos.go`<br>`internal/custom/golang/testdata/kratos_server.go` | — |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12260,7 +12260,10 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/go_zero.go","internal/custom/golang/testdata/go_zero_server.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -12269,13 +12272,18 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/go_zero.go","internal/custom/golang/testdata/go_zero_server.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/go_zero.go","internal/custom/golang/testdata/go_zero_server.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -13091,7 +13099,10 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/huma.go","internal/custom/golang/testdata/huma_security.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -13100,13 +13111,18 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/huma.go","internal/custom/golang/testdata/huma_security.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/huma.go","internal/custom/golang/testdata/huma_security.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -13507,7 +13523,10 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/kratos.go","internal/custom/golang/testdata/kratos_server.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -13516,13 +13535,18 @@
             "issue": "backfill:dictionary-completeness"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/kratos.go","internal/custom/golang/testdata/kratos_request.pb.validate.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/codegen_authmwval_test.go","internal/custom/golang/kratos.go","internal/custom/golang/testdata/kratos_server.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {

--- a/internal/custom/golang/codegen_authmwval_test.go
+++ b/internal/custom/golang/codegen_authmwval_test.go
@@ -1,0 +1,313 @@
+package golang_test
+
+import (
+	"testing"
+)
+
+// Tests for the middleware/auth/request_validation passes added to the three
+// Go codegen framework extractors (kratos, go-zero, huma) — issue #3255.
+// Reuses fullEntity/extractFull (middleware_auth_test.go), fi (extractors_test.go),
+// and fixtureInput (gorm_test.go).
+
+// findPattern returns the first SCOPE.Pattern entity matching name, or nil.
+func findPattern(ents []fullEntity, name string) *fullEntity {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Pattern" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// hasPatternKind reports whether any SCOPE.Pattern carries pattern_kind=kind.
+func hasPatternKind(ents []fullEntity, kind string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Props["pattern_kind"] == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// kratos
+// ---------------------------------------------------------------------------
+
+func TestKratosMiddlewareChain(t *testing.T) {
+	src := `
+import "github.com/go-kratos/kratos/v2/transport/http"
+func newServer() {
+	http.Middleware(recovery.Recovery(), logging.Server())
+}`
+	ents := extractFull(t, "custom_go_kratos", fi("server.go", "go", src))
+	for name, order := range map[string]string{
+		"recovery.Recovery()": "0",
+		"logging.Server()":    "1",
+	} {
+		mw := findPattern(ents, name)
+		if mw == nil {
+			t.Fatalf("missing middleware %q", name)
+		}
+		if mw.Props["pattern_kind"] != "middleware" {
+			t.Errorf("%s: pattern_kind=%q", name, mw.Props["pattern_kind"])
+		}
+		if mw.Props["mw_order"] != order {
+			t.Errorf("%s: mw_order=%q want %q", name, mw.Props["mw_order"], order)
+		}
+	}
+}
+
+func TestKratosAuthDetection(t *testing.T) {
+	src := `
+import "github.com/go-kratos/kratos/v2/transport/http"
+func newServer() {
+	http.Middleware(jwt.Server(keyFunc))
+}`
+	ents := extractFull(t, "custom_go_kratos", fi("server.go", "go", src))
+	mw := findPattern(ents, "jwt.Server(keyFunc)")
+	if mw == nil {
+		t.Fatal("missing jwt middleware")
+	}
+	if mw.Props["is_auth"] != "true" || mw.Props["auth_kind"] != "jwt" {
+		t.Errorf("jwt mw: is_auth=%q auth_kind=%q", mw.Props["is_auth"], mw.Props["auth_kind"])
+	}
+	if findPattern(ents, "auth:jwt.Server") == nil {
+		t.Error("expected dedicated auth:jwt.Server pattern")
+	}
+}
+
+func TestKratosRequestValidation(t *testing.T) {
+	src := `
+package v1
+func (m *HelloRequest) Validate() error { return nil }
+import "github.com/go-kratos/kratos/v2/middleware/validate"
+func mw() { validate.Validator() }`
+	ents := extractFull(t, "custom_go_kratos", fi("x.pb.validate.go", "go", src))
+	if findPattern(ents, "validation:rule:HelloRequest") == nil {
+		t.Error("expected pgv validation rule for HelloRequest")
+	}
+	if findPattern(ents, "validation:binding:validate_call") == nil {
+		t.Error("expected validate.Validator() binding pattern")
+	}
+}
+
+func TestKratosWiringFixture(t *testing.T) {
+	ents := extractFull(t, "custom_go_kratos", fixtureInput(t, "kratos_server.go", "go"))
+	if !hasPatternKind(ents, "middleware") {
+		t.Error("fixture: expected middleware patterns")
+	}
+	if !hasPatternKind(ents, "auth") {
+		t.Error("fixture: expected auth pattern (jwt via selector)")
+	}
+	if findPattern(ents, "validate.Validator()") == nil {
+		t.Error("fixture: expected validate.Validator() middleware")
+	}
+}
+
+func TestKratosPGVFixture(t *testing.T) {
+	ents := extractFull(t, "custom_go_kratos", fixtureInput(t, "kratos_request.pb.validate.go", "go"))
+	for _, msg := range []string{"validation:rule:HelloRequest", "validation:rule:CreateGreetingRequest"} {
+		if findPattern(ents, msg) == nil {
+			t.Errorf("fixture: expected %q", msg)
+		}
+	}
+}
+
+func TestKratosWiringNoMatch(t *testing.T) {
+	// Plain Go file with no kratos marker emits nothing.
+	ents := extractFull(t, "custom_go_kratos", fi("util.go", "go", `package util
+func Add(a, b int) int { return a + b }`))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// go-zero
+// ---------------------------------------------------------------------------
+
+func TestGoZeroMiddlewareChain(t *testing.T) {
+	src := `
+import "github.com/zeromicro/go-zero/rest"
+func s() {
+	rest.WithMiddleware(corsMiddleware, traceMiddleware)
+}`
+	ents := extractFull(t, "custom_go_go_zero", fi("server.go", "go", src))
+	for name, order := range map[string]string{
+		"corsMiddleware":  "0",
+		"traceMiddleware": "1",
+	} {
+		mw := findPattern(ents, name)
+		if mw == nil {
+			t.Fatalf("missing middleware %q", name)
+		}
+		if mw.Props["mw_order"] != order {
+			t.Errorf("%s: mw_order=%q want %q", name, mw.Props["mw_order"], order)
+		}
+	}
+}
+
+func TestGoZeroWithJwtAuth(t *testing.T) {
+	src := `
+import "github.com/zeromicro/go-zero/rest"
+func s() { rest.WithJwt("secret") }`
+	ents := extractFull(t, "custom_go_go_zero", fi("server.go", "go", src))
+	mw := findPattern(ents, "rest.WithJwt")
+	if mw == nil {
+		t.Fatal("missing rest.WithJwt pattern")
+	}
+	if mw.Props["is_auth"] != "true" || mw.Props["auth_kind"] != "jwt" {
+		t.Errorf("WithJwt: is_auth=%q auth_kind=%q", mw.Props["is_auth"], mw.Props["auth_kind"])
+	}
+	if findPattern(ents, "auth:rest.WithJwt") == nil {
+		t.Error("expected dedicated auth:rest.WithJwt pattern")
+	}
+}
+
+func TestGoZeroRequestValidation(t *testing.T) {
+	src := `
+import "github.com/zeromicro/go-zero/rest/httpx"
+type LoginRequest struct {
+	Username string ` + "`json:\"username\" validate:\"required,min=3\"`" + `
+}
+func h(r *http.Request) { var req LoginRequest; httpx.Parse(r, &req) }`
+	ents := extractFull(t, "custom_go_go_zero", fi("login.go", "go", src))
+	rule := findPattern(ents, "validation:rule:LoginRequest.Username")
+	if rule == nil {
+		t.Fatal("expected validate-tag rule for LoginRequest.Username")
+	}
+	if rule.Props["rules"] != "required,min=3" {
+		t.Errorf("rules=%q", rule.Props["rules"])
+	}
+	if findPattern(ents, "validation:binding:bind_call") == nil {
+		t.Error("expected httpx.Parse binding pattern")
+	}
+}
+
+func TestGoZeroWiringFixture(t *testing.T) {
+	ents := extractFull(t, "custom_go_go_zero", fixtureInput(t, "go_zero_server.go", "go"))
+	if !hasPatternKind(ents, "middleware") {
+		t.Error("fixture: expected middleware patterns")
+	}
+	if !hasPatternKind(ents, "auth") {
+		t.Error("fixture: expected auth pattern (WithJwt)")
+	}
+	for _, w := range []string{
+		"validation:rule:LoginRequest.Username",
+		"validation:rule:LoginRequest.Password",
+		"validation:binding:bind_call",
+	} {
+		if findPattern(ents, w) == nil {
+			t.Errorf("fixture: expected %q", w)
+		}
+	}
+}
+
+func TestGoZeroWiringNoMatch(t *testing.T) {
+	ents := extractFull(t, "custom_go_go_zero", fi("util.go", "go", `package util
+func Add(a, b int) int { return a + b }`))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// huma
+// ---------------------------------------------------------------------------
+
+func TestHumaMiddlewareChain(t *testing.T) {
+	src := `
+import "github.com/danielgtaylor/huma/v2"
+func r(api huma.API) { api.UseMiddleware(authMw, logMw) }`
+	ents := extractFull(t, "custom_go_huma", fi("api.go", "go", src))
+	for name, order := range map[string]string{"authMw": "0", "logMw": "1"} {
+		mw := findPattern(ents, name)
+		if mw == nil {
+			t.Fatalf("missing middleware %q", name)
+		}
+		if mw.Props["mw_order"] != order {
+			t.Errorf("%s: mw_order=%q want %q", name, mw.Props["mw_order"], order)
+		}
+	}
+}
+
+func TestHumaSecurityRequirement(t *testing.T) {
+	src := `
+import "github.com/danielgtaylor/huma/v2"
+func r(api huma.API) {
+	huma.Register(api, huma.Operation{
+		Method: "GET", Path: "/me",
+		Security: []map[string][]string{{"bearer": {}}},
+	}, handler)
+}`
+	ents := extractFull(t, "custom_go_huma", fi("api.go", "go", src))
+	au := findPattern(ents, "auth:requirement:bearer")
+	if au == nil {
+		t.Fatal("expected auth:requirement:bearer")
+	}
+	if au.Props["auth_kind"] != "jwt" || au.Props["auth_source"] != "operation_security" {
+		t.Errorf("auth_kind=%q auth_source=%q", au.Props["auth_kind"], au.Props["auth_source"])
+	}
+}
+
+func TestHumaSecurityScheme(t *testing.T) {
+	src := `
+import "github.com/danielgtaylor/huma/v2"
+func r(api huma.API) {
+	api.OpenAPI().Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"bearer": {Type: "http", Scheme: "bearer"},
+	}
+}`
+	ents := extractFull(t, "custom_go_huma", fi("api.go", "go", src))
+	au := findPattern(ents, "auth:scheme:bearer")
+	if au == nil {
+		t.Fatal("expected auth:scheme:bearer")
+	}
+	if au.Props["auth_source"] != "security_scheme" {
+		t.Errorf("auth_source=%q", au.Props["auth_source"])
+	}
+}
+
+func TestHumaRequestValidation(t *testing.T) {
+	src := `
+import "github.com/danielgtaylor/huma/v2"
+type CreateUserInput struct {
+	Body struct {
+		Name string ` + "`json:\"name\" required:\"true\" minLength:\"2\"`" + `
+	}
+}`
+	ents := extractFull(t, "custom_go_huma", fi("api.go", "go", src))
+	if findPattern(ents, "validation:rule:CreateUserInput.Name") == nil {
+		t.Error("expected huma validation rule for CreateUserInput.Name")
+	}
+}
+
+func TestHumaWiringFixture(t *testing.T) {
+	ents := extractFull(t, "custom_go_huma", fixtureInput(t, "huma_security.go", "go"))
+	if !hasPatternKind(ents, "middleware") {
+		t.Error("fixture: expected middleware patterns")
+	}
+	if findPattern(ents, "auth:requirement:bearer") == nil {
+		t.Error("fixture: expected operation security requirement")
+	}
+	if findPattern(ents, "auth:scheme:bearer") == nil {
+		t.Error("fixture: expected security scheme")
+	}
+	for _, w := range []string{
+		"validation:rule:CreateUserInput.Name",
+		"validation:rule:CreateUserInput.Email",
+		"validation:rule:CreateUserInput.Age",
+	} {
+		if findPattern(ents, w) == nil {
+			t.Errorf("fixture: expected %q", w)
+		}
+	}
+}
+
+func TestHumaWiringNoMatch(t *testing.T) {
+	ents := extractFull(t, "custom_go_huma", fi("util.go", "go", `package util
+func Add(a, b int) int { return a + b }`))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/golang/go_zero.go
+++ b/internal/custom/golang/go_zero.go
@@ -137,8 +137,15 @@ func (e *goZeroExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	}
 
 	src := string(file.Content)
-	// Gate on the generated routes-registration signature.
-	if !strings.Contains(src, "rest.Route") && !strings.Contains(src, "AddRoutes") {
+	// Two gates. The routing pass is gated on the generated routes-registration
+	// signature (rest.Route / AddRoutes). The middleware/auth/validation passes
+	// model the hand-written server-bootstrap + logic-layer wiring, so they run
+	// on any file carrying a go-zero marker. A file with neither emits nothing.
+	hasRoutes := strings.Contains(src, "rest.Route") || strings.Contains(src, "AddRoutes")
+	hasGoZeroMarker := strings.Contains(src, "zeromicro/go-zero") ||
+		strings.Contains(src, "rest.With") ||
+		strings.Contains(src, "httpx.Parse")
+	if !hasRoutes && !hasGoZeroMarker {
 		return nil, nil
 	}
 
@@ -153,6 +160,11 @@ func (e *goZeroExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		seen[key] = true
 		entities = append(entities, ent)
 	}
+
+	// middleware / auth / request_validation surfaces (issue #3255). Run on
+	// every go-zero file (the wiring may live apart from the generated routes).
+	e.extractMiddlewareAuth(src, file, add)
+	e.extractRequestValidation(src, file, add)
 
 	for _, loc := range reGoZeroAddRoutesHead.FindAllStringSubmatchIndex(src, -1) {
 		serverVar := submatch(src, loc, 2)
@@ -208,4 +220,183 @@ func (e *goZeroExtractor) Extract(ctx context.Context, file extractor.FileInput)
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Middleware + auth + request validation (issue #3255).
+//
+// go-zero's routing extractor above models the generated handler/routes.go.
+// The three capabilities below model the surrounding go-zero wiring, which the
+// routing pass does not touch:
+//
+//   - middleware_coverage : middleware is registered server-wide via the
+//       rest.WithMiddleware(mw, …) server option, and per-route via
+//       server.Use(mw) / a Middleware field on a rest.Route. Each middleware
+//       expression is one ordered SCOPE.Pattern (pattern_kind=middleware).
+//   - auth_coverage      : go-zero ships first-class JWT auth via the
+//       rest.WithJwt(secret) route option (and the Authorization config block);
+//       any middleware or WithJwt option that classifies as auth is flagged
+//       is_auth + auth_kind and re-emitted as a dedicated auth SCOPE.Pattern.
+//   - request_validation : request DTOs carry `validate:"…"` struct tags and an
+//       optional generated `func (r *Req) Validate() error`; the handler binds
+//       + validates them via httpx.Parse(r, &req). Both the tag rules and the
+//       httpx.Parse binding call site are validation surfaces.
+//
+// Honesty: heuristic identifier/substring/tag matches on source text with no
+// data-flow proof, so each capability is reported `partial`. go-zero genuinely
+// has all three concepts (not NA); the proving fixture exercises each.
+// ---------------------------------------------------------------------------
+
+var (
+	// rest.WithMiddleware( server-option call — balanced args hold a middleware
+	// chain. server.Use( / engine.Use( per-server middleware registration.
+	reGoZeroMWHead = regexp.MustCompile(`rest\.WithMiddleware\s*\(|\b\w+\.Use\s*\(`)
+	// rest.WithJwt("secret") — go-zero's first-class JWT route option.
+	reGoZeroWithJwt = regexp.MustCompile(`rest\.WithJwt\s*\(`)
+	// validate:"..." struct-field tags (go-zero embeds go-playground/validator).
+	reGoZeroValidateField = regexp.MustCompile(
+		"(?m)^\\s*(\\w+)\\s+[^`\\n]*`[^`]*\\bvalidate:\"([^\"]+)\"[^`]*`")
+	// httpx.Parse(r, &req) — the go-zero request bind+validate call site.
+	reGoZeroHttpxParse = regexp.MustCompile(`httpx\.Parse(?:JsonBody|Form|Header|Path)?\s*\(`)
+)
+
+// goZeroClassifyAuth — file-local auth classifier (shared helpers untouched).
+func goZeroClassifyAuth(expr string) string {
+	low := strings.ToLower(expr)
+	switch {
+	case strings.Contains(low, "jwt"), strings.Contains(low, "bearer"):
+		return "jwt"
+	case strings.Contains(low, "oauth"):
+		return "oauth"
+	case strings.Contains(low, "apikey"), strings.Contains(low, "api_key"), strings.Contains(low, "keyauth"):
+		return "api_key"
+	case strings.Contains(low, "basicauth"), strings.Contains(low, "basic_auth"):
+		return "basic"
+	case strings.Contains(low, "casbin"), strings.Contains(low, "rbac"):
+		return "rbac"
+	case strings.Contains(low, "authz"), strings.Contains(low, "authorize"):
+		return "authz"
+	case strings.Contains(low, "auth"):
+		return "auth"
+	}
+	return ""
+}
+
+var reGoZeroCallHead = regexp.MustCompile(`^[A-Za-z_][\w.]*`)
+
+// extractMiddlewareAuth scans rest.WithMiddleware(...) / .Use(...) chains and
+// rest.WithJwt(...) options, emitting ordered middleware SCOPE.Pattern entities
+// and dedicated auth SCOPE.Pattern entities for auth-classified middleware.
+func (e *goZeroExtractor) extractMiddlewareAuth(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	addAuth := func(name, expr string, line int) {
+		au := makeEntity("auth:"+name, "SCOPE.Pattern", "", file.Path, file.Language, line)
+		setProps(&au, "framework", "go_zero",
+			"provenance", "INFERRED_FROM_GOZERO_AUTH",
+			"pattern_kind", "auth",
+			"auth_kind", goZeroClassifyAuth(expr),
+			"middleware_name", name,
+			"middleware_expr", expr)
+		add(au)
+	}
+
+	for _, head := range reGoZeroMWHead.FindAllStringIndex(src, -1) {
+		open := head[1] - 1
+		args, end := balancedArgs(src, open)
+		if end < 0 {
+			continue
+		}
+		line := lineOf(src, head[0])
+		order := 0
+		for _, part := range splitTopLevelArgs(args) {
+			if part == "" || isStringLiteral(part) {
+				continue
+			}
+			name := reGoZeroCallHead.FindString(part)
+			if name == "" {
+				name = part
+			}
+			mw := makeEntity(part, "SCOPE.Pattern", "", file.Path, file.Language, line)
+			setProps(&mw, "framework", "go_zero",
+				"provenance", "INFERRED_FROM_GOZERO_MIDDLEWARE",
+				"pattern_kind", "middleware",
+				"middleware_name", name,
+				"mw_order", itoa(order))
+			if ak := goZeroClassifyAuth(part); ak != "" {
+				setProps(&mw, "is_auth", "true", "auth_kind", ak)
+				add(mw)
+				addAuth(name, part, line)
+			} else {
+				add(mw)
+			}
+			order++
+		}
+	}
+
+	// rest.WithJwt(secret) is a first-class JWT enforcement option, not a
+	// middleware-chain entry — emit it directly as an auth SCOPE.Pattern.
+	for _, m := range reGoZeroWithJwt.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		mw := makeEntity("rest.WithJwt", "SCOPE.Pattern", "", file.Path, file.Language, line)
+		setProps(&mw, "framework", "go_zero",
+			"provenance", "INFERRED_FROM_GOZERO_MIDDLEWARE",
+			"pattern_kind", "middleware",
+			"middleware_name", "rest.WithJwt",
+			"is_auth", "true", "auth_kind", "jwt")
+		add(mw)
+		addAuth("rest.WithJwt", "rest.WithJwt(...)", line)
+	}
+}
+
+// extractRequestValidation emits a validation SCOPE.Pattern per `validate:`
+// struct-tag field and per httpx.Parse(...) bind call site.
+func (e *goZeroExtractor) extractRequestValidation(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	// Index struct heads so each tagged field is attributed to its struct.
+	type head struct {
+		name string
+		off  int
+	}
+	var heads []head
+	for _, m := range reGoStructHead.FindAllStringSubmatchIndex(src, -1) {
+		heads = append(heads, head{name: src[m[2]:m[3]], off: m[0]})
+	}
+	structAt := func(off int) string {
+		name := ""
+		for _, h := range heads {
+			if h.off <= off {
+				name = h.name
+			} else {
+				break
+			}
+		}
+		return name
+	}
+
+	for _, m := range reGoZeroValidateField.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		rules := src[m[4]:m[5]]
+		if rules == "" || rules == "-" {
+			continue
+		}
+		st := structAt(m[0])
+		ent := makeEntity("validation:rule:"+st+"."+field, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "go_zero",
+			"provenance", "INFERRED_FROM_GOZERO_VALIDATION",
+			"pattern_kind", "validation",
+			"validation_kind", "rule",
+			"struct_name", st,
+			"field_name", field,
+			"rules", rules,
+			"rule_source", "validate")
+		add(ent)
+	}
+
+	for _, m := range reGoZeroHttpxParse.FindAllStringIndex(src, -1) {
+		ent := makeEntity("validation:binding:bind_call", "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "go_zero",
+			"provenance", "INFERRED_FROM_GOZERO_VALIDATION",
+			"pattern_kind", "validation",
+			"validation_kind", "binding",
+			"validation_subtype", "httpx_parse")
+		add(ent)
+	}
 }

--- a/internal/custom/golang/huma.go
+++ b/internal/custom/golang/huma.go
@@ -72,7 +72,9 @@ func (e *humaExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 	}
 
 	src := string(file.Content)
-	if !strings.Contains(src, "danielgtaylor/huma") && !strings.Contains(src, "huma.Register") {
+	hasMarker := strings.Contains(src, "danielgtaylor/huma") || strings.Contains(src, "huma.Register") ||
+		strings.Contains(src, "huma.API") || strings.Contains(src, "UseMiddleware")
+	if !hasMarker {
 		return nil, nil
 	}
 
@@ -87,6 +89,10 @@ func (e *humaExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 		seen[key] = true
 		entities = append(entities, ent)
 	}
+
+	// middleware / auth / request_validation surfaces (issue #3255).
+	e.extractMiddlewareAuth(src, file, add)
+	e.extractRequestValidation(src, file, add)
 
 	for _, loc := range reHumaRegisterHead.FindAllStringIndex(src, -1) {
 		open := loc[1] - 1 // index of the '(' that reHumaRegisterHead ends at
@@ -121,6 +127,233 @@ func (e *humaExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Middleware + auth + request validation (issue #3255).
+//
+// huma's routing extractor above models huma.Register endpoints. The three
+// capabilities below model huma's middleware/security/validation surface, which
+// the routing pass does not touch:
+//
+//   - middleware_coverage : middleware is installed on a huma.API via
+//       api.UseMiddleware(mw, …) (and the huma.Middlewares{…} slice). Each
+//       middleware expression is one ordered SCOPE.Pattern.
+//   - auth_coverage      : huma is OpenAPI-first — auth is declared by a
+//       Security field on a huma.Operation literal naming security schemes, and
+//       the schemes themselves are registered under Components.SecuritySchemes
+//       (often huma.SecurityScheme / type: "http", scheme: "bearer"). Both the
+//       per-operation Security requirement and the scheme registration are auth
+//       SCOPE.Pattern entities.
+//   - request_validation : huma auto-validates every input struct from its
+//       OpenAPI-schema field tags (required/minimum/maximum/maxLength/format/
+//       enum/pattern). Each validated field tag is a validation rule
+//       SCOPE.Pattern; the huma.Register call is itself the binding site.
+//
+// Honesty: heuristic identifier/substring/tag matches on source text with no
+// data-flow proof, so each capability is reported `partial`. huma genuinely has
+// all three concepts (not NA); the proving fixture exercises each.
+// ---------------------------------------------------------------------------
+
+var (
+	// api.UseMiddleware( — huma middleware install on an API value.
+	reHumaUseMiddleware = regexp.MustCompile(`\.UseMiddleware\s*\(`)
+	// huma.Middlewares{ … } slice literal of middleware values.
+	reHumaMiddlewaresHead = regexp.MustCompile(`huma\.Middlewares\s*\{`)
+	// Security: field on a huma.Operation literal. The value is a
+	// []map[string][]string{ {"<scheme>": {…}} } composite literal; the scheme
+	// names live in the trailing {…} block, so the match anchors on the field
+	// and the block is scanned forward from the first following '{'.
+	reHumaSecurityField = regexp.MustCompile(`\bSecurity\s*:`)
+	// A security-scheme name key inside a Security requirement / scheme registry:
+	// "bearer": { … } | "ApiKeyAuth": … . Captures the scheme name.
+	reHumaSchemeKey = regexp.MustCompile(`"([A-Za-z][\w-]*)"\s*:`)
+	// Components.SecuritySchemes registration site.
+	reHumaSecuritySchemes = regexp.MustCompile(`SecuritySchemes\b`)
+	// huma input-struct validation tags (OpenAPI-schema auto-validation). Each
+	// captures the field name + the tag key that drives validation.
+	reHumaValidatedField = regexp.MustCompile(
+		"(?m)^\\s*(\\w+)\\s+[^`\\n]*`[^`]*\\b(required|minimum|maximum|minLength|maxLength|pattern|format|enum|exclusiveMinimum|exclusiveMaximum):\"[^\"]*\"[^`]*`")
+)
+
+var reHumaCallHead = regexp.MustCompile(`^[A-Za-z_][\w.]*`)
+
+// humaClassifyAuth — file-local auth classifier for a scheme name / middleware
+// expression (shared helpers untouched).
+func humaClassifyAuth(s string) string {
+	low := strings.ToLower(s)
+	switch {
+	case strings.Contains(low, "jwt"), strings.Contains(low, "bearer"):
+		return "jwt"
+	case strings.Contains(low, "oauth"):
+		return "oauth"
+	case strings.Contains(low, "apikey"), strings.Contains(low, "api_key"), strings.Contains(low, "api-key"):
+		return "api_key"
+	case strings.Contains(low, "basic"):
+		return "basic"
+	default:
+		return "auth"
+	}
+}
+
+// extractMiddlewareAuth scans api.UseMiddleware(...) / huma.Middlewares{...}
+// chains (middleware), and Security:[...] requirements + SecuritySchemes
+// registrations (auth).
+func (e *humaExtractor) extractMiddlewareAuth(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	emitChain := func(args string, line int) {
+		order := 0
+		for _, part := range splitTopLevelArgs(args) {
+			if part == "" || isStringLiteral(part) {
+				continue
+			}
+			name := reHumaCallHead.FindString(part)
+			if name == "" {
+				name = part
+			}
+			mw := makeEntity(part, "SCOPE.Pattern", "", file.Path, file.Language, line)
+			setProps(&mw, "framework", "huma",
+				"provenance", "INFERRED_FROM_HUMA_MIDDLEWARE",
+				"pattern_kind", "middleware",
+				"middleware_name", name,
+				"mw_order", itoa(order))
+			add(mw)
+			order++
+		}
+	}
+	// api.UseMiddleware(mw, …)
+	for _, loc := range reHumaUseMiddleware.FindAllStringIndex(src, -1) {
+		open := loc[1] - 1
+		if args, end := balancedArgs(src, open); end >= 0 {
+			emitChain(args, lineOf(src, loc[0]))
+		}
+	}
+	// huma.Middlewares{ mw, … }
+	for _, loc := range reHumaMiddlewaresHead.FindAllStringIndex(src, -1) {
+		brace := loc[1] - 1
+		if args, end := balancedBraces(src, brace); end >= 0 {
+			emitChain(args, lineOf(src, loc[0]))
+		}
+	}
+
+	// Security:[...] requirements on huma.Operation literals — each named scheme
+	// is an auth SCOPE.Pattern (auth requirement on the operation).
+	for _, loc := range reHumaSecurityField.FindAllStringIndex(src, -1) {
+		rest := src[loc[1]:]
+		bi := strings.IndexByte(rest, '{')
+		if bi < 0 || bi > 60 {
+			continue
+		}
+		req, end := balancedBraces(src, loc[1]+bi)
+		if end < 0 {
+			continue
+		}
+		line := lineOf(src, loc[0])
+		for _, km := range reHumaSchemeKey.FindAllStringSubmatch(req, -1) {
+			scheme := km[1]
+			au := makeEntity("auth:requirement:"+scheme, "SCOPE.Pattern", "", file.Path, file.Language, line)
+			setProps(&au, "framework", "huma",
+				"provenance", "INFERRED_FROM_HUMA_AUTH",
+				"pattern_kind", "auth",
+				"auth_kind", humaClassifyAuth(scheme),
+				"scheme_name", scheme,
+				"auth_source", "operation_security")
+			add(au)
+		}
+	}
+
+	// Components.SecuritySchemes registrations — each scheme name keyed in the
+	// scheme map is an auth SCOPE.Pattern (scheme definition).
+	for _, loc := range reHumaSecuritySchemes.FindAllStringIndex(src, -1) {
+		// Scan the brace block following the SecuritySchemes token for scheme keys.
+		rest := src[loc[1]:]
+		bi := strings.IndexByte(rest, '{')
+		if bi < 0 || bi > 80 {
+			continue
+		}
+		block, end := balancedBraces(src, loc[1]+bi)
+		if end < 0 {
+			continue
+		}
+		line := lineOf(src, loc[0])
+		for _, km := range reHumaSchemeKey.FindAllStringSubmatch(block, -1) {
+			scheme := km[1]
+			au := makeEntity("auth:scheme:"+scheme, "SCOPE.Pattern", "", file.Path, file.Language, line)
+			setProps(&au, "framework", "huma",
+				"provenance", "INFERRED_FROM_HUMA_AUTH",
+				"pattern_kind", "auth",
+				"auth_kind", humaClassifyAuth(scheme),
+				"scheme_name", scheme,
+				"auth_source", "security_scheme")
+			add(au)
+		}
+	}
+}
+
+// extractRequestValidation emits a validation SCOPE.Pattern per huma input-
+// struct field carrying an OpenAPI-schema validation tag.
+func (e *humaExtractor) extractRequestValidation(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	type head struct {
+		name string
+		off  int
+	}
+	var heads []head
+	for _, m := range reGoStructHead.FindAllStringSubmatchIndex(src, -1) {
+		heads = append(heads, head{name: src[m[2]:m[3]], off: m[0]})
+	}
+	structAt := func(off int) string {
+		name := ""
+		for _, h := range heads {
+			if h.off <= off {
+				name = h.name
+			} else {
+				break
+			}
+		}
+		return name
+	}
+	for _, m := range reHumaValidatedField.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		tagKey := src[m[4]:m[5]]
+		st := structAt(m[0])
+		ent := makeEntity("validation:rule:"+st+"."+field, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "huma",
+			"provenance", "INFERRED_FROM_HUMA_VALIDATION",
+			"pattern_kind", "validation",
+			"validation_kind", "rule",
+			"struct_name", st,
+			"field_name", field,
+			"rules", tagKey,
+			"rule_source", "openapi_schema_tag")
+		add(ent)
+	}
+}
+
+// balancedBraces returns the text between the brace at index open and its match,
+// plus the index of the closing brace. Mirrors balancedArgs for `{}`.
+func balancedBraces(src string, open int) (string, int) {
+	depth := 0
+	var quote rune
+	for i := open; i < len(src); i++ {
+		r := rune(src[i])
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '"', '\'', '`':
+			quote = r
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(src[open+1 : i]), i
+			}
+		}
+	}
+	return "", -1
 }
 
 // balancedArgs returns the argument text between the paren at index open and

--- a/internal/custom/golang/kratos.go
+++ b/internal/custom/golang/kratos.go
@@ -97,11 +97,18 @@ func (e *kratosExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	}
 
 	src := string(file.Content)
-	// Gate on the generated-HTTP-transport signature: the registration entry
-	// point + the generated handler wrapper suffix. This keeps the extractor
-	// inert on hand-written kratos service/biz/data code (which carries no
-	// route registrations) and on unrelated Go files.
-	if !strings.Contains(src, "HTTPServer") || !strings.Contains(src, "_HTTP_Handler") {
+	// Two gates. The routing pass (steps 1–3) is gated on the generated-HTTP-
+	// transport signature (the RegisterXxxHTTPServer entry point + the generated
+	// _HTTP_Handler wrapper suffix), keeping it inert on hand-written kratos
+	// code. The middleware/auth/validation passes (step 4) model the hand-written
+	// wiring + the protoc-gen-validate output, so they run on any file carrying a
+	// kratos marker. A file with neither signature emits nothing.
+	hasTransport := strings.Contains(src, "HTTPServer") && strings.Contains(src, "_HTTP_Handler")
+	hasKratosMarker := strings.Contains(src, "go-kratos/kratos") ||
+		strings.Contains(src, "selector.Server") ||
+		strings.Contains(src, "validate.Validator") ||
+		reKratosPGVMethod.MatchString(src)
+	if !hasTransport && !hasKratosMarker {
 		return nil, nil
 	}
 
@@ -115,6 +122,15 @@ func (e *kratosExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		}
 		seen[key] = true
 		entities = append(entities, ent)
+	}
+
+	if !hasTransport {
+		// No generated transport in this file — only the wiring/validation
+		// passes apply. Skip the routing scans below.
+		e.extractMiddlewareAuth(src, file, add)
+		e.extractRequestValidation(src, file, add)
+		span.SetAttributes(attribute.Int("entity_count", len(entities)))
+		return entities, nil
 	}
 
 	// 1. RegisterXxxHTTPServer entry points -> SCOPE.Service (one per service).
@@ -166,6 +182,162 @@ func (e *kratosExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		add(ent)
 	}
 
+	// 4. middleware / auth / request_validation surfaces (issue #3255).
+	e.extractMiddlewareAuth(src, file, add)
+	e.extractRequestValidation(src, file, add)
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Middleware + auth + request validation (issue #3255).
+//
+// kratos's routing extractor above models the generated *_http.pb.go transport
+// only. The three capabilities below model the hand-written wiring layer of a
+// kratos service, which the routing pass does not touch:
+//
+//   - middleware_coverage : middleware is installed on a transport server via
+//       the http.Middleware(...) / grpc.Middleware(...) server option, and
+//       scoped per-operation via selector.Server(...).Match(...).Build(). Each
+//       middleware constructor in those lists is one ordered SCOPE.Pattern
+//       (pattern_kind=middleware).
+//   - auth_coverage      : kratos ships jwt.Server(...) / auth middleware; any
+//       middleware whose expression classifies as auth (jwt/oauth/…) is flagged
+//       is_auth + auth_kind and re-emitted as a dedicated auth SCOPE.Pattern.
+//   - request_validation : protoc-gen-validate generates a Validate()/
+//       ValidateAll() method on each request message; the kratos validate
+//       middleware (github.com/go-kratos/kratos/v2/middleware/validate) invokes
+//       it. Both the generated `func (m *X) Validate() error` method and the
+//       validate.Validator() middleware install are validation surfaces.
+//
+// Honesty: all three are heuristic identifier/substring matches on source text
+// with no data-flow proof that a middleware is actually wired into a live
+// request path, so each capability is reported `partial`. kratos genuinely has
+// all three concepts (it is not NA): the proving fixture exercises each.
+// ---------------------------------------------------------------------------
+
+var (
+	// http.Middleware( | grpc.Middleware( | .Middleware( server-option call —
+	// the balanced argument list holds an ordered middleware-constructor chain.
+	reKratosMiddlewareHead = regexp.MustCompile(`(?:\bhttp|\bgrpc|\w+)\.Middleware\s*\(`)
+	// selector.Server( per-operation middleware scoping: the argument list is a
+	// middleware chain applied to the matched operations.
+	reKratosSelectorHead = regexp.MustCompile(`selector\.Server\s*\(`)
+	// protoc-gen-validate generated method: func (m *HelloRequest) Validate() error
+	// (and the ValidateAll variant). Names the message type carrying the rules.
+	reKratosPGVMethod = regexp.MustCompile(
+		`(?m)func\s*\(\s*\w+\s+\*?(\w+)\s*\)\s*Validate(?:All)?\s*\(\s*\)\s*(?:error|\(\s*error)`,
+	)
+	// validate.Validator() — the kratos request-validation middleware install.
+	reKratosValidateMW = regexp.MustCompile(`validate\.Validator\s*\(`)
+)
+
+// kratosClassifyAuth returns a coarse auth kind for a middleware expression, or
+// "" if it does not look like an auth middleware. File-local so the shared
+// helpers stay untouched (contention rule). Mirrors the catalog used by the
+// gin/echo/fiber/chi shared detector, plus kratos-specific spellings.
+func kratosClassifyAuth(expr string) string {
+	low := strings.ToLower(expr)
+	switch {
+	case strings.Contains(low, "jwt"), strings.Contains(low, "bearer"):
+		return "jwt"
+	case strings.Contains(low, "oauth"):
+		return "oauth"
+	case strings.Contains(low, "apikey"), strings.Contains(low, "api_key"), strings.Contains(low, "keyauth"):
+		return "api_key"
+	case strings.Contains(low, "basicauth"), strings.Contains(low, "basic_auth"):
+		return "basic"
+	case strings.Contains(low, "casbin"), strings.Contains(low, "rbac"):
+		return "rbac"
+	case strings.Contains(low, "authz"), strings.Contains(low, "authorize"):
+		return "authz"
+	case strings.Contains(low, "auth"):
+		return "auth"
+	}
+	return ""
+}
+
+// reKratosCallHead extracts the leading identifier/selector of a middleware
+// expression (the part before any "(" call).
+var reKratosCallHead = regexp.MustCompile(`^[A-Za-z_][\w.]*`)
+
+// extractMiddlewareAuth scans http.Middleware(...) / grpc.Middleware(...) and
+// selector.Server(...) chains, emitting one ordered middleware SCOPE.Pattern
+// per constructor and a dedicated auth SCOPE.Pattern for auth-classified ones.
+func (e *kratosExtractor) extractMiddlewareAuth(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	emit := func(head []int, scope string) {
+		open := head[1] - 1
+		args, end := balancedArgs(src, open)
+		if end < 0 {
+			return
+		}
+		line := lineOf(src, head[0])
+		order := 0
+		for _, part := range splitTopLevelArgs(args) {
+			if part == "" || isStringLiteral(part) {
+				continue
+			}
+			name := reKratosCallHead.FindString(part)
+			if name == "" {
+				name = part
+			}
+			mw := makeEntity(part, "SCOPE.Pattern", "", file.Path, file.Language, line)
+			setProps(&mw, "framework", "kratos",
+				"provenance", "INFERRED_FROM_KRATOS_MIDDLEWARE",
+				"pattern_kind", "middleware",
+				"middleware_name", name,
+				"mw_scope", scope,
+				"mw_order", itoa(order))
+			authKind := kratosClassifyAuth(part)
+			if authKind != "" {
+				setProps(&mw, "is_auth", "true", "auth_kind", authKind)
+			}
+			add(mw)
+			if authKind != "" {
+				au := makeEntity("auth:"+name, "SCOPE.Pattern", "", file.Path, file.Language, line)
+				setProps(&au, "framework", "kratos",
+					"provenance", "INFERRED_FROM_KRATOS_AUTH",
+					"pattern_kind", "auth",
+					"auth_kind", authKind,
+					"middleware_name", name,
+					"middleware_expr", part)
+				add(au)
+			}
+			order++
+		}
+	}
+	for _, m := range reKratosMiddlewareHead.FindAllStringSubmatchIndex(src, -1) {
+		emit(m, "server")
+	}
+	for _, m := range reKratosSelectorHead.FindAllStringSubmatchIndex(src, -1) {
+		emit(m, "operation")
+	}
+}
+
+// extractRequestValidation emits a validation SCOPE.Pattern for each
+// protoc-gen-validate generated Validate()/ValidateAll() method (named by its
+// message type) and for the validate.Validator() middleware install.
+func (e *kratosExtractor) extractRequestValidation(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	for _, m := range reKratosPGVMethod.FindAllStringSubmatchIndex(src, -1) {
+		msg := submatch(src, m, 2)
+		ent := makeEntity("validation:rule:"+msg, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kratos",
+			"provenance", "INFERRED_FROM_KRATOS_VALIDATION",
+			"pattern_kind", "validation",
+			"validation_kind", "rule",
+			"validation_subtype", "pgv_message",
+			"struct_name", msg,
+			"rule_source", "protoc-gen-validate")
+		add(ent)
+	}
+	for _, m := range reKratosValidateMW.FindAllStringIndex(src, -1) {
+		ent := makeEntity("validation:binding:validate_call", "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kratos",
+			"provenance", "INFERRED_FROM_KRATOS_VALIDATION",
+			"pattern_kind", "validation",
+			"validation_kind", "binding",
+			"validation_subtype", "validate_middleware")
+		add(ent)
+	}
 }

--- a/internal/custom/golang/testdata/go_zero_server.go
+++ b/internal/custom/golang/testdata/go_zero_server.go
@@ -1,0 +1,34 @@
+// go-zero server-bootstrap + logic-layer wiring fixture (issue #3255).
+// Exercises middleware (rest.WithMiddleware + server.Use), first-class JWT auth
+// (rest.WithJwt), validate-tag request rules, and the httpx.Parse bind site.
+package main
+
+import (
+	"net/http"
+
+	"github.com/zeromicro/go-zero/rest"
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+// LoginRequest is a go-zero request DTO with go-playground validate tags.
+type LoginRequest struct {
+	Username string `json:"username" validate:"required,min=3"`
+	Password string `json:"password" validate:"required,min=8"`
+}
+
+func NewServer() *rest.Server {
+	server := rest.MustNewServer(rest.RestConf{},
+		rest.WithMiddleware(corsMiddleware, traceMiddleware),
+		rest.WithJwt("super-secret"),
+	)
+	server.Use(authMiddleware)
+	return server
+}
+
+func LoginHandler(w http.ResponseWriter, r *http.Request) {
+	var req LoginRequest
+	if err := httpx.Parse(r, &req); err != nil {
+		httpx.ErrorCtx(r.Context(), w, err)
+		return
+	}
+}

--- a/internal/custom/golang/testdata/huma_security.go
+++ b/internal/custom/golang/testdata/huma_security.go
@@ -1,0 +1,37 @@
+// huma middleware/security/validation wiring fixture (issue #3255). Exercises
+// api.UseMiddleware (middleware), a Components.SecuritySchemes registration +
+// an operation Security requirement (auth), and input-struct OpenAPI-schema
+// validation tags (request_validation).
+package api
+
+import (
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// CreateUserInput is a huma input struct; huma auto-validates each field from
+// its OpenAPI-schema tags.
+type CreateUserInput struct {
+	Body struct {
+		Name  string `json:"name" required:"true" minLength:"2" maxLength:"64"`
+		Email string `json:"email" format:"email"`
+		Age   int    `json:"age" minimum:"0" maximum:"130"`
+	}
+}
+
+func register(api huma.API) {
+	api.UseMiddleware(authMiddleware, loggingMiddleware)
+
+	api.OpenAPI().Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"bearer": {
+			Type:         "http",
+			Scheme:       "bearer",
+			BearerFormat: "JWT",
+		},
+	}
+
+	huma.Register(api, huma.Operation{
+		Method:   "POST",
+		Path:     "/users",
+		Security: []map[string][]string{{"bearer": {}}},
+	}, createUser)
+}

--- a/internal/custom/golang/testdata/kratos_request.pb.validate.go
+++ b/internal/custom/golang/testdata/kratos_request.pb.validate.go
@@ -1,0 +1,14 @@
+// Generated-style protoc-gen-validate output fixture (issue #3255). Each
+// request message gets a Validate()/ValidateAll() method — the request_
+// validation surface kratos enforces via the validate middleware.
+package v1
+
+import "github.com/go-kratos/kratos/v2"
+
+func (m *HelloRequest) Validate() error {
+	return m.validate(false)
+}
+
+func (m *CreateGreetingRequest) ValidateAll() error {
+	return m.validate(true)
+}

--- a/internal/custom/golang/testdata/kratos_server.go
+++ b/internal/custom/golang/testdata/kratos_server.go
@@ -1,0 +1,27 @@
+// Hand-written kratos transport-server wiring fixture (issue #3255). Exercises
+// the middleware/auth surface: http.Middleware(...) server option with an
+// ordered chain including the jwt.Server auth middleware, a per-operation
+// selector.Server(...) scope, and the validate.Validator() request-validation
+// middleware install.
+package server
+
+import (
+	"github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	"github.com/go-kratos/kratos/v2/middleware/logging"
+	"github.com/go-kratos/kratos/v2/middleware/recovery"
+	"github.com/go-kratos/kratos/v2/middleware/selector"
+	"github.com/go-kratos/kratos/v2/middleware/validate"
+	"github.com/go-kratos/kratos/v2/transport/http"
+)
+
+func NewHTTPServer() *http.Server {
+	opts := []http.ServerOption{
+		http.Middleware(
+			recovery.Recovery(),
+			logging.Server(),
+			validate.Validator(),
+			selector.Server(jwt.Server(keyFunc)).Match(needAuth).Build(),
+		),
+	}
+	return http.NewServer(opts...)
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -5632,6 +5632,50 @@ records:
             - file: internal/custom/golang/hertz_huma_test.go
           issues_implemented: ["2686", "3212"]
           verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # huma.go scans api.UseMiddleware(...) and huma.Middlewares{...} chains
+          # (balancedArgs/balancedBraces + splitTopLevelArgs) and emits one
+          # ordered SCOPE.Pattern (pattern_kind=middleware, mw_order) per
+          # middleware. Heuristic, no data-flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/huma.go
+              functions: [extractMiddlewareAuth, balancedBraces]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # huma is OpenAPI-first: auth is a Security requirement on a
+          # huma.Operation naming schemes registered under
+          # Components.SecuritySchemes. huma.go emits an auth SCOPE.Pattern for
+          # each operation Security requirement and each scheme registration,
+          # classifying the scheme (jwt/oauth/api_key/basic). Static name match,
+          # no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/huma.go
+              functions: [extractMiddlewareAuth, humaClassifyAuth]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # huma auto-validates each input struct from its OpenAPI-schema field
+          # tags (required/minimum/maxLength/format/enum/pattern). huma.go emits
+          # one validation SCOPE.Pattern (validation_kind=rule) per validated
+          # field tag. Heuristic tag match, no rule→call-site flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/huma.go
+              functions: [extractRequestValidation]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.kratos:
     capabilities:
@@ -5717,6 +5761,51 @@ records:
             - file: internal/custom/golang/kratos_gozero_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # kratos.go scans http.Middleware(...)/grpc.Middleware(...) server
+          # options and per-operation selector.Server(...) chains, emitting one
+          # ordered SCOPE.Pattern (pattern_kind=middleware, mw_order, mw_scope)
+          # per middleware constructor. Heuristic, no data-flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/kratos.go
+              functions: [extractMiddlewareAuth]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # kratosClassifyAuth substring-matches each middleware expression
+          # against an auth catalog (jwt/oauth/basic/api_key/rbac/…), flagging
+          # is_auth + auth_kind and emitting a dedicated auth SCOPE.Pattern
+          # (covers jwt.Server / selector.Server(jwt.Server(...))). Pattern match
+          # only, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/kratos.go
+              functions: [extractMiddlewareAuth, kratosClassifyAuth]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # kratos enforces request validation via protoc-gen-validate: each
+          # request message gets a generated Validate()/ValidateAll() method,
+          # invoked by the validate.Validator() middleware. kratos.go emits a
+          # validation SCOPE.Pattern per generated Validate method (named by its
+          # message type) and for the validate.Validator() install. Heuristic
+          # method/call match → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/kratos.go
+              functions: [extractRequestValidation]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.go-zero:
     capabilities:
@@ -5801,6 +5890,49 @@ records:
           tests:
             - file: internal/custom/golang/kratos_gozero_test.go
           issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # go_zero.go scans rest.WithMiddleware(...) server options and
+          # server.Use(...) registrations, emitting one ordered SCOPE.Pattern
+          # (pattern_kind=middleware, mw_order) per middleware expression.
+          # Heuristic, no data-flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/go_zero.go
+              functions: [extractMiddlewareAuth]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # go-zero ships first-class JWT auth via the rest.WithJwt(secret) route
+          # option. go_zero.go emits an auth SCOPE.Pattern for rest.WithJwt and
+          # for any middleware that goZeroClassifyAuth flags (jwt/oauth/…).
+          # Static option/name match, no enforcement proof → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/go_zero.go
+              functions: [extractMiddlewareAuth, goZeroClassifyAuth]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          # go-zero request DTOs carry `validate:"…"` struct tags and are bound +
+          # validated via httpx.Parse(r, &req). go_zero.go emits a validation
+          # SCOPE.Pattern (validation_kind=rule) per validate-tagged field and a
+          # binding pattern per httpx.Parse call site. Heuristic tag/call match,
+          # no rule→call-site flow → partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/go_zero.go
+              functions: [extractRequestValidation]
+          tests:
+            - file: internal/custom/golang/codegen_authmwval_test.go
+          issues_implemented: ["3255"]
           verified_at: "2026-05-30"
 
   lang.java.framework.spring-webflux:


### PR DESCRIPTION
Part of #3255 (slice 2 of the Go build-gap epic #3210).

The kratos/go-zero/huma custom extractors were **routing-only**, leaving their `Auth.auth_coverage`, `Middleware.middleware_coverage`, and `Validation.request_validation` cells `missing`. This extends each extractor (the 3 files I own: `kratos.go`, `go_zero.go`, `huma.go`) with dedicated passes that emit `SCOPE.Pattern` entities for these three genuinely-present concepts, flipping all **9 cells** to `partial`.

## What each framework now extracts

| framework | middleware_coverage | auth_coverage | request_validation |
|---|---|---|---|
| **kratos** | `http/grpc.Middleware(...)` + `selector.Server(...)` chains | jwt/auth classification | protoc-gen-validate `Validate()/ValidateAll()` methods + `validate.Validator()` middleware |
| **go-zero** | `rest.WithMiddleware(...)` / `.Use(...)` chains | `rest.WithJwt` + jwt classification | `validate:"…"` struct tags + `httpx.Parse` bind sites |
| **huma** | `api.UseMiddleware(...)` / `huma.Middlewares{...}` | operation `Security` requirements + `Components.SecuritySchemes` | OpenAPI-schema input-struct validation tags |

All 9 cells → **partial** (honest): detection is heuristic identifier/substring/tag matching with no data-flow enforcement proof.

## Honesty + isolation
- Routing gates preserved; new passes run under broader per-framework markers so wiring/validation files (which lack the generated routing signature) are still covered.
- **No shared files touched** — `helpers.go`, `validation.go`, `middleware_auth_extend.go`, `observability.go` untouched. All auth classifiers are file-local (`kratosClassifyAuth`/`goZeroClassifyAuth`/`humaClassifyAuth`).
- Dedicated `codegen_authmwval_test.go` + 4 new per-framework fixtures prove every flip.

## Validation
- `go build ./internal/... ./tools/coverage/...` ✓
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` ✓
- `coverage validate` exit 0, 0 errors ✓
- `coverage fmt --check` canonical ✓
- `gen` byte-stable (md5-identical across runs) ✓
- `gofmt -l` clean on all touched files ✓
- anti-dup key-count: kratos=1, go-zero=1, huma=1 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)