### PR TITLE
coverage(java): close 16/22 missing cells — recording-wins + honest-NA (#3256)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -123,7 +123,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
 | [java](../by-language/java.md) | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 6/7 | |
+| [java](../by-language/java.md) | [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [java](../by-language/java.md) | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
 | [java](../by-language/java.md) | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
@@ -161,8 +161,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
-| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 3/4 | |
-| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 3/4 | |
+| [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
+| [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [React](../detail/lang.jsts.framework.react.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 21/21 | |
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 17/17 | |
@@ -174,7 +174,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🔴 0/2 | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/7 | |
-| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟡 2/3 | 🟢 1/1 | 🟡 20/21 | 🟢 4/4 | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟢 2/2 | 🟢 1/1 | 🟡 20/21 | 🟢 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 11/11 | |
@@ -191,8 +191,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [.NET MAUI](../detail/lang.csharp.framework.net-maui.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/9 | |
 | [C#](../by-language/csharp.md) | [Xamarin](../detail/lang.csharp.framework.xamarin.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/9 | |
 | [go](../by-language/go.md) | [gomobile (mobile bindings)](../detail/lang.go.framework.gomobile.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟢 4/4 | |
-| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
-| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
+| [java](../by-language/java.md) | [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟡 6/8 | |
+| [java](../by-language/java.md) | [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟡 6/8 | |
 | [JS/TS](../by-language/jsts.md) | [Expo](../detail/lang.jsts.framework.expo.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 13/13 | |
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |

--- a/docs/coverage/by-language/java.md
+++ b/docs/coverage/by-language/java.md
@@ -27,7 +27,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Akka HTTP (Java DSL)](../detail/lang.java.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 20/20 | 🟡 6/7 | |
+| [Apache Struts](../detail/lang.java.framework.struts.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟡 6/7 | |
 | [Dropwizard](../detail/lang.java.framework.dropwizard.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
 | [Eclipse MicroProfile](../detail/lang.java.framework.microprofile.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [Helidon](../detail/lang.java.framework.helidon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 13/13 | |
@@ -45,23 +45,23 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 3/4 | |
-| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟡 3/4 | |
+| [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
+| [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟡 2/3 | 🟢 1/1 | 🟡 20/21 | 🟢 4/4 | |
+| [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟢 2/2 | 🟢 1/1 | 🟡 20/21 | 🟢 4/4 | |
 
 
 ### Mobile
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
-| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🔴 0/3 | 🟢 1/1 | 🟡 18/19 | 🟡 5/9 | |
+| [Android Jetpack (Compose / ViewModel / Room / Navigation / Hilt)](../detail/lang.java.framework.android-jetpack.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟡 6/8 | |
+| [Android SDK (Activity/Fragment routing)](../detail/lang.java.framework.android-sdk.md) | 🟢 2/2 | 🟢 1/1 | 🟢 18/18 | 🟡 6/8 | |
 
 
 ### AI Integration

--- a/docs/coverage/detail/lang.java.framework.android-jetpack.md
+++ b/docs/coverage/detail/lang.java.framework.android-jetpack.md
@@ -15,13 +15,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Context extraction | 🔴 `missing` | — | — | — | — |
+| Context extraction | 🔴 `missing` | — | 3256 | — | Genuine build: Android Context propagation (getContext()/getActivity()/requireContext() usage) not yet extracted; requires new regex patterns in android.go |
 
 ### Navigation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Deep link extraction | 🔴 `missing` | — | — | — | — |
+| Deep link extraction | 🔴 `missing` | — | 3256 | — | Genuine build: Android deep-link intent-filter patterns (<intent-filter> with BROWSE action + android:scheme/android:host in AndroidManifest.xml, @NavDeepLink annotations) not yet extracted |
 | Navigation extraction | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adIntentExplicitRE+adFragmentTransactionRE emit navigation edges (#3179) |
 | Screen detection | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adActivityClassRE+adFragmentClassRE detect Activity/Fragment screens (#3179) |
 
@@ -41,22 +41,22 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Branch conditions | 🔴 `missing` | — | — | — | — |
+| Branch conditions | 🟢 `partial` | `2026-05-30` | — | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android |
 | State management | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adViewModelClassRE+adViewModelProviderRE detect ViewModel/LiveData state (#3179) |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
-| Type alias extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits enum_declaration nodes for all Java frameworks including Android SDK/Jetpack; same as gwt/vaadin (partial) |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits interface_declaration nodes for all Java frameworks including Android SDK/Jetpack; same as gwt/vaadin (partial) |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type-alias syntax; all other Java frameworks are not_applicable for this cell |
 
 ### Lifecycle
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| State setter emission | 🔴 `missing` | — | — | — | — |
+| State setter emission | — `not_applicable` | — | — | — | Android SDK/Jetpack uses LiveData/StateFlow observer patterns rather than React-style useState setters; state_setter_emission is a React/JSX-paradigm capability that does not apply; gomobile (Go) is also not_applicable for the same reason |
 
 ### Testing
 
@@ -84,7 +84,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Request shape extraction | — `not_applicable` | — | 3154 | — | — |
 | Response shape extraction | — `not_applicable` | — | 3154 | — | — |
 | Sanitizer recognition | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
-| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | — `not_applicable` | — | — | — | Android SDK/Jetpack are mobile client frameworks with no server-side HTTP handlers; schema drift detection requires a producer-consumer HTTP endpoint pair; request_shape_extraction and response_shape_extraction are also not_applicable for these records |
 | Taint sink detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Taint source detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |

--- a/docs/coverage/detail/lang.java.framework.android-sdk.md
+++ b/docs/coverage/detail/lang.java.framework.android-sdk.md
@@ -15,13 +15,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Context extraction | 🔴 `missing` | — | — | — | — |
+| Context extraction | 🔴 `missing` | — | 3256 | — | Genuine build: Android Context propagation not yet extracted; requires new regex patterns in android.go |
 
 ### Navigation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Deep link extraction | 🔴 `missing` | — | — | — | — |
+| Deep link extraction | 🔴 `missing` | — | 3256 | — | Genuine build: Android deep-link intent-filter patterns not yet extracted; same build as android-jetpack |
 | Navigation extraction | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adIntentExplicitRE+adFragmentTransactionRE emit navigation edges (#3179) |
 | Screen detection | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adActivityClassRE+adFragmentClassRE detect Activity/Fragment screens (#3179) |
 
@@ -41,22 +41,22 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Branch conditions | 🔴 `missing` | — | — | — | — |
+| Branch conditions | 🟢 `partial` | `2026-05-30` | — | `internal/custom/java/android.go` | adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android |
 | State management | 🟢 `partial` | — | — | `internal/custom/java/android.go` | adViewModelClassRE+adViewModelProviderRE detect ViewModel/LiveData state (#3179) |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
-| Type alias extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits enum_declaration nodes for all Java frameworks including Android SDK/Jetpack; same as gwt/vaadin (partial) |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits interface_declaration nodes for all Java frameworks including Android SDK/Jetpack; same as gwt/vaadin (partial) |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type-alias syntax; all other Java frameworks are not_applicable for this cell |
 
 ### Lifecycle
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| State setter emission | 🔴 `missing` | — | — | — | — |
+| State setter emission | — `not_applicable` | — | — | — | Android SDK uses LiveData/observer patterns rather than React-style useState setters; state_setter_emission is a React/JSX-paradigm capability that does not apply |
 
 ### Testing
 
@@ -84,7 +84,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Request shape extraction | — `not_applicable` | — | 3154 | — | — |
 | Response shape extraction | — `not_applicable` | — | 3154 | — | — |
 | Sanitizer recognition | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
-| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | — `not_applicable` | — | — | — | Android SDK is a mobile client framework with no server-side HTTP handlers; schema drift detection requires a producer-consumer HTTP endpoint pair; request_shape_extraction and response_shape_extraction are also not_applicable for this record |
 | Taint sink detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Taint source detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |

--- a/docs/coverage/detail/lang.java.framework.gwt.md
+++ b/docs/coverage/detail/lang.java.framework.gwt.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Branch conditions | 🔴 `missing` | — | — | — | — |
+| Branch conditions | — `not_applicable` | — | — | — | GWT compiles Java to client-side JS but uses Java idioms with no mobile platform-discriminating branches; branch_conditions is a mobile/platform-conditional UI paradigm that does not apply; state_management and prop_extraction are also not_applicable for GWT |
 | Data fetching | 🟢 `partial` | `2026-05-30` | 3190 | `internal/custom/java/gwt_rpc.go` | GWT RPC + RequestFactory client-side data fetching: @RemoteServiceRelativePath RPC service interfaces, GWT.create(*.class) proxy-creation sites (linked FETCHES_FROM to the service), AsyncCallback<T> completion sites, RequestFactory/RequestContext interfaces, @ProxyFor EntityProxy/ValueProxy beans, and Request.fire(Receiver) sites. Heuristic regex detection, hence partial. |
 | Prop extraction | — `not_applicable` | — | 3091 | — | GWT compiles Java to client-side JS but uses Java idioms with no React-style concepts; prop_extraction is a React/JSX-paradigm capability that does not apply |
 | State management | — `not_applicable` | — | 3091 | — | GWT compiles Java to client-side JS but uses Java idioms with no React-style concepts; state_management is a React/JSX-paradigm capability that does not apply |

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -50,7 +50,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits enum_declaration nodes for all Java frameworks including Play (#3178). |
 | Interface extraction | 🟢 `partial` | `2026-05-29` | — | `internal/extractors/java/java.go` | Framework-blind Java extractor emits interface_declaration nodes for all Java frameworks including Play (#3178). |
-| Type alias extraction | 🔴 `missing` | — | — | — | — |
+| Type alias extraction | — `not_applicable` | — | — | — | Java has no type-alias syntax; all other Java frameworks are not_applicable for this cell |
 
 ### Lifecycle
 
@@ -82,7 +82,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Pure function tagging | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Reachability analysis | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Request shape extraction | 🟢 `partial` | — | 3090 | `internal/custom/java/play_routes.go` | — |
-| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | 3256 | — | Genuine build: Play Java uses play.mvc.Results.ok()/badRequest()/created() patterns rather than Spring ResponseEntity; payload_shapes_java.go does not detect Play-specific result patterns; requires dedicated Play response-shape regex |
 | Sanitizer recognition | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |
 | Schema drift detection | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_java.go` | Framework-blind payload shapes sniffer fires for all Java sources; no Play-specific gate required (#3178). |
 | Taint sink detection | 🟢 `partial` | — | 3154 | `internal/links/effect_propagation.go`<br>`internal/links/module_cycle_pass.go`<br>`internal/substrate/def_use_java.go`<br>`internal/substrate/effect_sinks_java.go`<br>`internal/substrate/entry_points_java.go`<br>`internal/substrate/taint_sites_java.go`<br>`internal/substrate/template_pattern_java.go` | — |

--- a/docs/coverage/detail/lang.java.framework.struts.md
+++ b/docs/coverage/detail/lang.java.framework.struts.md
@@ -30,7 +30,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🟢 `partial` | `2026-05-30` | 3191 | `internal/custom/java/struts_dto_test.go`<br>`internal/custom/java/struts_routes.go`<br>`testdata/fixtures/sources/java/struts/StrutsDtoFixture.java` | Detects Struts 1 ActionForm subclasses (incl. Validator/Dyna variants) and Struts 2 action field-binding (ActionSupport/Action/ModelDriven). Emits SCOPE.Schema DTO entities, SCOPE.Field bound fields from public OGNL setters (skipping framework plumbing), BINDS_INPUT relationships, and BINDS_MODEL for ModelDriven<T>. Heuristic regex over setters / extends-clauses, hence partial |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🔴 `missing` | — | 3256 | — | Genuine build: Struts 2 uses validate() method override on ActionSupport (and Struts 1 ActionForm.validate()) for request validation, not JAX-RS/Spring annotation patterns; no extractor currently detects this pattern |
 
 ### Middleware
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/java/junit5.go` | struts, struts2, apache-struts keys included in junit5Frameworks map in junit5.go; test-class detection fires for JUnit 5 @Test methods and Struts Test Plugin patterns |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.java.framework.vaadin.md
+++ b/docs/coverage/detail/lang.java.framework.vaadin.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Branch conditions | 🔴 `missing` | — | — | — | — |
+| Branch conditions | — `not_applicable` | — | — | — | Vaadin is a server-side Java UI framework with no mobile platform-discriminating branches; branch_conditions is a mobile/platform-conditional UI paradigm that does not apply; state_management and prop_extraction are also not_applicable for Vaadin |
 | Data fetching | 🟢 `partial` | — | 3091 | `internal/custom/java/vaadin_gwt.go` | — |
 | Prop extraction | — `not_applicable` | — | 3091 | — | Vaadin is a server-side Java UI framework with no React-style concepts; prop_extraction is a React/JSX-paradigm capability that does not apply |
 | State management | — `not_applicable` | — | 3091 | — | Vaadin is a server-side Java UI framework with no React-style concepts; state_management is a React/JSX-paradigm capability that does not apply |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -15227,12 +15227,16 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
+            "status": "missing",
+            "issue": "3256",
+            "notes": "Genuine build: Android Context propagation (getContext()/getActivity()/requireContext() usage) not yet extracted; requires new regex patterns in android.go"
           }
         },
         "Navigation": {
           "deep_link_extraction": {
-            "status": "missing"
+            "status": "missing",
+            "issue": "3256",
+            "notes": "Genuine build: Android deep-link intent-filter patterns (\u003cintent-filter\u003e with BROWSE action + android:scheme/android:host in AndroidManifest.xml, @NavDeepLink annotations) not yet extracted"
           },
           "navigation_extraction": {
             "status": "partial",
@@ -15261,7 +15265,10 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/android.go"],
+            "notes": "adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android",
+            "verified_at": "2026-05-30"
           },
           "state_management": {
             "status": "partial",
@@ -15271,18 +15278,26 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits enum_declaration nodes for all Java frameworks including Android SDK/Jetpack; same as gwt/vaadin (partial)",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits interface_declaration nodes for all Java frameworks including Android SDK/Jetpack; same as gwt/vaadin (partial)",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Java has no type-alias syntax; all other Java frameworks are not_applicable for this cell"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Android SDK/Jetpack uses LiveData/StateFlow observer patterns rather than React-style useState setters; state_setter_emission is a React/JSX-paradigm capability that does not apply; gomobile (Go) is also not_applicable for the same reason"
           }
         },
         "Testing": {
@@ -15374,8 +15389,8 @@
             "issue": "3154"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Android SDK/Jetpack are mobile client frameworks with no server-side HTTP handlers; schema drift detection requires a producer-consumer HTTP endpoint pair; request_shape_extraction and response_shape_extraction are also not_applicable for these records"
           },
           "taint_sink_detection": {
             "status": "partial",
@@ -15409,12 +15424,16 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
+            "status": "missing",
+            "issue": "3256",
+            "notes": "Genuine build: Android Context propagation not yet extracted; requires new regex patterns in android.go"
           }
         },
         "Navigation": {
           "deep_link_extraction": {
-            "status": "missing"
+            "status": "missing",
+            "issue": "3256",
+            "notes": "Genuine build: Android deep-link intent-filter patterns not yet extracted; same build as android-jetpack"
           },
           "navigation_extraction": {
             "status": "partial",
@@ -15443,7 +15462,10 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/android.go"],
+            "notes": "adSdkIntBranchRE detects Build.VERSION.SDK_INT comparisons as platform-branch control-flow sites; same extractor delivers Platform.platform_branching partial (#3188); the branch control-flow site entity mirrors the Data Flow.branch_conditions surface for Android",
+            "verified_at": "2026-05-30"
           },
           "state_management": {
             "status": "partial",
@@ -15453,18 +15475,26 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits enum_declaration nodes for all Java frameworks including Android SDK/Jetpack; same as gwt/vaadin (partial)",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/extractors/java/java.go"],
+            "notes": "Framework-blind Java extractor emits interface_declaration nodes for all Java frameworks including Android SDK/Jetpack; same as gwt/vaadin (partial)",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Java has no type-alias syntax; all other Java frameworks are not_applicable for this cell"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Android SDK uses LiveData/observer patterns rather than React-style useState setters; state_setter_emission is a React/JSX-paradigm capability that does not apply"
           }
         },
         "Testing": {
@@ -15556,8 +15586,8 @@
             "issue": "3154"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Android SDK is a mobile client framework with no server-side HTTP handlers; schema drift detection requires a producer-consumer HTTP endpoint pair; request_shape_extraction and response_shape_extraction are also not_applicable for this record"
           },
           "taint_sink_detection": {
             "status": "partial",
@@ -15881,7 +15911,8 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "GWT compiles Java to client-side JS but uses Java idioms with no mobile platform-discriminating branches; branch_conditions is a mobile/platform-conditional UI paradigm that does not apply; state_management and prop_extraction are also not_applicable for GWT"
           },
           "data_fetching": {
             "status": "partial",
@@ -17896,7 +17927,8 @@
             "verified_at": "2026-05-29"
           },
           "type_alias_extraction": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Java has no type-alias syntax; all other Java frameworks are not_applicable for this cell"
           }
         },
         "Lifecycle": {
@@ -17994,7 +18026,8 @@
           },
           "response_shape_extraction": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "3256",
+            "notes": "Genuine build: Play Java uses play.mvc.Results.ok()/badRequest()/created() patterns rather than Spring ResponseEntity; payload_shapes_java.go does not detect Play-specific result patterns; requires dedicated Play response-shape regex"
           },
           "sanitizer_recognition": {
             "status": "partial",
@@ -18996,7 +19029,8 @@
           },
           "request_validation": {
             "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "issue": "3256",
+            "notes": "Genuine build: Struts 2 uses validate() method override on ActionSupport (and Struts 1 ActionForm.validate()) for request validation, not JAX-RS/Spring annotation patterns; no extractor currently detects this pattern"
           }
         },
         "Middleware": {
@@ -19010,8 +19044,11 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/junit5.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "struts, struts2, apache-struts keys included in junit5Frameworks map in junit5.go; test-class detection fires for JUnit 5 @Test methods and Struts Test Plugin patterns",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -19249,7 +19286,8 @@
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Vaadin is a server-side Java UI framework with no mobile platform-discriminating branches; branch_conditions is a mobile/platform-conditional UI paradigm that does not apply; state_management and prop_extraction are also not_applicable for Vaadin"
           },
           "data_fetching": {
             "status": "partial",


### PR DESCRIPTION
## Summary

Gap-scans all 22 remaining missing Java cells across 6 frameworks and applies the 3-way classification rule. 16 cells resolved; 6 genuine-build cells left with tracking issue #3256.

**Recording-wins (7 cells):**
- `android-jetpack` + `android-sdk`: `Data Flow/branch_conditions` → **partial** — `adSdkIntBranchRE` in `android.go` already emits `SDK_INT` platform-branch operations (same extractor that delivers `Platform.platform_branching`)
- `android-jetpack` + `android-sdk`: `Type System/enum_extraction` → **partial** — framework-blind `java.go` emits `enum_declaration` nodes for all Java (consistent with gwt/vaadin which are also partial)
- `android-jetpack` + `android-sdk`: `Type System/interface_extraction` → **partial** — framework-blind `java.go` emits `interface_declaration` nodes (same reasoning)
- `struts`: `Testing/tests_linkage` → **partial** — `struts`/`struts2`/`apache-struts` keys already present in `junit5Frameworks` map in `junit5.go`

**Honest-NA (9 cells):**
- `android-jetpack` + `android-sdk`: `Type System/type_alias_extraction` → **not_applicable** — Java has no type-alias syntax; consistent with every other Java framework
- `android-jetpack` + `android-sdk`: `Lifecycle/state_setter_emission` → **not_applicable** — Android uses LiveData/StateFlow observer patterns, not React-style `useState` setters
- `android-jetpack` + `android-sdk`: `Substrate/schema_drift_detection` → **not_applicable** — mobile client apps have no server-side HTTP handlers; `request_shape_extraction`/`response_shape_extraction` are already `not_applicable`
- `gwt`: `Data Flow/branch_conditions` → **not_applicable** — GWT compiles Java to JS but has no mobile platform-discriminating branches; `state_management` already `not_applicable`
- `vaadin`: `Data Flow/branch_conditions` → **not_applicable** — server-side Java UI framework; no platform-discriminating branches; `state_management` already `not_applicable`
- `play`: `Type System/type_alias_extraction` → **not_applicable** — Java has no type-alias syntax

**Genuine-build remainder (6 cells — issue #3256 added as tracking):**
- `android-jetpack` + `android-sdk`: `Structure/context_extraction` — Android Context propagation patterns not yet in `android.go`
- `android-jetpack` + `android-sdk`: `Navigation/deep_link_extraction` — `intent-filter` deep-link + `@NavDeepLink` patterns not yet extracted
- `play`: `Substrate/response_shape_extraction` — `play.mvc.Results.ok()` pattern not in `payload_shapes_java.go`
- `struts`: `Validation/request_validation` — `validate()` method override pattern not yet extracted

## Test plan

- [x] `go build ./internal/... ./tools/coverage/...` — clean
- [x] `go test ./internal/custom/java/... ./internal/types/ ./tools/coverage/...` — all pass
- [x] `go run ./tools/coverage validate` — exit 0 (warnings only, no errors)
- [x] `go run ./tools/coverage fmt --check` — `ok: registry.json is canonical`
- [x] `go run ./tools/coverage gen` — byte-stable (no diff in tracked .md files beyond the expected status updates)
- [x] `gofmt -l` — no Go files modified
- [x] Java missing count: 22 → 6 (confirmed by `coverage gaps --language java`)

Part of #3256

🤖 Generated with [Claude Code](https://claude.com/claude-code)