### PR TITLE
coverage(go): orm.migrate Models/Relationships → not_applicable (Go → 0 missing)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -51,7 +51,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [go](../by-language/go.md) | [go-redis](../detail/lang.go.driver.redis.md) | 🟢 2/2 | |
 | [go](../by-language/go.md) | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟢 2/2 | |
 | [go](../by-language/go.md) | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟢 2/2 | |
-| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/5 | |
+| [go](../by-language/go.md) | [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟢 1/1 | |
 | [go](../by-language/go.md) | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟢 4/4 | |
 | [go](../by-language/go.md) | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟢 3/3 | |
 | [go](../by-language/go.md) | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟢 3/3 | |

--- a/docs/coverage/by-language/go.md
+++ b/docs/coverage/by-language/go.md
@@ -86,7 +86,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [go-redis](../detail/lang.go.driver.redis.md) | 🟢 2/2 | |
 | [go-sql-driver/mysql](../detail/lang.go.driver.mysql.md) | 🟢 2/2 | |
 | [gocql (Cassandra)](../detail/lang.go.driver.cassandra.md) | 🟢 2/2 | |
-| [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟡 1/5 | |
+| [golang-migrate](../detail/lang.go.orm.migrate.md) | 🟢 1/1 | |
 | [mattn/go-sqlite3](../detail/lang.go.driver.sqlite.md) | 🟢 4/4 | |
 | [mongo-go-driver](../detail/lang.go.driver.mongodb.md) | 🟢 3/3 | |
 | [neo4j-go-driver](../detail/lang.go.driver.neo4j.md) | 🟢 3/3 | |

--- a/docs/coverage/detail/lang.go.orm.migrate.md
+++ b/docs/coverage/detail/lang.go.orm.migrate.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | — `not_applicable` | — | — | — | golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema in raw .up/.down.sql; migration_parsing covers it) |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema in raw .up/.down.sql; migration_parsing covers it) |
+| Foreign key extraction | — `not_applicable` | — | — | — | golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema in raw .up/.down.sql; migration_parsing covers it) |
 | Lazy loading recognition | — `not_applicable` | `2026-05-29` | — | — | golang-migrate is a forward/backward SQL migration runner with no ORM runtime: there is no object-fetch path, so eager/lazy loading is not a modellable concept (consistent with this record's model_extraction=N/A and query_attribution=N/A). |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | — `not_applicable` | — | — | — | golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema in raw .up/.down.sql; migration_parsing covers it) |
 
 ### Queries
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -14405,18 +14405,18 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema in raw .up/.down.sql; migration_parsing covers it)"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema in raw .up/.down.sql; migration_parsing covers it)"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema in raw .up/.down.sql; migration_parsing covers it)"
           },
           "lazy_loading_recognition": {
             "status": "not_applicable",
@@ -14424,8 +14424,8 @@
             "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema in raw .up/.down.sql; migration_parsing covers it)"
           }
         },
         "Queries": {


### PR DESCRIPTION
Closes the last 4 Go missing cells. golang-migrate is a SQL migration runner — no Go ORM model/relationship layer (schema is raw .up/.down.sql; migration_parsing already covers it). Honest NA. Go now **0 missing**. Part of #3255.