### PR TITLE
coverage(kotlin): port 8 Java extractors to accept language=kotlin (#3274)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -136,11 +136,11 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🟡 9/15 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🟡 9/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🟡 12/15 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -21,7 +21,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 1/6 | |
 | [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 1/6 | |
 | [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 2/8 | |
-| [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | 🟡 2/8 | |
+| [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ✅ 8/8 | |
 | [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | 🟡 2/8 | |
 | [C#](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | 🔴 0/8 | |
 | [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | 🟡 1/6 | |
@@ -92,12 +92,12 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | ✅ 1/1 | |
 | [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟡 2/8 | |
-| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 5/8 | |
 | [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟡 2/8 | |
 | [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | 🟡 2/7 | |
 | [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 2/8 | |
 | [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 2/8 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 5/8 | |
 | [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/6 | |
 | [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🔴 0/8 | |
 | [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 2/8 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -89,7 +89,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 1/6 | |
 | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 1/6 | |
 | [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 2/8 | |
-| [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | 🟡 2/8 | |
+| [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | ✅ 8/8 | |
 | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | 🟡 2/8 | |
 | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | 🔴 0/8 | |
 | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | 🟡 1/6 | |

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -27,11 +27,11 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
 | [Ktor](../detail/lang.kotlin.framework.ktor.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🟡 9/15 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🟡 9/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🟡 12/15 | |
 | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
 | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
 
@@ -60,9 +60,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟡 2/8 | |
-| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 2/8 | |
+| [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 5/8 | |
 | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟡 2/8 | |
 | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | 🟡 2/7 | |
 | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 2/8 | |
 | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 2/8 | |
-| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 2/8 | |
+| [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 5/8 | |

--- a/docs/coverage/detail/lang.csharp.driver.cassandra.md
+++ b/docs/coverage/detail/lang.csharp.driver.cassandra.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/cassandra_csharp.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/cassandra_csharp.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.dynamodb.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/dynamodb_csharp.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/dynamodb_csharp.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.driver.elastic.md
+++ b/docs/coverage/detail/lang.csharp.driver.elastic.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/nest_elasticsearch.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/nest_elasticsearch.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.driver.mongodb.md
+++ b/docs/coverage/detail/lang.csharp.driver.mongodb.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/mongodb_csharp.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/mongodb_csharp.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.driver.mysql.md
+++ b/docs/coverage/detail/lang.csharp.driver.mysql.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/mysql_csharp.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/mysql_csharp.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.driver.neo4j.md
+++ b/docs/coverage/detail/lang.csharp.driver.neo4j.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/neo4j.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/neo4j.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.driver.npgsql.md
+++ b/docs/coverage/detail/lang.csharp.driver.npgsql.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/npgsql.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/npgsql.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.driver.redis.md
+++ b/docs/coverage/detail/lang.csharp.driver.redis.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/redis_stackexchange.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/redis_stackexchange.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.driver.sqlite.md
+++ b/docs/coverage/detail/lang.csharp.driver.sqlite.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/csharp/orms/sqlite_csharp.yaml` | — |
+| Query attribution | 🟢 `partial` | `2026-05-29` | 3262 | `internal/engine/rules/csharp/orms/sqlite_csharp.yaml` | — |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.csharp.orm.efcore.md
+++ b/docs/coverage/detail/lang.csharp.orm.efcore.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/csharp/frameworks/entity_framework_core.yaml`<br>`internal/engine/rules/csharp/orms/entity_framework_core.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | ✅ `full` | `2026-05-29` | 3262 | — | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | ✅ `full` | `2026-05-29` | 3262 | — | — |
+| Foreign key extraction | ✅ `full` | `2026-05-29` | 3262 | — | — |
+| Lazy loading recognition | ✅ `full` | `2026-05-29` | 3262 | — | — |
+| Relationship extraction | ✅ `full` | `2026-05-29` | 3262 | — | — |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | ✅ `full` | `2026-05-29` | 3262 | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -15,9 +15,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🔴 `missing` | — | — | — | — |
-| Handler attribution | 🔴 `missing` | — | — | — | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -65,25 +65,25 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Transaction propagation | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Transaction rollback rules | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Aspect extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Pointcut resolution | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -65,25 +65,25 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Transaction propagation | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Transaction rollback rules | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Aspect extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Pointcut resolution | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| DI injection point | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| DI scope resolution | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Transaction propagation | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Transaction rollback rules | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Aspect extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Pointcut resolution | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.orm.hibernate.md
+++ b/docs/coverage/detail/lang.kotlin.orm.hibernate.md
@@ -23,9 +23,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.kotlin.orm.spring-data.md
+++ b/docs/coverage/detail/lang.kotlin.orm.spring-data.md
@@ -23,9 +23,9 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | 3274 | — | — |
 
 ### Queries
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -29326,14 +29326,19 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -30022,44 +30027,53 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -30253,44 +30267,53 @@
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -30472,58 +30495,70 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -30708,16 +30743,19 @@
             "issue": "backfill:dictionary-completeness"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Queries": {
@@ -30908,16 +30946,19 @@
             "issue": "backfill:dictionary-completeness"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "issue": "3274",
+            "verified_at": "2026-05-30"
           }
         },
         "Queries": {

--- a/internal/custom/java/cdi_interceptors.go
+++ b/internal/custom/java/cdi_interceptors.go
@@ -31,7 +31,7 @@ var cdiFrameworks = map[string]bool{
 	"jakarta_ee": true, "jakarta-ee": true, "jakartaee": true,
 	"java_ee": true, "javaee": true,
 	"jaxrs": true, "jax-rs": true, "jax_rs": true,
-	"quarkus": true,
+	"quarkus":      true,
 	"microprofile": true, "micro_profile": true, "micro-profile": true,
 }
 
@@ -112,10 +112,13 @@ type cdiInterceptorInfo struct {
 }
 
 // ExtractCDIInterceptors runs the CDI interceptor / AOP extractor for
-// jakarta-ee, jaxrs, and quarkus frameworks.
+// jakarta-ee, jaxrs, and quarkus frameworks. Accepts both Java and Kotlin
+// source: Kotlin Quarkus uses the same @Interceptor/@AroundInvoke/
+// @InterceptorBinding annotations before class/fun declarations (regex
+// patterns match identically in both languages).
 func ExtractCDIInterceptors(ctx PatternContext) PatternResult {
 	var result PatternResult
-	if ctx.Language != "java" || !cdiFrameworks[ctx.Framework] {
+	if (ctx.Language != "java" && ctx.Language != "kotlin") || !cdiFrameworks[ctx.Framework] {
 		return result
 	}
 

--- a/internal/custom/java/hibernate.go
+++ b/internal/custom/java/hibernate.go
@@ -10,15 +10,30 @@ var hibernateFrameworks = map[string]bool{
 	"spring-data-jpa": true, "springdatajpa": true,
 }
 
+// kotlinHibernateFrameworks mirrors hibernateFrameworks for Kotlin ORM records
+// (lang.kotlin.orm.hibernate, lang.kotlin.orm.spring-data). Kotlin uses the
+// same JPA/Hibernate annotations (@Entity, @OneToMany, @JoinColumn, etc.)
+// before data class / class declarations, so the extractor applies unchanged.
+var kotlinHibernateFrameworks = map[string]bool{
+	"hibernate": true, "jpa": true, "spring_data_jpa": true,
+	"spring-data-jpa": true, "springdatajpa": true,
+}
+
 var (
 	hibEntityClassRE = regexp.MustCompile(
 		`(?s)@Entity\b(?:[^{]|\{[^}]*\})*?class\s+(\w+)`)
 	hibTableNameRE = regexp.MustCompile(
 		`(?s)@Table\s*\([^)]*name\s*=\s*\"([^\"]+)\"`)
+	// hibAssociationRE matches @OneToMany/@ManyToOne/@OneToOne/@ManyToMany
+	// association annotations. Accepts both:
+	//   Java:   private List<Employee> employees;
+	//   Kotlin: var employees: List<Employee>? = null  (no trailing semicolon)
+	// Group 1 = annotation name, group 2 = generic target type, group 3 = raw
+	// target type (non-generic), group 4 = field/property name.
 	hibAssociationRE = regexp.MustCompile(
 		`(?s)@(OneToMany|ManyToOne|OneToOne|ManyToMany)\b(?:\s*\([^)]*\))?` +
-			`\s*(?:@\w+(?:\s*\([^)]*\))?\s*)*(?:private|protected|public|)\s+` +
-			`(?:(?:final|transient)\s+)*(?:\w+<(\w+)>|(\w+))\s+(\w+)\s*;`)
+			`\s*(?:@\w+(?:\s*\([^)]*\))?\s*)*(?:private|protected|public|var|val|)\s+` +
+			`(?:(?:final|transient)\s+)*(?:\w+<(\w+)>|(\w+))\s+(\w+)(?:\s*[:?=;])`)
 	hibNamedQueryRE = regexp.MustCompile(
 		`(?s)@NamedQuery\s*\(\s*` +
 			`(?:name\s*=\s*\"(?P<name>[^\"]*)\"\s*,\s*query\s*=\s*\"(?P<query>[^\"]*)\"` +
@@ -38,9 +53,12 @@ var (
 )
 
 // ExtractHibernate runs the Hibernate/JPA extractor.
+// Accepts both Java and Kotlin source: Kotlin JPA entities use the same
+// @Entity, @Table, @OneToMany, @ManyToOne, @JoinColumn annotations before
+// class / data class declarations (regex patterns match identically).
 func ExtractHibernate(ctx PatternContext) PatternResult {
 	var result PatternResult
-	if ctx.Language != "java" || !hibernateFrameworks[ctx.Framework] {
+	if (ctx.Language != "java" && ctx.Language != "kotlin") || !hibernateFrameworks[ctx.Framework] {
 		return result
 	}
 

--- a/internal/custom/java/javalin_routes.go
+++ b/internal/custom/java/javalin_routes.go
@@ -26,7 +26,12 @@ import (
 //                   transaction_rollback_rules                                   → not_applicable
 
 // javalinFrameworks is the set of framework identifiers that activate the
-// Javalin extractor.
+// Javalin extractor. Kotlin Javalin uses the same DSL:
+//
+//	app.get("/path") { ctx -> ... }
+//
+// The route regex (verb + path in quoted string) matches both Java lambda style
+// and Kotlin trailing-lambda style identically.
 var javalinFrameworks = map[string]bool{
 	"javalin": true,
 }
@@ -95,9 +100,12 @@ var (
 
 // ExtractJavalin runs the Javalin extractor for route, middleware, DTO, auth,
 // and test-linkage patterns.
+// Accepts both Java and Kotlin source: Kotlin Javalin uses the same
+// app.get("/path") { ctx -> ... } routing DSL — the path-extraction regex
+// matches identically for both languages.
 func ExtractJavalin(ctx PatternContext) PatternResult {
 	var result PatternResult
-	if ctx.Language != "java" || !javalinFrameworks[ctx.Framework] {
+	if (ctx.Language != "java" && ctx.Language != "kotlin") || !javalinFrameworks[ctx.Framework] {
 		return result
 	}
 
@@ -293,8 +301,8 @@ func ExtractJavalin(ctx PatternContext) PatternResult {
 			Provenance: "INFERRED_FROM_JAVALIN_VALIDATION",
 			Ref:        ref,
 			Properties: map[string]any{
-				"framework":        "javalin",
-				"dto_source":       "ctx.bodyValidator",
+				"framework":         "javalin",
+				"dto_source":        "ctx.bodyValidator",
 				"request_validated": true,
 			},
 		}

--- a/internal/custom/java/kotlin_port_test.go
+++ b/internal/custom/java/kotlin_port_test.go
@@ -1,0 +1,735 @@
+package java
+
+// kotlin_port_test.go — proves that the 7 ported Java extractors fire on
+// Kotlin source (language="kotlin") in addition to Java.
+//
+// Each test passes language="kotlin" to the same extractor functions,
+// verifying that the language-gate relaxation from ctx.Language != "java"
+// to (ctx.Language != "java" && ctx.Language != "kotlin") is effective.
+// Java behaviour is unchanged (existing tests still run).
+//
+// Part of #3274 / #3272 — Kotlin Java-extractor language-gate port.
+
+import (
+	"strings"
+	"testing"
+)
+
+// ============================================================================
+// 1. Spring Boot DI (spring_boot.go) — Kotlin
+// ============================================================================
+
+// TestKotlinSpringBoot_Component_Issue3274 verifies that @Component/@Service/
+// @Repository annotations on Kotlin classes produce DI entities.
+// Registry target: lang.kotlin.framework.spring-boot DI/* → partial.
+func TestKotlinSpringBoot_Component_Issue3274(t *testing.T) {
+	source := `
+import org.springframework.stereotype.Service
+import org.springframework.stereotype.Repository
+import org.springframework.stereotype.Component
+
+@Service
+class UserService {
+    fun findAll(): List<User> = emptyList()
+}
+
+@Repository
+class UserRepository {
+    fun findById(id: Long): User? = null
+}
+
+@Component
+class AuditLogger {
+    fun log(msg: String) {}
+}
+`
+	r := ExtractSpringBoot(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "spring_boot",
+		FilePath:  "UserService.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin spring_boot] expected DI entities, got 0")
+	}
+	byStereotype := make(map[string]bool)
+	for _, e := range r.Entities {
+		if s, ok := e.Properties["stereotype"]; ok {
+			byStereotype[s.(string)] = true
+		}
+	}
+	for _, want := range []string{"service", "repository", "component"} {
+		if !byStereotype[want] {
+			t.Errorf("[#3274 kotlin spring_boot] missing stereotype=%q, got %v", want, byStereotype)
+		}
+	}
+}
+
+// TestKotlinSpringBoot_Autowired_Issue3274 verifies @Autowired constructor
+// injection on Kotlin classes emits DEPENDS_ON relationships.
+func TestKotlinSpringBoot_Autowired_Issue3274(t *testing.T) {
+	source := `
+import org.springframework.stereotype.Service
+import org.springframework.beans.factory.annotation.Autowired
+
+@Service
+class OrderService @Autowired constructor(
+    private val userRepository: UserRepository
+) {
+    fun placeOrder() {}
+}
+`
+	r := ExtractSpringBoot(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "spring_boot",
+		FilePath:  "OrderService.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin spring_boot autowired] expected entities, got 0")
+	}
+}
+
+// TestKotlinSpringBoot_Scope_Issue3274 verifies @Scope/@RequestScope on Kotlin
+// classes emits scope entities.
+func TestKotlinSpringBoot_Scope_Issue3274(t *testing.T) {
+	source := `
+import org.springframework.stereotype.Component
+import org.springframework.context.annotation.Scope
+import org.springframework.web.context.annotation.RequestScope
+
+@RequestScope
+@Component
+class RequestContext {
+    var userId: String = ""
+}
+
+@SessionScope
+@Component
+class SessionData {
+    var token: String = ""
+}
+`
+	r := ExtractSpringBoot(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "spring_boot",
+		FilePath:  "Scoped.kt",
+	})
+	// @RequestScope or @SessionScope should emit a scoped-bean entity
+	found := false
+	for _, e := range r.Entities {
+		if strings.Contains(e.Provenance, "SCOPE") {
+			found = true
+		}
+		if e.Ref != "" && strings.Contains(e.Ref, "scoped_bean") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("[#3274 kotlin spring_boot scope] expected a scoped-bean entity, got entities: %v", r.Entities)
+	}
+}
+
+// TestKotlinSpringBoot_WrongLanguage_Issue3274 verifies language gate still
+// rejects languages other than java/kotlin.
+func TestKotlinSpringBoot_WrongLanguage_Issue3274(t *testing.T) {
+	source := `@Service class Foo {}`
+	r := ExtractSpringBoot(PatternContext{
+		Source:    source,
+		Language:  "python",
+		Framework: "spring_boot",
+		FilePath:  "Foo.kt",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3274 kotlin spring_boot gate] expected 0 entities for python, got %d", len(r.Entities))
+	}
+}
+
+// ============================================================================
+// 2. Transactional (transactional.go) — Kotlin
+// ============================================================================
+
+// TestKotlinTransactional_Method_Issue3274 verifies @Transactional before a
+// Kotlin `fun` declaration is detected as a transaction boundary.
+// Registry target: lang.kotlin.framework.spring-boot Transaction/* → partial.
+func TestKotlinTransactional_Method_Issue3274(t *testing.T) {
+	source := `
+import org.springframework.transaction.annotation.Transactional
+
+class OrderService {
+
+    @Transactional
+    fun placeOrder(order: Order) {
+        // ...
+    }
+
+    @Transactional(readOnly = true)
+    fun getOrders(): List<Order> = emptyList()
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = [Exception::class])
+    fun processPayment(payment: Payment) {
+        // ...
+    }
+}
+`
+	r := ExtractTransactional(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "spring_boot",
+		FilePath:  "OrderService.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin @Transactional] expected transaction entities, got 0")
+	}
+	foundBoundary := false
+	foundPropagation := false
+	for _, e := range r.Entities {
+		if e.Subtype == "transaction_boundary" {
+			foundBoundary = true
+		}
+		if p, ok := e.Properties["propagation"]; ok && p != nil {
+			foundPropagation = true
+		}
+	}
+	if !foundBoundary {
+		t.Error("[#3274 kotlin @Transactional] no transaction_boundary entity found")
+	}
+	if !foundPropagation {
+		t.Error("[#3274 kotlin @Transactional] no propagation attribute captured")
+	}
+}
+
+// TestKotlinTransactional_Quarkus_Issue3274 verifies Kotlin Quarkus uses JTA @Transactional.
+func TestKotlinTransactional_Quarkus_Issue3274(t *testing.T) {
+	source := `
+import jakarta.transaction.Transactional
+
+@Transactional
+class ProductService {
+    fun save(product: Product) {}
+}
+`
+	r := ExtractTransactional(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "quarkus",
+		FilePath:  "ProductService.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin quarkus @Transactional] expected entities, got 0")
+	}
+}
+
+// TestKotlinTransactional_WrongLanguage_Issue3274 verifies the gate still
+// rejects non-JVM languages.
+func TestKotlinTransactional_WrongLanguage_Issue3274(t *testing.T) {
+	source := `@Transactional fun save() {}`
+	r := ExtractTransactional(PatternContext{
+		Source:    source,
+		Language:  "python",
+		Framework: "spring_boot",
+		FilePath:  "service.py",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3274 kotlin @Transactional gate] expected 0 for python, got %d", len(r.Entities))
+	}
+}
+
+// ============================================================================
+// 3. Spring AOP (spring_aop.go) — Kotlin
+// ============================================================================
+
+// TestKotlinSpringAOP_Aspect_Issue3274 verifies @Aspect on a Kotlin class
+// emits an aspect entity with OWNS edges to advice methods.
+// Registry target: lang.kotlin.framework.spring-boot AOP/* → partial.
+func TestKotlinSpringAOP_Aspect_Issue3274(t *testing.T) {
+	source := `
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class LoggingAspect {
+
+    @Pointcut("execution(* com.example.service.*.*(..))")
+    fun serviceMethods() {}
+
+    @Before("serviceMethods()")
+    fun logBefore(): Unit {
+        // log entry
+    }
+}
+`
+	r := ExtractSpringAOP(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "spring_boot",
+		FilePath:  "LoggingAspect.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin spring aop] expected AOP entities, got 0")
+	}
+	foundAspect := false
+	foundPointcut := false
+	foundAdvice := false
+	for _, e := range r.Entities {
+		switch e.Subtype {
+		case "aspect":
+			foundAspect = true
+		case "pointcut":
+			foundPointcut = true
+		case "advice":
+			foundAdvice = true
+		}
+	}
+	if !foundAspect {
+		t.Error("[#3274 kotlin spring aop] no aspect entity found")
+	}
+	if !foundPointcut {
+		t.Error("[#3274 kotlin spring aop] no pointcut entity found")
+	}
+	if !foundAdvice {
+		t.Error("[#3274 kotlin spring aop] no advice entity found")
+	}
+}
+
+// TestKotlinSpringAOP_WrongLanguage_Issue3274 verifies gate rejects non-JVM.
+func TestKotlinSpringAOP_WrongLanguage_Issue3274(t *testing.T) {
+	source := `@Aspect class Foo {}`
+	r := ExtractSpringAOP(PatternContext{
+		Source:    source,
+		Language:  "ruby",
+		Framework: "spring_boot",
+		FilePath:  "Foo.rb",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3274 kotlin spring aop gate] expected 0 for ruby, got %d", len(r.Entities))
+	}
+}
+
+// ============================================================================
+// 4. Micronaut AOP (micronaut_aop.go) — Kotlin
+// ============================================================================
+
+// TestKotlinMicronautAOP_Interceptor_Issue3274 verifies Micronaut AOP
+// interceptor classes in Kotlin emit aspect/advice entities.
+// Registry target: lang.kotlin.framework.micronaut AOP/* → partial.
+func TestKotlinMicronautAOP_Interceptor_Issue3274(t *testing.T) {
+	source := `
+import io.micronaut.aop.Around
+import io.micronaut.aop.InterceptorBean
+import io.micronaut.aop.MethodInterceptor
+import io.micronaut.aop.MethodInvocationContext
+
+@Around
+@interface Loggable
+
+@InterceptorBean(Loggable::class)
+class LoggingInterceptor : MethodInterceptor<Any, Any> {
+    override fun intercept(context: MethodInvocationContext<Any, Any>): Any? {
+        return context.proceed()
+    }
+}
+`
+	r := ExtractMicronautAOP(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "micronaut",
+		FilePath:  "LoggingInterceptor.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin micronaut aop] expected AOP entities, got 0")
+	}
+	foundAspect := false
+	for _, e := range r.Entities {
+		if e.Subtype == "aspect" || e.Subtype == "advice" || e.Subtype == "pointcut" {
+			foundAspect = true
+		}
+	}
+	if !foundAspect {
+		t.Error("[#3274 kotlin micronaut aop] no AOP entity found")
+	}
+}
+
+// ============================================================================
+// 5. Observability (observability.go) — Kotlin
+// ============================================================================
+
+// TestKotlinObservability_Slf4j_Issue3274 verifies @Slf4j annotation and
+// LoggerFactory.getLogger on Kotlin classes emit logger entities.
+// Registry target: lang.kotlin.framework.spring-boot Observability/* → partial.
+func TestKotlinObservability_Slf4j_Issue3274(t *testing.T) {
+	source := `
+import mu.KotlinLogging
+import org.slf4j.LoggerFactory
+
+@Slf4j
+class UserService {
+    fun processUser(id: Long) {
+        log.info("Processing user {}", id)
+        log.debug("Debug trace")
+    }
+}
+
+class PaymentService {
+    private val logger = LoggerFactory.getLogger(PaymentService::class.java)
+
+    fun processPayment() {
+        logger.warn("payment started")
+    }
+}
+`
+	r := ExtractObservability(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "spring_boot",
+		FilePath:  "UserService.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin observability] expected observability entities, got 0")
+	}
+	foundLogger := false
+	foundLogStmt := false
+	for _, e := range r.Entities {
+		switch e.Subtype {
+		case "logger":
+			foundLogger = true
+		case "log_statement":
+			foundLogStmt = true
+		}
+	}
+	if !foundLogger {
+		t.Error("[#3274 kotlin observability] no logger entity found")
+	}
+	if !foundLogStmt {
+		t.Error("[#3274 kotlin observability] no log_statement entity found")
+	}
+}
+
+// TestKotlinObservability_Micrometer_Issue3274 verifies @Timed and
+// Counter.builder on Kotlin code emits metric entities.
+func TestKotlinObservability_Micrometer_Issue3274(t *testing.T) {
+	source := `
+import io.micrometer.core.annotation.Timed
+import io.micrometer.core.instrument.Counter
+
+class OrderMetrics(private val meterRegistry: MeterRegistry) {
+
+    @Timed("orders.placed")
+    fun placeOrder(order: Order) {}
+
+    fun recordCancel() {
+        Counter.builder("orders.cancelled")
+            .register(meterRegistry)
+            .increment()
+    }
+}
+`
+	r := ExtractObservability(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "spring_boot",
+		FilePath:  "OrderMetrics.kt",
+	})
+	foundMetric := false
+	for _, e := range r.Entities {
+		if e.Subtype == "metric" {
+			foundMetric = true
+		}
+	}
+	if !foundMetric {
+		t.Errorf("[#3274 kotlin observability metrics] expected metric entity, got %v", r.Entities)
+	}
+}
+
+// TestKotlinObservability_OTel_Issue3274 verifies @WithSpan on Kotlin functions
+// emits trace_span entities.
+func TestKotlinObservability_OTel_Issue3274(t *testing.T) {
+	source := `
+import io.opentelemetry.instrumentation.annotations.WithSpan
+
+class CheckoutService {
+
+    @WithSpan("checkout.process")
+    fun processCheckout(cart: Cart): Order {
+        return Order()
+    }
+
+    @WithSpan
+    fun validateCart(cart: Cart): Boolean = true
+}
+`
+	r := ExtractObservability(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "spring_boot",
+		FilePath:  "CheckoutService.kt",
+	})
+	foundTrace := false
+	for _, e := range r.Entities {
+		if e.Subtype == "trace_span" {
+			foundTrace = true
+		}
+	}
+	if !foundTrace {
+		t.Errorf("[#3274 kotlin observability trace] expected trace_span entity, got %v", r.Entities)
+	}
+}
+
+// TestKotlinObservability_WrongLanguage_Issue3274 verifies gate rejects non-JVM.
+func TestKotlinObservability_WrongLanguage_Issue3274(t *testing.T) {
+	source := `@Slf4j class Foo { log.info("hi") }`
+	r := ExtractObservability(PatternContext{
+		Source:    source,
+		Language:  "go",
+		Framework: "spring_boot",
+		FilePath:  "service.go",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3274 kotlin observability gate] expected 0 for go, got %d", len(r.Entities))
+	}
+}
+
+// ============================================================================
+// 6. Hibernate / JPA (hibernate.go + jpa_fk_lazy.go) — Kotlin
+// ============================================================================
+
+// TestKotlinHibernate_Entity_Issue3274 verifies @Entity on a Kotlin data class
+// emits an entity record and associations.
+// Registry target: lang.kotlin.orm.hibernate relationship_extraction,
+// foreign_key_extraction, lazy_loading_recognition → partial.
+func TestKotlinHibernate_Entity_Issue3274(t *testing.T) {
+	source := `
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.OneToMany
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.FetchType
+
+@Entity
+@Table(name = "orders")
+data class Order(
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id")
+    val customer: Customer? = null,
+
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY)
+    val items: List<OrderItem> = emptyList()
+)
+
+@Entity
+@Table(name = "customers")
+data class Customer(
+    val id: Long = 0,
+    val name: String = ""
+)
+`
+	r := ExtractHibernate(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "hibernate",
+		FilePath:  "Order.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin hibernate] expected entities, got 0")
+	}
+	foundEntity := false
+	foundFK := false
+	foundFetch := false
+	for _, e := range r.Entities {
+		if e.Kind == "SCOPE.Schema" {
+			foundEntity = true
+		}
+		if e.Provenance == "INFERRED_FROM_JPA_JOIN_COLUMN" {
+			foundFK = true
+		}
+		if e.Provenance == "INFERRED_FROM_JPA_FETCH_TYPE" {
+			foundFetch = true
+		}
+	}
+	if !foundEntity {
+		t.Error("[#3274 kotlin hibernate] no SCOPE.Schema entity found")
+	}
+	if !foundFK {
+		t.Error("[#3274 kotlin hibernate] no JPA foreign_key entity found")
+	}
+	if !foundFetch {
+		t.Error("[#3274 kotlin hibernate] no fetch_config entity found")
+	}
+}
+
+// TestKotlinHibernate_Associations_Issue3274 verifies @OneToMany / @ManyToOne
+// produce DEPENDS_ON relationships.
+func TestKotlinHibernate_Associations_Issue3274(t *testing.T) {
+	source := `
+import jakarta.persistence.Entity
+import jakarta.persistence.OneToMany
+import jakarta.persistence.ManyToOne
+import java.util.List
+
+@Entity
+class Department {
+    @OneToMany
+    var employees: List<Employee>? = null
+}
+
+@Entity
+class Employee {
+    @ManyToOne
+    var department: Department? = null
+}
+`
+	r := ExtractHibernate(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "hibernate",
+		FilePath:  "Dept.kt",
+	})
+	if len(r.Relationships) == 0 {
+		t.Error("[#3274 kotlin hibernate assoc] expected DEPENDS_ON relationships, got 0")
+	}
+}
+
+// TestKotlinHibernate_WrongLanguage_Issue3274 verifies gate rejects non-JVM.
+func TestKotlinHibernate_WrongLanguage_Issue3274(t *testing.T) {
+	source := `@Entity class Foo {}`
+	r := ExtractHibernate(PatternContext{
+		Source:    source,
+		Language:  "python",
+		Framework: "hibernate",
+		FilePath:  "model.py",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3274 kotlin hibernate gate] expected 0 for python, got %d", len(r.Entities))
+	}
+}
+
+// ============================================================================
+// 5b. CDI Interceptors (cdi_interceptors.go) — Kotlin / Quarkus
+// ============================================================================
+
+// TestKotlinCDIInterceptors_Issue3274 verifies @Interceptor/@AroundInvoke on
+// Kotlin classes for Quarkus emit aspect/advice entities.
+// Registry target: lang.kotlin.framework.quarkus AOP/* → partial.
+func TestKotlinCDIInterceptors_Issue3274(t *testing.T) {
+	source := `
+import jakarta.interceptor.Interceptor
+import jakarta.interceptor.AroundInvoke
+import jakarta.interceptor.InvocationContext
+import jakarta.interceptor.InterceptorBinding
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@InterceptorBinding
+annotation class Logged
+
+@Logged
+@Interceptor
+class LoggingInterceptor {
+
+    @AroundInvoke
+    fun log(ctx: InvocationContext): Any? {
+        return ctx.proceed()
+    }
+}
+`
+	r := ExtractCDIInterceptors(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "quarkus",
+		FilePath:  "LoggingInterceptor.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin cdi interceptors] expected entities, got 0")
+	}
+	foundAspect := false
+	for _, e := range r.Entities {
+		if e.Subtype == "aspect" || e.Subtype == "advice" || e.Subtype == "pointcut" {
+			foundAspect = true
+		}
+	}
+	if !foundAspect {
+		t.Error("[#3274 kotlin cdi interceptors] no AOP entity found")
+	}
+}
+
+// ============================================================================
+// 7. Javalin routes (javalin_routes.go) — Kotlin
+// ============================================================================
+
+// TestKotlinJavalin_Routes_Issue3274 verifies Kotlin Javalin trailing-lambda
+// route DSL is extracted correctly.
+// Registry target: lang.kotlin.framework.javalin Routing/* → partial.
+func TestKotlinJavalin_Routes_Issue3274(t *testing.T) {
+	source := `
+import io.javalin.Javalin
+
+fun main() {
+    val app = Javalin.create().start(7070)
+
+    app.get("/users") { ctx ->
+        ctx.json(userService.findAll())
+    }
+
+    app.post("/users") { ctx ->
+        val user = ctx.bodyAsClass(UserRequest::class.java)
+        ctx.status(201)
+    }
+
+    app.delete("/users/{id}") { ctx ->
+        val id = ctx.pathParam("id")
+        userService.delete(id)
+        ctx.status(204)
+    }
+
+    app.before { ctx ->
+        // auth check
+    }
+}
+`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "kotlin",
+		Framework: "javalin",
+		FilePath:  "App.kt",
+	})
+	if len(r.Entities) == 0 {
+		t.Fatal("[#3274 kotlin javalin] expected route entities, got 0")
+	}
+	routes := make(map[string]bool)
+	for _, e := range r.Entities {
+		if e.Provenance == "INFERRED_FROM_JAVALIN_ROUTE" {
+			if verb, ok := e.Properties["http_verb"]; ok {
+				if path, ok2 := e.Properties["path"]; ok2 {
+					routes[verb.(string)+":"+path.(string)] = true
+				}
+			}
+		}
+	}
+	for _, want := range []string{"GET:/users", "POST:/users", "DELETE:/users/{id}"} {
+		if !routes[want] {
+			t.Errorf("[#3274 kotlin javalin] missing route %q; got %v", want, routes)
+		}
+	}
+}
+
+// TestKotlinJavalin_WrongLanguage_Issue3274 verifies that non-java/kotlin
+// languages are still rejected.
+func TestKotlinJavalin_WrongLanguage_Issue3274(t *testing.T) {
+	source := `app.get("/foo") { ctx -> }`
+	r := ExtractJavalin(PatternContext{
+		Source:    source,
+		Language:  "scala",
+		Framework: "javalin",
+		FilePath:  "App.scala",
+	})
+	if len(r.Entities) != 0 {
+		t.Errorf("[#3274 kotlin javalin gate] expected 0 for scala, got %d", len(r.Entities))
+	}
+}

--- a/internal/custom/java/micronaut_aop.go
+++ b/internal/custom/java/micronaut_aop.go
@@ -72,9 +72,12 @@ var (
 
 // ExtractMicronautAOP detects Micronaut AOP interceptors and HttpServerFilter
 // middleware, emitting SCOPE.Pattern and SCOPE.Component entities.
+// Accepts both Java and Kotlin source: Micronaut Kotlin uses the same
+// @Around, @InterceptorBean, and @Filter annotations before class/fun
+// declarations (regex patterns are identical in Kotlin).
 func ExtractMicronautAOP(ctx PatternContext) PatternResult {
 	var result PatternResult
-	if ctx.Language != "java" || !micronautFrameworks[ctx.Framework] {
+	if (ctx.Language != "java" && ctx.Language != "kotlin") || !micronautFrameworks[ctx.Framework] {
 		return result
 	}
 

--- a/internal/custom/java/observability.go
+++ b/internal/custom/java/observability.go
@@ -34,6 +34,8 @@ import "regexp"
 // obsFrameworks gates the JVM backend frameworks for which observability
 // extraction runs. These are the http_framework / microprofile records that
 // carry the log/metric/trace cells in the coverage registry.
+// Kotlin frameworks are included because SLF4J/Micrometer/OTel annotations
+// and logger patterns are identical in Kotlin source.
 var obsFrameworks = map[string]bool{
 	"spring_boot": true, "spring-boot": true, "springboot": true,
 	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
@@ -161,10 +163,13 @@ func canonicalObsFramework(framework string) string {
 	}
 }
 
-// ExtractObservability runs the Java observability extractor.
+// ExtractObservability runs the Java/Kotlin observability extractor.
+// Accepts both Java and Kotlin source: SLF4J, Micrometer, and OTel patterns
+// (LoggerFactory.getLogger, @Timed, @WithSpan, etc.) are syntactically
+// identical in Kotlin files.
 func ExtractObservability(ctx PatternContext) PatternResult {
 	var result PatternResult
-	if ctx.Language != "java" || !obsFrameworks[ctx.Framework] {
+	if (ctx.Language != "java" && ctx.Language != "kotlin") || !obsFrameworks[ctx.Framework] {
 		return result
 	}
 

--- a/internal/custom/java/spring_aop.go
+++ b/internal/custom/java/spring_aop.go
@@ -25,6 +25,8 @@ import "regexp"
 // aopFrameworks gates the frameworks for which Spring AOP extraction runs.
 // Spring AOP / AspectJ proxying is idiomatic only on the Spring frameworks;
 // other JVM frameworks are intentionally left red (see issue #3004).
+// Kotlin Spring Boot uses the same @Aspect/@Pointcut/@Before/@After/@Around
+// annotation syntax, so Kotlin is admitted under the same Spring framework IDs.
 var aopFrameworks = map[string]bool{
 	"spring_boot": true, "spring-boot": true, "springboot": true,
 	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
@@ -50,9 +52,11 @@ var (
 
 	// aopPointcutRE matches a @Pointcut method declaration, capturing the
 	// pointcut expression (group 1) and the declaring method name (group 2).
+	// Handles both Java (`void name()`) and Kotlin (`fun name()`) syntax so
+	// that Kotlin Spring Boot @Pointcut methods are correctly recognised.
 	aopPointcutRE = regexp.MustCompile(
 		`@Pointcut\s*\(\s*"([^"]*)"\s*\)\s*` +
-			`(?:(?:public|protected|private)\s+)?(?:abstract\s+)?void\s+(\w+)`)
+			`(?:(?:public|protected|private)\s+)?(?:abstract\s+)?(?:void|fun)\s+(\w+)`)
 
 	// aopAdviceMethodNameRE captures the method name that follows an advice
 	// annotation (skipping modifiers / return type) so an advice entity can be
@@ -129,9 +133,12 @@ func aopReferencedPointcut(expr string) string {
 }
 
 // ExtractSpringAOP runs the Spring AOP / AspectJ extractor.
+// Accepts both Java and Kotlin source: Kotlin Spring Boot uses the same
+// @Aspect/@Pointcut/@Before/@After/@Around annotation syntax before class/fun
+// declarations (patterns are regex-equivalent in Kotlin).
 func ExtractSpringAOP(ctx PatternContext) PatternResult {
 	var result PatternResult
-	if ctx.Language != "java" || !aopFrameworks[ctx.Framework] {
+	if (ctx.Language != "java" && ctx.Language != "kotlin") || !aopFrameworks[ctx.Framework] {
 		return result
 	}
 

--- a/internal/custom/java/spring_boot.go
+++ b/internal/custom/java/spring_boot.go
@@ -13,6 +13,15 @@ var springBootFrameworks = map[string]bool{
 	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
 }
 
+// kotlinSpringBootFrameworks is the set of Kotlin framework identifiers that
+// map to Spring Boot / Spring WebFlux. Kotlin Spring Boot uses identical
+// annotation syntax (@Autowired, @Bean, @Component, @Scope, etc.) so the same
+// extractor applies — we just gate on language "kotlin" in addition to "java".
+var kotlinSpringBootFrameworks = map[string]bool{
+	"spring_boot": true, "spring-boot": true, "springboot": true,
+	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
+}
+
 var (
 	// actuator_detection: @Endpoint/@ReadOperation/@WriteOperation/@DeleteOperation
 	sbActuatorEndpointRE = regexp.MustCompile(
@@ -82,9 +91,13 @@ var sbHTTPMappingVerbs = map[string]string{
 }
 
 // ExtractSpringBoot runs the Spring Boot custom extractor.
+// It accepts both Java and Kotlin source files: Kotlin Spring Boot uses the
+// same annotations (@Autowired, @Bean, @Component, @Scope, @RestController,
+// etc.) with `fun` instead of method declarations and `class` declarations
+// that are otherwise syntactically identical to Java for these patterns.
 func ExtractSpringBoot(ctx PatternContext) PatternResult {
 	var result PatternResult
-	if ctx.Language != "java" || !springBootFrameworks[ctx.Framework] {
+	if (ctx.Language != "java" && ctx.Language != "kotlin") || !springBootFrameworks[ctx.Framework] {
 		return result
 	}
 

--- a/internal/custom/java/transactional.go
+++ b/internal/custom/java/transactional.go
@@ -23,6 +23,8 @@ import "regexp"
 
 // txFrameworks gates the frameworks for which @Transactional extraction runs.
 // All entries share the Spring/JTA @Transactional annotation surface.
+// Kotlin frameworks are included because Kotlin Spring Boot / Quarkus / Micronaut
+// use the identical @Transactional annotation syntax before fun/class declarations.
 var txFrameworks = map[string]bool{
 	"spring_boot": true, "spring-boot": true, "springboot": true,
 	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
@@ -143,9 +145,11 @@ var methodNameStopwords = map[string]bool{
 }
 
 // ExtractTransactional runs the @Transactional extractor.
+// Accepts both Java and Kotlin source: Kotlin uses the identical @Transactional
+// annotation before fun/class declarations (same regex patterns apply).
 func ExtractTransactional(ctx PatternContext) PatternResult {
 	var result PatternResult
-	if ctx.Language != "java" || !txFrameworks[ctx.Framework] {
+	if (ctx.Language != "java" && ctx.Language != "kotlin") || !txFrameworks[ctx.Framework] {
 		return result
 	}
 


### PR DESCRIPTION
## Summary

Relaxes the `ctx.Language != "java"` gate in 8 Java-extractor files to also admit `ctx.Language == "kotlin"`. Kotlin is JVM and shares Java's annotation namespace — the existing regex patterns match Kotlin source identically, requiring only two small regex fixes for Kotlin-specific syntax.

**Regex fixes:**
- `spring_aop.go` `aopPointcutRE`: added `fun` alongside `void` for Kotlin pointcut method declarations
- `hibernate.go` `hibAssociationRE`: added `var`/`val` as field modifiers and `[:?=;]` as property terminators for Kotlin data class fields

**Extractors ported (java → java|kotlin gate):**
1. `spring_boot.go` — di_binding_extraction, di_injection_point, di_scope_resolution
2. `transactional.go` — transaction_boundary_extraction, transaction_propagation, transaction_rollback_rules
3. `spring_aop.go` — AOP cells for Kotlin Spring Boot
4. `micronaut_aop.go` — AOP cells for Kotlin Micronaut
5. `cdi_interceptors.go` — AOP cells for Kotlin Quarkus
6. `observability.go` — log_extraction, metric_extraction, trace_extraction
7. `hibernate.go` + `jpa_fk_lazy.go` — relationship_extraction, foreign_key_extraction, lazy_loading_recognition
8. `javalin_routes.go` — route_extraction, endpoint_synthesis, handler_attribution

**Registry cells flipped (missing → partial): 39 total**
- `lang.kotlin.framework.spring-boot`: 12 cells
- `lang.kotlin.framework.micronaut`: 9 cells
- `lang.kotlin.framework.quarkus`: 9 cells
- `lang.kotlin.framework.javalin`: 3 cells
- `lang.kotlin.orm.hibernate`: 3 cells
- `lang.kotlin.orm.spring-data`: 3 cells

## Test plan

- [x] 20 new Kotlin-specific tests in `internal/custom/java/kotlin_port_test.go` prove each extractor fires on `language=kotlin` fixtures
- [x] All existing Java tests still pass: `go test ./internal/custom/java/... ./internal/engine/... ./internal/custom/kotlin/... ./internal/types/... ./tools/coverage/...` — all green
- [x] `go run ./tools/coverage validate` exits 0
- [x] `go run ./tools/coverage fmt --check` passes (registry is canonical)
- [x] `go build ./internal/... ./tools/coverage/...` clean
- [x] `gofmt -l` empty on all modified files

Part of #3274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)