### PR TITLE
coverage(go): shared dto_extraction extractor for 15 HTTP frameworks (#3255)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -39,21 +39,21 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟡 1/2 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/5 | |
 | [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
-| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟡 5/6 | |
-| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
-| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
-| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/6 | |
-| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/5 | |
-| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
-| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/6 | |
+| [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [Fiber](../detail/lang.go.framework.fiber.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
+| [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 5/5 | |
+| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Beego](../detail/lang.go.framework.beego.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Echo](../detail/lang.go.framework.echo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Fiber](../detail/lang.go.framework.fiber.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Gin](../detail/lang.go.framework.gin.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟡 5/6 | |
-| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
-| [Iris](../detail/lang.go.framework.iris.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
-| [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/6 | |
-| [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
-| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/5 | |
-| [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 4/7 | |
-| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/6 | |
+| [Beego](../detail/lang.go.framework.beego.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [Echo](../detail/lang.go.framework.echo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [Fiber](../detail/lang.go.framework.fiber.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [Gin](../detail/lang.go.framework.gin.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [Iris](../detail/lang.go.framework.iris.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
+| [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
+| [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 5/5 | |
+| [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
 
 
 ### Mobile

--- a/docs/coverage/detail/lang.go.framework.beego.md
+++ b/docs/coverage/detail/lang.go.framework.beego.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.buffalo.md
+++ b/docs/coverage/detail/lang.go.framework.buffalo.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.chi.md
+++ b/docs/coverage/detail/lang.go.framework.chi.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ✅ `full` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.echo.md
+++ b/docs/coverage/detail/lang.go.framework.echo.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ✅ `full` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.fasthttp.md
+++ b/docs/coverage/detail/lang.go.framework.fasthttp.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | — `not_applicable` | `2026-05-29` | — | — | No struct-tag request binding: fasthttp's RequestCtx exposes raw byte accessors only and Revel binds params positionally via controller-method signatures, so there is no validate:/binding: tag surface to extract. |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.fiber.md
+++ b/docs/coverage/detail/lang.go.framework.fiber.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ✅ `full` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.gin.md
+++ b/docs/coverage/detail/lang.go.framework.gin.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ✅ `full` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3213) | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.gorilla-mux.md
+++ b/docs/coverage/detail/lang.go.framework.gorilla-mux.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ✅ `full` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.hertz.md
+++ b/docs/coverage/detail/lang.go.framework.hertz.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.iris.md
+++ b/docs/coverage/detail/lang.go.framework.iris.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.net-http.md
+++ b/docs/coverage/detail/lang.go.framework.net-http.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | ✅ `full` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | 🟢 `partial` | `2026-05-29` | 3213 | `internal/custom/golang/validation.go`<br>`internal/custom/golang/validation_test.go` | — |
 
 ### Middleware

--- a/docs/coverage/detail/lang.go.framework.revel.md
+++ b/docs/coverage/detail/lang.go.framework.revel.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
 | Request validation | — `not_applicable` | `2026-05-29` | — | — | No struct-tag request binding: fasthttp's RequestCtx exposes raw byte accessors only and Revel binds params positionally via controller-method signatures, so there is no validate:/binding: tag surface to extract. |
 
 ### Middleware

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10721,8 +10721,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -10932,8 +10934,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -11143,8 +11147,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -11352,8 +11358,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -11560,8 +11568,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "not_applicable",
@@ -11769,8 +11779,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -12060,8 +12072,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -12265,8 +12279,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "missing",
@@ -12672,8 +12688,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -12885,8 +12903,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -13096,8 +13116,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "missing",
@@ -13303,8 +13325,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -13512,8 +13536,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "missing",
@@ -13718,8 +13744,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "partial",
@@ -13928,8 +13956,10 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/dto.go","internal/custom/golang/dto_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3255",
+            "verified_at": "2026-05-29"
           },
           "request_validation": {
             "status": "not_applicable",

--- a/internal/custom/golang/dto.go
+++ b/internal/custom/golang/dto.go
@@ -1,0 +1,383 @@
+package golang
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// dto.go — a framework-agnostic request/response DTO-struct scanner for the Go
+// HTTP framework family (issue #3255, part of the Go greening epic #3210).
+//
+// It detects the *struct models* that handlers bind as request bodies or
+// serialise as response bodies, and emits one SCOPE.Schema entity (subtype=dto)
+// per resolved DTO struct, carrying its field list. This is DISTINCT from the
+// request_validation scanner in validation.go: that emits validation
+// rule/validator/binding SCOPE.Pattern entities (the *rules*); this emits the
+// DTO *struct shapes* bound as request/response bodies (the *models*), with a
+// direction (request | response) and the binding/serialisation call that proves
+// the role.
+//
+// Detected binding/serialisation surfaces (the canonical Go HTTP idioms, shared
+// across all 15 frameworks):
+//
+//   request  : c.ShouldBindJSON(&x) / c.ShouldBind(&x) / c.Bind(&x) /
+//              c.BindJSON(&x) / c.MustBindWith(&x, ...)        (gin/buffalo/hertz)
+//              c.BodyParser(&x) / c.QueryParser(&x)            (fiber)
+//              ctx.ReadJSON(&x) / ctx.ReadBody(&x)             (iris)
+//              this.ParseForm(&x)                              (beego)
+//              render.Bind(r, &x) / render.DecodeJSON(b, &x)   (chi)
+//              json.NewDecoder(r.Body).Decode(&x)              (net-http/gorilla/fasthttp/revel)
+//   response : c.JSON(code, x) / ctx.JSON(x) / render.JSON(w, r, x) /
+//              json.NewEncoder(w).Encode(x)                    (all frameworks)
+//
+// For each binding/serialisation site the scanner resolves the bound variable's
+// struct type from same-file declarations (`var x T`, `x := T{}`, `x T{...}`,
+// or a `x T` / `x *T` function parameter), then looks up the matching
+// `type T struct { ... }` definition in the file and emits the DTO with its
+// fields. A site whose type cannot be resolved to a file-local struct still
+// yields a DTO entity carrying the variable/expression and the binding role
+// (resolved=false), so the request/response surface is never silently dropped.
+//
+// Honesty (registry coverage status):
+//
+// Detection is a heuristic regex match on source text plus a same-file type
+// resolution. It does NOT perform cross-file/import type resolution or confirm
+// the binding executes on a real request path. Frameworks are therefore
+// reported `partial` by default. The flagship set (gin/echo/fiber/chi) plus the
+// net/http-decode family carry dedicated end-to-end fixtures that prove the
+// general request-bind + response-serialise + struct-field case, so those flip
+// to `full`; the remaining frameworks (whose binding/serialisation idioms are a
+// subset of the same catalog but lack a per-framework proving fixture) stay
+// `partial`.
+//
+// Framework attribution mirrors observability.go / validation.go: the scanner
+// runs on every Go file and infers the framework from canonical engine/context
+// markers, stamping it on each emitted entity. A file with no recognised marker
+// emits nothing.
+
+func init() {
+	extractor.Register("custom_go_dto", &dtoExtractor{})
+}
+
+type dtoExtractor struct{}
+
+func (e *dtoExtractor) Language() string { return "custom_go_dto" }
+
+// ---------------------------------------------------------------------------
+// Framework detection
+// ---------------------------------------------------------------------------
+
+// dtoFrameworkMarkers attributes a file to a framework via its canonical engine
+// constructor / request-context type. The catalog is the full 15-framework Go
+// HTTP set from issue #3255. Kept file-local to avoid editing shared helpers
+// (contention avoidance). net-http is placed last because its `http.*` markers
+// are the broadest.
+var dtoFrameworkMarkers = []struct {
+	name string
+	re   *regexp.Regexp
+}{
+	{"gin", regexp.MustCompile(`\bgin\.(?:Default|New|Engine|Context|HandlerFunc)\b`)},
+	{"echo", regexp.MustCompile(`\becho\.(?:New|Echo|Context|HandlerFunc|MiddlewareFunc)\b`)},
+	{"fiber", regexp.MustCompile(`\bfiber\.(?:New|App|Ctx|Handler)\b`)},
+	{"chi", regexp.MustCompile(`\bchi\.(?:NewRouter|Router|Mux)\b`)},
+	{"beego", regexp.MustCompile(`\b(?:beego|web)\.(?:Router|NewNamespace|Run|InsertFilter|AutoRouter|Controller)\b`)},
+	{"iris", regexp.MustCompile(`\biris\.(?:New|Default|Application|Context|Party)\b`)},
+	{"hertz", regexp.MustCompile(`\bserver\.(?:Default|New|Hertz)\b|\bapp\.RequestContext\b`)},
+	{"buffalo", regexp.MustCompile(`\bbuffalo\.(?:New|App|Options|Context)\b`)},
+	{"gorilla-mux", regexp.MustCompile(`\bmux\.(?:NewRouter|Router|Vars)\b`)},
+	{"revel", regexp.MustCompile(`\brevel\.(?:Result|Controller|Intercept(?:Func|Method)|BEFORE|AFTER)\b`)},
+	{"go-zero", regexp.MustCompile(`\b(?:rest|httpx)\.(?:MustNewServer|Server|Parse|OkJson(?:Ctx)?|WriteJson|Error)\b`)},
+	{"kratos", regexp.MustCompile(`\b(?:khttp|transhttp|http)\.(?:NewServer|Context|ServeHTTP)\b|kratos\.New\b`)},
+	{"huma", regexp.MustCompile(`\bhuma\.(?:New|Register|Context|API)\b`)},
+	{"fasthttp", regexp.MustCompile(`\bfasthttp\.(?:RequestCtx|RequestHandler|ListenAndServe)\b`)},
+	{"net-http", regexp.MustCompile(`\bhttp\.(?:NewServeMux|HandleFunc|ListenAndServe|ListenAndServeTLS|ResponseWriter|Request)\b`)},
+}
+
+// detectDtoFramework returns the framework a file belongs to, or "" when no
+// recognised marker is present. First match wins in declaration order.
+func detectDtoFramework(src string) string {
+	for _, m := range dtoFrameworkMarkers {
+		if m.re.MatchString(src) {
+			return m.name
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Binding / serialisation call sites
+// ---------------------------------------------------------------------------
+
+// dtoBindSignal is one request-bind or response-serialise call form. The bound
+// DTO is referenced by the argGroup submatch — for request binds the `&x` /
+// `x` pointer argument, for response serialisers the serialised value.
+type dtoBindSignal struct {
+	re        *regexp.Regexp
+	direction string // request | response
+	subtype   string // bind call dialect, e.g. should_bind | body_parser | json_encode
+	argGroup  int    // 1-based submatch holding the bound expression
+}
+
+var dtoBindSignals = []dtoBindSignal{
+	// --- request binds: &x pointer to the destination DTO ----------------
+	// gin / buffalo / hertz: ShouldBind*/Bind*/BindJSON/MustBindWith
+	{regexp.MustCompile(`\b\w+\.(?:ShouldBind\w*|BindJSON|Bind)\s*\(\s*&(\w+)`), "request", "should_bind", 1},
+	{regexp.MustCompile(`\b\w+\.MustBindWith\s*\(\s*&(\w+)`), "request", "must_bind_with", 1},
+	// fiber: BodyParser / QueryParser / ParamsParser
+	{regexp.MustCompile(`\b\w+\.(?:BodyParser|QueryParser|ParamsParser|ReqHeaderParser)\s*\(\s*&(\w+)`), "request", "body_parser", 1},
+	// iris: ctx.ReadJSON / ReadBody / ReadForm ...
+	{regexp.MustCompile(`\b\w+\.Read(?:JSON|Body|Form|Query|XML|YAML|Protobuf)\s*\(\s*&(\w+)`), "request", "read_body", 1},
+	// beego: this.ParseForm(&x)
+	{regexp.MustCompile(`\b\w+\.ParseForm\s*\(\s*&(\w+)`), "request", "parse_form", 1},
+	// chi: render.Bind(r, &x) / render.DecodeJSON(b, &x)
+	{regexp.MustCompile(`\brender\.(?:Bind|DecodeJSON)\s*\([^,]*,\s*&(\w+)`), "request", "render_bind", 1},
+	// stdlib decode: json.NewDecoder(r.Body).Decode(&x)  (net-http/gorilla/fasthttp/revel)
+	{regexp.MustCompile(`\bjson\.NewDecoder\s*\([^)]*\)\s*\.Decode\s*\(\s*&(\w+)`), "request", "json_decode", 1},
+
+	// --- response serialisers: the value being written -------------------
+	// gin/hertz/iris/beego: c.JSON(code, x) or ctx.JSON(x)
+	{regexp.MustCompile(`\b\w+\.JSON\s*\(\s*(?:[\w.]+\s*,\s*)?(?:&)?(\w+)\s*\)`), "response", "ctx_json", 1},
+	// chi: render.JSON(w, r, x)
+	{regexp.MustCompile(`\brender\.JSON\s*\([^,]*,[^,]*,\s*(?:&)?(\w+)\s*\)`), "response", "render_json", 1},
+	// stdlib encode: json.NewEncoder(w).Encode(x)
+	{regexp.MustCompile(`\bjson\.NewEncoder\s*\([^)]*\)\s*\.Encode\s*\(\s*(?:&)?(\w+)\s*\)`), "response", "json_encode", 1},
+}
+
+// ---------------------------------------------------------------------------
+// Struct catalog + local type resolution
+// ---------------------------------------------------------------------------
+
+// dtoStruct is a `type T struct { ... }` definition with its fields.
+type dtoStruct struct {
+	Name   string
+	Fields []dtoField
+	Off    int // source offset of the `type` keyword
+	Line   int
+}
+
+type dtoField struct {
+	Name string
+	Type string
+}
+
+// reDtoStructHead locates a `type <Name> struct {` opening.
+var reDtoStructHead = regexp.MustCompile(`type\s+(\w+)\s+struct\s*\{`)
+
+// reDtoStructField matches one exported/unexported field line inside a struct
+// body: a leading identifier and a type token. Embedded fields (a bare type) and
+// blank lines are skipped by requiring two tokens. Best-effort; complex types
+// (maps/funcs) are captured as their leading token.
+var reDtoStructField = regexp.MustCompile(`(?m)^\s*([A-Za-z_]\w*)\s+([\w\.\*\[\]]+)`)
+
+// catalogStructs parses every `type T struct {...}` in src into a name→struct
+// map, capturing each struct's field list by scanning to the matching closing
+// brace (paren/brace balanced, quote-aware).
+func catalogStructs(src string) map[string]dtoStruct {
+	out := make(map[string]dtoStruct)
+	for _, m := range reDtoStructHead.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		open := m[1] - 1 // index of the '{'
+		end := matchBrace(src, open)
+		if end < 0 {
+			continue
+		}
+		body := src[open+1 : end]
+		var fields []dtoField
+		for _, fm := range reDtoStructField.FindAllStringSubmatch(body, -1) {
+			fname := fm[1]
+			// skip Go keywords that can lead a line inside a struct body
+			if fname == "struct" || fname == "func" {
+				continue
+			}
+			fields = append(fields, dtoField{Name: fname, Type: fm[2]})
+		}
+		out[name] = dtoStruct{
+			Name:   name,
+			Fields: fields,
+			Off:    m[0],
+			Line:   lineOf(src, m[0]),
+		}
+	}
+	return out
+}
+
+// matchBrace returns the index of the '}' matching the '{' at openIdx, or -1.
+// Quote-aware so braces inside string/rune/raw literals are ignored.
+func matchBrace(src string, openIdx int) int {
+	depth := 0
+	var quote rune
+	for i := openIdx; i < len(src); i++ {
+		r := rune(src[i])
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch r {
+		case '"', '\'', '`':
+			quote = r
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// reDtoVarDecls resolves a local variable's struct type from same-file
+// declarations. Three idioms:
+//
+//	var x T            / var x *T
+//	x := T{...}        / x := &T{...}
+//	x T  / x *T        (function parameter or short field)
+//
+// Each regex captures (var, type).
+var dtoVarDeclForms = []*regexp.Regexp{
+	regexp.MustCompile(`\bvar\s+(\w+)\s+\*?(\w+)\b`),
+	regexp.MustCompile(`\b(\w+)\s*:=\s*&?(\w+)\s*\{`),
+	regexp.MustCompile(`\b(\w+)\s+\*?(\w+)\s*[,)]`),
+}
+
+// resolveVarType returns the struct type name bound to varName in src, looking
+// up the var-declaration forms and returning the first whose captured type is a
+// known struct. Returns "" when unresolved.
+func resolveVarType(src, varName string, structs map[string]dtoStruct) string {
+	for _, re := range dtoVarDeclForms {
+		for _, m := range re.FindAllStringSubmatch(src, -1) {
+			if m[1] != varName {
+				continue
+			}
+			if _, ok := structs[m[2]]; ok {
+				return m[2]
+			}
+		}
+	}
+	// The bound expression may itself be a struct name (e.g. responding with a
+	// composite literal var that shares the type name, or a direct type ref).
+	if _, ok := structs[varName]; ok {
+		return varName
+	}
+	return ""
+}
+
+func (e *dtoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/golang")
+	_, span := tracer.Start(ctx, "indexer.dto_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "go" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	framework := detectDtoFramework(src)
+	if framework == "" {
+		span.SetAttributes(attribute.String("framework", ""))
+		return nil, nil
+	}
+
+	structs := catalogStructs(src)
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	prov := func(detail string) string {
+		return "INFERRED_FROM_" + strings.ToUpper(framework) + "_" + strings.ToUpper(detail)
+	}
+
+	// A DTO struct may be referenced by several call sites; track the role we
+	// have already emitted per (struct,direction) so we don't dedup a request
+	// DTO into a response one (or vice versa) but still collapse repeats.
+	for _, sig := range dtoBindSignals {
+		for _, m := range sig.re.FindAllStringSubmatchIndex(src, -1) {
+			boundExpr := submatch(src, m, sig.argGroup*2)
+			if boundExpr == "" {
+				continue
+			}
+			// Response serialisers fire on a lot of generic identifiers; only
+			// emit a response DTO when the value resolves to a known struct, to
+			// avoid flooding the graph with non-DTO locals (err, code, msg…).
+			structName := resolveVarType(src, boundExpr, structs)
+			if sig.direction == "response" && structName == "" {
+				continue
+			}
+
+			line := lineOf(src, m[0])
+			name := "dto:" + framework + ":" + sig.direction + ":"
+			if structName != "" {
+				name += structName
+			} else {
+				name += boundExpr
+			}
+
+			ent := makeEntity(name, "SCOPE.Schema", "dto", file.Path, file.Language, line)
+			setProps(&ent,
+				"framework", framework,
+				"provenance", prov("DTO_"+strings.ToUpper(sig.direction)),
+				"pattern_kind", "dto",
+				"dto_direction", sig.direction,
+				"binding_subtype", sig.subtype,
+				"bound_expr", boundExpr)
+
+			if structName != "" {
+				st := structs[structName]
+				ent.StartLine = st.Line
+				ent.EndLine = st.Line
+				setProps(&ent,
+					"struct_name", structName,
+					"resolved", "true",
+					"field_count", strconv.Itoa(len(st.Fields)),
+					"fields", joinDtoFields(st.Fields))
+			} else {
+				setProps(&ent, "resolved", "false")
+			}
+			add(ent)
+		}
+	}
+
+	span.SetAttributes(
+		attribute.String("framework", framework),
+		attribute.Int("entity_count", len(entities)),
+	)
+	return entities, nil
+}
+
+// joinDtoFields renders a struct's fields as a stable "Name:Type" comma list for
+// the entity's "fields" property.
+func joinDtoFields(fields []dtoField) string {
+	parts := make([]string, 0, len(fields))
+	for _, f := range fields {
+		parts = append(parts, f.Name+":"+f.Type)
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/custom/golang/dto_test.go
+++ b/internal/custom/golang/dto_test.go
@@ -1,0 +1,215 @@
+package golang_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for the framework-agnostic request/response DTO-struct scanner
+// (issue #3255, part of #3210): request-bind + response-serialise call sites
+// resolved to file-local struct models, emitted as SCOPE.Schema (subtype=dto).
+
+// dtoEntities returns all DTO schema entities (subtype carried in the name and
+// pattern_kind=dto prop).
+func dtoEntities(ents []fullEntity) []fullEntity {
+	var out []fullEntity
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Props["pattern_kind"] == "dto" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// findDto returns the DTO entity for the given direction whose resolved struct
+// name (or, when unresolved, bound expr) matches, or nil.
+func findDto(ents []fullEntity, direction, name string) *fullEntity {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind != "SCOPE.Schema" || e.Props["pattern_kind"] != "dto" {
+			continue
+		}
+		if e.Props["dto_direction"] != direction {
+			continue
+		}
+		if e.Props["struct_name"] == name || e.Props["bound_expr"] == name {
+			return e
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Framework attribution: no recognised framework marker => no emit.
+// ---------------------------------------------------------------------------
+
+func TestDtoNoFrameworkNoEmit(t *testing.T) {
+	src := "package x\n" +
+		"type Req struct {\n\tName string `json:\"name\"`\n}\n" +
+		"func h() { json.NewDecoder(r).Decode(&req) }\n"
+	ents := extractFull(t, "custom_go_dto", fi("main.go", "go", src))
+	if got := dtoEntities(ents); len(got) != 0 {
+		t.Fatalf("expected no DTO entities without a framework marker, got %d: %+v", len(got), got)
+	}
+}
+
+func TestDtoNonGoNoEmit(t *testing.T) {
+	src := "r := gin.Default(); c.ShouldBindJSON(&req)"
+	ents := extractFull(t, "custom_go_dto", fi("main.py", "python", src))
+	if len(ents) != 0 {
+		t.Fatalf("non-go file should yield nothing, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Request binding resolves the bound variable to its struct type + fields.
+// ---------------------------------------------------------------------------
+
+func TestDtoRequestResolvesStruct(t *testing.T) {
+	src := "r := gin.Default()\n" +
+		"type CreateReq struct {\n" +
+		"\tEmail string `json:\"email\"`\n" +
+		"\tAge   int    `json:\"age\"`\n" +
+		"}\n" +
+		"func h(c *gin.Context) {\n" +
+		"\tvar req CreateReq\n" +
+		"\tc.ShouldBindJSON(&req)\n" +
+		"}\n"
+	ents := extractFull(t, "custom_go_dto", fi("main.go", "go", src))
+	d := findDto(ents, "request", "CreateReq")
+	if d == nil {
+		t.Fatalf("missing request DTO CreateReq; got %+v", dtoEntities(ents))
+	}
+	if d.Props["resolved"] != "true" {
+		t.Errorf("resolved=%q want true", d.Props["resolved"])
+	}
+	if d.Props["field_count"] != "2" {
+		t.Errorf("field_count=%q want 2", d.Props["field_count"])
+	}
+	if !strings.Contains(d.Props["fields"], "Email:string") || !strings.Contains(d.Props["fields"], "Age:int") {
+		t.Errorf("fields=%q missing Email/Age", d.Props["fields"])
+	}
+	if d.Props["framework"] != "gin" {
+		t.Errorf("framework=%q want gin", d.Props["framework"])
+	}
+	if d.Props["binding_subtype"] != "should_bind" {
+		t.Errorf("binding_subtype=%q want should_bind", d.Props["binding_subtype"])
+	}
+}
+
+// ':=' composite-literal declaration also resolves the type.
+func TestDtoShortDeclResolves(t *testing.T) {
+	src := "app := fiber.New()\n" +
+		"type Body struct {\n\tX string `json:\"x\"`\n}\n" +
+		"func h(c *fiber.Ctx) error {\n" +
+		"\tbody := Body{}\n" +
+		"\treturn c.BodyParser(&body)\n" +
+		"}\n"
+	ents := extractFull(t, "custom_go_dto", fi("main.go", "go", src))
+	d := findDto(ents, "request", "Body")
+	if d == nil {
+		t.Fatalf("missing request DTO Body; got %+v", dtoEntities(ents))
+	}
+	if d.Props["resolved"] != "true" || d.Props["binding_subtype"] != "body_parser" {
+		t.Errorf("unexpected props %+v", d.Props)
+	}
+}
+
+// An unresolvable bound var still emits a request DTO with resolved=false.
+func TestDtoUnresolvedRequestStillEmits(t *testing.T) {
+	src := "r := gin.Default()\n" +
+		"func h(c *gin.Context) { c.ShouldBindJSON(&mystery) }\n"
+	ents := extractFull(t, "custom_go_dto", fi("main.go", "go", src))
+	d := findDto(ents, "request", "mystery")
+	if d == nil {
+		t.Fatalf("missing unresolved request DTO; got %+v", dtoEntities(ents))
+	}
+	if d.Props["resolved"] != "false" {
+		t.Errorf("resolved=%q want false", d.Props["resolved"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Response serialiser only emits when it resolves to a known struct (avoids
+// flooding the graph with generic locals like err/code).
+// ---------------------------------------------------------------------------
+
+func TestDtoResponseRequiresKnownStruct(t *testing.T) {
+	src := "r := gin.Default()\n" +
+		"type Resp struct {\n\tID int `json:\"id\"`\n}\n" +
+		"func h(c *gin.Context) {\n" +
+		"\tresp := Resp{}\n" +
+		"\tc.JSON(200, resp)\n" +
+		"\tc.JSON(400, err)\n" +
+		"}\n"
+	ents := extractFull(t, "custom_go_dto", fi("main.go", "go", src))
+	if findDto(ents, "response", "Resp") == nil {
+		t.Fatalf("missing response DTO Resp; got %+v", dtoEntities(ents))
+	}
+	// `err` does not resolve to a struct -> no response DTO for it.
+	if findDto(ents, "response", "err") != nil {
+		t.Errorf("generic local err should not emit a response DTO")
+	}
+}
+
+func TestDtoProvenance(t *testing.T) {
+	src := "r := gin.Default()\n" +
+		"type Req struct {\n\tA string `json:\"a\"`\n}\n" +
+		"func h(c *gin.Context) { var req Req; c.ShouldBindJSON(&req) }\n"
+	ents := extractFull(t, "custom_go_dto", fi("main.go", "go", src))
+	d := findDto(ents, "request", "Req")
+	if d == nil {
+		t.Fatal("missing request DTO Req")
+	}
+	if d.Props["provenance"] != "INFERRED_FROM_GIN_DTO_REQUEST" {
+		t.Errorf("provenance=%q want INFERRED_FROM_GIN_DTO_REQUEST", d.Props["provenance"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fixture-driven end-to-end checks. Each fixture carries a request DTO struct
+// bound in a handler + a response DTO struct serialised back. These prove the
+// general request-bind + response-serialise + struct-field case across the
+// flagship gin/echo/fiber/chi frameworks plus the stdlib-decode family
+// (net-http / gorilla-mux).
+// ---------------------------------------------------------------------------
+
+func TestDtoFixtures(t *testing.T) {
+	cases := []struct {
+		fixture, framework, reqStruct, respStruct, reqField string
+	}{
+		{"gin_dto.go", "gin", "CreateUserReq", "UserResp", "Email"},
+		{"echo_dto.go", "echo", "LoginReq", "TokenResp", "Username"},
+		{"fiber_dto.go", "fiber", "SignupReq", "SignupResp", "Email"},
+		{"chi_dto.go", "chi", "OrderReq", "OrderResp", "SKU"},
+		{"nethttp_dto.go", "net-http", "NetHTTPSignupReq", "NetHTTPSignupResp", "Username"},
+		{"gorilla_mux_dto.go", "gorilla-mux", "MuxCreateUserReq", "MuxUserResp", "Email"},
+	}
+	for _, c := range cases {
+		t.Run(c.framework, func(t *testing.T) {
+			ents := extractFull(t, "custom_go_dto", fixtureFile(t, c.fixture))
+
+			req := findDto(ents, "request", c.reqStruct)
+			if req == nil {
+				t.Fatalf("%s: missing request DTO %s; got %+v", c.framework, c.reqStruct, dtoEntities(ents))
+			}
+			if req.Props["resolved"] != "true" {
+				t.Errorf("%s: request DTO not resolved: %+v", c.framework, req.Props)
+			}
+			if !strings.Contains(req.Props["fields"], c.reqField+":") {
+				t.Errorf("%s: request DTO fields %q missing %s", c.framework, req.Props["fields"], c.reqField)
+			}
+
+			if resp := findDto(ents, "response", c.respStruct); resp == nil {
+				t.Errorf("%s: missing response DTO %s; got %+v", c.framework, c.respStruct, dtoEntities(ents))
+			}
+
+			// every emitted DTO must be attributed to this framework.
+			for _, e := range dtoEntities(ents) {
+				if e.Props["framework"] != c.framework {
+					t.Errorf("%s: entity %q framework=%q", c.framework, e.Name, e.Props["framework"])
+				}
+			}
+		})
+	}
+}

--- a/internal/custom/golang/testdata/chi_dto.go
+++ b/internal/custom/golang/testdata/chi_dto.go
@@ -1,0 +1,35 @@
+package testdata
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+// OrderReq is the request DTO bound by chi's render.Bind.
+type OrderReq struct {
+	SKU      string `json:"sku" validate:"required"`
+	Quantity int    `json:"quantity" validate:"gte=1"`
+}
+
+// OrderResp is the response DTO serialised by render.JSON.
+type OrderResp struct {
+	OrderID string `json:"order_id"`
+	Total   int    `json:"total"`
+}
+
+func createOrder(w http.ResponseWriter, r *http.Request) {
+	var req OrderReq
+	if err := render.Bind(r, &req); err != nil {
+		return
+	}
+	resp := OrderResp{OrderID: "o-1", Total: 99}
+	render.JSON(w, r, resp)
+}
+
+func setupChi() {
+	mux := chi.NewRouter()
+	mux.Post("/orders", createOrder)
+	_ = mux
+}

--- a/internal/custom/golang/testdata/echo_dto.go
+++ b/internal/custom/golang/testdata/echo_dto.go
@@ -1,0 +1,30 @@
+package testdata
+
+import "github.com/labstack/echo/v4"
+
+// LoginReq is the request DTO bound by echo's c.Bind.
+type LoginReq struct {
+	Username string `json:"username" validate:"required"`
+	Password string `json:"password" validate:"required,min=6"`
+}
+
+// TokenResp is the response DTO serialised by c.JSON.
+type TokenResp struct {
+	Token   string `json:"token"`
+	Expires int64  `json:"expires"`
+}
+
+func login(c echo.Context) error {
+	var req LoginReq
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+	resp := TokenResp{Token: "abc", Expires: 3600}
+	return c.JSON(200, resp)
+}
+
+func setupEcho() {
+	e := echo.New()
+	e.POST("/login", login)
+	_ = e
+}

--- a/internal/custom/golang/testdata/fiber_dto.go
+++ b/internal/custom/golang/testdata/fiber_dto.go
@@ -1,0 +1,30 @@
+package testdata
+
+import "github.com/gofiber/fiber/v2"
+
+// SignupReq is the request DTO parsed by fiber's BodyParser.
+type SignupReq struct {
+	Email string `json:"email" validate:"required,email"`
+	Name  string `json:"name"`
+}
+
+// SignupResp is the response DTO serialised by c.JSON.
+type SignupResp struct {
+	ID      int    `json:"id"`
+	Message string `json:"message"`
+}
+
+func signup(c *fiber.Ctx) error {
+	var req SignupReq
+	if err := c.BodyParser(&req); err != nil {
+		return err
+	}
+	resp := SignupResp{ID: 7, Message: "ok"}
+	return c.JSON(resp)
+}
+
+func setupFiber() {
+	app := fiber.New()
+	app.Post("/signup", signup)
+	_ = app
+}

--- a/internal/custom/golang/testdata/gin_dto.go
+++ b/internal/custom/golang/testdata/gin_dto.go
@@ -1,0 +1,32 @@
+package testdata
+
+import "github.com/gin-gonic/gin"
+
+// CreateUserReq is the request DTO bound from the JSON body.
+type CreateUserReq struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required,min=8"`
+	Age      int    `json:"age"`
+}
+
+// UserResp is the response DTO serialised back to the client.
+type UserResp struct {
+	ID    int    `json:"id"`
+	Email string `json:"email"`
+}
+
+func createUser(c *gin.Context) {
+	var req CreateUserReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+	resp := UserResp{ID: 1, Email: req.Email}
+	c.JSON(200, resp)
+}
+
+func setup() {
+	r := gin.Default()
+	r.POST("/users", createUser)
+	_ = r
+}

--- a/internal/custom/golang/testdata/gorilla_mux_dto.go
+++ b/internal/custom/golang/testdata/gorilla_mux_dto.go
@@ -1,0 +1,36 @@
+package testdata
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// MuxCreateUserReq is the request DTO decoded from the request body.
+type MuxCreateUserReq struct {
+	Email string `json:"email" validate:"required,email"`
+	Name  string `json:"name" validate:"required"`
+}
+
+// MuxUserResp is the response DTO encoded back to the client.
+type MuxUserResp struct {
+	ID    int    `json:"id"`
+	Email string `json:"email"`
+}
+
+func muxCreateUser(w http.ResponseWriter, r *http.Request) {
+	var req MuxCreateUserReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp := MuxUserResp{ID: 42, Email: req.Email}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func setupMux() {
+	r := mux.NewRouter()
+	r.HandleFunc("/users", muxCreateUser).Methods("POST")
+	_ = r
+}

--- a/internal/custom/golang/testdata/nethttp_dto.go
+++ b/internal/custom/golang/testdata/nethttp_dto.go
@@ -1,0 +1,35 @@
+package testdata
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// NetHTTPSignupReq is the request DTO decoded from the raw request body via the
+// idiomatic stdlib json.NewDecoder(r.Body).Decode pattern.
+type NetHTTPSignupReq struct {
+	Username string `json:"username" validate:"required"`
+	Email    string `json:"email" validate:"required,email"`
+}
+
+// NetHTTPSignupResp is the response DTO encoded via json.NewEncoder(w).Encode.
+type NetHTTPSignupResp struct {
+	ID     int    `json:"id"`
+	Status string `json:"status"`
+}
+
+func nethttpSignup(w http.ResponseWriter, r *http.Request) {
+	var req NetHTTPSignupReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp := NetHTTPSignupResp{ID: 1, Status: "created"}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func setupNetHTTP() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/signup", nethttpSignup)
+	_ = mux
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -2680,6 +2680,22 @@ records:
           verified_at: "2026-05-30"
 
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto, dto_direction=request|response) per DTO with
+          # its field list. Distinct from request_validation (which emits the rules):
+          # this emits the bound struct shapes. Dedicated end-to-end fixture proves
+          # the request-bind + response-serialise + struct-field case for this
+          # framework -> full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans gin-context files for
           # `binding:"..."` struct-tag rules on bound DTOs, validator.New()/
@@ -2960,6 +2976,22 @@ records:
           verified_at: "2026-05-30"
 
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto, dto_direction=request|response) per DTO with
+          # its field list. Distinct from request_validation (which emits the rules):
+          # this emits the bound struct shapes. Dedicated end-to-end fixture proves
+          # the request-bind + response-serialise + struct-field case for this
+          # framework -> full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans echo-context files for
           # `validate:"..."` struct-tag rules (go-playground), validator.New()/
@@ -3137,6 +3169,22 @@ records:
           verified_at: "2026-05-30"
 
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto, dto_direction=request|response) per DTO with
+          # its field list. Distinct from request_validation (which emits the rules):
+          # this emits the bound struct shapes. Dedicated end-to-end fixture proves
+          # the request-bind + response-serialise + struct-field case for this
+          # framework -> full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans fiber-context files for
           # `validate:"..."` struct-tag rules (go-playground), validator.New()/
@@ -3321,6 +3369,22 @@ records:
           verified_at: "2026-05-30"
 
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto, dto_direction=request|response) per DTO with
+          # its field list. Distinct from request_validation (which emits the rules):
+          # this emits the bound struct shapes. Dedicated end-to-end fixture proves
+          # the request-bind + response-serialise + struct-field case for this
+          # framework -> full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans chi-context files for
           # `validate:"..."` struct-tag rules (go-playground), validator.New()/
@@ -3494,6 +3558,22 @@ records:
             - file: internal/custom/golang/observability_test.go
           verified_at: "2026-05-30"
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto, dto_direction=request|response) per DTO with
+          # its field list. Distinct from request_validation (which emits the rules):
+          # this emits the bound struct shapes. Dedicated end-to-end fixture proves
+          # the request-bind + response-serialise + struct-field case for this
+          # framework -> full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans gorilla-mux-attributed files for
           # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
@@ -3632,6 +3712,20 @@ records:
             - file: internal/custom/golang/observability_test.go
           verified_at: "2026-05-30"
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans buffalo-attributed files for
           # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
@@ -3768,6 +3862,20 @@ records:
             - file: internal/custom/golang/observability_test.go
           verified_at: "2026-05-30"
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # Revel binds request params positionally via controller-method signatures, not via validate:/binding: struct tags.
           # There is no struct-tag binding surface to extract, so the cell is
@@ -4904,6 +5012,20 @@ records:
             - file: internal/custom/golang/observability_test.go
           verified_at: "2026-05-30"
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # fasthttp's RequestCtx exposes raw byte accessors only (no struct-tag
           # request binding), so there is no validate:/binding: tag surface to
@@ -5036,6 +5158,22 @@ records:
             - file: internal/custom/golang/observability_test.go
           verified_at: "2026-05-30"
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto, dto_direction=request|response) per DTO with
+          # its field list. Distinct from request_validation (which emits the rules):
+          # this emits the bound struct shapes. Dedicated end-to-end fixture proves
+          # the request-bind + response-serialise + struct-field case for this
+          # framework -> full.
+          status: full
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans net-http-attributed files for
           # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
@@ -5204,6 +5342,20 @@ records:
             - file: internal/custom/golang/observability_test.go
           verified_at: "2026-05-30"
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans beego-attributed files for
           # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
@@ -5370,6 +5522,20 @@ records:
             - file: internal/custom/golang/observability_test.go
           verified_at: "2026-05-30"
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans iris-attributed files for
           # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
@@ -5539,6 +5705,20 @@ records:
             - file: internal/custom/golang/observability_test.go
           verified_at: "2026-05-30"
       Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
         request_validation:
           # validation.go (custom_go_validation) scans hertz-attributed files for
           # `validate:`/`binding:` struct-tag rules on bound DTOs, validator.New()
@@ -5632,6 +5812,21 @@ records:
             - file: internal/custom/golang/hertz_huma_test.go
           issues_implemented: ["2686", "3212"]
           verified_at: "2026-05-30"
+      Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.kratos:
     capabilities:
@@ -5717,6 +5912,21 @@ records:
             - file: internal/custom/golang/kratos_gozero_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
 
   lang.go.framework.go-zero:
     capabilities:
@@ -5801,6 +6011,21 @@ records:
           tests:
             - file: internal/custom/golang/kratos_gozero_test.go
           issues_implemented: ["3212"]
+          verified_at: "2026-05-30"
+      Validation:
+        dto_extraction:
+          # dto.go (custom_go_dto) resolves request-bind / response-
+          # serialise call sites to their file-local struct models and emits one
+          # SCOPE.Schema (subtype=dto) per DTO with its field list. Heuristic same-
+          # file type resolution, no cross-file/import resolution and no per-framework
+          # proving fixture for this framework -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/dto.go
+              functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
+          tests:
+            - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
           verified_at: "2026-05-30"
 
   lang.java.framework.spring-webflux:


### PR DESCRIPTION
Part of #3255 (Go greening epic #3210).

## What

New `internal/custom/golang/dto.go` (`custom_go_dto`): a framework-agnostic request/response **DTO-struct** scanner closing the 15-framework `Validation/dto_extraction` build-gap.

It detects the canonical Go HTTP request-bind and response-serialise call sites and resolves the bound variable to its file-local struct model, emitting one `SCOPE.Schema` (subtype=`dto`, `dto_direction`=request|response) per DTO with its field list:

- **request**: `c.ShouldBindJSON/Bind/BindJSON(&x)`, `c.BodyParser/QueryParser(&x)`, `ctx.ReadJSON/ReadBody(&x)`, `this.ParseForm(&x)`, `render.Bind/DecodeJSON(.., &x)`, `json.NewDecoder(r.Body).Decode(&x)`
- **response**: `c.JSON(code, x)` / `ctx.JSON(x)`, `render.JSON(w, r, x)`, `json.NewEncoder(w).Encode(x)`

This is **distinct** from the existing `request_validation` scanner (`validation.go`), which emits the validation *rules*; `dto_extraction` emits the bound struct *models*.

## Honesty

Heuristic regex match + same-file type resolution (no cross-file/import resolution, no request-path proof).

- **full (6)**: gin, echo, fiber, chi, net-http, gorilla-mux — each carries a dedicated end-to-end fixture proving the request-bind + response-serialise + struct-field case.
- **partial (9)**: beego, buffalo, fasthttp, go-zero, hertz, huma, iris, kratos, revel — same idiom catalog, no per-framework proving fixture.

## Contention / anti-dup

- New file only: `dto.go` + `dto_test.go` + 6 fixtures. No edits to other extractors, `helpers.go`, `validation.go`, or `go_routes.go`.
- Registry + `capability-map.yaml` cells **merged** into the existing per-framework records — one `dto_extraction` key per framework (guard verified, each ≤1).

## Validate

`go build` ./internal/... ./tools/coverage/... clean; `go test` ./internal/custom/golang/... ./internal/types/ ./tools/coverage/... pass; `coverage validate` exit 0 (0 new dto warnings); `gen` byte-stable; `fmt --check` clean; `gofmt -l` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)