### PR TITLE
coverage(ruby): observability + auth extractors, flip 31 missing cells (Part of #3282)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -40562,7 +40562,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/auth.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -40607,16 +40609,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -40799,16 +40807,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -40948,7 +40962,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/auth.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -40993,16 +41009,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -41142,7 +41164,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/auth.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -41187,16 +41211,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -41336,7 +41366,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/auth.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -41381,16 +41413,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -41530,7 +41568,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/auth.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -41575,16 +41615,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -41724,7 +41770,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/auth.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -41769,16 +41817,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -41918,7 +41972,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/auth.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -41963,16 +42019,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/ruby/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {

--- a/internal/custom/ruby/auth.go
+++ b/internal/custom/ruby/auth.go
@@ -1,0 +1,479 @@
+// auth.go — Ruby auth extractor (auth_coverage).
+//
+// Covers the Auth lane for Ruby http_backend frameworks by detecting:
+//
+//	Devise        — devise_for, before_action :authenticate_user!, current_user,
+//	                devise :registerable, require_login
+//	JWT           — JWT.encode / JWT.decode, jwt_token, jwt_header
+//	Warden        — Warden::Manager / env['warden'] / warden.authenticate
+//	CanCanCan     — authorize!, load_and_authorize_resource, can? / cannot?
+//	Pundit        — authorize, policy_scope, Pundit::Policy
+//	Doorkeeper    — doorkeeper_for :all, before_action :doorkeeper_authorize!
+//	Rack::Auth    — Rack::Auth::Basic, Rack::Auth::Digest
+//	OmniAuth      — OmniAuth::Builder / provider :github
+//
+// All cells are flipped to `partial` because detection is heuristic
+// (require/pattern matching) and does not perform cross-file dataflow.
+// This is consistent with the Java and Python observability extractors.
+//
+// Part of issue #3282.
+package ruby
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("ruby_auth", &rubyAuthExtractor{})
+}
+
+// rubyAuthExtractor detects auth patterns across Ruby source files.
+type rubyAuthExtractor struct{}
+
+func (e *rubyAuthExtractor) Language() string { return "ruby_auth" }
+
+// ---------------------------------------------------------------------------
+// Compiled regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// --------------- Devise ---------------
+
+	// devise_for :users / devise_for :admins, ...
+	rbDeviseForRe = regexp.MustCompile(
+		`(?m)\bdevise_for\s+:([a-z_]+)`)
+
+	// before_action :authenticate_user! / :authenticate_admin!
+	rbDeviseAuthenticateRe = regexp.MustCompile(
+		`(?m)\bbefore_action\s+:authenticate_([a-z_]+)!`)
+
+	// devise :registerable, :authenticatable, ...
+	rbDeviseModulesRe = regexp.MustCompile(
+		`(?m)\bdevise\s+:([a-z_]+(?:,\s*:[a-z_]+)*)`)
+
+	// current_user / current_admin helper references
+	rbDeviseCurrentUserRe = regexp.MustCompile(
+		`(?m)\bcurrent_([a-z_]+)\b`)
+
+	// require_login (Sorcery / Clearance compatibility)
+	rbRequireLoginRe = regexp.MustCompile(
+		`(?m)\b(?:require_login|login_required)\b`)
+
+	// --------------- JWT ---------------
+
+	// require 'jwt'
+	rbJWTRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"]jwt['"]`)
+
+	// JWT.encode(payload, secret, ...) / JWT.decode(token, secret, ...)
+	rbJWTEncodeDecodeRe = regexp.MustCompile(
+		`(?m)\bJWT\.(encode|decode)\s*\(`)
+
+	// jwt_token / Authorization: Bearer pattern
+	rbJWTTokenRe = regexp.MustCompile(
+		`(?m)(?:jwt_token|bearer_token|Authorization.*Bearer|decode_jwt)\b`)
+
+	// --------------- Warden ---------------
+
+	// Warden::Manager.new / use Warden::Manager
+	rbWardenManagerRe = regexp.MustCompile(
+		`(?m)\bWarden::Manager\b`)
+
+	// env['warden'] / env["warden"]
+	rbWardenEnvRe = regexp.MustCompile(
+		`(?m)\benv\[['"]warden['"]\]`)
+
+	// warden.authenticate / warden.authenticate!
+	rbWardenAuthRe = regexp.MustCompile(
+		`(?m)\b(\w+)\.authenticate!?\s*\(\s*:`)
+
+	// --------------- CanCanCan ---------------
+
+	// authorize! :action, resource
+	rbCanCanAuthorizeRe = regexp.MustCompile(
+		`(?m)\bauthorize!\s+:[a-z_]+`)
+
+	// load_and_authorize_resource / load_and_permit_resource
+	rbCanCanLoadRe = regexp.MustCompile(
+		`(?m)\b(?:load_and_authorize_resource|load_and_permit_resource|can\?|cannot\?)\b`)
+
+	// ability.can :action, Model / can :manage, :all
+	rbCanCanAbilityRe = regexp.MustCompile(
+		`(?m)\b(?:can|cannot)\s+:[a-z_]+,\s+`)
+
+	// --------------- Pundit ---------------
+
+	// authorize @resource / authorize resource
+	rbPunditAuthorizeRe = regexp.MustCompile(
+		`(?m)\bauthorize\s+[@a-z_]`)
+
+	// policy_scope(Model) / policy(resource)
+	rbPunditPolicyScopeRe = regexp.MustCompile(
+		`(?m)\b(?:policy_scope|policy)\s*\(`)
+
+	// Pundit::Policy / include Pundit
+	rbPunditClassRe = regexp.MustCompile(
+		`(?m)\b(?:Pundit::Policy\b|include Pundit\b)`)
+
+	// --------------- Doorkeeper ---------------
+
+	// before_action :doorkeeper_authorize!
+	rbDoorkeeperAuthorizeRe = regexp.MustCompile(
+		`(?m)\bbefore_action\s+:doorkeeper_authorize!`)
+
+	// doorkeeper_for :all / use_doorkeeper
+	rbDoorkeeperForRe = regexp.MustCompile(
+		`(?m)\b(?:doorkeeper_for\s+:|use_doorkeeper)\b`)
+
+	// --------------- Rack::Auth / OmniAuth ---------------
+
+	// Rack::Auth::Basic / Rack::Auth::Digest
+	rbRackAuthRe = regexp.MustCompile(
+		`(?m)\bRack::Auth::(Basic|Digest)\b`)
+
+	// OmniAuth::Builder / OmniAuth.config / provider :github
+	rbOmniAuthRe = regexp.MustCompile(
+		`(?m)\b(?:OmniAuth(?:::Builder|\.config)|provider\s+:[a-z_]+)\b`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *rubyAuthExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.ruby_auth")
+	_, span := tracer.Start(ctx, "custom.ruby_auth")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Fast guard: skip files with no auth-relevant tokens.
+	hasAuth := strings.Contains(src, "devise") || strings.Contains(src, "Devise") ||
+		strings.Contains(src, "authenticate") || strings.Contains(src, "JWT") ||
+		strings.Contains(src, "jwt") || strings.Contains(src, "Warden") ||
+		strings.Contains(src, "warden") || strings.Contains(src, "authorize") ||
+		strings.Contains(src, "CanCan") || strings.Contains(src, "Pundit") ||
+		strings.Contains(src, "doorkeeper") || strings.Contains(src, "Doorkeeper") ||
+		strings.Contains(src, "OmniAuth") || strings.Contains(src, "Rack::Auth") ||
+		strings.Contains(src, "require_login") || strings.Contains(src, "login_required")
+	if !hasAuth {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	out = append(out, extractDevise(src, file.Path)...)
+	out = append(out, extractJWT(src, file.Path)...)
+	out = append(out, extractWarden(src, file.Path)...)
+	out = append(out, extractCanCanCan(src, file.Path)...)
+	out = append(out, extractPundit(src, file.Path)...)
+	out = append(out, extractDoorkeeper(src, file.Path)...)
+	out = append(out, extractRackOmniAuth(src, file.Path)...)
+
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Devise
+// ---------------------------------------------------------------------------
+
+func extractDevise(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// devise_for :model
+	for _, idx := range rbDeviseForRe.FindAllStringSubmatchIndex(src, -1) {
+		model := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("devise_for:"+model, string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "devise", "kind", "route_registration", "model", model)
+		out = append(out, e)
+	}
+
+	// before_action :authenticate_<model>!
+	for _, idx := range rbDeviseAuthenticateRe.FindAllStringSubmatchIndex(src, -1) {
+		model := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("authenticate_"+model+"!", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "devise", "kind", "before_action", "model", model)
+		out = append(out, e)
+	}
+
+	// devise :registerable, :authenticatable ...
+	for _, idx := range rbDeviseModulesRe.FindAllStringSubmatchIndex(src, -1) {
+		modules := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("devise_modules", string(types.EntityKindPattern), "auth_config", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "devise", "kind", "modules", "modules_list", modules)
+		out = append(out, e)
+	}
+
+	// require_login / login_required
+	if rbRequireLoginRe.MatchString(src) {
+		loc := rbRequireLoginRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("require_login", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "devise_compat", "kind", "before_action")
+		out = append(out, e)
+	}
+
+	// current_user / current_admin usage (only emit when devise_for is present)
+	if rbDeviseForRe.MatchString(src) {
+		for _, idx := range rbDeviseCurrentUserRe.FindAllStringSubmatchIndex(src, -1) {
+			model := src[idx[2]:idx[3]]
+			// Skip very common non-user models that appear in many contexts
+			if model == "user" || model == "admin" || model == "member" || model == "account" {
+				ln := lineOf(src, idx[0])
+				e := makeEntity("current_"+model, string(types.EntityKindPattern), "auth_helper", fp, "ruby", ln)
+				setProps(&e, "signal", "auth", "library", "devise", "kind", "helper", "model", model)
+				out = append(out, e)
+			}
+		}
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// JWT
+// ---------------------------------------------------------------------------
+
+func extractJWT(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	if !rbJWTRequireRe.MatchString(src) && !rbJWTEncodeDecodeRe.MatchString(src) &&
+		!rbJWTTokenRe.MatchString(src) {
+		return nil
+	}
+
+	// JWT.encode / JWT.decode call sites
+	for _, idx := range rbJWTEncodeDecodeRe.FindAllStringSubmatchIndex(src, -1) {
+		op := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("JWT."+op, string(types.EntityKindPattern), "auth_token", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "jwt", "kind", "token_operation", "operation", op)
+		out = append(out, e)
+	}
+
+	// jwt_token / Bearer pattern
+	if rbJWTTokenRe.MatchString(src) && !rbJWTEncodeDecodeRe.MatchString(src) {
+		loc := rbJWTTokenRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("jwt_token", string(types.EntityKindPattern), "auth_token", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "jwt", "kind", "token_usage")
+		out = append(out, e)
+	}
+
+	// file-level signal when only require
+	if rbJWTRequireRe.MatchString(src) && !rbJWTEncodeDecodeRe.MatchString(src) && !rbJWTTokenRe.MatchString(src) {
+		loc := rbJWTRequireRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("jwt", string(types.EntityKindPattern), "auth_token", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "jwt", "kind", "require")
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Warden
+// ---------------------------------------------------------------------------
+
+func extractWarden(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	if !rbWardenManagerRe.MatchString(src) && !rbWardenEnvRe.MatchString(src) &&
+		!rbWardenAuthRe.MatchString(src) {
+		return nil
+	}
+
+	// Warden::Manager
+	if rbWardenManagerRe.MatchString(src) {
+		loc := rbWardenManagerRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("Warden::Manager", string(types.EntityKindPattern), "auth_middleware", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "warden", "kind", "middleware_setup")
+		out = append(out, e)
+	}
+
+	// env['warden'] usage
+	if rbWardenEnvRe.MatchString(src) {
+		loc := rbWardenEnvRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("env.warden", string(types.EntityKindPattern), "auth_helper", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "warden", "kind", "env_access")
+		out = append(out, e)
+	}
+
+	// warden.authenticate! / warden.authenticate
+	for _, idx := range rbWardenAuthRe.FindAllStringSubmatchIndex(src, -1) {
+		receiver := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity(receiver+".authenticate", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "warden", "kind", "authenticate_call", "receiver", receiver)
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// CanCanCan
+// ---------------------------------------------------------------------------
+
+func extractCanCanCan(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	if !rbCanCanAuthorizeRe.MatchString(src) && !rbCanCanLoadRe.MatchString(src) &&
+		!rbCanCanAbilityRe.MatchString(src) {
+		return nil
+	}
+
+	// authorize! :action
+	for _, idx := range rbCanCanAuthorizeRe.FindAllStringSubmatchIndex(src, -1) {
+		ln := lineOf(src, idx[0])
+		e := makeEntity("authorize!", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "authorization_check")
+		out = append(out, e)
+	}
+
+	// load_and_authorize_resource / can? / cannot?
+	if rbCanCanLoadRe.MatchString(src) {
+		loc := rbCanCanLoadRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		callSite := src[loc[0]:loc[1]]
+		e := makeEntity(strings.TrimSpace(callSite), string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "resource_authorization")
+		out = append(out, e)
+	}
+
+	// can :manage, :all / cannot :destroy, Article
+	for _, idx := range rbCanCanAbilityRe.FindAllStringSubmatchIndex(src, -1) {
+		ln := lineOf(src, idx[0])
+		callSite := strings.TrimSpace(src[idx[0]:idx[1]])
+		if len(callSite) > 50 {
+			callSite = callSite[:50]
+		}
+		e := makeEntity(callSite, string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "ability_rule")
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Pundit
+// ---------------------------------------------------------------------------
+
+func extractPundit(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	if !rbPunditAuthorizeRe.MatchString(src) && !rbPunditPolicyScopeRe.MatchString(src) &&
+		!rbPunditClassRe.MatchString(src) {
+		return nil
+	}
+
+	// authorize @resource
+	for _, idx := range rbPunditAuthorizeRe.FindAllStringSubmatchIndex(src, -1) {
+		ln := lineOf(src, idx[0])
+		e := makeEntity("authorize", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "pundit", "kind", "authorize_call")
+		out = append(out, e)
+	}
+
+	// policy_scope(...) / policy(...)
+	for _, idx := range rbPunditPolicyScopeRe.FindAllStringSubmatchIndex(src, -1) {
+		ln := lineOf(src, idx[0])
+		callSite := strings.TrimSpace(src[idx[0]:idx[1]])
+		e := makeEntity(callSite, string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "pundit", "kind", "policy_scope")
+		out = append(out, e)
+	}
+
+	// Pundit::Policy / include Pundit
+	if rbPunditClassRe.MatchString(src) {
+		loc := rbPunditClassRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("Pundit::Policy", string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "pundit", "kind", "policy_class")
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Doorkeeper
+// ---------------------------------------------------------------------------
+
+func extractDoorkeeper(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	if !rbDoorkeeperAuthorizeRe.MatchString(src) && !rbDoorkeeperForRe.MatchString(src) {
+		return nil
+	}
+
+	// before_action :doorkeeper_authorize!
+	if rbDoorkeeperAuthorizeRe.MatchString(src) {
+		loc := rbDoorkeeperAuthorizeRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("doorkeeper_authorize!", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "doorkeeper", "kind", "before_action")
+		out = append(out, e)
+	}
+
+	// doorkeeper_for :all / use_doorkeeper
+	if rbDoorkeeperForRe.MatchString(src) {
+		loc := rbDoorkeeperForRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("doorkeeper", string(types.EntityKindPattern), "auth_config", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "doorkeeper", "kind", "oauth_setup")
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Rack::Auth + OmniAuth
+// ---------------------------------------------------------------------------
+
+func extractRackOmniAuth(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// Rack::Auth::Basic / Rack::Auth::Digest
+	for _, idx := range rbRackAuthRe.FindAllStringSubmatchIndex(src, -1) {
+		scheme := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("Rack::Auth::"+scheme, string(types.EntityKindPattern), "auth_middleware", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "rack_auth", "kind", "middleware", "scheme", scheme)
+		out = append(out, e)
+	}
+
+	// OmniAuth::Builder / provider :provider_name
+	for _, idx := range rbOmniAuthRe.FindAllStringSubmatchIndex(src, -1) {
+		ln := lineOf(src, idx[0])
+		callSite := strings.TrimSpace(src[idx[0]:idx[1]])
+		if len(callSite) > 50 {
+			callSite = callSite[:50]
+		}
+		e := makeEntity(callSite, string(types.EntityKindPattern), "auth_config", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "omniauth", "kind", "provider_registration")
+		out = append(out, e)
+	}
+
+	return out
+}

--- a/internal/custom/ruby/auth_test.go
+++ b/internal/custom/ruby/auth_test.go
@@ -1,0 +1,286 @@
+package ruby_test
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Auth — Devise
+// ---------------------------------------------------------------------------
+
+func TestRubyAuthDeviseFor(t *testing.T) {
+	src := `
+Rails.application.routes.draw do
+  devise_for :users
+  devise_for :admins, controllers: { sessions: 'admins/sessions' }
+end
+`
+	ents := extract(t, "ruby_auth", fi("config/routes.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "devise_for:users") {
+		t.Error("expected devise_for:users entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "devise_for:admins") {
+		t.Error("expected devise_for:admins entity")
+	}
+}
+
+func TestRubyAuthDeviseAuthenticate(t *testing.T) {
+	src := `
+class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/controllers/application_controller.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "authenticate_user!") {
+		t.Error("expected authenticate_user! entity")
+	}
+}
+
+func TestRubyAuthDeviseModules(t *testing.T) {
+	src := `
+class User < ApplicationRecord
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/models/user.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "devise_modules") {
+		t.Error("expected devise_modules entity")
+	}
+}
+
+func TestRubyAuthRequireLogin(t *testing.T) {
+	src := `
+class PostsController < ApplicationController
+  before_filter :require_login
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/controllers/posts_controller.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "require_login") {
+		t.Error("expected require_login entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — JWT
+// ---------------------------------------------------------------------------
+
+func TestRubyAuthJWTEncodeDecode(t *testing.T) {
+	src := `
+require 'jwt'
+
+def encode_token(payload)
+  JWT.encode(payload, Rails.application.secret_key_base)
+end
+
+def decode_token(token)
+  JWT.decode(token, Rails.application.secret_key_base, true, algorithm: 'HS256')
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/lib/jwt_helper.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "JWT.encode") {
+		t.Error("expected JWT.encode entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "JWT.decode") {
+		t.Error("expected JWT.decode entity")
+	}
+}
+
+func TestRubyAuthJWTRequireOnly(t *testing.T) {
+	src := `require 'jwt'`
+	ents := extract(t, "ruby_auth", fi("lib/auth.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "jwt") {
+		t.Error("expected jwt require entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — Warden
+// ---------------------------------------------------------------------------
+
+func TestRubyAuthWarden(t *testing.T) {
+	src := `
+use Warden::Manager do |manager|
+  manager.default_strategies :password
+  manager.failure_app = Proc.new { |env|
+    ['401', {'Content-Type' => 'application/json'}, ['']]
+  }
+end
+`
+	ents := extract(t, "ruby_auth", fi("config.ru", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Warden::Manager") {
+		t.Error("expected Warden::Manager entity")
+	}
+}
+
+func TestRubyAuthWardenEnv(t *testing.T) {
+	src := `
+def current_user
+  @current_user ||= env['warden'].user
+end
+`
+	ents := extract(t, "ruby_auth", fi("lib/auth_helper.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "env.warden") {
+		t.Error("expected env.warden entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — CanCanCan
+// ---------------------------------------------------------------------------
+
+func TestRubyAuthCanCanAuthorize(t *testing.T) {
+	src := `
+class ArticlesController < ApplicationController
+  def show
+    @article = Article.find(params[:id])
+    authorize! :read, @article
+  end
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/controllers/articles_controller.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "authorize!") {
+		t.Error("expected authorize! entity")
+	}
+}
+
+func TestRubyAuthCanCanLoadAndAuthorize(t *testing.T) {
+	src := `
+class PostsController < ApplicationController
+  load_and_authorize_resource
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/controllers/posts_controller.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "load_and_authorize_resource") {
+		t.Error("expected load_and_authorize_resource entity")
+	}
+}
+
+func TestRubyAuthCanCanAbility(t *testing.T) {
+	src := `
+class Ability
+  include CanCan::Ability
+  def initialize(user)
+    can :manage, :all if user.admin?
+    can :read, Article
+    cannot :destroy, Article, archived: true
+  end
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/models/ability.rb", "ruby", src))
+	if len(ents) == 0 {
+		t.Error("expected CanCanCan ability entities")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — Pundit
+// ---------------------------------------------------------------------------
+
+func TestRubyAuthPunditAuthorize(t *testing.T) {
+	src := `
+class ArticlesController < ApplicationController
+  include Pundit
+
+  def update
+    @article = Article.find(params[:id])
+    authorize @article
+    @article.update(article_params)
+  end
+
+  def index
+    @articles = policy_scope(Article)
+  end
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/controllers/articles_controller.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "authorize") {
+		t.Error("expected Pundit authorize entity")
+	}
+}
+
+func TestRubyAuthPunditPolicy(t *testing.T) {
+	src := `
+class ArticlePolicy < ApplicationPolicy
+  include Pundit
+
+  def update?
+    user.admin? || record.author == user
+  end
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/policies/article_policy.rb", "ruby", src))
+	if len(ents) == 0 {
+		t.Error("expected at least one Pundit entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — Doorkeeper
+// ---------------------------------------------------------------------------
+
+func TestRubyAuthDoorkeeper(t *testing.T) {
+	src := `
+class ApiController < ApplicationController
+  before_action :doorkeeper_authorize!
+
+  def index
+    @resources = Resource.all
+  end
+end
+`
+	ents := extract(t, "ruby_auth", fi("app/controllers/api_controller.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "doorkeeper_authorize!") {
+		t.Error("expected doorkeeper_authorize! entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — Rack::Auth + OmniAuth
+// ---------------------------------------------------------------------------
+
+func TestRubyAuthRackAuth(t *testing.T) {
+	src := `
+use Rack::Auth::Basic, "Protected Area" do |username, password|
+  ActiveSupport::SecurityUtils.secure_compare(
+    ::Digest::SHA256.hexdigest(password),
+    ::Digest::SHA256.hexdigest(ENV['ADMIN_PASSWORD'])
+  )
+end
+`
+	ents := extract(t, "ruby_auth", fi("config.ru", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Rack::Auth::Basic") {
+		t.Error("expected Rack::Auth::Basic entity")
+	}
+}
+
+func TestRubyAuthOmniAuth(t *testing.T) {
+	src := `
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET']
+  provider :google_oauth2, ENV['GOOGLE_ID'], ENV['GOOGLE_SECRET']
+end
+`
+	ents := extract(t, "ruby_auth", fi("config/initializers/omniauth.rb", "ruby", src))
+	if len(ents) == 0 {
+		t.Error("expected OmniAuth entities")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// No match: plain Ruby file
+// ---------------------------------------------------------------------------
+
+func TestRubyAuthNoMatch(t *testing.T) {
+	src := `
+class Calculator
+  def add(a, b)
+    a + b
+  end
+end
+`
+	ents := extract(t, "ruby_auth", fi("lib/calculator.rb", "ruby", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/ruby/observability.go
+++ b/internal/custom/ruby/observability.go
@@ -1,0 +1,465 @@
+// observability.go — Ruby observability extractor (log/metric/trace).
+//
+// Covers the Observability lane for all 8 Ruby http_backend frameworks:
+//
+//	log_extraction   — Rails.logger.*, Logger.new, logger.info, SemanticLogger
+//	metric_extraction — prometheus-client, Datadog::Statsd, Yabeda, statsd-client
+//	trace_extraction  — OpenTelemetry::SDK, tracer.in_span, OpenTracing, Skylight
+//
+// Detection is import/require-heuristic: the extractor recognises library
+// requires and canonical call-site patterns but does NOT perform cross-file
+// dataflow, so all cells are flipped to `partial` rather than `full`. This
+// matches the honesty discipline established by the Java and Python observability
+// extractors (internal/custom/java/observability.go,
+// internal/custom/python/observability.go).
+//
+// A single extractor key "ruby_observability" is registered; the extractor
+// runs on any Ruby file regardless of framework.
+//
+// Part of issue #3282.
+package ruby
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("ruby_observability", &rubyObservabilityExtractor{})
+}
+
+// rubyObservabilityExtractor detects log, metric, and trace instrumentation
+// across Ruby source files.
+type rubyObservabilityExtractor struct{}
+
+func (e *rubyObservabilityExtractor) Language() string { return "ruby_observability" }
+
+// ---------------------------------------------------------------------------
+// Compiled regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// --------------- log_extraction ---------------
+
+	// require 'logger' / require "logger"
+	rbLoggerRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"]logger['"]`)
+
+	// Rails.logger.info / Rails.logger.error / etc.
+	rbRailsLoggerRe = regexp.MustCompile(
+		`(?m)\bRails\.logger\.(debug|info|warn|error|fatal|unknown)\s*[\({]`)
+
+	// Logger.new(...) — stdlib logger instantiation
+	rbLoggerNewRe = regexp.MustCompile(
+		`(?m)\bLogger\.new\s*\(`)
+
+	// logger.info / logger.warn / logger.error etc. (any receiver)
+	rbLogCallRe = regexp.MustCompile(
+		`(?m)\b(\w+)\.(debug|info|warn|warning|error|fatal|unknown)\s*[\({]`)
+
+	// semantic_logger: require 'semantic_logger'
+	rbSemanticLoggerRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"]semantic_logger['"]`)
+
+	// SemanticLogger.add_appender / include SemanticLogger
+	rbSemanticLoggerUsageRe = regexp.MustCompile(
+		`(?m)(?:SemanticLogger\.|include SemanticLogger)`)
+
+	// --------------- metric_extraction ---------------
+
+	// require 'prometheus/client' / require "prometheus-client"
+	rbPrometheusRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"]prometheus(?:/client|-client)['"]`)
+
+	// Prometheus::Client::Counter/Gauge/Histogram/Summary.new(...)
+	rbPrometheusMetricRe = regexp.MustCompile(
+		`(?m)\bPrometheus::Client::(Counter|Gauge|Histogram|Summary|Meter)\b`)
+
+	// require 'datadog/statsd' / require "dogstatsd-ruby"
+	rbDatadogRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"](?:datadog/statsd|dogstatsd-ruby|ddtrace)['"]`)
+
+	// Datadog::Statsd.new(...)
+	rbDatadogStatsdNewRe = regexp.MustCompile(
+		`(?m)\bDatadog::Statsd\.new\s*\(`)
+
+	// statsd.increment / statsd.gauge / statsd.histogram etc.
+	rbStatsdCallRe = regexp.MustCompile(
+		`(?m)\b(\w+)\.(increment|decrement|count|gauge|histogram|timing|set|event|service_check)\s*\(\s*['"]([^'"]+)['"]`)
+
+	// Yabeda: require 'yabeda'
+	rbYabedaRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"]yabeda(?:/[a-z_-]+)?['"]`)
+
+	// Yabeda.counter / Yabeda.gauge / Yabeda.histogram
+	rbYabedaMetricRe = regexp.MustCompile(
+		`(?m)\bYabeda\.(counter|gauge|histogram|summary|meter)\s*\(`)
+
+	// statsd-client gem: StatsD.measure / StatsD.increment
+	rbStatsDRubyRe = regexp.MustCompile(
+		`(?m)\bStatsD\.(measure|increment|gauge|histogram|set|event|service_check)\s*\(`)
+
+	// --------------- trace_extraction ---------------
+
+	// require 'opentelemetry-sdk' / require 'opentelemetry/sdk'
+	rbOtelRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"]opentelemetry(?:-sdk|/sdk|/trace)?['"]`)
+
+	// OpenTelemetry::SDK.configure / OpenTelemetry.tracer_provider
+	rbOtelSDKRe = regexp.MustCompile(
+		`(?m)\bOpenTelemetry(?:::SDK)?\.(?:configure|tracer_provider|logger)\b`)
+
+	// tracer.in_span("name") do ... end
+	rbOtelInSpanRe = regexp.MustCompile(
+		`(?m)\b(\w+)\.in_span\s*\(\s*['"]([^'"]+)['"]`)
+
+	// require 'ddtrace' / require "datadog"
+	rbDdtraceRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"](?:ddtrace|datadog)['"]`)
+
+	// Datadog::Tracing.trace("name") / Datadog.configure
+	rbDdtraceCallRe = regexp.MustCompile(
+		`(?m)\bDatadog(?:::Tracing)?\.(?:trace|configure)\s*\(`)
+
+	// require 'skylight'
+	rbSkylightRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"]skylight(?:/[a-z_-]+)?['"]`)
+
+	// Skylight.instrument(title: "name") { }
+	rbSkylightInstrumentRe = regexp.MustCompile(
+		`(?m)\bSkylight\.instrument\s*\(`)
+
+	// require 'opentracing'
+	rbOpenTracingRequireRe = regexp.MustCompile(
+		`(?m)\brequire\s+['"]opentracing['"]`)
+
+	// OpenTracing.start_span("name") / OpenTracing.global_tracer
+	rbOpenTracingCallRe = regexp.MustCompile(
+		`(?m)\bOpenTracing\.(?:start_span|global_tracer|start_active_span)\s*\(`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *rubyObservabilityExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.ruby_observability")
+	_, span := tracer.Start(ctx, "custom.ruby_observability")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Fast guard: skip files that contain none of the observability library tokens.
+	hasLog := strings.Contains(src, "logger") || strings.Contains(src, "Logger") ||
+		strings.Contains(src, "SemanticLogger") || strings.Contains(src, "Rails.logger")
+	hasMetric := strings.Contains(src, "prometheus") || strings.Contains(src, "Prometheus") ||
+		strings.Contains(src, "Datadog::Statsd") || strings.Contains(src, "Yabeda") ||
+		strings.Contains(src, "StatsD") || strings.Contains(src, "statsd")
+	hasTrace := strings.Contains(src, "OpenTelemetry") || strings.Contains(src, "opentelemetry") ||
+		strings.Contains(src, "ddtrace") || strings.Contains(src, "Datadog::Tracing") ||
+		strings.Contains(src, "Skylight") || strings.Contains(src, "OpenTracing") ||
+		strings.Contains(src, "opentracing")
+
+	if !hasLog && !hasMetric && !hasTrace {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	out = append(out, extractRubyLogging(src, file.Path)...)
+	out = append(out, extractRubyMetrics(src, file.Path)...)
+	out = append(out, extractRubyTracing(src, file.Path)...)
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// log_extraction
+// ---------------------------------------------------------------------------
+
+func extractRubyLogging(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// Rails.logger.<level> call sites
+	for _, idx := range rbRailsLoggerRe.FindAllStringSubmatchIndex(src, -1) {
+		level := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("Rails.logger."+level, string(types.EntityKindPattern), "log_statement", fp, "ruby", ln)
+		setProps(&e, "signal", "log", "library", "rails_logger", "log_level", level, "receiver", "Rails.logger")
+		out = append(out, e)
+	}
+
+	// stdlib Logger.new
+	for _, idx := range rbLoggerNewRe.FindAllStringSubmatchIndex(src, -1) {
+		ln := lineOf(src, idx[0])
+		e := makeEntity("Logger.new", string(types.EntityKindPattern), "logger", fp, "ruby", ln)
+		setProps(&e, "signal", "log", "library", "ruby_stdlib_logger", "kind", "instantiation")
+		out = append(out, e)
+	}
+
+	// require 'logger' — file-level signal
+	if rbLoggerRequireRe.MatchString(src) && !rbLoggerNewRe.MatchString(src) && !rbRailsLoggerRe.MatchString(src) {
+		loc := rbLoggerRequireRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("logger", string(types.EntityKindPattern), "logger", fp, "ruby", ln)
+		setProps(&e, "signal", "log", "library", "ruby_stdlib_logger", "kind", "require")
+		out = append(out, e)
+	}
+
+	// SemanticLogger
+	if rbSemanticLoggerRequireRe.MatchString(src) || rbSemanticLoggerUsageRe.MatchString(src) {
+		var loc []int
+		if rbSemanticLoggerRequireRe.MatchString(src) {
+			loc = rbSemanticLoggerRequireRe.FindStringIndex(src)
+		} else {
+			loc = rbSemanticLoggerUsageRe.FindStringIndex(src)
+		}
+		ln := lineOf(src, loc[0])
+		e := makeEntity("SemanticLogger", string(types.EntityKindPattern), "logger", fp, "ruby", ln)
+		setProps(&e, "signal", "log", "library", "semantic_logger", "kind", "logger")
+		out = append(out, e)
+	}
+
+	// Generic logger.<level> calls (when a log library is present)
+	hasLogLib := rbLoggerRequireRe.MatchString(src) || rbRailsLoggerRe.MatchString(src) ||
+		rbSemanticLoggerRequireRe.MatchString(src) || rbSemanticLoggerUsageRe.MatchString(src) ||
+		strings.Contains(src, "Rails.logger")
+	if hasLogLib {
+		for _, idx := range rbLogCallRe.FindAllStringSubmatchIndex(src, -1) {
+			receiver := src[idx[2]:idx[3]]
+			level := src[idx[4]:idx[5]]
+			// Skip common false positives
+			if receiver == "response" || receiver == "resp" || receiver == "res" ||
+				receiver == "request" || receiver == "req" || receiver == "Rails" {
+				continue
+			}
+			ln := lineOf(src, idx[0])
+			e := makeEntity(receiver+"."+level, string(types.EntityKindPattern), "log_statement", fp, "ruby", ln)
+			setProps(&e, "signal", "log", "library", "ruby_logger", "log_level", level, "receiver", receiver)
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// metric_extraction
+// ---------------------------------------------------------------------------
+
+func extractRubyMetrics(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// --- prometheus-client ---
+	if rbPrometheusRequireRe.MatchString(src) || rbPrometheusMetricRe.MatchString(src) {
+		for _, idx := range rbPrometheusMetricRe.FindAllStringSubmatchIndex(src, -1) {
+			meterType := src[idx[2]:idx[3]]
+			ln := lineOf(src, idx[0])
+			e := makeEntity("Prometheus::Client::"+meterType, string(types.EntityKindPattern), "metric", fp, "ruby", ln)
+			setProps(&e, "signal", "metric", "library", "prometheus_client", "metric_type", strings.ToLower(meterType))
+			out = append(out, e)
+		}
+		if !rbPrometheusMetricRe.MatchString(src) {
+			loc := rbPrometheusRequireRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("prometheus_client", string(types.EntityKindPattern), "metric", fp, "ruby", ln)
+			setProps(&e, "signal", "metric", "library", "prometheus_client", "kind", "require")
+			out = append(out, e)
+		}
+	}
+
+	// --- Datadog::Statsd ---
+	if rbDatadogRequireRe.MatchString(src) || rbDatadogStatsdNewRe.MatchString(src) {
+		// Always emit instantiation entity when Datadog::Statsd.new is present
+		if rbDatadogStatsdNewRe.MatchString(src) {
+			loc := rbDatadogStatsdNewRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("Datadog::Statsd.new", string(types.EntityKindPattern), "metric", fp, "ruby", ln)
+			setProps(&e, "signal", "metric", "library", "datadog_statsd", "kind", "instantiation")
+			out = append(out, e)
+		}
+		// Emit per-call metric entities
+		for _, idx := range rbStatsdCallRe.FindAllStringSubmatchIndex(src, -1) {
+			receiver := src[idx[2]:idx[3]]
+			method := src[idx[4]:idx[5]]
+			metricName := src[idx[6]:idx[7]]
+			ln := lineOf(src, idx[0])
+			e := makeEntity(metricName, string(types.EntityKindPattern), "metric", fp, "ruby", ln)
+			setProps(&e, "signal", "metric", "library", "datadog_statsd",
+				"metric_type", rubyStatsdType(method), "metric_name", metricName, "receiver", receiver)
+			out = append(out, e)
+		}
+		// File-level signal when only require and nothing else
+		if !rbDatadogStatsdNewRe.MatchString(src) && !rbStatsdCallRe.MatchString(src) {
+			loc := rbDatadogRequireRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("datadog_statsd", string(types.EntityKindPattern), "metric", fp, "ruby", ln)
+			setProps(&e, "signal", "metric", "library", "datadog_statsd", "kind", "require")
+			out = append(out, e)
+		}
+	}
+
+	// --- Yabeda ---
+	if rbYabedaRequireRe.MatchString(src) || rbYabedaMetricRe.MatchString(src) {
+		for _, idx := range rbYabedaMetricRe.FindAllStringSubmatchIndex(src, -1) {
+			meterType := src[idx[2]:idx[3]]
+			ln := lineOf(src, idx[0])
+			e := makeEntity("Yabeda."+meterType, string(types.EntityKindPattern), "metric", fp, "ruby", ln)
+			setProps(&e, "signal", "metric", "library", "yabeda", "metric_type", meterType)
+			out = append(out, e)
+		}
+		if !rbYabedaMetricRe.MatchString(src) {
+			loc := rbYabedaRequireRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("yabeda", string(types.EntityKindPattern), "metric", fp, "ruby", ln)
+			setProps(&e, "signal", "metric", "library", "yabeda", "kind", "require")
+			out = append(out, e)
+		}
+	}
+
+	// --- StatsD ruby gem ---
+	for _, idx := range rbStatsDRubyRe.FindAllStringSubmatchIndex(src, -1) {
+		method := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("StatsD."+method, string(types.EntityKindPattern), "metric", fp, "ruby", ln)
+		setProps(&e, "signal", "metric", "library", "statsd_ruby", "metric_type", rubyStatsdType(method))
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// trace_extraction
+// ---------------------------------------------------------------------------
+
+func extractRubyTracing(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// --- OpenTelemetry ---
+	if rbOtelRequireRe.MatchString(src) || rbOtelSDKRe.MatchString(src) {
+		// tracer.in_span("name") do … end
+		for _, idx := range rbOtelInSpanRe.FindAllStringSubmatchIndex(src, -1) {
+			tracerVar := src[idx[2]:idx[3]]
+			spanName := src[idx[4]:idx[5]]
+			ln := lineOf(src, idx[0])
+			e := makeEntity(spanName, string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "opentelemetry",
+				"span_kind", "block", "span_name", spanName, "tracer_var", tracerVar)
+			out = append(out, e)
+		}
+		if rbOtelSDKRe.MatchString(src) && !rbOtelInSpanRe.MatchString(src) {
+			loc := rbOtelSDKRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("OpenTelemetry::SDK", string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "opentelemetry", "kind", "sdk_configure")
+			out = append(out, e)
+		}
+		if !rbOtelSDKRe.MatchString(src) && !rbOtelInSpanRe.MatchString(src) {
+			loc := rbOtelRequireRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("opentelemetry", string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "opentelemetry", "kind", "require")
+			out = append(out, e)
+		}
+	}
+
+	// --- ddtrace / Datadog::Tracing ---
+	if rbDdtraceRequireRe.MatchString(src) || rbDdtraceCallRe.MatchString(src) {
+		for _, idx := range rbDdtraceCallRe.FindAllStringSubmatchIndex(src, -1) {
+			ln := lineOf(src, idx[0])
+			callSite := src[idx[0]:idx[1]]
+			name := strings.TrimSpace(callSite)
+			if len(name) > 40 {
+				name = name[:40]
+			}
+			e := makeEntity(name, string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "ddtrace", "kind", "trace_call")
+			out = append(out, e)
+		}
+		if !rbDdtraceCallRe.MatchString(src) {
+			loc := rbDdtraceRequireRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("ddtrace", string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "ddtrace", "kind", "require")
+			out = append(out, e)
+		}
+	}
+
+	// --- Skylight ---
+	if rbSkylightRequireRe.MatchString(src) || rbSkylightInstrumentRe.MatchString(src) {
+		for _, idx := range rbSkylightInstrumentRe.FindAllStringSubmatchIndex(src, -1) {
+			ln := lineOf(src, idx[0])
+			e := makeEntity("Skylight.instrument", string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "skylight", "kind", "instrument")
+			out = append(out, e)
+		}
+		if !rbSkylightInstrumentRe.MatchString(src) {
+			loc := rbSkylightRequireRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("skylight", string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "skylight", "kind", "require")
+			out = append(out, e)
+		}
+	}
+
+	// --- OpenTracing ---
+	if rbOpenTracingRequireRe.MatchString(src) || rbOpenTracingCallRe.MatchString(src) {
+		for _, idx := range rbOpenTracingCallRe.FindAllStringSubmatchIndex(src, -1) {
+			ln := lineOf(src, idx[0])
+			callSite := src[idx[0]:idx[1]]
+			name := strings.TrimSpace(callSite)
+			if len(name) > 50 {
+				name = name[:50]
+			}
+			e := makeEntity(name, string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "opentracing", "kind", "span_call")
+			out = append(out, e)
+		}
+		if !rbOpenTracingCallRe.MatchString(src) {
+			loc := rbOpenTracingRequireRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("opentracing", string(types.EntityKindPattern), "trace_span", fp, "ruby", ln)
+			setProps(&e, "signal", "trace", "library", "opentracing", "kind", "require")
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Helper: metric-type normalisation
+// ---------------------------------------------------------------------------
+
+func rubyStatsdType(method string) string {
+	switch method {
+	case "increment", "decrement", "count":
+		return "counter"
+	case "gauge":
+		return "gauge"
+	case "timing":
+		return "timer"
+	case "histogram":
+		return "histogram"
+	case "set":
+		return "set"
+	case "event":
+		return "event"
+	case "service_check":
+		return "service_check"
+	case "measure":
+		return "timer"
+	default:
+		return method
+	}
+}

--- a/internal/custom/ruby/observability_test.go
+++ b/internal/custom/ruby/observability_test.go
@@ -1,0 +1,202 @@
+package ruby_test
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Observability — log_extraction
+// ---------------------------------------------------------------------------
+
+func TestRubyObsRailsLogger(t *testing.T) {
+	src := `
+class PostsController < ApplicationController
+  def index
+    Rails.logger.info("Loading posts")
+    Rails.logger.error("Something went wrong")
+    @posts = Post.all
+  end
+end
+`
+	ents := extract(t, "ruby_observability", fi("app/controllers/posts_controller.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Rails.logger.info") {
+		t.Error("expected Rails.logger.info entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "Rails.logger.error") {
+		t.Error("expected Rails.logger.error entity")
+	}
+}
+
+func TestRubyObsLoggerNew(t *testing.T) {
+	src := `
+require 'logger'
+logger = Logger.new(STDOUT)
+logger.info "Application started"
+`
+	ents := extract(t, "ruby_observability", fi("config/initializer.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Logger.new") {
+		t.Error("expected Logger.new entity")
+	}
+}
+
+func TestRubyObsSemanticLogger(t *testing.T) {
+	src := `
+require 'semantic_logger'
+SemanticLogger.add_appender(file_name: 'development.log', formatter: :color)
+`
+	ents := extract(t, "ruby_observability", fi("config/initializer.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "SemanticLogger") {
+		t.Error("expected SemanticLogger entity")
+	}
+}
+
+func TestRubyObsLoggerRequireOnly(t *testing.T) {
+	src := `require 'logger'`
+	ents := extract(t, "ruby_observability", fi("lib/app.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "logger") {
+		t.Error("expected logger require entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Observability — metric_extraction
+// ---------------------------------------------------------------------------
+
+func TestRubyObsPrometheus(t *testing.T) {
+	src := `
+require 'prometheus/client'
+prometheus = Prometheus::Client.registry
+counter = Prometheus::Client::Counter.new(:http_requests, docstring: 'A counter')
+gauge = Prometheus::Client::Gauge.new(:cpu_usage, docstring: 'CPU gauge')
+`
+	ents := extract(t, "ruby_observability", fi("lib/metrics.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Prometheus::Client::Counter") {
+		t.Error("expected Prometheus::Client::Counter entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "Prometheus::Client::Gauge") {
+		t.Error("expected Prometheus::Client::Gauge entity")
+	}
+}
+
+func TestRubyObsDatadogStatsd(t *testing.T) {
+	src := `
+require 'datadog/statsd'
+statsd = Datadog::Statsd.new('localhost', 8125)
+statsd.increment('page.views', tags: ['page:home'])
+statsd.gauge('account.balance', 1000.0)
+`
+	ents := extract(t, "ruby_observability", fi("lib/metrics.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Datadog::Statsd.new") {
+		t.Error("expected Datadog::Statsd.new entity")
+	}
+}
+
+func TestRubyObsYabeda(t *testing.T) {
+	src := `
+require 'yabeda'
+Yabeda.counter(:http_requests_total, comment: "Total HTTP requests")
+Yabeda.histogram(:request_duration, comment: "Duration", buckets: [0.1, 0.5, 1.0])
+`
+	ents := extract(t, "ruby_observability", fi("config/metrics.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Yabeda.counter") {
+		t.Error("expected Yabeda.counter entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "Yabeda.histogram") {
+		t.Error("expected Yabeda.histogram entity")
+	}
+}
+
+func TestRubyObsStatsDRuby(t *testing.T) {
+	src := `
+StatsD.measure('request.time') { do_work }
+StatsD.increment('request.count')
+`
+	ents := extract(t, "ruby_observability", fi("lib/tracking.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "StatsD.measure") {
+		t.Error("expected StatsD.measure entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "StatsD.increment") {
+		t.Error("expected StatsD.increment entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Observability — trace_extraction
+// ---------------------------------------------------------------------------
+
+func TestRubyObsOpenTelemetry(t *testing.T) {
+	src := `
+require 'opentelemetry-sdk'
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = 'my-app'
+end
+tracer = OpenTelemetry.tracer_provider.tracer('my-tracer')
+tracer.in_span("process_order") do |span|
+  span.set_attribute('order.id', order_id)
+end
+`
+	ents := extract(t, "ruby_observability", fi("config/initializer.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "process_order") {
+		t.Error("expected process_order trace_span entity from in_span")
+	}
+}
+
+func TestRubyObsDdtrace(t *testing.T) {
+	src := `
+require 'ddtrace'
+Datadog::Tracing.trace("web.request") do |span|
+  span.resource = '/users'
+end
+Datadog.configure do |c|
+  c.service = 'my-service'
+end
+`
+	ents := extract(t, "ruby_observability", fi("config/ddtrace.rb", "ruby", src))
+	if len(ents) == 0 {
+		t.Error("expected at least one trace entity from ddtrace")
+	}
+}
+
+func TestRubyObsSkylight(t *testing.T) {
+	src := `
+require 'skylight'
+Skylight.instrument(title: "perform_query") do
+  run_query
+end
+`
+	ents := extract(t, "ruby_observability", fi("lib/query.rb", "ruby", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Skylight.instrument") {
+		t.Error("expected Skylight.instrument entity")
+	}
+}
+
+func TestRubyObsOpenTracing(t *testing.T) {
+	src := `
+require 'opentracing'
+OpenTracing.start_active_span('operation_name') do |scope|
+  scope.span.set_tag('user', user_id)
+end
+`
+	ents := extract(t, "ruby_observability", fi("lib/tracing.rb", "ruby", src))
+	if len(ents) == 0 {
+		t.Error("expected at least one entity from opentracing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// No match: plain Ruby file
+// ---------------------------------------------------------------------------
+
+func TestRubyObsNoMatch(t *testing.T) {
+	src := `
+class User
+  def name
+    "Alice"
+  end
+end
+`
+	ents := extract(t, "ruby_observability", fi("app/models/user.rb", "ruby", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Summary

Part of #3282 — Ruby coverage greening (observability + auth builds).

### New extractors

**`internal/custom/ruby/observability.go`** — `ruby_observability` extractor:
- **log_extraction**: `Rails.logger.*`, `Logger.new`, `SemanticLogger`, generic `logger.info/warn/error`
- **metric_extraction**: `prometheus-client` (Counter/Gauge/Histogram), `Datadog::Statsd`, `Yabeda`, `StatsD` ruby gem
- **trace_extraction**: `OpenTelemetry::SDK` / `tracer.in_span`, `ddtrace`/`Datadog::Tracing`, `Skylight`, `OpenTracing`

**`internal/custom/ruby/auth.go`** — `ruby_auth` extractor:
- **Devise**: `devise_for`, `before_action :authenticate_user!`, `devise :modules`
- **JWT**: `JWT.encode`/`JWT.decode`, bearer token patterns
- **Warden**: `Warden::Manager`, `env['warden']`, `warden.authenticate!`
- **CanCanCan**: `authorize!`, `load_and_authorize_resource`, ability rules (`can`/`cannot`)
- **Pundit**: `authorize`, `policy_scope`, `Pundit::Policy`
- **Doorkeeper**: `doorkeeper_authorize!`, `use_doorkeeper`
- **Rack::Auth**: `Rack::Auth::Basic/Digest`
- **OmniAuth**: `OmniAuth::Builder`, `provider :name`

All cells `partial` — heuristic require/pattern detection, no cross-file dataflow (consistent with Java + Python observability extractors).

### Registry flips (31 cells)

| Category | Cell | Frameworks | Before → After |
|---|---|---|---|
| Observability | `log_extraction` | all 8 (rails/sinatra/grape/hanami/padrino/roda/cuba/dry-rb) | missing → partial |
| Observability | `metric_extraction` | all 8 | missing → partial |
| Observability | `trace_extraction` | all 8 | missing → partial |
| Auth | `auth_coverage` | 7 (excl. dry-rb which was already `not_applicable`) | missing → partial |

**Ruby missing before: 131 → after: 100**

### Test plan

- [x] `go build ./internal/... ./tools/coverage/...` — clean
- [x] `go test ./internal/custom/ruby/... ./internal/types/... ./tools/coverage/...` — all pass (31 tests added)
- [x] `go run ./tools/coverage validate` — exit 0
- [x] `gofmt -l` — empty (no formatting issues)
- [x] Ruby missing count confirmed dropped: 131 → 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)