### PR TITLE
feat(c-cpp): endpoint_synthesis + handler_attribution for Drogon/Crow/Pistache/cpprestsdk (Part of #3280)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -14,14 +14,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
@@ -97,14 +97,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Strawberry GraphQL](../detail/lang.python.framework.strawberry-graphql.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [Tornado](../detail/lang.python.framework.tornado.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [aiohttp](../detail/lang.python.framework.aiohttp.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 1/2 | — | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/5 | |
+| [ruby](../by-language/ruby.md) | [Cuba](../detail/lang.ruby.framework.cuba.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ruby](../by-language/ruby.md) | [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 1/2 | — | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/5 | |
 | [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 2/3 | 🔴 0/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
 | [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 2/3 | 🔴 0/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
 | [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 2/3 | 🔴 0/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -29,14 +29,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -26,14 +26,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Cuba](../detail/lang.ruby.framework.cuba.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/6 | |
-| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 1/2 | — | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🔴 0/5 | |
+| [Cuba](../detail/lang.ruby.framework.cuba.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Grape](../detail/lang.ruby.framework.grape.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Roda](../detail/lang.ruby.framework.roda.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 1/2 | — | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/5 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🔴 `missing` | — | — | — | — |
-| Handler attribution | 🔴 `missing` | — | — | — | — |
+| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3280 | `internal/custom/cpp/cpprestsdk_routes.go` | — |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | 3280 | `internal/custom/cpp/cpprestsdk_routes.go` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🔴 `missing` | — | — | — | — |
-| Handler attribution | 🔴 `missing` | — | — | — | — |
+| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3280 | `internal/custom/cpp/crow_routes.go` | — |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | 3280 | `internal/custom/cpp/crow_routes.go` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🔴 `missing` | — | — | — | — |
-| Handler attribution | 🔴 `missing` | — | — | — | — |
+| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3280 | `internal/custom/cpp/drogon_routes.go` | — |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | 3280 | `internal/custom/cpp/drogon_routes.go` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🔴 `missing` | — | — | — | — |
-| Handler attribution | 🔴 `missing` | — | — | — | — |
+| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3280 | `internal/custom/cpp/pistache_routes.go` | — |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | 3280 | `internal/custom/cpp/pistache_routes.go` | — |
 | Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Auth

--- a/docs/coverage/detail/lang.ruby.framework.cuba.md
+++ b/docs/coverage/detail/lang.ruby.framework.cuba.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.ruby.framework.dry-rb.md
+++ b/docs/coverage/detail/lang.ruby.framework.dry-rb.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.ruby.framework.grape.md
+++ b/docs/coverage/detail/lang.ruby.framework.grape.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.ruby.framework.hanami.md
+++ b/docs/coverage/detail/lang.ruby.framework.hanami.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.ruby.framework.padrino.md
+++ b/docs/coverage/detail/lang.ruby.framework.padrino.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.ruby.framework.roda.md
+++ b/docs/coverage/detail/lang.ruby.framework.roda.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
 
 ### Validation
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2503,10 +2503,16 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/cpprestsdk_routes.go"],
+            "issue": "3280",
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/cpprestsdk_routes.go"],
+            "issue": "3280",
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
             "status": "missing",
@@ -2696,10 +2702,16 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/crow_routes.go"],
+            "issue": "3280",
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/crow_routes.go"],
+            "issue": "3280",
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
             "status": "missing",
@@ -2889,10 +2901,16 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/drogon_routes.go"],
+            "issue": "3280",
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/drogon_routes.go"],
+            "issue": "3280",
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
             "status": "missing",
@@ -3854,10 +3872,16 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/pistache_routes.go"],
+            "issue": "3280",
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/pistache_routes.go"],
+            "issue": "3280",
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
             "status": "missing",

--- a/internal/custom/cpp/cpprestsdk_routes.go
+++ b/internal/custom/cpp/cpprestsdk_routes.go
@@ -1,0 +1,181 @@
+package cpp
+
+// cpprestsdk_routes.go — cpprestsdk (Casablanca) C++ HTTP route/handler extractor.
+//
+// Covered DSL surfaces:
+//
+//  1. listener.support(methods::GET, handler)
+//     — direct method→handler registration on an http_listener
+//  2. listener.support(handler)
+//     — catch-all registration (verb ANY)
+//  3. router.support(methods::GET, handler)  (same API on http_listener aliases)
+//
+// Each matched route emits one SCOPE.Operation/endpoint entity with
+// provenance INFERRED_FROM_CPPRESTSDK_ROUTE.  Handler identifiers are stamped
+// in handler_name to support handler_attribution.
+//
+// cpprestsdk uses listener construction to declare the base URL (path), but
+// the path is typically a runtime variable, not a string literal at the
+// .support() call site.  We therefore record path as "<listener>" to indicate
+// that the full URL is bound at listener construction time.  When the listener
+// variable is declared nearby with a string literal we capture it via
+// reCppRestListenerInit.
+//
+// Status: partial (regex/heuristic; no AST).
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_cpprestsdk", &cppRestSDKExtractor{})
+}
+
+type cppRestSDKExtractor struct{}
+
+func (e *cppRestSDKExtractor) Language() string { return "custom_cpp_cpprestsdk" }
+
+var (
+	// listener.support(methods::GET, handler)
+	// Capture: (1) receiver var, (2) verb (methods::GET → GET), (3) handler
+	reCppRestSupport = regexp.MustCompile(
+		`(?m)(\w+)\s*\.\s*support\s*\(\s*methods\s*::\s*([A-Z_]+)\s*,\s*([^)]+)\)`,
+	)
+
+	// listener.support(handler)  — no verb argument → ANY
+	reCppRestSupportAny = regexp.MustCompile(
+		`(?m)(\w+)\s*\.\s*support\s*\(\s*([A-Za-z_&][A-Za-z0-9_:&\s]*)\)`,
+	)
+
+	// http_listener listener("http://0.0.0.0:8080/api/v1");
+	// web::http::experimental::listener::http_listener listener(U("/path"));
+	// Capture: (1) variable name, (2) URL/path string
+	reCppRestListenerInit = regexp.MustCompile(
+		`(?m)http_listener\s+(\w+)\s*\(\s*(?:U\s*\(\s*)?['""]([^'"")]+)['""]`,
+	)
+)
+
+func (e *cppRestSDKExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpprestsdk_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "cpprestsdk"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !strings.Contains(src, ".support(") && !strings.Contains(src, "http_listener") {
+		return nil, nil
+	}
+
+	// Build a listener-var → path map from declarations in this file.
+	listenerPaths := make(map[string]string)
+	for _, m := range reCppRestListenerInit.FindAllStringSubmatchIndex(src, -1) {
+		varName := src[m[2]:m[3]]
+		urlPath := src[m[4]:m[5]]
+		listenerPaths[varName] = urlPath
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// Track which receiver vars matched the verb form so we don't double-emit.
+	verbMatchedReceivers := make(map[int]bool)
+
+	// 1. listener.support(methods::GET, handler)
+	for _, m := range reCppRestSupport.FindAllStringSubmatchIndex(src, -1) {
+		verbMatchedReceivers[m[0]] = true
+		receiverVar := src[m[2]:m[3]]
+		verb := strings.ToUpper(src[m[4]:m[5]])
+		handlerExpr := strings.TrimSpace(src[m[6]:m[7]])
+		if idx := strings.IndexAny(handlerExpr, " \t\r\n)"); idx > 0 {
+			handlerExpr = handlerExpr[:idx]
+		}
+		handler := strings.TrimLeft(handlerExpr, "&")
+
+		path := listenerPaths[receiverVar]
+		if path == "" {
+			path = "<" + receiverVar + ">"
+		}
+
+		name := verb + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "cpprestsdk",
+			"provenance", "INFERRED_FROM_CPPRESTSDK_ROUTE",
+			"http_method", verb,
+			"route_path", path,
+			"handler_name", handler,
+			"listener_var", receiverVar,
+			"dsl", "support",
+		)
+		add(ent)
+	}
+
+	// 2. listener.support(handler) — catch-all, but only when no verb form matched
+	//    at this position (to avoid re-processing the verb form's receiver).
+	for _, m := range reCppRestSupportAny.FindAllStringSubmatchIndex(src, -1) {
+		if verbMatchedReceivers[m[0]] {
+			continue
+		}
+		receiverVar := src[m[2]:m[3]]
+		handlerExpr := strings.TrimSpace(src[m[4]:m[5]])
+		// If the first argument looks like methods::XXX this was already matched.
+		if strings.Contains(handlerExpr, "methods::") {
+			continue
+		}
+		if idx := strings.IndexAny(handlerExpr, " \t\r\n)"); idx > 0 {
+			handlerExpr = handlerExpr[:idx]
+		}
+		handler := strings.TrimLeft(handlerExpr, "&")
+
+		path := listenerPaths[receiverVar]
+		if path == "" {
+			path = "<" + receiverVar + ">"
+		}
+
+		name := "ANY " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "cpprestsdk",
+			"provenance", "INFERRED_FROM_CPPRESTSDK_ROUTE",
+			"http_method", "ANY",
+			"route_path", path,
+			"handler_name", handler,
+			"listener_var", receiverVar,
+			"dsl", "support",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/cpp/crow_routes.go
+++ b/internal/custom/cpp/crow_routes.go
@@ -1,0 +1,168 @@
+package cpp
+
+// crow_routes.go — Crow C++ HTTP framework route/handler extractor.
+//
+// Covered DSL surfaces:
+//
+//  1. CROW_ROUTE(app, "/path")(handler)
+//     — basic route, verb defaults to GET
+//  2. CROW_ROUTE(app, "/path").methods("GET"_method, "POST"_method)(handler)
+//     — explicit method list
+//  3. CROW_BP_ROUTE(bp, "/path")(handler)      — blueprint route (same shape)
+//  4. CROW_CATCHALL_ROUTE(app)(handler)         — catch-all, path "*"
+//
+// Each matched route emits one SCOPE.Operation/endpoint entity with
+// provenance INFERRED_FROM_CROW_ROUTE.  Handler names are stamped in
+// handler_name to support handler_attribution.
+//
+// Status: partial (regex/heuristic; no AST).
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_crow", &crowExtractor{})
+}
+
+type crowExtractor struct{}
+
+func (e *crowExtractor) Language() string { return "custom_cpp_crow" }
+
+var (
+	// CROW_ROUTE(app, "/path")          optional .methods("GET"_method)(handler)
+	// CROW_BP_ROUTE(bp, "/path")        optional .methods("GET"_method)(handler)
+	//
+	// We capture:
+	//   group 1: path string
+	//   group 2: optional methods list (content inside .methods(...))
+	//   group 3: handler identifier (first token inside the trailing call parens)
+	reCrowRoute = regexp.MustCompile(
+		`(?m)\bCROW(?:_BP)?_ROUTE\s*\(\s*\w+\s*,\s*"([^"]+)"\s*\)` +
+			`(?:\s*\.methods\s*\(([^)]+)\))?` +
+			`\s*\(\s*([A-Za-z_&][A-Za-z0-9_:&\s]*)`,
+	)
+	// CROW_CATCHALL_ROUTE(app)(handler)
+	reCrowCatchAll = regexp.MustCompile(
+		`(?m)\bCROW_CATCHALL_ROUTE\s*\(\s*\w+\s*\)\s*\(\s*([A-Za-z_&][A-Za-z0-9_:&\s]*)`,
+	)
+
+	// "_method" suffix used in Crow method literals — "GET"_method → GET
+	reCrowMethodLiteral = regexp.MustCompile(`"([A-Z]+)"_method`)
+)
+
+// crowVerbs parses the methods(...) argument list, e.g.:
+//
+//	"GET"_method,"POST"_method  →  "GET,POST"
+//	(empty)                     →  "GET"  (Crow default)
+func crowVerbs(methodsRaw string) string {
+	if strings.TrimSpace(methodsRaw) == "" {
+		return "GET"
+	}
+	var verbs []string
+	for _, m := range reCrowMethodLiteral.FindAllStringSubmatch(methodsRaw, -1) {
+		verbs = append(verbs, m[1])
+	}
+	if len(verbs) == 0 {
+		return "ANY"
+	}
+	return strings.Join(verbs, ",")
+}
+
+func (e *crowExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.crow_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "crow"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !strings.Contains(src, "CROW_ROUTE") && !strings.Contains(src, "CROW_BP_ROUTE") &&
+		!strings.Contains(src, "CROW_CATCHALL_ROUTE") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. CROW_ROUTE / CROW_BP_ROUTE
+	for _, m := range reCrowRoute.FindAllStringSubmatchIndex(src, -1) {
+		path := src[m[2]:m[3]]
+		methodsRaw := ""
+		if m[4] >= 0 {
+			methodsRaw = src[m[4]:m[5]]
+		}
+		handlerRaw := strings.TrimSpace(src[m[6]:m[7]])
+		// strip trailing whitespace/newlines captured by the lazy group
+		if idx := strings.IndexAny(handlerRaw, " \t\r\n)"); idx > 0 {
+			handlerRaw = handlerRaw[:idx]
+		}
+		handler := strings.TrimLeft(handlerRaw, "&")
+
+		methods := crowVerbs(methodsRaw)
+		name := methods + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "crow",
+			"provenance", "INFERRED_FROM_CROW_ROUTE",
+			"http_method", methods,
+			"route_path", path,
+			"handler_name", handler,
+			"dsl", "CROW_ROUTE",
+		)
+		add(ent)
+	}
+
+	// 2. CROW_CATCHALL_ROUTE
+	for _, m := range reCrowCatchAll.FindAllStringSubmatchIndex(src, -1) {
+		handlerRaw := strings.TrimSpace(src[m[2]:m[3]])
+		if idx := strings.IndexAny(handlerRaw, " \t\r\n)"); idx > 0 {
+			handlerRaw = handlerRaw[:idx]
+		}
+		handler := strings.TrimLeft(handlerRaw, "&")
+
+		name := "ANY *"
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "crow",
+			"provenance", "INFERRED_FROM_CROW_ROUTE",
+			"http_method", "ANY",
+			"route_path", "*",
+			"handler_name", handler,
+			"dsl", "CROW_CATCHALL_ROUTE",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/cpp/drogon_routes.go
+++ b/internal/custom/cpp/drogon_routes.go
@@ -1,0 +1,173 @@
+package cpp
+
+// drogon_routes.go — Drogon C++ HTTP framework route/handler extractor.
+//
+// Covered DSL surfaces:
+//
+//  1. ADD_METHOD_TO(Controller::method, "/path", Get[, Post, ...])
+//  2. METHOD_ADD(Controller, "/path", method[, method...])
+//  3. app().registerHandler("/path", handler, {Get[, Post, ...]})
+//
+// Each matched route emits one SCOPE.Operation/endpoint entity with
+// provenance INFERRED_FROM_DROGON_ROUTE.  Handler names are stamped in the
+// handler_name property to support handler_attribution.
+//
+// Status: partial (regex/heuristic; no AST).  A proving fixture per pattern
+// lives in extractors_test.go.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_drogon", &drogonExtractor{})
+}
+
+type drogonExtractor struct{}
+
+func (e *drogonExtractor) Language() string { return "custom_cpp_drogon" }
+
+var (
+	// ADD_METHOD_TO(Controller::method, "/path", Get)
+	// ADD_METHOD_TO(Controller::method, "/path", Get, Post)
+	reDrogonAddMethodTo = regexp.MustCompile(
+		`(?m)\bADD_METHOD_TO\s*\(\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)+)\s*,\s*"([^"]+)"\s*,\s*([^)]+)\)`,
+	)
+	// METHOD_ADD(Controller, "/path", Get)
+	reDrogonMethodAdd = regexp.MustCompile(
+		`(?m)\bMETHOD_ADD\s*\(\s*([A-Za-z_]\w*)\s*,\s*"([^"]+)"\s*,\s*([^)]+)\)`,
+	)
+	// app().registerHandler("/path", handler, {Get})
+	// app().registerHandler("/path", handler, {Get, Post})
+	reDrogonRegisterHandler = regexp.MustCompile(
+		`(?m)\bregisterHandler\s*\(\s*"([^"]+)"\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\s*,\s*\{([^}]+)\}`,
+	)
+)
+
+// drogonVerbs normalises the method list string from the macro to a
+// comma-separated, upper-cased verb list (e.g. "Get,Post" → "GET,POST").
+func drogonVerbs(raw string) string {
+	parts := strings.Split(raw, ",")
+	var verbs []string
+	for _, p := range parts {
+		v := strings.TrimSpace(p)
+		// Strip drogon:: prefix if present
+		if idx := strings.LastIndex(v, "::"); idx >= 0 {
+			v = v[idx+2:]
+		}
+		v = strings.ToUpper(v)
+		if v == "" {
+			continue
+		}
+		verbs = append(verbs, v)
+	}
+	if len(verbs) == 0 {
+		return "ANY"
+	}
+	return strings.Join(verbs, ",")
+}
+
+func (e *drogonExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.drogon_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "drogon"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	// Cheap pre-filter.
+	if !strings.Contains(src, "ADD_METHOD_TO") &&
+		!strings.Contains(src, "METHOD_ADD") &&
+		!strings.Contains(src, "registerHandler") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. ADD_METHOD_TO(Controller::method, "/path", Get[, Post...])
+	for _, m := range reDrogonAddMethodTo.FindAllStringSubmatchIndex(src, -1) {
+		handler := src[m[2]:m[3]]
+		path := src[m[4]:m[5]]
+		methods := drogonVerbs(src[m[6]:m[7]])
+		name := methods + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "drogon",
+			"provenance", "INFERRED_FROM_DROGON_ROUTE",
+			"http_method", methods,
+			"route_path", path,
+			"handler_name", handler,
+			"dsl", "ADD_METHOD_TO",
+		)
+		add(ent)
+	}
+
+	// 2. METHOD_ADD(Controller, "/path", Get)
+	for _, m := range reDrogonMethodAdd.FindAllStringSubmatchIndex(src, -1) {
+		handler := src[m[2]:m[3]]
+		path := src[m[4]:m[5]]
+		methods := drogonVerbs(src[m[6]:m[7]])
+		name := methods + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "drogon",
+			"provenance", "INFERRED_FROM_DROGON_ROUTE",
+			"http_method", methods,
+			"route_path", path,
+			"handler_name", handler,
+			"dsl", "METHOD_ADD",
+		)
+		add(ent)
+	}
+
+	// 3. app().registerHandler("/path", handler, {Get, Post})
+	for _, m := range reDrogonRegisterHandler.FindAllStringSubmatchIndex(src, -1) {
+		path := src[m[2]:m[3]]
+		handler := src[m[4]:m[5]]
+		methods := drogonVerbs(src[m[6]:m[7]])
+		name := methods + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "drogon",
+			"provenance", "INFERRED_FROM_DROGON_ROUTE",
+			"http_method", methods,
+			"route_path", path,
+			"handler_name", handler,
+			"dsl", "registerHandler",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/cpp/pistache_routes.go
+++ b/internal/custom/cpp/pistache_routes.go
@@ -1,0 +1,161 @@
+package cpp
+
+// pistache_routes.go — Pistache C++ HTTP framework route/handler extractor.
+//
+// Covered DSL surfaces:
+//
+//  1. Routes::Get(router, "/path", Routes::bind(&Handler::method))
+//  2. Routes::Post(router, "/path", Routes::bind(&Handler::method))
+//     … and all other HTTP verbs (Put, Delete, Patch, Head, Options, Any)
+//  3. router.get("/path", Routes::bind(&Handler::method))
+//     … method-shorthand form on a Rest::Router instance
+//
+// Each matched route emits one SCOPE.Operation/endpoint entity with
+// provenance INFERRED_FROM_PISTACHE_ROUTE.  Handler names are extracted from
+// Routes::bind() and stamped in handler_name.
+//
+// Status: partial (regex/heuristic; no AST).
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_pistache", &pistacheExtractor{})
+}
+
+type pistacheExtractor struct{}
+
+func (e *pistacheExtractor) Language() string { return "custom_cpp_pistache" }
+
+// Pistache HTTP verbs as seen in Routes:: static calls.
+var pistacheVerbSet = map[string]bool{
+	"Get": true, "Post": true, "Put": true, "Delete": true,
+	"Patch": true, "Head": true, "Options": true, "Any": true,
+}
+
+var (
+	// Routes::Get(router, "/path", Routes::bind(&Handler::method))
+	// Routes::Post(router, "/path", handler)
+	//
+	// capture groups: (1) verb, (2) path, (3) handler expression
+	rePistacheStaticRoute = regexp.MustCompile(
+		`(?m)\bRoutes\s*::\s*(Get|Post|Put|Delete|Patch|Head|Options|Any)\s*\(` +
+			`\s*\w+\s*,\s*"([^"]+)"\s*,\s*([^)]+)\)`,
+	)
+
+	// router.get("/path", Routes::bind(&Handler::method))
+	// Only match method names that map to known verbs (case-insensitive first char).
+	rePistacheInstanceRoute = regexp.MustCompile(
+		`(?m)\.(?i)(get|post|put|delete|patch|head|options|any)\s*\(\s*"([^"]+)"\s*,\s*([^)]+)\)`,
+	)
+
+	// Routes::bind(&Handler::method) — extract the handler pointer
+	rePistacheBind = regexp.MustCompile(
+		`Routes\s*::\s*bind\s*\(\s*&?\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)`,
+	)
+)
+
+// pistacheHandler extracts the handler name from an expression like
+// "Routes::bind(&Handler::method)" or a plain identifier "handler".
+func pistacheHandler(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if m := rePistacheBind.FindStringSubmatch(expr); m != nil {
+		return m[1]
+	}
+	// Strip leading & and trailing noise
+	expr = strings.TrimLeft(expr, "&")
+	if idx := strings.IndexAny(expr, " \t\r\n,)"); idx > 0 {
+		expr = expr[:idx]
+	}
+	return expr
+}
+
+func (e *pistacheExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.pistache_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "pistache"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	if !strings.Contains(src, "Routes::") && !strings.Contains(src, "Rest::Router") &&
+		!strings.Contains(src, "Pistache") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Routes::Get(router, "/path", handler)
+	for _, m := range rePistacheStaticRoute.FindAllStringSubmatchIndex(src, -1) {
+		verb := strings.ToUpper(src[m[2]:m[3]])
+		path := src[m[4]:m[5]]
+		handlerExpr := src[m[6]:m[7]]
+		handler := pistacheHandler(handlerExpr)
+
+		name := verb + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "pistache",
+			"provenance", "INFERRED_FROM_PISTACHE_ROUTE",
+			"http_method", verb,
+			"route_path", path,
+			"handler_name", handler,
+			"dsl", "Routes::"+src[m[2]:m[3]],
+		)
+		add(ent)
+	}
+
+	// 2. router.get("/path", handler)
+	for _, m := range rePistacheInstanceRoute.FindAllStringSubmatchIndex(src, -1) {
+		verb := strings.ToUpper(src[m[2]:m[3]])
+		path := src[m[4]:m[5]]
+		handlerExpr := src[m[6]:m[7]]
+		handler := pistacheHandler(handlerExpr)
+
+		name := verb + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "pistache",
+			"provenance", "INFERRED_FROM_PISTACHE_ROUTE",
+			"http_method", verb,
+			"route_path", path,
+			"handler_name", handler,
+			"dsl", "router.method",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/cpp/routes_test.go
+++ b/internal/custom/cpp/routes_test.go
@@ -1,0 +1,271 @@
+package cpp_test
+
+// routes_test.go — per-framework golden fixture tests for
+// drogon_routes.go, crow_routes.go, pistache_routes.go, cpprestsdk_routes.go.
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Drogon
+// ---------------------------------------------------------------------------
+
+func TestDrogonAddMethodTo(t *testing.T) {
+	src := `
+ADD_METHOD_TO(UserCtrl::getUser, "/api/users/{id}", Get);
+ADD_METHOD_TO(UserCtrl::createUser, "/api/users", Post);
+`
+	ents := extract(t, "custom_cpp_drogon", fi("routes.cc", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/users/{id}") {
+		t.Error("expected GET /api/users/{id} endpoint from ADD_METHOD_TO")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "POST /api/users") {
+		t.Error("expected POST /api/users endpoint from ADD_METHOD_TO")
+	}
+}
+
+func TestDrogonAddMethodToMultiVerb(t *testing.T) {
+	src := `ADD_METHOD_TO(MyCtrl::handler, "/api/items", Get, Post);`
+	ents := extract(t, "custom_cpp_drogon", fi("routes.cc", "cpp", src))
+	// Multi-verb: GET,POST /api/items
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Name == "GET,POST /api/items" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected GET,POST /api/items for multi-verb ADD_METHOD_TO, got %v", ents)
+	}
+}
+
+func TestDrogonMethodAdd(t *testing.T) {
+	src := `METHOD_ADD(ItemCtrl, "/items/{id}", Get);`
+	ents := extract(t, "custom_cpp_drogon", fi("ctrl.cc", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /items/{id}") {
+		t.Error("expected GET /items/{id} endpoint from METHOD_ADD")
+	}
+}
+
+func TestDrogonRegisterHandler(t *testing.T) {
+	src := `app().registerHandler("/health", healthHandler, {Get});`
+	ents := extract(t, "custom_cpp_drogon", fi("app.cc", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /health") {
+		t.Error("expected GET /health endpoint from registerHandler")
+	}
+}
+
+func TestDrogonRegisterHandlerMultiVerb(t *testing.T) {
+	src := `app().registerHandler("/upload", uploadHandler, {Post, Put});`
+	ents := extract(t, "custom_cpp_drogon", fi("app.cc", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Name == "POST,PUT /upload" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected POST,PUT /upload endpoint, got %v", ents)
+	}
+}
+
+func TestDrogonNoMatch(t *testing.T) {
+	src := `#include <drogon/drogon.h>
+int main() { return 0; }
+`
+	ents := extract(t, "custom_cpp_drogon", fi("main.cc", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for plain main, got %d", len(ents))
+	}
+}
+
+func TestDrogonWrongLanguage(t *testing.T) {
+	src := `ADD_METHOD_TO(Ctrl::fn, "/path", Get);`
+	ents := extract(t, "custom_cpp_drogon", fi("routes.c", "c", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Crow
+// ---------------------------------------------------------------------------
+
+func TestCrowRouteBasic(t *testing.T) {
+	src := `CROW_ROUTE(app, "/hello")(helloHandler);`
+	ents := extract(t, "custom_cpp_crow", fi("main.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /hello") {
+		t.Errorf("expected GET /hello endpoint from basic CROW_ROUTE, got %v", ents)
+	}
+}
+
+func TestCrowRouteWithMethods(t *testing.T) {
+	src := `CROW_ROUTE(app, "/users").methods("GET"_method, "POST"_method)(usersHandler);`
+	ents := extract(t, "custom_cpp_crow", fi("main.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Name == "GET,POST /users" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected GET,POST /users endpoint, got %v", ents)
+	}
+}
+
+func TestCrowRoutePostOnly(t *testing.T) {
+	src := `CROW_ROUTE(app, "/login").methods("POST"_method)(loginHandler);`
+	ents := extract(t, "custom_cpp_crow", fi("main.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "POST /login") {
+		t.Errorf("expected POST /login endpoint, got %v", ents)
+	}
+}
+
+func TestCrowBPRoute(t *testing.T) {
+	src := `CROW_BP_ROUTE(bp, "/api/status")(statusHandler);`
+	ents := extract(t, "custom_cpp_crow", fi("bp.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/status") {
+		t.Errorf("expected GET /api/status endpoint from CROW_BP_ROUTE, got %v", ents)
+	}
+}
+
+func TestCrowCatchAll(t *testing.T) {
+	src := `CROW_CATCHALL_ROUTE(app)(notFoundHandler);`
+	ents := extract(t, "custom_cpp_crow", fi("main.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "ANY *") {
+		t.Errorf("expected ANY * endpoint from CROW_CATCHALL_ROUTE, got %v", ents)
+	}
+}
+
+func TestCrowNoMatch(t *testing.T) {
+	src := `#include <crow.h>
+int main() { app.port(8080).run(); }`
+	ents := extract(t, "custom_cpp_crow", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+func TestCrowWrongLanguage(t *testing.T) {
+	src := `CROW_ROUTE(app, "/foo")(handler);`
+	ents := extract(t, "custom_cpp_crow", fi("main.c", "c", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pistache
+// ---------------------------------------------------------------------------
+
+func TestPistacheStaticGet(t *testing.T) {
+	src := `Routes::Get(router, "/api/users", Routes::bind(&UserHandler::getUsers));`
+	ents := extract(t, "custom_cpp_pistache", fi("server.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/users") {
+		t.Errorf("expected GET /api/users endpoint, got %v", ents)
+	}
+}
+
+func TestPistacheStaticPost(t *testing.T) {
+	src := `Routes::Post(router, "/api/users", Routes::bind(&UserHandler::createUser));`
+	ents := extract(t, "custom_cpp_pistache", fi("server.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "POST /api/users") {
+		t.Errorf("expected POST /api/users endpoint, got %v", ents)
+	}
+}
+
+func TestPistacheStaticDelete(t *testing.T) {
+	src := `Routes::Delete(router, "/api/users/:id", Routes::bind(&UserHandler::deleteUser));`
+	ents := extract(t, "custom_cpp_pistache", fi("server.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "DELETE /api/users/:id") {
+		t.Errorf("expected DELETE /api/users/:id endpoint, got %v", ents)
+	}
+}
+
+func TestPistacheStaticAny(t *testing.T) {
+	src := `Routes::Any(router, "/health", Routes::bind(&HealthHandler::check));`
+	ents := extract(t, "custom_cpp_pistache", fi("server.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "ANY /health") {
+		t.Errorf("expected ANY /health endpoint, got %v", ents)
+	}
+}
+
+func TestPistacheInstanceMethod(t *testing.T) {
+	src := `router.get("/status", Routes::bind(&StatusHandler::get));`
+	ents := extract(t, "custom_cpp_pistache", fi("server.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /status") {
+		t.Errorf("expected GET /status from instance .get(), got %v", ents)
+	}
+}
+
+func TestPistacheNoMatch(t *testing.T) {
+	src := `#include <pistache/endpoint.h>
+int main() { return 0; }`
+	ents := extract(t, "custom_cpp_pistache", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+func TestPistacheWrongLanguage(t *testing.T) {
+	src := `Routes::Get(router, "/foo", Routes::bind(&H::fn));`
+	ents := extract(t, "custom_cpp_pistache", fi("srv.c", "c", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cpprestsdk
+// ---------------------------------------------------------------------------
+
+func TestCppRestSDKSupportVerb(t *testing.T) {
+	src := `
+http_listener listener("http://localhost:8080/api");
+listener.support(methods::GET, handleGet);
+listener.support(methods::POST, handlePost);
+`
+	ents := extract(t, "custom_cpp_cpprestsdk", fi("server.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET http://localhost:8080/api") {
+		t.Errorf("expected GET endpoint, got %v", ents)
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "POST http://localhost:8080/api") {
+		t.Errorf("expected POST endpoint, got %v", ents)
+	}
+}
+
+func TestCppRestSDKSupportAny(t *testing.T) {
+	src := `
+http_listener listener("http://localhost:9090/");
+listener.support(handleAll);
+`
+	ents := extract(t, "custom_cpp_cpprestsdk", fi("server.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "ANY http://localhost:9090/") {
+		t.Errorf("expected ANY endpoint, got %v", ents)
+	}
+}
+
+func TestCppRestSDKSupportUnknownPath(t *testing.T) {
+	// No listener init in file — path falls back to <varname>
+	src := `listener.support(methods::GET, getHandler);`
+	ents := extract(t, "custom_cpp_cpprestsdk", fi("server.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET <listener>") {
+		t.Errorf("expected GET <listener> fallback path, got %v", ents)
+	}
+}
+
+func TestCppRestSDKNoMatch(t *testing.T) {
+	src := `#include <cpprest/http_listener.h>
+int main() { return 0; }`
+	ents := extract(t, "custom_cpp_cpprestsdk", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+func TestCppRestSDKWrongLanguage(t *testing.T) {
+	src := `listener.support(methods::GET, handler);`
+	ents := extract(t, "custom_cpp_cpprestsdk", fi("srv.c", "c", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -9529,6 +9529,91 @@ records:
               functions: [runTaintFlowPass, computeFindings]
           issues_implemented: ["2773"]
           verified_at: "2026-05-28"
+      Routing:
+        endpoint_synthesis:
+          status: partial
+          symbols:
+            - file: internal/custom/cpp/crow_routes.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/cpp/routes_test.go
+          issues_implemented: ["3280"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          status: partial
+          symbols:
+            - file: internal/custom/cpp/crow_routes.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/cpp/routes_test.go
+          issues_implemented: ["3280"]
+          verified_at: "2026-05-30"
+
+  lang.c-cpp.framework.drogon:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          status: partial
+          symbols:
+            - file: internal/custom/cpp/drogon_routes.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/cpp/routes_test.go
+          issues_implemented: ["3280"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          status: partial
+          symbols:
+            - file: internal/custom/cpp/drogon_routes.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/cpp/routes_test.go
+          issues_implemented: ["3280"]
+          verified_at: "2026-05-30"
+
+  lang.c-cpp.framework.pistache:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          status: partial
+          symbols:
+            - file: internal/custom/cpp/pistache_routes.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/cpp/routes_test.go
+          issues_implemented: ["3280"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          status: partial
+          symbols:
+            - file: internal/custom/cpp/pistache_routes.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/cpp/routes_test.go
+          issues_implemented: ["3280"]
+          verified_at: "2026-05-30"
+
+  lang.c-cpp.framework.cpprestsdk:
+    capabilities:
+      Routing:
+        endpoint_synthesis:
+          status: partial
+          symbols:
+            - file: internal/custom/cpp/cpprestsdk_routes.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/cpp/routes_test.go
+          issues_implemented: ["3280"]
+          verified_at: "2026-05-30"
+        handler_attribution:
+          status: partial
+          symbols:
+            - file: internal/custom/cpp/cpprestsdk_routes.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/cpp/routes_test.go
+          issues_implemented: ["3280"]
+          verified_at: "2026-05-30"
 
   protocol.c-asm:
     capabilities:


### PR DESCRIPTION
## Summary

Adds regex/heuristic C++ HTTP route extractors for 4 frameworks with the clearest route DSLs, flipping 8 registry cells from `missing` → `partial`.

**New files** (all under `internal/custom/cpp/`):

| File | Framework | DSLs covered |
|---|---|---|
| `drogon_routes.go` | Drogon | `ADD_METHOD_TO`, `METHOD_ADD`, `app().registerHandler` |
| `crow_routes.go` | Crow | `CROW_ROUTE`, `CROW_BP_ROUTE`, `CROW_CATCHALL_ROUTE` |
| `pistache_routes.go` | Pistache | `Routes::Get/Post/…/Any`, `router.method()` |
| `cpprestsdk_routes.go` | cpprestsdk | `listener.support(methods::VERB, handler)`, catch-all |
| `routes_test.go` | all 4 | per-framework golden fixtures |

Each extractor emits `SCOPE.Operation/endpoint` with `http_method`, `route_path`, `handler_name` properties. Status is `partial` (regex heuristic, no AST) — honest per convention.

**Registry cells flipped** (8 cells, 4 frameworks × 2 capabilities):
- `lang.c-cpp.framework.drogon`: `endpoint_synthesis`, `handler_attribution` → partial
- `lang.c-cpp.framework.crow`: `endpoint_synthesis`, `handler_attribution` → partial
- `lang.c-cpp.framework.pistache`: `endpoint_synthesis`, `handler_attribution` → partial
- `lang.c-cpp.framework.cpprestsdk`: `endpoint_synthesis`, `handler_attribution` → partial

c-cpp endpoint missing count: **28 → 20** (14 frameworks × 2 cells before; 10 remaining after).

## Test plan

- [x] `go build ./internal/... ./tools/coverage/...` — clean
- [x] `go test ./internal/custom/cpp/... ./internal/types/ ./tools/coverage/...` — all pass
- [x] `go run ./tools/coverage validate` — exit 0 (558 records, no errors)
- [x] `go run ./tools/coverage fmt --check` — canonical
- [x] `go run ./tools/coverage gen` — byte-stable (558 records)
- [x] `gofmt -l ./internal/custom/cpp/` — empty (no formatting issues)

Part of #3280

🤖 Generated with [Claude Code](https://claude.com/claude-code)