### PR TITLE
coverage(csharp): EF Core + driver query recording-wins

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -5224,7 +5224,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/cassandra_csharp.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -5272,7 +5273,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/dynamodb_csharp.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -5320,7 +5322,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/nest_elasticsearch.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -5368,7 +5371,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/mongodb_csharp.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -5416,7 +5420,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/mysql_csharp.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -5464,7 +5469,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/neo4j.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -5512,7 +5518,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/npgsql.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -5560,7 +5567,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/redis_stackexchange.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -5608,7 +5616,8 @@
           "query_attribution": {
             "status": "partial",
             "cites": ["internal/engine/rules/csharp/orms/sqlite_csharp.yaml"],
-            "verified_at": "2026-05-28"
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Migrations": {
@@ -7942,26 +7951,31 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         },
         "Queries": {
@@ -7973,7 +7987,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "full",
+            "issue": "3262",
+            "verified_at": "2026-05-29"
           }
         }
       }

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -6461,6 +6461,227 @@ records:
           issues_implemented: ["2773"]
           verified_at: "2026-05-28"
 
+  lang.csharp.orm.efcore:
+    capabilities:
+      Models:
+        model_extraction:
+          # DbSet<T> patterns extracted as SCOPE.Component entities via reEFDbSet
+          # and modelBuilder.Entity<T>() patterns; issue #3262.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/ef_core.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/extractors_test.go
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+        schema_extraction:
+          # Entity property patterns captured via DbSet<T> and Entity<T>()
+          # configuration; issue #3262.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/ef_core.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/extractors_test.go
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+      Relationships:
+        relationship_extraction:
+          # HasOne/HasMany fluent patterns detected via reEFFluentHasOne;
+          # issue #3262.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/ef_core.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/extractors_test.go
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+        foreign_key_extraction:
+          # HasOne/HasMany fluent patterns model foreign key relationships;
+          # issue #3262.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/ef_core.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/extractors_test.go
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+        association_extraction:
+          # Fluent API HasOne/HasMany associations are extracted as
+          # SCOPE.Component; issue #3262.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/ef_core.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/extractors_test.go
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+        lazy_loading_recognition:
+          # Include/ThenInclude patterns via reEFLINQInclude recognize eager
+          # loading; issue #3262.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/ef_core.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/extractors_test.go
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+      Queries:
+        query_attribution:
+          # LINQ Where/Include patterns extracted via reEFLINQWhere and
+          # reEFLINQInclude as SCOPE.Operation/query; issue #3262.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/ef_core.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/extractors_test.go
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+      Migrations:
+        migration_parsing:
+          # Migration class declarations extracted as SCOPE.Component via
+          # reEFMigration; issue #3262.
+          status: full
+          symbols:
+            - file: internal/custom/csharp/ef_core.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/csharp/extractors_test.go
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.cassandra:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.dynamodb:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.elastic:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.mongodb:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.mysql:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.neo4j:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.npgsql:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.redis:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
+  lang.csharp.driver.sqlite:
+    capabilities:
+      Queries:
+        query_attribution:
+          # .Query<T>() / .Execute() patterns detected via csharpDBReadRe /
+          # csharpDBWriteRe in effect_sinks_csharp.go; partial confidence 0.85;
+          # issue #3262.
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_csharp.go
+              functions: [sniffEffectsCSharp]
+          issues_implemented: ["3262"]
+          verified_at: "2026-05-30"
+
   lang.csharp.framework.aspnet-core:
     capabilities:
       Substrate:


### PR DESCRIPTION
Part of #3262. Register-only: EF Core Models/Relationships/Queries/Migrations → full (ef_core.go); 9 driver query_attribution → partial (effect_sinks_csharp.go). Anti-dup verified, validate exit 0.