### PR TITLE
coverage(go): kratos/go-zero/huma auth+middleware+request_validation (#3255)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -46,13 +46,13 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [Gin](../detail/lang.go.framework.gin.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [go](../by-language/go.md) | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Iris](../detail/lang.go.framework.iris.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [go](../by-language/go.md) | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 5/5 | |
-| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [go](../by-language/go.md) | [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -33,13 +33,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Gin](../detail/lang.go.framework.gin.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Gorilla Mux](../detail/lang.go.framework.gorilla-mux.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [Hertz (CloudWeGo)](../detail/lang.go.framework.hertz.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [Huma](../detail/lang.go.framework.huma.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [Iris](../detail/lang.go.framework.iris.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [Kratos (Bilibili)](../detail/lang.go.framework.kratos.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [Revel](../detail/lang.go.framework.revel.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
 | [chi](../detail/lang.go.framework.chi.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [fasthttp](../detail/lang.go.framework.fasthttp.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 5/5 | |
-| [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🔴 0/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 5/7 | |
+| [go-zero](../detail/lang.go.framework.go-zero.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 6/6 | |
 
 

--- a/docs/coverage/detail/lang.go.framework.go-zero.md
+++ b/docs/coverage/detail/lang.go.framework.go-zero.md
@@ -23,20 +23,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/go_zero.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/go_zero.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/go_zero.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.huma.md
+++ b/docs/coverage/detail/lang.go.framework.huma.md
@@ -23,20 +23,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/huma.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/huma.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/huma.go` | — |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.go.framework.kratos.md
+++ b/docs/coverage/detail/lang.go.framework.kratos.md
@@ -23,20 +23,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/kratos.go` | — |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🟢 `partial` | `2026-05-29` | [link](https://github.com/cajasmota/archigraph/issues/3255) | `internal/custom/golang/dto.go`<br>`internal/custom/golang/dto_test.go` | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/kratos.go` | — |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/golang/kratos.go` | — |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -12274,7 +12274,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/go_zero.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -12285,13 +12287,16 @@
             "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/go_zero.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/go_zero.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -13114,7 +13119,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/huma.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -13125,13 +13132,16 @@
             "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/huma.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/huma.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {
@@ -13534,7 +13544,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/kratos.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Validation": {
@@ -13545,13 +13557,16 @@
             "verified_at": "2026-05-29"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/golang/kratos.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/golang/kratos.go"],
+            "verified_at": "2026-05-29"
           }
         },
         "Type System": {

--- a/internal/custom/golang/go_zero.go
+++ b/internal/custom/golang/go_zero.go
@@ -67,6 +67,28 @@ var (
 	)
 	// rest.WithPrefix("/api/v1") — group prefix option on an AddRoutes call.
 	reGoZeroWithPrefix = regexp.MustCompile(`rest\.WithPrefix\s*\(\s*"([^"]+)"`)
+
+	// --- middleware (#3255) -------------------------------------------------
+	// rest.WithMiddleware(mw, routes…) / rest.WithMiddlewares([]rest.Middleware{…}, …)
+	// — the goctl/go-zero idiom for wrapping a route group in a middleware. The
+	// first balanced argument is the middleware expression.
+	reGoZeroWithMiddleware = regexp.MustCompile(`rest\.WithMiddlewares?\s*\(`)
+	// server.Use(mw) — global middleware registration on a rest.Server.
+	reGoZeroUse = regexp.MustCompile(`(\w+)\.Use\s*\(`)
+
+	// --- auth (#3255) -------------------------------------------------------
+	// rest.WithJwt(secret) / rest.WithJwtTransition(secret, prevSecret) — the
+	// built-in go-zero JWT auth option attached to a route group in the
+	// generated routes.go. Marks the group as JWT-protected.
+	reGoZeroWithJwt = regexp.MustCompile(`rest\.WithJwt(?:Transition)?\s*\(`)
+
+	// --- request validation (#3255) ----------------------------------------
+	// httpx.Parse(r, &req) / httpx.ParseJsonBody(r, &req) — the go-zero request
+	// binding call that triggers validation of the typed request struct (its
+	// `validate:` / go-zero `,optional`/range tags). Captures the bound var.
+	reGoZeroHttpxParse = regexp.MustCompile(
+		`httpx\.Parse(?:JsonBody|Form|Header|Path)?\s*\(\s*[\w.]+\s*,\s*&(\w+)`,
+	)
 )
 
 // goZeroVerb resolves the HTTP verb from a Method-field match, normalising both
@@ -137,8 +159,13 @@ func (e *goZeroExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	}
 
 	src := string(file.Content)
-	// Gate on the generated routes-registration signature.
-	if !strings.Contains(src, "rest.Route") && !strings.Contains(src, "AddRoutes") {
+	// Routing is gated on the generated routes-registration signature; the
+	// middleware/auth/validation passes run on any go-zero file (gated on the
+	// broader zeromicro/go-zero import or rest/httpx markers) so they also cover
+	// the handler/logic files where httpx.Parse(...) binds request structs and
+	// the types file where `validate:` tags live.
+	hasRouting := strings.Contains(src, "rest.Route") || strings.Contains(src, "AddRoutes")
+	if !hasRouting && !isGoZeroFile(src) {
 		return nil, nil
 	}
 
@@ -152,6 +179,13 @@ func (e *goZeroExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		}
 		seen[key] = true
 		entities = append(entities, ent)
+	}
+
+	if !hasRouting {
+		emitGoZeroMiddlewareAndAuth(add, src, file.Path, file.Language)
+		emitGoZeroValidation(add, src, file.Path, file.Language)
+		span.SetAttributes(attribute.Int("entity_count", len(entities)))
+		return entities, nil
 	}
 
 	for _, loc := range reGoZeroAddRoutesHead.FindAllStringSubmatchIndex(src, -1) {
@@ -206,6 +240,123 @@ func (e *goZeroExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		}
 	}
 
+	// middleware / auth / request-validation surfaces (#3255) — also run on the
+	// routes.go file, where rest.WithMiddleware(...)/rest.WithJwt(...) options
+	// commonly sit alongside the AddRoutes(...) registrations.
+	emitGoZeroMiddlewareAndAuth(add, src, file.Path, file.Language)
+	emitGoZeroValidation(add, src, file.Path, file.Language)
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// isGoZeroFile reports whether src looks like a go-zero source file — used to
+// gate the middleware/auth/validation passes on non-routing go-zero files
+// (handler/logic/types). Markers: the zeromicro import path and the rest/httpx
+// packages go-zero services are built on.
+func isGoZeroFile(src string) bool {
+	return strings.Contains(src, "zeromicro/go-zero") ||
+		strings.Contains(src, "go-zero/rest") ||
+		strings.Contains(src, "httpx.Parse")
+}
+
+// emitGoZeroMiddlewareAndAuth detects go-zero middleware registration + JWT auth.
+//
+//	rest.WithMiddleware(mw, …) / rest.WithMiddlewares([]rest.Middleware{…}, …)
+//	server.Use(mw)                                  — middleware
+//	rest.WithJwt(secret) / rest.WithJwtTransition   — built-in JWT auth option
+//
+// Each middleware expression becomes a SCOPE.Pattern (pattern_kind=middleware),
+// auth-classified via the shared catalog; rest.WithJwt yields a dedicated auth
+// SCOPE.Pattern (auth_kind=jwt) regardless of the wrapped expression, since the
+// option itself is the auth enforcement point.
+//
+// Honesty: heuristic source match; no data-flow proof of enforcement or
+// route-binding. Reported `partial`.
+func emitGoZeroMiddlewareAndAuth(add func(types.EntityRecord), src, filePath, language string) {
+	const mwProv = "INFERRED_FROM_GOZERO_MIDDLEWARE"
+	const authProv = "INFERRED_FROM_GOZERO_AUTH"
+
+	emitChain := func(headRe *regexp.Regexp, form string) {
+		for _, loc := range headRe.FindAllStringSubmatchIndex(src, -1) {
+			open := loc[1] - 1
+			args, end := balancedArgs(src, open)
+			if end < 0 {
+				continue
+			}
+			chain := parseMiddlewareChain(args)
+			line := lineOf(src, loc[0])
+			for _, a := range chain {
+				mw := makeEntity(a.Expr, "SCOPE.Pattern", "", filePath, language, line)
+				setProps(&mw, "framework", "go_zero", "provenance", mwProv,
+					"pattern_kind", "middleware",
+					"middleware_name", a.Name,
+					"middleware_form", form,
+					"mw_order", itoa(a.Order))
+				if a.AuthKind != "" {
+					setProps(&mw, "is_auth", "true", "auth_kind", a.AuthKind)
+				}
+				add(mw)
+				if a.AuthKind != "" {
+					au := makeEntity("auth:"+a.Name, "SCOPE.Pattern", "", filePath, language, line)
+					setProps(&au, "framework", "go_zero", "provenance", authProv,
+						"pattern_kind", "auth", "auth_kind", a.AuthKind,
+						"middleware_name", a.Name, "middleware_expr", a.Expr)
+					add(au)
+				}
+			}
+		}
+	}
+
+	emitChain(reGoZeroWithMiddleware, "with_middleware")
+	emitChain(reGoZeroUse, "use")
+
+	// rest.WithJwt(...) — the built-in JWT auth option. One auth SCOPE.Pattern
+	// per occurrence (the option IS the enforcement point).
+	for _, loc := range reGoZeroWithJwt.FindAllStringIndex(src, -1) {
+		line := lineOf(src, loc[0])
+		au := makeEntity("auth:rest.WithJwt", "SCOPE.Pattern", "", filePath, language, line)
+		setProps(&au, "framework", "go_zero", "provenance", authProv,
+			"pattern_kind", "auth", "auth_kind", "jwt",
+			"middleware_name", "rest.WithJwt", "auth_form", "with_jwt")
+		add(au)
+	}
+}
+
+// emitGoZeroValidation detects go-zero request validation.
+//
+//	rule    — struct fields carrying `validate:` (go-playground) tags on a
+//	          go-zero typed request struct
+//	binding — httpx.Parse(r, &req) / httpx.ParseJsonBody(...) call sites that
+//	          decode-and-validate the request struct
+//
+// go-zero's httpx.Parse runs the field validators after JSON decoding, so the
+// Parse call is the validation-enforcement surface. Struct-tag rules reuse the
+// shared findValidationRules scanner (validate.go), keeping the property shape
+// identical to the gin/echo/fiber/chi validation cells.
+//
+// Honesty: heuristic source match; no proof every rule fires on a real request
+// path. Reported `partial`.
+func emitGoZeroValidation(add func(types.EntityRecord), src, filePath, language string) {
+	const prov = "INFERRED_FROM_GOZERO_VALIDATION"
+
+	for _, r := range findValidationRules(src) {
+		name := "validation:rule:" + r.Struct + "." + r.Field
+		ent := makeEntity(name, "SCOPE.Pattern", "", filePath, language, r.Line)
+		setProps(&ent, "framework", "go_zero", "provenance", prov,
+			"pattern_kind", "validation", "validation_kind", "rule",
+			"struct_name", r.Struct, "field_name", r.Field,
+			"rules", r.Rules, "rule_source", r.Source)
+		add(ent)
+	}
+
+	for _, m := range reGoZeroHttpxParse.FindAllStringSubmatchIndex(src, -1) {
+		boundVar := submatch(src, m, 2)
+		name := "validation:binding:httpx_parse:" + boundVar
+		ent := makeEntity(name, "SCOPE.Pattern", "", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "go_zero", "provenance", prov,
+			"pattern_kind", "validation", "validation_kind", "binding",
+			"validation_subtype", "httpx_parse", "bound_var", boundVar)
+		add(ent)
+	}
 }

--- a/internal/custom/golang/huma.go
+++ b/internal/custom/golang/huma.go
@@ -42,6 +42,36 @@ var (
 	)
 	// Path field of an Operation literal: Path: "/users/{id}".
 	reHumaPathField = regexp.MustCompile(`Path\s*:\s*"([^"]+)"`)
+
+	// --- middleware (#3255) -------------------------------------------------
+	// api.UseMiddleware(mw1, mw2, …) — huma's API-level middleware registration.
+	// The balanced argument span is captured so each middleware is one entry.
+	reHumaUseMiddleware = regexp.MustCompile(`(\w+)\.UseMiddleware\s*\(`)
+	// huma.Middlewares{mw1, mw2} — the Operation.Middlewares slice literal form
+	// (per-operation middleware). Captured by balanced brace scan.
+	reHumaMiddlewares = regexp.MustCompile(`huma\.Middlewares\s*\{`)
+
+	// --- auth (#3255) -------------------------------------------------------
+	// Security field of an Operation literal:
+	//   Security: []map[string][]string{{"bearer": {"read"}}}
+	// Marks the operation as auth-protected. We detect the presence of the
+	// Security key and capture the first scheme name referenced.
+	reHumaOpSecurity = regexp.MustCompile(`Security\s*:\s*\[\]map\[string\]\[\]string\{`)
+	// SecuritySchemes registration on the OpenAPI config / components:
+	//   SecuritySchemes: map[string]*huma.SecurityScheme{"bearer": {Type:"http", Scheme:"bearer"}}
+	// and the scheme-name keys inside it.
+	reHumaSecuritySchemes = regexp.MustCompile(`SecuritySchemes\s*[:=]\s*map\[string\]\*?huma\.SecurityScheme\{`)
+	// A "name": { ... } scheme entry key inside a SecuritySchemes / Security map.
+	reHumaSchemeKey = regexp.MustCompile(`"([A-Za-z_][\w-]*)"\s*:`)
+
+	// --- request validation (#3255) ----------------------------------------
+	// huma derives request validation from the input struct's schema tags
+	// (minimum/maxLength/pattern/enum/format/required) declared on fields of the
+	// *Input struct bound as the handler's second parameter. Each field carrying
+	// such a tag is one validation rule. The field name + the constraint tag are
+	// captured.
+	reHumaSchemaField = regexp.MustCompile(
+		"(?m)^\\s*(\\w+)\\s+[^`\\n]*`[^`]*?\\b(minimum|maximum|minLength|maxLength|pattern|enum|format|required|exclusiveMinimum|exclusiveMaximum|multipleOf|minItems|maxItems|uniqueItems):\"([^\"]*)\"[^`]*`")
 )
 
 // humaVerb resolves the HTTP verb from a Method-field match, normalising both
@@ -117,10 +147,180 @@ func (e *humaExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 			ent.Properties["handler"] = handler
 		}
 		add(ent)
+
+		// Per-operation Security: an Operation literal carrying a Security field
+		// is auth-protected. Emit a dedicated auth SCOPE.Pattern bound to this
+		// endpoint, capturing the first referenced scheme name.
+		if reHumaOpSecurity.MatchString(opLit) {
+			scheme := ""
+			if km := reHumaSchemeKey.FindStringSubmatch(
+				opLit[strings.Index(opLit, "Security"):]); km != nil {
+				scheme = km[1]
+			}
+			au := makeEntity("auth:"+verb+" "+path, "SCOPE.Pattern", "", file.Path, file.Language, line)
+			setProps(&au, "framework", "huma", "provenance", "INFERRED_FROM_HUMA_AUTH",
+				"pattern_kind", "auth", "auth_kind", humaAuthKind(scheme),
+				"route_path", path, "http_method", verb, "security_scheme", scheme)
+			add(au)
+		}
 	}
+
+	emitHumaMiddleware(add, src, file.Path, file.Language)
+	emitHumaSecuritySchemes(add, src, file.Path, file.Language)
+	emitHumaValidation(add, src, file.Path, file.Language)
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// humaAuthKind maps a huma security-scheme name to a coarse auth kind via the
+// shared classifier, falling back to a name-shape heuristic and finally to the
+// generic "auth" kind so a Security-protected operation is never left unkinded.
+func humaAuthKind(scheme string) string {
+	if k := classifyAuthMiddleware(scheme); k != "" {
+		return k
+	}
+	low := strings.ToLower(scheme)
+	switch {
+	case strings.Contains(low, "bearer") || strings.Contains(low, "jwt"):
+		return "jwt"
+	case strings.Contains(low, "oauth"):
+		return "oauth"
+	case strings.Contains(low, "apikey") || strings.Contains(low, "api_key") || strings.Contains(low, "key"):
+		return "api_key"
+	case strings.Contains(low, "basic"):
+		return "basic"
+	default:
+		return "auth"
+	}
+}
+
+// emitHumaMiddleware detects huma middleware registration:
+//
+//	api.UseMiddleware(mw1, mw2, …)   — API-level middleware chain
+//	huma.Middlewares{mw1, mw2}       — per-operation Middlewares slice literal
+//
+// Each middleware expression becomes an ordered SCOPE.Pattern
+// (pattern_kind=middleware), auth-classified via the shared catalog.
+//
+// Honesty: heuristic source match, no enforcement proof. Reported `partial`.
+func emitHumaMiddleware(add func(types.EntityRecord), src, filePath, language string) {
+	const mwProv = "INFERRED_FROM_HUMA_MIDDLEWARE"
+	const authProv = "INFERRED_FROM_HUMA_AUTH"
+
+	emit := func(chain []middlewareArg, form string, line int) {
+		for _, a := range chain {
+			mw := makeEntity(a.Expr, "SCOPE.Pattern", "", filePath, language, line)
+			setProps(&mw, "framework", "huma", "provenance", mwProv,
+				"pattern_kind", "middleware",
+				"middleware_name", a.Name,
+				"middleware_form", form,
+				"mw_order", itoa(a.Order))
+			if a.AuthKind != "" {
+				setProps(&mw, "is_auth", "true", "auth_kind", a.AuthKind)
+			}
+			add(mw)
+			if a.AuthKind != "" {
+				au := makeEntity("auth:"+a.Name, "SCOPE.Pattern", "", filePath, language, line)
+				setProps(&au, "framework", "huma", "provenance", authProv,
+					"pattern_kind", "auth", "auth_kind", a.AuthKind,
+					"middleware_name", a.Name, "middleware_expr", a.Expr)
+				add(au)
+			}
+		}
+	}
+
+	// api.UseMiddleware(...) — balanced paren args.
+	for _, loc := range reHumaUseMiddleware.FindAllStringSubmatchIndex(src, -1) {
+		open := loc[1] - 1
+		args, end := balancedArgs(src, open)
+		if end < 0 {
+			continue
+		}
+		emit(parseMiddlewareChain(args), "use_middleware", lineOf(src, loc[0]))
+	}
+
+	// huma.Middlewares{...} — balanced brace literal.
+	for _, loc := range reHumaMiddlewares.FindAllStringIndex(src, -1) {
+		open := loc[1] - 1 // index of the '{'
+		end := matchBrace(src, open)
+		if end < 0 {
+			continue
+		}
+		emit(parseMiddlewareChain(src[open+1:end]), "middlewares_slice", lineOf(src, loc[0]))
+	}
+}
+
+// emitHumaSecuritySchemes detects the OpenAPI SecuritySchemes registration on
+// the huma config/components and emits one auth SCOPE.Pattern per declared
+// scheme name (subtype scheme), describing the available auth schemes.
+func emitHumaSecuritySchemes(add func(types.EntityRecord), src, filePath, language string) {
+	const authProv = "INFERRED_FROM_HUMA_AUTH"
+	for _, loc := range reHumaSecuritySchemes.FindAllStringIndex(src, -1) {
+		open := loc[1] - 1 // the '{'
+		end := matchBrace(src, open)
+		if end < 0 {
+			continue
+		}
+		body := src[open+1 : end]
+		line := lineOf(src, loc[0])
+		for _, km := range reHumaSchemeKey.FindAllStringSubmatch(body, -1) {
+			scheme := km[1]
+			au := makeEntity("auth:scheme:"+scheme, "SCOPE.Pattern", "", filePath, language, line)
+			setProps(&au, "framework", "huma", "provenance", authProv,
+				"pattern_kind", "auth", "auth_kind", humaAuthKind(scheme),
+				"auth_form", "security_scheme", "security_scheme", scheme)
+			add(au)
+		}
+	}
+}
+
+// emitHumaValidation detects huma request validation derived from OpenAPI schema
+// tags on input-struct fields (minimum/maxLength/pattern/enum/format/required/…).
+// Each constrained field is one validation rule attributed to its enclosing
+// struct (resolved via the shared findValidationRules struct-head index logic,
+// reimplemented here against the huma constraint-tag set).
+//
+// Honesty: heuristic source match; no proof the struct is actually bound as a
+// handler input. Reported `partial`.
+func emitHumaValidation(add func(types.EntityRecord), src, filePath, language string) {
+	const prov = "INFERRED_FROM_HUMA_VALIDATION"
+
+	// Index struct heads by offset so each constrained field finds its struct.
+	type head struct {
+		name string
+		off  int
+	}
+	var heads []head
+	for _, m := range reGoStructHead.FindAllStringSubmatchIndex(src, -1) {
+		heads = append(heads, head{name: src[m[2]:m[3]], off: m[0]})
+	}
+	structAt := func(off int) string {
+		name := ""
+		for _, h := range heads {
+			if h.off <= off {
+				name = h.name
+			} else {
+				break
+			}
+		}
+		return name
+	}
+
+	for _, m := range reHumaSchemaField.FindAllStringSubmatchIndex(src, -1) {
+		field := submatch(src, m, 2)
+		tag := submatch(src, m, 4)
+		value := submatch(src, m, 6)
+		st := structAt(m[0])
+		name := "validation:rule:" + st + "." + field + ":" + tag
+		ent := makeEntity(name, "SCOPE.Pattern", "", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "huma", "provenance", prov,
+			"pattern_kind", "validation", "validation_kind", "rule",
+			"validation_subtype", "openapi_schema_tag",
+			"struct_name", st, "field_name", field,
+			"constraint", tag, "constraint_value", value)
+		add(ent)
+	}
 }
 
 // balancedArgs returns the argument text between the paren at index open and

--- a/internal/custom/golang/kratos.go
+++ b/internal/custom/golang/kratos.go
@@ -68,6 +68,35 @@ var (
 	reKratosHandler = regexp.MustCompile(
 		`^_(\w+?)_(\w+?)(\d+)_HTTP_Handler$`,
 	)
+
+	// --- middleware (#3255) -------------------------------------------------
+	// http.Middleware(mw1, mw2, …) server option (and the grpc.Middleware twin)
+	// that registers a global middleware chain on a kratos transport server:
+	//
+	//	srv := http.NewServer(http.Middleware(recovery.Recovery(), auth.JWT(...)))
+	//
+	// The balanced argument span is scanned forward so nested middleware
+	// constructors are captured whole. Captures the receiver selector (e.g.
+	// "http") so we can stamp the transport on the chain.
+	reKratosMiddleware = regexp.MustCompile(`(\w+)\.Middleware\s*\(`)
+	// selector.Server(mw…).Match(fn).Build() — per-route middleware selector,
+	// a kratos idiom for applying middleware to a subset of operations. The
+	// Server(...) argument list is the middleware chain; captured by balanced
+	// scan from the opening paren.
+	reKratosSelectorServer = regexp.MustCompile(`selector\s*\.\s*Server\s*\(`)
+
+	// --- request validation (#3255) ----------------------------------------
+	// protoc-gen-validate (PGV) generates a Validate()/ValidateAll() method per
+	// message. kratos's validate middleware calls it on the decoded request.
+	// Two surfaces are detected:
+	//   1. the generated method definition: func (m *XReq) Validate() error
+	//   2. the call site that enforces it:  if err := in.Validate(); err != nil
+	reKratosValidateDef = regexp.MustCompile(
+		`(?m)func\s*\(\s*\w+\s+\*?(\w+)\s*\)\s*(Validate|ValidateAll)\s*\(\s*\)\s*error`,
+	)
+	reKratosValidateCall = regexp.MustCompile(
+		`(\w+)\.(Validate|ValidateAll)\s*\(\s*\)`,
+	)
 )
 
 // kratosMethodFromHandler recovers the underlying service method name from a
@@ -97,11 +126,15 @@ func (e *kratosExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	}
 
 	src := string(file.Content)
-	// Gate on the generated-HTTP-transport signature: the registration entry
-	// point + the generated handler wrapper suffix. This keeps the extractor
-	// inert on hand-written kratos service/biz/data code (which carries no
-	// route registrations) and on unrelated Go files.
-	if !strings.Contains(src, "HTTPServer") || !strings.Contains(src, "_HTTP_Handler") {
+	// Routing is gated on the generated-HTTP-transport signature (registration
+	// entry point + generated handler wrapper suffix); middleware/auth/request-
+	// validation run on any kratos file, gated on the broader kratos import/
+	// transport marker so they also cover the hand-written server-wiring file
+	// (where http.Middleware(...)/selector.Server(...) live) and the generated
+	// *.pb.validate.go file (where the PGV Validate() methods live). A file with
+	// neither signature is not kratos — emit nothing.
+	hasRouting := strings.Contains(src, "HTTPServer") && strings.Contains(src, "_HTTP_Handler")
+	if !hasRouting && !isKratosFile(src) {
 		return nil, nil
 	}
 
@@ -115,6 +148,15 @@ func (e *kratosExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		}
 		seen[key] = true
 		entities = append(entities, ent)
+	}
+
+	if !hasRouting {
+		// Non-routing kratos file (server wiring / generated PGV validators):
+		// only the middleware/auth/validation passes apply.
+		emitKratosMiddlewareAndAuth(add, src, file.Path, file.Language)
+		emitKratosValidation(add, src, file.Path, file.Language)
+		span.SetAttributes(attribute.Int("entity_count", len(entities)))
+		return entities, nil
 	}
 
 	// 1. RegisterXxxHTTPServer entry points -> SCOPE.Service (one per service).
@@ -166,6 +208,117 @@ func (e *kratosExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		add(ent)
 	}
 
+	// 4. middleware / auth / request-validation surfaces (#3255). These also run
+	//    on the routing file when present (e.g. a hand-edited *_http.pb.go or a
+	//    server file that both registers routes and wires middleware).
+	emitKratosMiddlewareAndAuth(add, src, file.Path, file.Language)
+	emitKratosValidation(add, src, file.Path, file.Language)
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// isKratosFile reports whether src looks like a go-kratos source file — used to
+// gate the middleware/auth/validation passes on non-routing kratos files
+// (server wiring, generated PGV validators). The markers are the kratos import
+// path and its transport/middleware constructs.
+func isKratosFile(src string) bool {
+	return strings.Contains(src, "go-kratos/kratos") ||
+		strings.Contains(src, "kratos/v2/middleware") ||
+		strings.Contains(src, "transport/http") && strings.Contains(src, ".Middleware(")
+}
+
+// emitKratosMiddlewareAndAuth detects kratos middleware registration and
+// classifies auth middleware. Two surfaces:
+//
+//	http.Middleware(mw1, mw2, …)      — global transport middleware chain
+//	selector.Server(mw…).Match(…)     — per-route middleware selector
+//
+// Each middleware expression becomes an ordered SCOPE.Pattern
+// (pattern_kind=middleware); any expression that classifies as auth (jwt/…)
+// also yields a dedicated auth SCOPE.Pattern. JWT is the canonical kratos auth
+// middleware (github.com/go-kratos/kratos/v2/middleware/auth/jwt), so the
+// shared classifier already recognises it via the "jwt" needle.
+//
+// Honesty: heuristic substring/identifier match on source text; no import
+// resolution or data-flow proof that the value enforces auth, and no binding to
+// a specific route. Reported `partial`.
+func emitKratosMiddlewareAndAuth(add func(types.EntityRecord), src, filePath, language string) {
+	const mwProv = "INFERRED_FROM_KRATOS_MIDDLEWARE"
+	const authProv = "INFERRED_FROM_KRATOS_AUTH"
+
+	emit := func(headRe *regexp.Regexp, form string) {
+		for _, loc := range headRe.FindAllStringSubmatchIndex(src, -1) {
+			open := loc[1] - 1 // the '(' the head ends at
+			args, end := balancedArgs(src, open)
+			if end < 0 {
+				continue
+			}
+			chain := parseMiddlewareChain(args)
+			line := lineOf(src, loc[0])
+			for _, a := range chain {
+				mw := makeEntity(a.Expr, "SCOPE.Pattern", "", filePath, language, line)
+				setProps(&mw, "framework", "kratos", "provenance", mwProv,
+					"pattern_kind", "middleware",
+					"middleware_name", a.Name,
+					"middleware_form", form,
+					"mw_order", itoa(a.Order))
+				if a.AuthKind != "" {
+					setProps(&mw, "is_auth", "true", "auth_kind", a.AuthKind)
+				}
+				add(mw)
+				if a.AuthKind != "" {
+					au := makeEntity("auth:"+a.Name, "SCOPE.Pattern", "", filePath, language, line)
+					setProps(&au, "framework", "kratos", "provenance", authProv,
+						"pattern_kind", "auth", "auth_kind", a.AuthKind,
+						"middleware_name", a.Name, "middleware_expr", a.Expr)
+					add(au)
+				}
+			}
+		}
+	}
+
+	emit(reKratosMiddleware, "transport_middleware")
+	emit(reKratosSelectorServer, "selector_server")
+}
+
+// emitKratosValidation detects protoc-gen-validate (PGV) request validation.
+// PGV generates a Validate()/ValidateAll() method per request message and the
+// kratos validate middleware (or handler code) invokes it on the decoded
+// request. Two surfaces:
+//
+//	rule       — the generated `func (m *XReq) Validate() error` method def
+//	binding    — the enforcing call site `in.Validate()` / `req.ValidateAll()`
+//
+// Honesty: heuristic source match; it does not confirm the method is wired into
+// a request path or that every field rule is enforced. Reported `partial`.
+func emitKratosValidation(add func(types.EntityRecord), src, filePath, language string) {
+	const prov = "INFERRED_FROM_KRATOS_VALIDATION"
+
+	for _, m := range reKratosValidateDef.FindAllStringSubmatchIndex(src, -1) {
+		msg := submatch(src, m, 2)
+		method := submatch(src, m, 4)
+		name := "validation:rule:" + msg + "." + method
+		ent := makeEntity(name, "SCOPE.Pattern", "", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kratos", "provenance", prov,
+			"pattern_kind", "validation", "validation_kind", "rule",
+			"validation_subtype", "protoc_gen_validate",
+			"message_type", msg, "validate_method", method)
+		add(ent)
+	}
+
+	for _, m := range reKratosValidateCall.FindAllStringSubmatchIndex(src, -1) {
+		recv := submatch(src, m, 2)
+		method := submatch(src, m, 4)
+		// Skip the method-definition receiver lines (already emitted as rule);
+		// those carry the `func (...)` prefix which the call regex won't anchor,
+		// but a defensive dedup via the add() key handles any overlap.
+		name := "validation:binding:" + method + ":" + recv
+		ent := makeEntity(name, "SCOPE.Pattern", "", filePath, language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kratos", "provenance", prov,
+			"pattern_kind", "validation", "validation_kind", "binding",
+			"validation_subtype", "validate_call",
+			"receiver", recv, "validate_method", method)
+		add(ent)
+	}
 }

--- a/internal/custom/golang/kratos_gozero_huma_amv2_test.go
+++ b/internal/custom/golang/kratos_gozero_huma_amv2_test.go
@@ -1,0 +1,274 @@
+package golang_test
+
+import "testing"
+
+// Tests for the auth / middleware / request_validation surfaces added to the
+// kratos, go-zero and huma custom extractors (#3255). These complement the
+// routing tests in kratos_gozero_test.go / hertz_huma_test.go.
+
+// findPattern returns the first SCOPE.Pattern entity with the given name.
+func findPattern(ents []fullEntity, name string) *fullEntity {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Pattern" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// hasPatternKind reports whether any SCOPE.Pattern carries pattern_kind==kind.
+func hasPatternKind(ents []fullEntity, kind string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Props["pattern_kind"] == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// kratos: middleware + auth (jwt) + request_validation (protoc-gen-validate)
+// ---------------------------------------------------------------------------
+
+func TestKratosMiddlewareChain(t *testing.T) {
+	src := `package server
+import "github.com/go-kratos/kratos/v2/transport/http"
+func New() *http.Server {
+	return http.NewServer(http.Middleware(recovery.Recovery(), jwt.Server(kf)))
+}`
+	ents := extractFull(t, "custom_go_kratos", fi("server.go", "go", src))
+	rec := findPattern(ents, "recovery.Recovery()")
+	if rec == nil || rec.Props["pattern_kind"] != "middleware" {
+		t.Fatalf("expected recovery middleware pattern, got %+v", rec)
+	}
+	if rec.Props["mw_order"] != "0" {
+		t.Errorf("expected recovery at order 0, got %q", rec.Props["mw_order"])
+	}
+	jw := findPattern(ents, "jwt.Server(kf)")
+	if jw == nil || jw.Props["is_auth"] != "true" || jw.Props["auth_kind"] != "jwt" {
+		t.Fatalf("expected jwt auth middleware, got %+v", jw)
+	}
+}
+
+func TestKratosAuthPattern(t *testing.T) {
+	src := `package server
+import "github.com/go-kratos/kratos/v2/transport/http"
+func New() *http.Server {
+	return http.NewServer(http.Middleware(jwt.Server(kf)))
+}`
+	ents := extractFull(t, "custom_go_kratos", fi("server.go", "go", src))
+	au := findPattern(ents, "auth:jwt.Server")
+	if au == nil || au.Props["pattern_kind"] != "auth" || au.Props["auth_kind"] != "jwt" {
+		t.Fatalf("expected dedicated jwt auth pattern, got %+v", au)
+	}
+}
+
+func TestKratosSelectorServerMiddleware(t *testing.T) {
+	src := `package server
+import "github.com/go-kratos/kratos/v2/middleware/selector"
+func wire(srv *http.Server) {
+	srv.Use(selector.Server(jwt.Server(kf)).Match(m).Build())
+}`
+	ents := extractFull(t, "custom_go_kratos", fi("server.go", "go", src))
+	jw := findPattern(ents, "jwt.Server(kf)")
+	if jw == nil || jw.Props["middleware_form"] != "selector_server" {
+		t.Fatalf("expected selector_server middleware, got %+v", jw)
+	}
+}
+
+func TestKratosRequestValidation(t *testing.T) {
+	src := `package server
+import "github.com/go-kratos/kratos/v2/transport/http"
+func (m *CreateUserRequest) Validate() error { return nil }
+func h(in *CreateUserRequest) error {
+	if err := in.Validate(); err != nil { return err }
+	return nil
+}`
+	ents := extractFull(t, "custom_go_kratos", fi("svc.go", "go", src))
+	rule := findPattern(ents, "validation:rule:CreateUserRequest.Validate")
+	if rule == nil || rule.Props["validation_kind"] != "rule" ||
+		rule.Props["validation_subtype"] != "protoc_gen_validate" {
+		t.Fatalf("expected PGV validation rule, got %+v", rule)
+	}
+	if !hasBinding(ents, "validation") {
+		t.Error("expected a validation binding call entity")
+	}
+}
+
+func TestKratosAMVFixture(t *testing.T) {
+	ents := extractFull(t, "custom_go_kratos", fixtureFile(t, "kratos_server.go"))
+	if !hasPatternKind(ents, "middleware") {
+		t.Error("fixture: expected middleware patterns")
+	}
+	if !hasPatternKind(ents, "auth") {
+		t.Error("fixture: expected auth patterns")
+	}
+	if findPattern(ents, "validation:rule:CreateUserRequest.Validate") == nil {
+		t.Error("fixture: expected CreateUserRequest.Validate PGV rule")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// go-zero: middleware + auth (rest.WithJwt) + request_validation (httpx.Parse)
+// ---------------------------------------------------------------------------
+
+func TestGoZeroMiddleware(t *testing.T) {
+	src := `package handler
+import "github.com/zeromicro/go-zero/rest"
+func wire(server *rest.Server, mw rest.Middleware) {
+	server.Use(mw)
+	server.AddRoutes([]rest.Route{{Method: "GET", Path: "/x", Handler: h}}, rest.WithMiddleware(mw))
+}`
+	ents := extractFull(t, "custom_go_go_zero", fi("routes.go", "go", src))
+	if !hasPatternKind(ents, "middleware") {
+		t.Fatal("expected middleware patterns from .Use / rest.WithMiddleware")
+	}
+}
+
+func TestGoZeroJwtAuth(t *testing.T) {
+	src := `package handler
+import "github.com/zeromicro/go-zero/rest"
+func wire(server *rest.Server) {
+	server.AddRoutes([]rest.Route{{Method: "GET", Path: "/x", Handler: h}}, rest.WithJwt("secret"))
+}`
+	ents := extractFull(t, "custom_go_go_zero", fi("routes.go", "go", src))
+	au := findPattern(ents, "auth:rest.WithJwt")
+	if au == nil || au.Props["auth_kind"] != "jwt" || au.Props["auth_form"] != "with_jwt" {
+		t.Fatalf("expected rest.WithJwt auth pattern, got %+v", au)
+	}
+}
+
+func TestGoZeroRequestValidation(t *testing.T) {
+	src := `package logic
+import "github.com/zeromicro/go-zero/rest/httpx"
+type CreateReq struct {
+	Name string ` + "`json:\"name\" validate:\"required,min=2\"`" + `
+}
+func handle(w http.ResponseWriter, r *http.Request) {
+	var req CreateReq
+	if err := httpx.Parse(r, &req); err != nil { return }
+}`
+	ents := extractFull(t, "custom_go_go_zero", fi("logic.go", "go", src))
+	rule := findPattern(ents, "validation:rule:CreateReq.Name")
+	if rule == nil || rule.Props["rules"] != "required,min=2" {
+		t.Fatalf("expected CreateReq.Name validate rule, got %+v", rule)
+	}
+	bind := findPattern(ents, "validation:binding:httpx_parse:req")
+	if bind == nil || bind.Props["validation_subtype"] != "httpx_parse" {
+		t.Fatalf("expected httpx.Parse binding, got %+v", bind)
+	}
+}
+
+func TestGoZeroAMVFixture(t *testing.T) {
+	ents := extractFull(t, "custom_go_go_zero", fixtureFile(t, "go_zero_server.go"))
+	if !hasPatternKind(ents, "middleware") {
+		t.Error("fixture: expected middleware patterns")
+	}
+	if findPattern(ents, "auth:rest.WithJwt") == nil {
+		t.Error("fixture: expected rest.WithJwt auth pattern")
+	}
+	if findPattern(ents, "validation:rule:CreateUserReq.Email") == nil {
+		t.Error("fixture: expected CreateUserReq.Email validate rule")
+	}
+	if findPattern(ents, "validation:binding:httpx_parse:req") == nil {
+		t.Error("fixture: expected httpx.Parse binding")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// huma: middleware + auth (Security/SecuritySchemes) + request_validation
+// ---------------------------------------------------------------------------
+
+func TestHumaUseMiddleware(t *testing.T) {
+	src := `package h
+import "github.com/danielgtaylor/huma/v2"
+func r(api huma.API) { api.UseMiddleware(logMW, authMW) }`
+	ents := extractFull(t, "custom_go_huma", fi("h.go", "go", src))
+	first := findPattern(ents, "logMW")
+	if first == nil || first.Props["mw_order"] != "0" ||
+		first.Props["middleware_form"] != "use_middleware" {
+		t.Fatalf("expected logMW middleware at order 0, got %+v", first)
+	}
+}
+
+func TestHumaOperationSecurity(t *testing.T) {
+	src := `package h
+import "github.com/danielgtaylor/huma/v2"
+func r(api huma.API) {
+	huma.Register(api, huma.Operation{
+		Method: "POST", Path: "/users",
+		Security: []map[string][]string{{"bearer": {"write"}}},
+	}, createUser)
+}`
+	ents := extractFull(t, "custom_go_huma", fi("h.go", "go", src))
+	au := findPattern(ents, "auth:POST /users")
+	if au == nil || au.Props["auth_kind"] != "jwt" || au.Props["security_scheme"] != "bearer" {
+		t.Fatalf("expected per-operation Security auth pattern, got %+v", au)
+	}
+}
+
+func TestHumaSecuritySchemes(t *testing.T) {
+	src := `package h
+import "github.com/danielgtaylor/huma/v2"
+func cfg(config huma.Config) {
+	config.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"bearer": {Type: "http", Scheme: "bearer"},
+		"apiKey": {Type: "apiKey"},
+	}
+}`
+	ents := extractFull(t, "custom_go_huma", fi("h.go", "go", src))
+	if findPattern(ents, "auth:scheme:bearer") == nil {
+		t.Error("expected bearer security scheme auth pattern")
+	}
+	ak := findPattern(ents, "auth:scheme:apiKey")
+	if ak == nil || ak.Props["auth_kind"] != "api_key" {
+		t.Fatalf("expected apiKey scheme with api_key kind, got %+v", ak)
+	}
+}
+
+func TestHumaRequestValidation(t *testing.T) {
+	src := `package h
+import "github.com/danielgtaylor/huma/v2"
+type CreateInput struct {
+	Body struct {
+		Name string ` + "`json:\"name\" minLength:\"2\" maxLength:\"50\"`" + `
+		Age  int    ` + "`json:\"age\" minimum:\"0\"`" + `
+	}
+}
+func r(api huma.API) {}`
+	ents := extractFull(t, "custom_go_huma", fi("h.go", "go", src))
+	rule := findPattern(ents, "validation:rule:CreateInput.Name:minLength")
+	if rule == nil || rule.Props["constraint"] != "minLength" ||
+		rule.Props["constraint_value"] != "2" {
+		t.Fatalf("expected minLength schema-tag rule, got %+v", rule)
+	}
+	if findPattern(ents, "validation:rule:CreateInput.Age:minimum") == nil {
+		t.Error("expected Age minimum schema-tag rule")
+	}
+}
+
+func TestHumaAMVFixture(t *testing.T) {
+	ents := extractFull(t, "custom_go_huma", fixtureFile(t, "huma_secured.go"))
+	if !hasPatternKind(ents, "middleware") {
+		t.Error("fixture: expected middleware patterns")
+	}
+	if findPattern(ents, "auth:scheme:bearer") == nil {
+		t.Error("fixture: expected bearer security scheme")
+	}
+	if findPattern(ents, "auth:POST /users") == nil {
+		t.Error("fixture: expected per-operation Security on POST /users")
+	}
+	if findPattern(ents, "validation:rule:CreateUserInput.Email:format") == nil {
+		t.Error("fixture: expected Email format schema-tag rule")
+	}
+}
+
+// hasBinding reports whether any validation SCOPE.Pattern is a binding kind.
+func hasBinding(ents []fullEntity, _ string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Props["validation_kind"] == "binding" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/custom/golang/testdata/go_zero_server.go
+++ b/internal/custom/golang/testdata/go_zero_server.go
@@ -1,0 +1,37 @@
+// go-zero server-wiring + validation fixture (#3255).
+// Covers middleware (rest.WithMiddleware + server.Use), built-in JWT auth
+// (rest.WithJwt), and request validation via httpx.Parse(...) on a typed
+// request struct carrying go-playground `validate:` tags.
+package handler
+
+import (
+	"net/http"
+
+	"github.com/zeromicro/go-zero/rest"
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+type CreateUserReq struct {
+	Name  string `json:"name" validate:"required,min=2"`
+	Email string `json:"email" validate:"required,email"`
+	Age   int    `json:"age" validate:"gte=0,lte=130"`
+}
+
+func RegisterMiddleware(server *rest.Server, authMW rest.Middleware) {
+	server.Use(authMW)
+	server.AddRoutes(
+		[]rest.Route{
+			{Method: http.MethodPost, Path: "/users", Handler: createUserHandler},
+		},
+		rest.WithMiddleware(authMW),
+		rest.WithJwt("secret-signing-key"),
+	)
+}
+
+func createUserHandler(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserReq
+	if err := httpx.Parse(r, &req); err != nil {
+		httpx.Error(w, err)
+		return
+	}
+}

--- a/internal/custom/golang/testdata/huma_secured.go
+++ b/internal/custom/golang/testdata/huma_secured.go
@@ -1,0 +1,52 @@
+// Huma middleware + auth + validation fixture (#3255).
+// Covers API-level middleware (api.UseMiddleware), OpenAPI SecuritySchemes
+// registration, a per-operation Security requirement, and request validation
+// derived from OpenAPI schema tags on the input struct fields.
+package humafixture
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type CreateUserInput struct {
+	Body struct {
+		Name  string `json:"name" minLength:"2" maxLength:"50" required:"true"`
+		Email string `json:"email" format:"email"`
+		Age   int    `json:"age" minimum:"0" maximum:"130"`
+	}
+}
+
+type CreateUserOutput struct {
+	Body struct {
+		ID string `json:"id"`
+	}
+}
+
+func configure(config huma.Config) huma.Config {
+	config.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"bearer": {Type: "http", Scheme: "bearer", BearerFormat: "JWT"},
+		"apiKey": {Type: "apiKey", In: "header", Name: "X-API-Key"},
+	}
+	return config
+}
+
+func registerSecured(api huma.API) {
+	api.UseMiddleware(loggingMiddleware, authMiddleware)
+
+	huma.Register(api, huma.Operation{
+		Method:   http.MethodPost,
+		Path:     "/users",
+		Summary:  "Create user",
+		Security: []map[string][]string{{"bearer": {"write"}}},
+	}, createUser)
+}
+
+func createUser(ctx context.Context, in *CreateUserInput) (*CreateUserOutput, error) {
+	return &CreateUserOutput{}, nil
+}
+
+func loggingMiddleware(ctx huma.Context, next func(huma.Context)) { next(ctx) }
+func authMiddleware(ctx huma.Context, next func(huma.Context))    { next(ctx) }

--- a/internal/custom/golang/testdata/kratos_server.go
+++ b/internal/custom/golang/testdata/kratos_server.go
@@ -1,0 +1,42 @@
+// Kratos server-wiring + PGV validation fixture (#3255).
+// Hand-written kratos server file: wires the global middleware chain via
+// http.Middleware(...) (recovery + jwt auth), a per-route selector via
+// selector.Server(...), and enforces protoc-gen-validate Validate() on the
+// decoded request. The generated *.pb.validate.go Validate() method def is
+// also present so the request_validation rule surface resolves.
+package server
+
+import (
+	"github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	"github.com/go-kratos/kratos/v2/middleware/recovery"
+	"github.com/go-kratos/kratos/v2/middleware/selector"
+	"github.com/go-kratos/kratos/v2/transport/http"
+)
+
+func NewHTTPServer() *http.Server {
+	srv := http.NewServer(
+		http.Middleware(
+			recovery.Recovery(),
+			jwt.Server(keyFunc),
+		),
+	)
+	srv.Use(selector.Server(jwt.Server(keyFunc)).Match(authMatcher).Build())
+	return srv
+}
+
+// CreateUserRequest is a protoc-gen-validate message; the generated Validate()
+// method enforces the field rules.
+func (m *CreateUserRequest) Validate() error {
+	return m.validate(false)
+}
+
+func (m *CreateUserRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func handleCreate(in *CreateUserRequest) error {
+	if err := in.Validate(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -5829,6 +5829,39 @@ records:
             - file: internal/custom/golang/hertz_huma_test.go
           issues_implemented: ["2686", "3212"]
           verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # huma is OpenAPI-first: auth is declared via an Operation's Security
+          # field (per-operation requirement) and the OpenAPI SecuritySchemes
+          # registration (available schemes). huma.go emits an auth SCOPE.Pattern
+          # bound to the endpoint for each Security-protected Operation, and one
+          # per declared SecurityScheme, kinded via humaAuthKind (jwt/oauth/
+          # api_key/basic). Auth-classified UseMiddleware entries also yield auth
+          # patterns. Heuristic source match, no enforcement proof -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/huma.go
+              functions: [Extract, emitHumaSecuritySchemes, humaAuthKind]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # huma middleware registration: api.UseMiddleware(mw…) (API-level
+          # chain) and the huma.Middlewares{…} per-operation slice literal.
+          # emitHumaMiddleware parses each into an ordered SCOPE.Pattern
+          # (pattern_kind=middleware) via the shared parseMiddlewareChain, with
+          # auth classification. Heuristic source match, no enforcement proof or
+          # route-binding -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/huma.go
+              functions: [Extract, emitHumaMiddleware]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
       Validation:
         dto_extraction:
           # dto.go (custom_go_dto) resolves request-bind / response-
@@ -5842,6 +5875,21 @@ records:
               functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
           tests:
             - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+        request_validation:
+          # huma derives request validation from OpenAPI schema tags on the
+          # input-struct fields (minimum/maximum/minLength/maxLength/pattern/
+          # enum/format/required/…). emitHumaValidation indexes struct heads by
+          # offset and emits one validation rule SCOPE.Pattern per constrained
+          # field, attributed to its enclosing struct. Heuristic source match; no
+          # proof the struct is bound as a real handler input -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/huma.go
+              functions: [Extract, emitHumaValidation]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
           issues_implemented: ["3255"]
           verified_at: "2026-05-30"
 
@@ -5929,6 +5977,39 @@ records:
             - file: internal/custom/golang/kratos_gozero_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # kratos auth is the JWT middleware
+          # (kratos/v2/middleware/auth/jwt), registered in the global
+          # http.Middleware(...) chain or a selector.Server(...) per-route
+          # selector. emitKratosMiddlewareAndAuth parses both surfaces and emits
+          # a dedicated auth SCOPE.Pattern for any expression the shared
+          # classifier recognises as auth (jwt.Server -> auth_kind=jwt).
+          # Heuristic substring match, no enforcement proof -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/kratos.go
+              functions: [Extract, emitKratosMiddlewareAndAuth, isKratosFile]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # kratos middleware registration: the http.Middleware(mw…) transport
+          # server option (global chain) and selector.Server(mw…).Match(…).Build()
+          # (per-route selector). emitKratosMiddlewareAndAuth scans both balanced
+          # argument spans into ordered SCOPE.Pattern (pattern_kind=middleware)
+          # entities via the shared parseMiddlewareChain. Heuristic source match,
+          # no enforcement proof or route-binding -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/kratos.go
+              functions: [Extract, emitKratosMiddlewareAndAuth]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
       Validation:
         dto_extraction:
           # dto.go (custom_go_dto) resolves request-bind / response-
@@ -5942,6 +6023,21 @@ records:
               functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
           tests:
             - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+        request_validation:
+          # kratos request validation is protoc-gen-validate (PGV): a generated
+          # Validate()/ValidateAll() method per request message, enforced by the
+          # validate middleware / handler. emitKratosValidation emits a rule
+          # SCOPE.Pattern per generated method definition and a binding pattern
+          # per enforcing in.Validate() call site. Heuristic source match; no
+          # proof the method is wired into a request path -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/kratos.go
+              functions: [Extract, emitKratosValidation]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
           issues_implemented: ["3255"]
           verified_at: "2026-05-30"
 
@@ -6029,6 +6125,38 @@ records:
             - file: internal/custom/golang/kratos_gozero_test.go
           issues_implemented: ["3212"]
           verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          # go-zero ships a built-in JWT auth option, rest.WithJwt(secret) /
+          # rest.WithJwtTransition(...), attached to a route group in the
+          # generated routes.go. emitGoZeroMiddlewareAndAuth emits a dedicated
+          # auth SCOPE.Pattern (auth_kind=jwt) per occurrence (the option itself
+          # is the enforcement point), plus auth classification of middleware
+          # expressions. Heuristic source match, no enforcement proof -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/go_zero.go
+              functions: [Extract, emitGoZeroMiddlewareAndAuth, isGoZeroFile]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+      Middleware:
+        middleware_coverage:
+          # go-zero middleware registration: rest.WithMiddleware(mw, …) /
+          # rest.WithMiddlewares([]rest.Middleware{…}) route-group options and the
+          # server.Use(mw) global form. emitGoZeroMiddlewareAndAuth parses each
+          # balanced argument span into ordered SCOPE.Pattern
+          # (pattern_kind=middleware) entities via the shared parseMiddlewareChain.
+          # Heuristic source match, no enforcement proof -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/go_zero.go
+              functions: [Extract, emitGoZeroMiddlewareAndAuth]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
       Validation:
         dto_extraction:
           # dto.go (custom_go_dto) resolves request-bind / response-
@@ -6042,6 +6170,22 @@ records:
               functions: [Extract, catalogStructs, resolveVarType, detectDtoFramework]
           tests:
             - file: internal/custom/golang/dto_test.go
+          issues_implemented: ["3255"]
+          verified_at: "2026-05-30"
+        request_validation:
+          # go-zero request validation: typed request structs carry go-playground
+          # `validate:` tags, decoded-and-validated by httpx.Parse(r, &req) /
+          # httpx.ParseJsonBody(...). emitGoZeroValidation emits a rule
+          # SCOPE.Pattern per validated struct field (via the shared
+          # findValidationRules scanner) and a binding pattern per httpx.Parse
+          # call site. Heuristic source match; no proof every rule fires on a real
+          # request path -> partial.
+          status: partial
+          symbols:
+            - file: internal/custom/golang/go_zero.go
+              functions: [Extract, emitGoZeroValidation]
+          tests:
+            - file: internal/custom/golang/kratos_gozero_huma_amv2_test.go
           issues_implemented: ["3255"]
           verified_at: "2026-05-30"
 


### PR DESCRIPTION
Part of #3255 — builds the **auth_coverage + middleware_coverage + request_validation** cells (9 total) for the three codegen/OpenAPI-driven Go frameworks (**kratos, go-zero, huma**) whose custom extractors were routing-only. All honest `partial` (heuristic source match, no enforcement/data-flow proof), fixture-proven.

## 9-cell flip (all missing → partial)

| framework | auth_coverage | middleware_coverage | request_validation |
|---|---|---|---|
| **kratos** | partial — jwt.Server in http.Middleware/selector.Server | partial — http.Middleware(...) / selector.Server(...).Match().Build() | partial — protoc-gen-validate Validate()/ValidateAll() defs + call sites |
| **go-zero** | partial — rest.WithJwt / WithJwtTransition | partial — rest.WithMiddleware(s) / server.Use | partial — `validate:` struct tags + httpx.Parse(...) |
| **huma** | partial — per-op Security + OpenAPI SecuritySchemes | partial — api.UseMiddleware / huma.Middlewares{} | partial — input-struct OpenAPI schema tags (minLength/pattern/format/…) |

## Design
- Each extractor's gate is broadened from its routing signature to a framework import/marker (`isKratosFile`/`isGoZeroFile`/huma import), so the mw/auth/validation passes also cover server-wiring, handler/logic and generated-validator files — not just the generated routes file.
- New entities funnel through the shared helpers (`parseMiddlewareChain`/`classifyAuthMiddleware`/`findValidationRules`/`balancedArgs`/`matchBrace`) for an identical property shape across frameworks. No shared helper files were edited (contention rule).
- kratos/go-zero/huma are absent from the agnostic `middleware_auth_extend` / `validation` passes, so **no double-emit**.
- `request_validation` added as a **new cell inside the EXISTING `Validation:` group** (alongside `dto_extraction`) — exactly one `Validation` group per record, in both registry.json and capability-map.yaml.

## Tests / fixtures
- `kratos_gozero_huma_amv2_test.go` — inline + fixture tests for all 9 cells.
- Fixtures: `testdata/kratos_server.go`, `testdata/go_zero_server.go`, `testdata/huma_secured.go`.

## Validation (scoped)
- `go build ./internal/... ./tools/coverage/...` ✅
- `go test ./internal/custom/golang/... ./internal/types/ ./tools/coverage/...` ✅
- `go run ./tools/coverage validate` → **exit 0**, 0 errors, no "already defined"
- `fmt --check` canonical ✅ · `gen` byte-stable ✅ · `gofmt -l` clean on all touched files ✅
- Anti-duplicate guard: exactly **one `Validation` group per record** (kratos/go-zero/huma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)