### PR TITLE
coverage(kotlin): register substrate recording-wins + tests_linkage for spring-boot

### DIFF
--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -7067,6 +7067,49 @@ records:
               functions: [runTaintFlowPass, computeFindings]
           issues_implemented: ["2773"]
           verified_at: "2026-05-28"
+        pure_function_tagging:
+          status: partial
+          symbols:
+            - file: internal/links/pure_function_pass.go
+              functions: [runPureFunctionPass]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        module_cycle_detection:
+          status: partial
+          symbols:
+            - file: internal/links/module_cycle_pass.go
+              functions: [runModuleCyclePass, strongConnect]
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        def_use_chain_extraction:
+          status: partial
+          symbols:
+            - file: internal/links/def_use_pass.go
+              functions: [runDefUsePass, formatDefUseSummary]
+            - file: internal/substrate/def_use.go
+            - file: internal/substrate/def_use_kotlin.go
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+        template_pattern_catalog:
+          status: partial
+          symbols:
+            - file: internal/links/template_pattern_pass.go
+              functions: [runTemplatePatternPass]
+            - file: internal/substrate/template_pattern.go
+            - file: internal/substrate/template_pattern_kotlin.go
+          issues_implemented: ["2774"]
+          verified_at: "2026-05-28"
+      Testing:
+        tests_linkage:
+          status: partial
+          symbols:
+            - file: internal/substrate/entry_points_kotlin.go
+              functions: [sniffKotlinEntryPoints]
+            - file: internal/engine/rules/kotlin/test_patterns.yaml
+          issues_implemented: ["2767"]
+          verified_at: "2026-05-28"
 
   lang.elixir.framework.phoenix:
     capabilities:


### PR DESCRIPTION
## Summary

Stamp substrate recording-wins onto lang.kotlin.framework.spring-boot.

## Changes

Mirror 5 shared-code substrate cells from Kotlin extractors onto spring-boot:
- `def_use_chain_extraction` (def_use_kotlin.go) — partial
- `template_pattern_catalog` (template_pattern_kotlin.go) — partial
- `pure_function_tagging` (pure_function_pass.go) — partial
- `module_cycle_detection` (module_cycle_pass.go) — partial
- `tests_linkage` (entry_points_kotlin.go + test_patterns.yaml) — partial under Testing

No extractor code changed; registration-only PR per #3273.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>