### PR TITLE
coverage(csharp): real extractors for C# trace/metric/log/auth cells

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -25,12 +25,12 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 4/6 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
 | [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -26,12 +26,12 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 1/6 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🔴 0/6 | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 4/6 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/4 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/csharp/auth.go` | [Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_csharp.go` | template_pattern sniffer captures _logger.Log<Level>/Console.WriteLine; recording-win, no dedicated emitter |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic |
 
 ### Data
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/csharp/auth.go` | [Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_csharp.go` | template_pattern sniffer captures _logger.Log<Level>/Console.WriteLine; recording-win, no dedicated emitter |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic |
 
 ### Data
 

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/csharp/auth.go` | [Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_csharp.go` | template_pattern sniffer captures _logger.Log<Level>/Console.WriteLine; recording-win, no dedicated emitter |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic |
 
 ### Data
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/csharp/auth.go` | [Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_csharp.go` | template_pattern sniffer captures _logger.Log<Level>/Console.WriteLine; recording-win, no dedicated emitter |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic |
 
 ### Data
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/csharp/auth.go` | [Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_csharp.go` | template_pattern sniffer captures _logger.Log<Level>/Console.WriteLine; recording-win, no dedicated emitter |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic |
 
 ### Data
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/csharp/auth.go` | [Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_csharp.go` | template_pattern sniffer captures _logger.Log<Level>/Console.WriteLine; recording-win, no dedicated emitter |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/observability.go` | OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -5775,7 +5775,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/auth.go"],
+            "notes": "[Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic"
           }
         },
         "Validation": {
@@ -5821,16 +5823,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_csharp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "template_pattern sniffer captures _logger.Log\u003cLevel\u003e/Console.WriteLine; recording-win, no dedicated emitter"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic"
           }
         },
         "Substrate": {
@@ -5970,7 +5978,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/auth.go"],
+            "notes": "[Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic"
           }
         },
         "Validation": {
@@ -6014,16 +6024,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_csharp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "template_pattern sniffer captures _logger.Log\u003cLevel\u003e/Console.WriteLine; recording-win, no dedicated emitter"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic"
           }
         },
         "Substrate": {
@@ -6660,7 +6676,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/auth.go"],
+            "notes": "[Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic"
           }
         },
         "Validation": {
@@ -6704,16 +6722,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_csharp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "template_pattern sniffer captures _logger.Log\u003cLevel\u003e/Console.WriteLine; recording-win, no dedicated emitter"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic"
           }
         },
         "Substrate": {
@@ -6849,7 +6873,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/auth.go"],
+            "notes": "[Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic"
           }
         },
         "Validation": {
@@ -6893,16 +6919,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_csharp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "template_pattern sniffer captures _logger.Log\u003cLevel\u003e/Console.WriteLine; recording-win, no dedicated emitter"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic"
           }
         },
         "Substrate": {
@@ -7176,7 +7208,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/auth.go"],
+            "notes": "[Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic"
           }
         },
         "Validation": {
@@ -7220,16 +7254,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_csharp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "template_pattern sniffer captures _logger.Log\u003cLevel\u003e/Console.WriteLine; recording-win, no dedicated emitter"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic"
           }
         },
         "Substrate": {
@@ -7539,7 +7579,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/auth.go"],
+            "notes": "[Authorize]/[AllowAnonymous]/RequireAuthorization/AddPolicy regex extractor; heuristic"
           }
         },
         "Validation": {
@@ -7583,16 +7625,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/template_pattern_csharp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "template_pattern sniffer captures _logger.Log\u003cLevel\u003e/Console.WriteLine; recording-win, no dedicated emitter"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel Meter/CreateCounter/CreateHistogram regex extractor; heuristic"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel ActivitySource/StartActivity/Activity.Current regex extractor; heuristic"
           }
         },
         "Substrate": {

--- a/internal/custom/csharp/auth.go
+++ b/internal/custom/csharp/auth.go
@@ -1,0 +1,214 @@
+// Package csharp — auth extractor for C# source files.
+//
+// Detects ASP.NET Core / Microsoft.AspNetCore.Authorization patterns:
+//   - [Authorize] / [Authorize(Roles="...")] / [Authorize(Policy="...")] attributes
+//   - [AllowAnonymous] attribute
+//   - RequireAuthorization() / RequireAuthorization("policy") minimal-API calls
+//   - AddAuthorization() / AddAuthorization(options => ...) service registration
+//   - AddPolicy("name", ...) policy definition
+//
+// Emits SCOPE.Pattern entities with subtype "auth_coverage" so the coverage
+// cells light up for the 6 backend frameworks.
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_auth", &csharpAuthExtractor{})
+}
+
+type csharpAuthExtractor struct{}
+
+func (e *csharpAuthExtractor) Language() string { return "custom_csharp_auth" }
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// [Authorize] — plain, no arguments
+	reAuthorize = regexp.MustCompile(
+		`\[Authorize\s*\]`,
+	)
+	// [Authorize(Roles = "...")] or [Authorize(Roles="...")]
+	reAuthorizeRoles = regexp.MustCompile(
+		`\[Authorize\s*\(\s*Roles\s*=\s*"([^"]+)"`,
+	)
+	// [Authorize(Policy = "...")] or [Authorize(Policy="...")]
+	reAuthorizePolicy = regexp.MustCompile(
+		`\[Authorize\s*\(\s*Policy\s*=\s*"([^"]+)"`,
+	)
+	// [Authorize("policyName")] — positional first arg as policy name
+	reAuthorizePositional = regexp.MustCompile(
+		`\[Authorize\s*\(\s*"([^"]+)"\s*\)`,
+	)
+	// [AllowAnonymous]
+	reAllowAnonymous = regexp.MustCompile(
+		`\[AllowAnonymous\s*\]`,
+	)
+	// .RequireAuthorization() / .RequireAuthorization("policyName")
+	reRequireAuthorization = regexp.MustCompile(
+		`\.RequireAuthorization\s*\(\s*(?:"([^"]+)")?\s*\)`,
+	)
+	// services.AddAuthorization(...) — DI registration
+	reAddAuthorization = regexp.MustCompile(
+		`\bAddAuthorization\s*\(`,
+	)
+	// options.AddPolicy("name", ...) — policy builder
+	reAddPolicy = regexp.MustCompile(
+		`\.AddPolicy\s*\(\s*"([^"]+)"`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *csharpAuthExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.csharp_auth_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "csharp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// [Authorize] — plain attribute
+	for _, m := range reAuthorize.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		name := "auth:Authorize:plain:" + file.Path + ":" + itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "auth_coverage", file.Path, "csharp", line)
+		setProps(&ent, "auth_pattern", "Authorize", "detail", "plain")
+		add(ent)
+	}
+
+	// [Authorize(Roles="...")]
+	for _, m := range reAuthorizeRoles.FindAllStringSubmatchIndex(src, -1) {
+		roles := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "auth:Authorize:roles:" + roles
+		ent := makeEntity(name, "SCOPE.Pattern", "auth_coverage", file.Path, "csharp", line)
+		setProps(&ent, "auth_pattern", "Authorize.Roles", "roles", roles)
+		add(ent)
+	}
+
+	// [Authorize(Policy="...")]
+	for _, m := range reAuthorizePolicy.FindAllStringSubmatchIndex(src, -1) {
+		policy := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "auth:Authorize:policy:" + policy
+		ent := makeEntity(name, "SCOPE.Pattern", "auth_coverage", file.Path, "csharp", line)
+		setProps(&ent, "auth_pattern", "Authorize.Policy", "policy_name", policy)
+		add(ent)
+	}
+
+	// [Authorize("policyName")] positional
+	for _, m := range reAuthorizePositional.FindAllStringSubmatchIndex(src, -1) {
+		policy := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "auth:Authorize:policy:" + policy
+		ent := makeEntity(name, "SCOPE.Pattern", "auth_coverage", file.Path, "csharp", line)
+		setProps(&ent, "auth_pattern", "Authorize.Policy", "policy_name", policy)
+		add(ent)
+	}
+
+	// [AllowAnonymous]
+	for _, m := range reAllowAnonymous.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		name := "auth:AllowAnonymous:" + file.Path + ":" + itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "auth_coverage", file.Path, "csharp", line)
+		setProps(&ent, "auth_pattern", "AllowAnonymous")
+		add(ent)
+	}
+
+	// .RequireAuthorization(...)
+	for _, m := range reRequireAuthorization.FindAllStringSubmatchIndex(src, -1) {
+		line := lineOf(src, m[0])
+		policy := ""
+		if m[2] >= 0 {
+			policy = src[m[2]:m[3]]
+		}
+		name := "auth:RequireAuthorization:" + policy + ":" + file.Path + ":" + itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "auth_coverage", file.Path, "csharp", line)
+		setProps(&ent, "auth_pattern", "RequireAuthorization", "policy_name", policy)
+		add(ent)
+	}
+
+	// AddAuthorization() — service registration (emit once per file)
+	if reAddAuthorization.MatchString(src) {
+		line := 1
+		if idx := reAddAuthorization.FindStringIndex(src); idx != nil {
+			line = lineOf(src, idx[0])
+		}
+		name := "auth:AddAuthorization:" + file.Path
+		ent := makeEntity(name, "SCOPE.Pattern", "auth_coverage", file.Path, "csharp", line)
+		setProps(&ent, "auth_pattern", "AddAuthorization")
+		add(ent)
+	}
+
+	// .AddPolicy("name", ...)
+	for _, m := range reAddPolicy.FindAllStringSubmatchIndex(src, -1) {
+		policy := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "auth:AddPolicy:" + policy
+		ent := makeEntity(name, "SCOPE.Pattern", "auth_coverage", file.Path, "csharp", line)
+		setProps(&ent, "auth_pattern", "AddPolicy", "policy_name", policy)
+		add(ent)
+	}
+
+	return entities, nil
+}
+
+// itoa converts an int to its decimal string representation without importing strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := [20]byte{}
+	pos := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/internal/custom/csharp/auth_test.go
+++ b/internal/custom/csharp/auth_test.go
@@ -1,0 +1,157 @@
+package csharp_test
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Auth — auth_coverage
+// ---------------------------------------------------------------------------
+
+func TestAuthAuthorizeAttribute(t *testing.T) {
+	src := `
+[ApiController]
+[Authorize]
+public class SecureController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() => Ok();
+}
+`
+	ents := extract(t, "custom_csharp_auth", fi("SecureController.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "auth_coverage" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected auth_coverage SCOPE.Pattern from [Authorize]")
+	}
+}
+
+func TestAuthAuthorizeRoles(t *testing.T) {
+	src := `[Authorize(Roles = "Admin,Manager")]`
+	ents := extract(t, "custom_csharp_auth", fi("AdminController.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "auth_coverage" && e.Name == "auth:Authorize:roles:Admin,Manager" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected auth:Authorize:roles:Admin,Manager entity")
+	}
+}
+
+func TestAuthAuthorizePolicy(t *testing.T) {
+	src := `[Authorize(Policy = "RequireAdminRole")]`
+	ents := extract(t, "custom_csharp_auth", fi("Controller.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "auth_coverage" && e.Name == "auth:Authorize:policy:RequireAdminRole" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected auth:Authorize:policy:RequireAdminRole entity")
+	}
+}
+
+func TestAuthAuthorizePositional(t *testing.T) {
+	src := `[Authorize("AdminOnly")]`
+	ents := extract(t, "custom_csharp_auth", fi("Controller.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "auth_coverage" && e.Name == "auth:Authorize:policy:AdminOnly" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected auth:Authorize:policy:AdminOnly from positional [Authorize(\"AdminOnly\")]")
+	}
+}
+
+func TestAuthAllowAnonymous(t *testing.T) {
+	src := `
+[AllowAnonymous]
+public IActionResult Login() => Ok();
+`
+	ents := extract(t, "custom_csharp_auth", fi("AuthController.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "auth_coverage" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected auth_coverage entity from [AllowAnonymous]")
+	}
+}
+
+func TestAuthRequireAuthorization(t *testing.T) {
+	src := `
+app.MapGet("/secure", () => "secret").RequireAuthorization();
+app.MapPost("/admin", Handler).RequireAuthorization("AdminPolicy");
+`
+	ents := extract(t, "custom_csharp_auth", fi("Program.cs", "csharp", src))
+	count := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "auth_coverage" {
+			count++
+		}
+	}
+	if count < 2 {
+		t.Errorf("expected at least 2 auth_coverage entities from RequireAuthorization, got %d", count)
+	}
+}
+
+func TestAuthAddAuthorization(t *testing.T) {
+	src := `
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"));
+    options.AddPolicy("PremiumUser", policy => policy.RequireClaim("subscription", "premium"));
+});
+`
+	ents := extract(t, "custom_csharp_auth", fi("Program.cs", "csharp", src))
+	addAuthFound := false
+	policyFound := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "auth_coverage" {
+			if e.Name == "auth:AddAuthorization:Program.cs" {
+				addAuthFound = true
+			}
+			if e.Name == "auth:AddPolicy:AdminOnly" || e.Name == "auth:AddPolicy:PremiumUser" {
+				policyFound++
+			}
+		}
+	}
+	if !addAuthFound {
+		t.Error("expected auth:AddAuthorization:Program.cs entity")
+	}
+	if policyFound < 2 {
+		t.Errorf("expected 2 AddPolicy entities, got %d", policyFound)
+	}
+}
+
+func TestAuthNoMatch(t *testing.T) {
+	src := `namespace App { class Helper { public void DoWork() {} } }`
+	ents := extract(t, "custom_csharp_auth", fi("Helper.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 auth entities, got %d", len(ents))
+	}
+}
+
+func TestAuthWrongLanguageSkipped(t *testing.T) {
+	src := `[Authorize]`
+	ents := extract(t, "custom_csharp_auth", fi("file.java", "java", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for non-csharp language, got %d", len(ents))
+	}
+}

--- a/internal/custom/csharp/observability.go
+++ b/internal/custom/csharp/observability.go
@@ -1,0 +1,191 @@
+// Package csharp — observability extractor for C# source files.
+//
+// Detects OpenTelemetry tracing (ActivitySource / Activity) and metrics
+// (Meter / Counter<T> / Histogram<T>) patterns, emitting SCOPE.Pattern
+// entities so the coverage cells trace_extraction and metric_extraction
+// light up for the C# backend frameworks.
+//
+// log_extraction is NOT duplicated here — it is already handled by the
+// template_pattern sniffer in internal/substrate/template_pattern_csharp.go
+// (csharpLogRe captures _logger.LogInformation etc.).
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_observability", &csharpObservabilityExtractor{})
+}
+
+type csharpObservabilityExtractor struct{}
+
+func (e *csharpObservabilityExtractor) Language() string { return "custom_csharp_observability" }
+
+// ---------------------------------------------------------------------------
+// Trace regexes — OpenTelemetry ActivitySource / Activity.Current
+// ---------------------------------------------------------------------------
+
+var (
+	// new ActivitySource("name") or new ActivitySource(nameof(T)) — producer declaration
+	reActivitySourceNew = regexp.MustCompile(
+		`new\s+ActivitySource\s*\(\s*"([^"]+)"`,
+	)
+	// activitySource.StartActivity("operationName") — span start
+	reStartActivity = regexp.MustCompile(
+		`\.\s*StartActivity\s*\(\s*"([^"]+)"`,
+	)
+	// Activity.Current?.SetTag / AddTag / SetStatus — usage site
+	reActivityCurrent = regexp.MustCompile(
+		`\bActivity\s*\.\s*Current\b`,
+	)
+	// field/var typed as ActivitySource — declaration
+	reActivitySourceDecl = regexp.MustCompile(
+		`\bActivitySource\b`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Metric regexes — OpenTelemetry Meter / Counter / Histogram
+// ---------------------------------------------------------------------------
+
+var (
+	// new Meter("name") — meter declaration
+	reMeterNew = regexp.MustCompile(
+		`new\s+Meter\s*\(\s*"([^"]+)"`,
+	)
+	// meter.CreateCounter<T>("name") / meter.CreateHistogram<T>("name")
+	reMeterCreate = regexp.MustCompile(
+		`\.\s*Create(Counter|Histogram|ObservableGauge|ObservableCounter|ObservableUpDownCounter|UpDownCounter)\s*<[^>]+>\s*\(\s*"([^"]+)"`,
+	)
+	// Counter<T> or Histogram<T> field/var declaration
+	reMetricTypeDecl = regexp.MustCompile(
+		`\b(Counter|Histogram|ObservableGauge|ObservableCounter|UpDownCounter)\s*<`,
+	)
+	// meter.CreateCounter / meter.CreateHistogram without generic — also valid
+	reMeterCreateNoGeneric = regexp.MustCompile(
+		`\.\s*Create(Counter|Histogram|UpDownCounter)\s*\(\s*"([^"]+)"`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *csharpObservabilityExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.csharp_observability_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "csharp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// --- trace_extraction ---------------------------------------------------
+
+	// ActivitySource declaration
+	for _, m := range reActivitySourceNew.FindAllStringSubmatchIndex(src, -1) {
+		name := "otel:trace:ActivitySource:" + src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(name, "SCOPE.Pattern", "trace_extraction", file.Path, "csharp", line)
+		setProps(&ent, "otel_signal", "trace", "pattern", "ActivitySource.new")
+		add(ent)
+	}
+
+	// StartActivity call sites
+	for _, m := range reStartActivity.FindAllStringSubmatchIndex(src, -1) {
+		name := "otel:trace:StartActivity:" + src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(name, "SCOPE.Pattern", "trace_extraction", file.Path, "csharp", line)
+		setProps(&ent, "otel_signal", "trace", "pattern", "StartActivity")
+		add(ent)
+	}
+
+	// Activity.Current usage (emit one per file, not per usage)
+	if reActivityCurrent.MatchString(src) {
+		name := "otel:trace:Activity.Current:" + file.Path
+		ent := makeEntity(name, "SCOPE.Pattern", "trace_extraction", file.Path, "csharp", 1)
+		setProps(&ent, "otel_signal", "trace", "pattern", "Activity.Current")
+		add(ent)
+	}
+
+	// ActivitySource type declaration (covers field: private static readonly ActivitySource _src = ...)
+	if reActivitySourceDecl.MatchString(src) && !reActivitySourceNew.MatchString(src) {
+		name := "otel:trace:ActivitySource:decl:" + file.Path
+		ent := makeEntity(name, "SCOPE.Pattern", "trace_extraction", file.Path, "csharp", 1)
+		setProps(&ent, "otel_signal", "trace", "pattern", "ActivitySource.decl")
+		add(ent)
+	}
+
+	// --- metric_extraction --------------------------------------------------
+
+	// Meter declaration
+	for _, m := range reMeterNew.FindAllStringSubmatchIndex(src, -1) {
+		name := "otel:metric:Meter:" + src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(name, "SCOPE.Pattern", "metric_extraction", file.Path, "csharp", line)
+		setProps(&ent, "otel_signal", "metric", "pattern", "Meter.new")
+		add(ent)
+	}
+
+	// meter.CreateCounter / CreateHistogram etc. (generic form)
+	for _, m := range reMeterCreate.FindAllStringSubmatchIndex(src, -1) {
+		kind := src[m[2]:m[3]]
+		mname := src[m[4]:m[5]]
+		name := "otel:metric:" + kind + ":" + mname
+		line := lineOf(src, m[0])
+		ent := makeEntity(name, "SCOPE.Pattern", "metric_extraction", file.Path, "csharp", line)
+		setProps(&ent, "otel_signal", "metric", "pattern", "Create"+kind, "metric_name", mname)
+		add(ent)
+	}
+
+	// meter.CreateCounter etc. (non-generic form)
+	for _, m := range reMeterCreateNoGeneric.FindAllStringSubmatchIndex(src, -1) {
+		kind := src[m[2]:m[3]]
+		mname := src[m[4]:m[5]]
+		name := "otel:metric:" + kind + ":" + mname
+		line := lineOf(src, m[0])
+		ent := makeEntity(name, "SCOPE.Pattern", "metric_extraction", file.Path, "csharp", line)
+		setProps(&ent, "otel_signal", "metric", "pattern", "Create"+kind, "metric_name", mname)
+		add(ent)
+	}
+
+	// Counter<T> / Histogram<T> type declarations
+	if reMetricTypeDecl.MatchString(src) && !reMeterCreate.MatchString(src) && !reMeterCreateNoGeneric.MatchString(src) {
+		name := "otel:metric:TypeDecl:" + file.Path
+		ent := makeEntity(name, "SCOPE.Pattern", "metric_extraction", file.Path, "csharp", 1)
+		setProps(&ent, "otel_signal", "metric", "pattern", "metric_type_decl")
+		add(ent)
+	}
+
+	return entities, nil
+}

--- a/internal/custom/csharp/observability_test.go
+++ b/internal/custom/csharp/observability_test.go
@@ -1,0 +1,135 @@
+package csharp_test
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Observability — trace_extraction
+// ---------------------------------------------------------------------------
+
+func TestObservabilityActivitySourceNew(t *testing.T) {
+	src := `
+private static readonly ActivitySource _tracer = new ActivitySource("MyService.Orders");
+
+public void ProcessOrder(int id)
+{
+    using var activity = _tracer.StartActivity("process-order");
+    activity?.SetTag("order_id", id);
+}
+`
+	ents := extract(t, "custom_csharp_observability", fi("OrderService.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "trace_extraction" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one trace_extraction SCOPE.Pattern from ActivitySource")
+	}
+}
+
+func TestObservabilityStartActivity(t *testing.T) {
+	src := `
+public void Handle()
+{
+    using var span = _activitySource.StartActivity("handle-request");
+}
+`
+	ents := extract(t, "custom_csharp_observability", fi("Handler.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "trace_extraction" && e.Name == "otel:trace:StartActivity:handle-request" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected otel:trace:StartActivity:handle-request from StartActivity call")
+	}
+}
+
+func TestObservabilityActivityCurrent(t *testing.T) {
+	src := `Activity.Current?.SetTag("user_id", userId);`
+	ents := extract(t, "custom_csharp_observability", fi("Middleware.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "trace_extraction" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected trace_extraction entity from Activity.Current usage")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Observability — metric_extraction
+// ---------------------------------------------------------------------------
+
+func TestObservabilityMeterNew(t *testing.T) {
+	src := `var meter = new Meter("MyService.Metrics");`
+	ents := extract(t, "custom_csharp_observability", fi("Metrics.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "metric_extraction" && e.Name == "otel:metric:Meter:MyService.Metrics" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected otel:metric:Meter:MyService.Metrics from new Meter()")
+	}
+}
+
+func TestObservabilityCreateCounter(t *testing.T) {
+	src := `
+var meter = new Meter("MyApp");
+var requestCounter = meter.CreateCounter<long>("http.requests", "requests", "Total HTTP requests");
+`
+	ents := extract(t, "custom_csharp_observability", fi("Instrumentation.cs", "csharp", src))
+	counterFound := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "metric_extraction" && e.Name == "otel:metric:Counter:http.requests" {
+			counterFound = true
+			break
+		}
+	}
+	if !counterFound {
+		t.Error("expected otel:metric:Counter:http.requests from CreateCounter<long>")
+	}
+}
+
+func TestObservabilityCreateHistogram(t *testing.T) {
+	src := `var latency = meter.CreateHistogram<double>("request.duration", "ms", "Request latency");`
+	ents := extract(t, "custom_csharp_observability", fi("Metrics.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "metric_extraction" && e.Name == "otel:metric:Histogram:request.duration" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected otel:metric:Histogram:request.duration from CreateHistogram")
+	}
+}
+
+func TestObservabilityNoMatch(t *testing.T) {
+	src := `namespace App { class Helper { public void DoWork() {} } }`
+	ents := extract(t, "custom_csharp_observability", fi("Helper.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 observability entities, got %d", len(ents))
+	}
+}
+
+func TestObservabilityWrongLanguageSkipped(t *testing.T) {
+	src := `var meter = new Meter("test");`
+	ents := extract(t, "custom_csharp_observability", fi("file.py", "python", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for non-csharp language, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Summary

Part of #3263.

- **`internal/custom/csharp/observability.go`** — new extractor detecting OTel `ActivitySource` / `StartActivity` / `Activity.Current` → `trace_extraction` and `Meter` / `CreateCounter<T>` / `CreateHistogram<T>` → `metric_extraction`. Emits `SCOPE.Pattern` entities.
- **`internal/custom/csharp/auth.go`** — new extractor detecting `[Authorize]` / `[Authorize(Roles=)]` / `[Authorize(Policy=)]` / `[AllowAnonymous]` / `RequireAuthorization()` / `AddAuthorization()` / `AddPolicy()` → `auth_coverage` `SCOPE.Pattern` entities.
- Dedicated `_test.go` files for both extractors with per-fixture tests.

### Cells flipped (6 backend frameworks: aspnet-core, aspnet-mvc, carter, fastendpoints, nancyfx, servicestack)

| Cell | Before | After | Cites |
|---|---|---|---|
| `trace_extraction` | missing | **partial** | `observability.go` |
| `metric_extraction` | missing | **partial** | `observability.go` |
| `log_extraction` | missing | **partial** | `template_pattern_csharp.go` (recording-win: existing sniffer captures `_logger.Log<Level>`) |
| `auth_coverage` | missing | **partial** | `auth.go` |

Honest: all heuristic regex → `partial`; `full` requires proven round-trip fixtures.

## Test plan

- [x] `go build ./internal/... ./tools/coverage/...` — clean
- [x] `go test ./internal/custom/csharp/... ./internal/types/ ./tools/coverage/...` — all pass
- [x] `go run ./tools/coverage validate` — exit 0 (warnings only, no errors)
- [x] `go run ./tools/coverage fmt --check` — canonical
- [x] `gofmt -l` on new files — empty (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)