### PR TITLE
coverage(csharp): validation extractor + enum/record type-system — flip 36 missing cells (Part of #3263)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -25,12 +25,12 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
 | [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 4/6 | |
-| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
-| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
-| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
-| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
-| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
+| [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
+| [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
+| [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
+| [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
 | [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
 | [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/6 | |
@@ -158,9 +158,9 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
 | [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | 🟡 1/3 | 🟢 1/1 | 🟢 21/21 | 🔴 0/8 | |
-| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
-| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
-| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ✅ 2/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
+| [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 17/17 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 4/6 | |
-| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
-| [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
-| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
-| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
-| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🔴 0/3 | 🟢 1/1 | 🔴 0/3 | 🔴 0/1 | 🟢 21/21 | 🟡 3/6 | |
+| [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟢 6/6 | |
+| [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
+| [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
+| [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
+| [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
+| [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
-| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
-| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | 🔴 0/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
+| [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ✅ 2/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
+| [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
+| [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🔴 0/1 | 🟢 21/21 | 🔴 0/8 | |
 
 
 ### Mobile

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-core.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | DTO types inferred from FluentValidation AbstractValidator<T> type arg and DataAnnotation model classes; heuristic |
+| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | FluentValidation AbstractValidator<T> + DataAnnotations [Required]/[StringLength]/[Range]/[RegularExpression] regex extractor; heuristic |
 
 ### Middleware
 
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum; members collected in Signature |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface; was already extracted, cell now confirmed |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST class/struct/record_declaration → SCOPE.Component; record_declaration added this PR |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
+++ b/docs/coverage/detail/lang.csharp.framework.aspnet-mvc.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic |
+| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | FluentValidation AbstractValidator<T> + DataAnnotations regex extractor; heuristic |
 
 ### Middleware
 
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.csharp.framework.blazor-server.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-server.md
@@ -37,8 +37,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
 
 ### Lifecycle

--- a/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor-wasm.md
@@ -37,8 +37,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
 
 ### Lifecycle

--- a/docs/coverage/detail/lang.csharp.framework.blazor.md
+++ b/docs/coverage/detail/lang.csharp.framework.blazor.md
@@ -37,8 +37,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
 
 ### Lifecycle

--- a/docs/coverage/detail/lang.csharp.framework.carter.md
+++ b/docs/coverage/detail/lang.csharp.framework.carter.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic |
+| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | FluentValidation AbstractValidator<T> + DataAnnotations regex extractor; heuristic |
 
 ### Middleware
 
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
+++ b/docs/coverage/detail/lang.csharp.framework.fastendpoints.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic |
+| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | FluentValidation AbstractValidator<T> + DataAnnotations regex extractor; heuristic |
 
 ### Middleware
 
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.csharp.framework.nancyfx.md
+++ b/docs/coverage/detail/lang.csharp.framework.nancyfx.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic |
+| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | FluentValidation AbstractValidator<T> + DataAnnotations regex extractor; heuristic |
 
 ### Middleware
 
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.csharp.framework.servicestack.md
+++ b/docs/coverage/detail/lang.csharp.framework.servicestack.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic |
+| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/csharp/validation.go` | FluentValidation AbstractValidator<T> + DataAnnotations regex extractor; heuristic |
 
 ### Middleware
 
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST enum_declaration → SCOPE.Schema/enum |
+| Interface extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST interface_declaration → SCOPE.Component/interface |
 | Type alias extraction | — `not_applicable` | — | — | — | C# has only file-scoped using-aliases, not first-class type aliases |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ✅ `full` | — | — | `internal/extractors/csharp/csharp.go` | tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -5806,12 +5806,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "DTO types inferred from FluentValidation AbstractValidator\u003cT\u003e type arg and DataAnnotation model classes; heuristic"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "FluentValidation AbstractValidator\u003cT\u003e + DataAnnotations [Required]/[StringLength]/[Range]/[RegularExpression] regex extractor; heuristic"
           }
         },
         "Middleware": {
@@ -5823,20 +5827,23 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum; members collected in Signature"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface; was already extracted, cell now confirmed"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
             "notes": "C# has only file-scoped using-aliases, not first-class type aliases"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST class/struct/record_declaration → SCOPE.Component; record_declaration added this PR"
           }
         },
         "Testing": {
@@ -6009,12 +6016,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "FluentValidation AbstractValidator\u003cT\u003e + DataAnnotations regex extractor; heuristic"
           }
         },
         "Middleware": {
@@ -6024,20 +6035,23 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
             "notes": "C# has only file-scoped using-aliases, not first-class type aliases"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR"
           }
         },
         "Testing": {
@@ -6214,10 +6228,14 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
@@ -6382,10 +6400,14 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
@@ -6550,10 +6572,14 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
@@ -6710,12 +6736,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "FluentValidation AbstractValidator\u003cT\u003e + DataAnnotations regex extractor; heuristic"
           }
         },
         "Middleware": {
@@ -6725,20 +6755,23 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
             "notes": "C# has only file-scoped using-aliases, not first-class type aliases"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR"
           }
         },
         "Testing": {
@@ -6907,12 +6940,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "FluentValidation AbstractValidator\u003cT\u003e + DataAnnotations regex extractor; heuristic"
           }
         },
         "Middleware": {
@@ -6922,20 +6959,23 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
             "notes": "C# has only file-scoped using-aliases, not first-class type aliases"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR"
           }
         },
         "Testing": {
@@ -7242,12 +7282,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "FluentValidation AbstractValidator\u003cT\u003e + DataAnnotations regex extractor; heuristic"
           }
         },
         "Middleware": {
@@ -7257,20 +7301,23 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
             "notes": "C# has only file-scoped using-aliases, not first-class type aliases"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR"
           }
         },
         "Testing": {
@@ -7614,12 +7661,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "DTO types inferred from FluentValidation + DataAnnotation model classes; heuristic"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/csharp/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "FluentValidation AbstractValidator\u003cT\u003e + DataAnnotations regex extractor; heuristic"
           }
         },
         "Middleware": {
@@ -7629,20 +7680,23 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST enum_declaration → SCOPE.Schema/enum"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST interface_declaration → SCOPE.Component/interface"
           },
           "type_alias_extraction": {
             "status": "not_applicable",
             "notes": "C# has only file-scoped using-aliases, not first-class type aliases"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/csharp/csharp.go"],
+            "notes": "tree-sitter CST class/struct/record_declaration → SCOPE.Component; record added this PR"
           }
         },
         "Testing": {

--- a/internal/custom/csharp/validation.go
+++ b/internal/custom/csharp/validation.go
@@ -1,0 +1,242 @@
+// Package csharp — validation extractor for C# source files.
+//
+// Detects two validation styles:
+//
+//  1. FluentValidation: AbstractValidator<T> subclasses with .RuleFor(...) chains.
+//     Emits SCOPE.Pattern (subtype="request_validation") per validator class
+//     and SCOPE.Schema (subtype="dto") per validated DTO type T.
+//
+//  2. DataAnnotations: [Required]/[StringLength]/[Range]/[RegularExpression]/[EmailAddress]/
+//     [MinLength]/[MaxLength]/[Compare]/[Phone]/[Url] attributes on model properties.
+//     Emits SCOPE.Pattern (subtype="request_validation") per annotated property site
+//     and SCOPE.Schema (subtype="dto") per model class bearing annotations.
+//
+//  3. [ApiController] auto-validation: presence of [ApiController] attribute triggers
+//     automatic ModelState validation. Emits a single SCOPE.Pattern per file.
+//
+// These entities cause request_validation and dto_extraction coverage cells to light up
+// for the 6 C# backend framework records.
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_validation", &csharpValidationExtractor{})
+}
+
+type csharpValidationExtractor struct{}
+
+func (e *csharpValidationExtractor) Language() string { return "custom_csharp_validation" }
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// FluentValidation: class FooValidator : AbstractValidator<FooDto>
+	reAbstractValidator = regexp.MustCompile(
+		`\bclass\s+(\w+)\s*:\s*(?:\w+\.)*AbstractValidator\s*<\s*(\w+)\s*>`,
+	)
+
+	// FluentValidation: .RuleFor(x => x.Property)
+	reRuleFor = regexp.MustCompile(
+		`\.RuleFor\s*\(`,
+	)
+
+	// DataAnnotations on properties/fields — the most common validation attributes.
+	// Matches [Required], [StringLength(...)], [Range(...)], [RegularExpression(...)],
+	// [EmailAddress], [MinLength(...)], [MaxLength(...)], [Compare(...)], [Phone], [Url].
+	reDataAnnotation = regexp.MustCompile(
+		`\[\s*(?:Required|StringLength|Range|RegularExpression|EmailAddress|MinLength|MaxLength|Compare|Phone|Url)\s*(?:\([^)]*\))?\s*\]`,
+	)
+
+	// Model class that has data annotations — we capture the class name.
+	// Matches "public class FooModel" or "public class FooRequest" etc.
+	// We use this to emit a DTO entity for the model bearing annotations.
+	reClassDecl = regexp.MustCompile(
+		`(?m)^\s*(?:public\s+)?(?:partial\s+)?(?:internal\s+)?class\s+(\w+)`,
+	)
+
+	// [ApiController] auto-validation marker.
+	reApiController = regexp.MustCompile(
+		`\[ApiController\s*\]`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *csharpValidationExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.csharp_validation_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "csharp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. FluentValidation — AbstractValidator<T> subclasses
+	// -----------------------------------------------------------------------
+	for _, m := range reAbstractValidator.FindAllStringSubmatchIndex(src, -1) {
+		validatorName := src[m[2]:m[3]]
+		dtoType := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+
+		// Emit validation pattern for the validator class itself.
+		name := "validation:fluent:" + validatorName
+		ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "csharp", line)
+		setProps(&ent,
+			"validation_framework", "FluentValidation",
+			"validator_class", validatorName,
+			"validated_type", dtoType,
+		)
+		add(ent)
+
+		// Emit DTO schema entity for the validated type (if not primitive).
+		if !csharpPrimitives[dtoType] {
+			dtoEnt := makeEntity(dtoType, "SCOPE.Schema", "dto", file.Path, "csharp", line)
+			setProps(&dtoEnt,
+				"validation_framework", "FluentValidation",
+				"provenance", "INFERRED_FROM_ABSTRACT_VALIDATOR",
+			)
+			add(dtoEnt)
+		}
+	}
+
+	// If the file has any .RuleFor(... calls and we found validators, emit a
+	// "has_rule_for" marker per file (idempotent — used as supporting signal).
+	if reRuleFor.MatchString(src) {
+		hasValidator := reAbstractValidator.MatchString(src)
+		if hasValidator {
+			name := "validation:fluent:rule_for:" + file.Path
+			ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "csharp", 1)
+			setProps(&ent, "validation_framework", "FluentValidation", "detail", "rule_for_present")
+			add(ent)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. DataAnnotations — [Required] / [StringLength] / etc.
+	// -----------------------------------------------------------------------
+	if reDataAnnotation.MatchString(src) {
+		// Emit a per-annotation-site pattern entity.
+		for _, m := range reDataAnnotation.FindAllStringIndex(src, -1) {
+			attrText := src[m[0]:m[1]]
+			// Trim brackets and args to get the attribute name.
+			attrName := reDataAnnotation.FindString(attrText)
+			// Extract just the attribute identifier (before '(' or ']').
+			cleanAttr := attrName
+			if idx := indexByte(cleanAttr, '('); idx >= 0 {
+				cleanAttr = cleanAttr[:idx]
+			}
+			if idx := indexByte(cleanAttr, ']'); idx >= 0 {
+				cleanAttr = cleanAttr[:idx]
+			}
+			// Strip leading '[' and whitespace.
+			cleanAttr = trimLeadingBracketSpace(cleanAttr)
+
+			line := lineOf(src, m[0])
+			name := "validation:annotation:" + cleanAttr + ":" + file.Path + ":" + itoa(line)
+			ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "csharp", line)
+			setProps(&ent,
+				"validation_framework", "DataAnnotations",
+				"annotation", cleanAttr,
+			)
+			add(ent)
+		}
+
+		// Emit DTO schema entities for classes in this file that carry annotations.
+		for _, m := range reClassDecl.FindAllStringSubmatchIndex(src, -1) {
+			className := src[m[2]:m[3]]
+			if csharpPrimitives[className] {
+				continue
+			}
+			line := lineOf(src, m[0])
+			dtoEnt := makeEntity(className, "SCOPE.Schema", "dto", file.Path, "csharp", line)
+			setProps(&dtoEnt,
+				"validation_framework", "DataAnnotations",
+				"provenance", "INFERRED_FROM_DATA_ANNOTATION",
+			)
+			add(dtoEnt)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. [ApiController] auto-validation — emit once per file.
+	// -----------------------------------------------------------------------
+	if reApiController.MatchString(src) {
+		idx := reApiController.FindStringIndex(src)
+		line := 1
+		if idx != nil {
+			line = lineOf(src, idx[0])
+		}
+		name := "validation:ApiController:auto:" + file.Path
+		ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "csharp", line)
+		setProps(&ent,
+			"validation_framework", "ApiController",
+			"detail", "auto_model_state_validation",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// String helpers (no extra imports)
+// ---------------------------------------------------------------------------
+
+// indexByte returns the index of the first occurrence of b in s, or -1.
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+// trimLeadingBracketSpace strips a leading '[' and any surrounding whitespace.
+func trimLeadingBracketSpace(s string) string {
+	for len(s) > 0 && (s[0] == '[' || s[0] == ' ' || s[0] == '\t') {
+		s = s[1:]
+	}
+	for len(s) > 0 && (s[len(s)-1] == ' ' || s[len(s)-1] == '\t') {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/custom/csharp/validation_test.go
+++ b/internal/custom/csharp/validation_test.go
@@ -1,0 +1,184 @@
+package csharp_test
+
+// ---------------------------------------------------------------------------
+// Validation — request_validation + dto_extraction
+// ---------------------------------------------------------------------------
+
+import "testing"
+
+// FluentValidation: AbstractValidator<T> subclass
+func TestValidationFluentAbstractValidator(t *testing.T) {
+	src := `
+using FluentValidation;
+
+public class CreateOrderValidator : AbstractValidator<CreateOrderDto>
+{
+    public CreateOrderValidator()
+    {
+        RuleFor(x => x.CustomerId).NotEmpty();
+        RuleFor(x => x.Amount).GreaterThan(0);
+    }
+}
+`
+	ents := extract(t, "custom_csharp_validation", fi("CreateOrderValidator.cs", "csharp", src))
+
+	validationFound := false
+	dtoFound := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "request_validation" && e.Name == "validation:fluent:CreateOrderValidator" {
+			validationFound = true
+		}
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "dto" && e.Name == "CreateOrderDto" {
+			dtoFound = true
+		}
+	}
+	if !validationFound {
+		t.Error("expected validation:fluent:CreateOrderValidator SCOPE.Pattern entity")
+	}
+	if !dtoFound {
+		t.Error("expected CreateOrderDto SCOPE.Schema dto entity from AbstractValidator")
+	}
+}
+
+// FluentValidation: qualified namespace (FluentValidation.AbstractValidator<T>)
+func TestValidationFluentQualifiedNamespace(t *testing.T) {
+	src := `
+public class UserValidator : FluentValidation.AbstractValidator<UserRequest>
+{
+    public UserValidator()
+    {
+        RuleFor(u => u.Email).NotEmpty().EmailAddress();
+    }
+}
+`
+	ents := extract(t, "custom_csharp_validation", fi("UserValidator.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "request_validation" && e.Name == "validation:fluent:UserValidator" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected validation:fluent:UserValidator from qualified FluentValidation.AbstractValidator<T>")
+	}
+}
+
+// DataAnnotations: [Required] on model properties
+func TestValidationDataAnnotationsRequired(t *testing.T) {
+	src := `
+using System.ComponentModel.DataAnnotations;
+
+public class RegisterRequest
+{
+    [Required]
+    public string Username { get; set; }
+
+    [Required]
+    [StringLength(100, MinimumLength = 6)]
+    public string Password { get; set; }
+
+    [EmailAddress]
+    public string Email { get; set; }
+}
+`
+	ents := extract(t, "custom_csharp_validation", fi("RegisterRequest.cs", "csharp", src))
+
+	validationCount := 0
+	dtoFound := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "request_validation" {
+			validationCount++
+		}
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "dto" && e.Name == "RegisterRequest" {
+			dtoFound = true
+		}
+	}
+	if validationCount == 0 {
+		t.Error("expected at least one request_validation SCOPE.Pattern from DataAnnotations")
+	}
+	if !dtoFound {
+		t.Error("expected RegisterRequest SCOPE.Schema dto from DataAnnotation model")
+	}
+}
+
+// DataAnnotations: [Range] and [RegularExpression]
+func TestValidationDataAnnotationsRangeRegex(t *testing.T) {
+	src := `
+public class ProductDto
+{
+    [Range(0.01, 9999.99)]
+    public decimal Price { get; set; }
+
+    [RegularExpression(@"^[A-Z]{2,4}$")]
+    public string Code { get; set; }
+}
+`
+	ents := extract(t, "custom_csharp_validation", fi("ProductDto.cs", "csharp", src))
+	rangeFound := false
+	regexFound := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "request_validation" {
+			if containsEntity([]entitySummary{{Kind: e.Kind, Subtype: e.Subtype, Name: e.Name}}, "SCOPE.Pattern", e.Name) {
+				// Just check they exist
+				if e.Name != "" {
+					rangeFound = rangeFound || (len(e.Name) > 0)
+					regexFound = regexFound || (len(e.Name) > 0)
+				}
+			}
+		}
+	}
+	count := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "request_validation" {
+			count++
+		}
+	}
+	if count < 2 {
+		t.Errorf("expected at least 2 DataAnnotation validation patterns, got %d", count)
+	}
+	_ = rangeFound
+	_ = regexFound
+}
+
+// [ApiController] auto-validation
+func TestValidationApiControllerAutoValidation(t *testing.T) {
+	src := `
+[ApiController]
+[Route("api/[controller]")]
+public class OrdersController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Create([FromBody] CreateOrderDto dto) => Ok();
+}
+`
+	ents := extract(t, "custom_csharp_validation", fi("OrdersController.cs", "csharp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "request_validation" && e.Name == "validation:ApiController:auto:OrdersController.cs" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected validation:ApiController:auto entity from [ApiController]")
+	}
+}
+
+// Wrong language should produce no entities.
+func TestValidationWrongLanguageSkipped(t *testing.T) {
+	src := `[Required] public string Name { get; set; }`
+	ents := extract(t, "custom_csharp_validation", fi("file.java", "java", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for non-csharp language, got %d", len(ents))
+	}
+}
+
+// No match — plain file with no validation patterns.
+func TestValidationNoMatch(t *testing.T) {
+	src := `namespace App { class Helper { public void DoWork() {} } }`
+	ents := extract(t, "custom_csharp_validation", fi("Helper.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 validation entities, got %d", len(ents))
+	}
+}

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -6,6 +6,8 @@
 //   - class_declaration       → Kind="SCOPE.Component", Subtype="class"
 //   - interface_declaration   → Kind="SCOPE.Component", Subtype="interface"
 //   - struct_declaration      → Kind="SCOPE.Component", Subtype="struct"
+//   - record_declaration      → Kind="SCOPE.Component", Subtype="type"
+//   - enum_declaration        → Kind="SCOPE.Schema",    Subtype="enum"
 //   - using_directive         → IMPORTS relationship
 //
 // Issue #368 — relationship parity. The extractor emits:
@@ -97,13 +99,15 @@ func walk(
 	}
 
 	switch node.Type() {
-	case "class_declaration", "interface_declaration", "struct_declaration":
+	case "class_declaration", "interface_declaration", "struct_declaration", "record_declaration":
 		subtype := "class"
 		switch node.Type() {
 		case "interface_declaration":
 			subtype = "interface"
 		case "struct_declaration":
 			subtype = "struct"
+		case "record_declaration":
+			subtype = "type"
 		}
 		rec, ok := buildComponent(node, file, subtype)
 		if !ok {
@@ -134,6 +138,12 @@ func walk(
 						Kind: "CONTAINS",
 					})
 			}
+		}
+		return
+
+	case "enum_declaration":
+		if rec, ok := buildEnumEntity(node, file); ok {
+			*out = append(*out, rec)
 		}
 		return
 
@@ -208,6 +218,48 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 		StartLine:          int(node.StartPoint().Row) + 1,
 		EndLine:            int(node.EndPoint().Row) + 1,
 		Signature:          buildClassSignature(node, file.Content),
+		EnrichmentRequired: false,
+	}, true
+}
+
+// buildEnumEntity creates a SCOPE.Schema entity (subtype="enum") for enum declarations.
+// Enum member names are collected and stored in the Signature field as a comma-separated
+// list so the graph carries the full member set without additional enrichment.
+func buildEnumEntity(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	name := childFieldText(node, "name", file.Content)
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+
+	// Collect member names from enum_member_declaration_list children.
+	var members []string
+	for _, memberList := range findAllNodes(node, "enum_member_declaration_list") {
+		for _, member := range findAllNodes(memberList, "enum_member_declaration") {
+			// The first identifier child is the member name.
+			for i := 0; i < int(member.ChildCount()); i++ {
+				ch := member.Child(i)
+				if ch != nil && ch.Type() == "identifier" {
+					members = append(members, string(file.Content[ch.StartByte():ch.EndByte()]))
+					break
+				}
+			}
+		}
+	}
+
+	sig := name
+	if len(members) > 0 {
+		sig = name + " { " + strings.Join(members, ", ") + " }"
+	}
+
+	return types.EntityRecord{
+		Name:               name,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "enum",
+		SourceFile:         file.Path,
+		Language:           "csharp",
+		StartLine:          int(node.StartPoint().Row) + 1,
+		EndLine:            int(node.EndPoint().Row) + 1,
+		Signature:          sig,
 		EnrichmentRequired: false,
 	}, true
 }

--- a/internal/extractors/csharp/typesystem_test.go
+++ b/internal/extractors/csharp/typesystem_test.go
@@ -1,0 +1,181 @@
+package csharp_test
+
+// ---------------------------------------------------------------------------
+// Type-system: enum_declaration + record_declaration
+// ---------------------------------------------------------------------------
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+func TestCSharpExtractor_EnumDeclaration(t *testing.T) {
+	src := `
+public enum OrderStatus
+{
+    Pending,
+    Processing,
+    Shipped,
+    Delivered,
+    Cancelled
+}
+`
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("csharp")
+	if !ok {
+		t.Fatal("csharp extractor not registered")
+	}
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "OrderStatus.cs",
+		Content:  []byte(src),
+		Language: "csharp",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var found bool
+	for _, e := range got {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "enum" && e.Name == "OrderStatus" {
+			found = true
+			// Verify members appear in signature.
+			if e.Signature == "" {
+				t.Error("expected non-empty Signature for enum entity")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Schema/enum entity for OrderStatus")
+	}
+}
+
+func TestCSharpExtractor_EnumSimpleOneLine(t *testing.T) {
+	src := `public enum Color { Red, Green, Blue }`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("csharp")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "Color.cs",
+		Content:  []byte(src),
+		Language: "csharp",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range got {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "enum" && e.Name == "Color" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Schema/enum for one-line Color enum")
+	}
+}
+
+func TestCSharpExtractor_RecordDeclarationPositional(t *testing.T) {
+	src := `public record UserDto(string FirstName, string LastName, int Age);`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("csharp")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "UserDto.cs",
+		Content:  []byte(src),
+		Language: "csharp",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range got {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "type" && e.Name == "UserDto" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Component/type for record UserDto; got %d entities", len(got))
+	}
+}
+
+func TestCSharpExtractor_RecordDeclarationBlock(t *testing.T) {
+	src := `
+public record OrderRecord
+{
+    public string Id { get; init; }
+    public decimal Total { get; init; }
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("csharp")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "OrderRecord.cs",
+		Content:  []byte(src),
+		Language: "csharp",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, e := range got {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "type" && e.Name == "OrderRecord" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Component/type for block record OrderRecord")
+	}
+}
+
+func TestCSharpExtractor_MultipleTypeSystemEntities(t *testing.T) {
+	src := `
+public enum PaymentMethod { CreditCard, Debit, PayPal }
+
+public interface IPayable { void Pay(decimal amount); }
+
+public class Invoice { }
+
+public record InvoiceDto(string Number, decimal Amount);
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("csharp")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "types.cs",
+		Content:  []byte(src),
+		Language: "csharp",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	counts := map[string]int{}
+	for _, e := range got {
+		key := e.Kind + "/" + e.Subtype
+		counts[key]++
+	}
+
+	if counts["SCOPE.Schema/enum"] == 0 {
+		t.Error("expected at least one SCOPE.Schema/enum entity")
+	}
+	if counts["SCOPE.Component/interface"] == 0 {
+		t.Error("expected at least one SCOPE.Component/interface entity")
+	}
+	if counts["SCOPE.Component/class"] == 0 {
+		t.Error("expected at least one SCOPE.Component/class entity")
+	}
+	if counts["SCOPE.Component/type"] == 0 {
+		t.Error("expected at least one SCOPE.Component/type (record) entity")
+	}
+}


### PR DESCRIPTION
## Summary

Part of #3263.

### Validation — `request_validation` + `dto_extraction` (6 backend frameworks)

New `internal/custom/csharp/validation.go`:

- **FluentValidation**: detects `AbstractValidator<T>` subclasses → emits `SCOPE.Pattern/request_validation` per validator class + `SCOPE.Schema/dto` for the type parameter `T`
- **DataAnnotations**: detects `[Required]`/`[StringLength]`/`[Range]`/`[RegularExpression]`/`[EmailAddress]`/`[MinLength]`/`[MaxLength]`/`[Compare]`/`[Phone]`/`[Url]` on model properties → emits `SCOPE.Pattern/request_validation` per annotation site + `SCOPE.Schema/dto` for the model class
- **`[ApiController]` auto-validation**: presence of the attribute signals automatic ModelState validation → emits `SCOPE.Pattern/request_validation`

Both cells flipped to **`partial`** (heuristic regex) for: `aspnet-core`, `aspnet-mvc`, `carter`, `fastendpoints`, `nancyfx`, `servicestack`.

### Type-system — `enum_extraction` / `interface_extraction` / `type_extraction` (CST-proven)

Extended `internal/extractors/csharp/csharp.go` (tree-sitter walk):

- **`enum_declaration`** → `SCOPE.Schema/enum` — member names collected from `enum_member_declaration_list` and stored in `Signature`
- **`record_declaration`** → `SCOPE.Component/type` — positional and block forms both handled via `findTypeBody`
- **`interface_declaration`** was already extracted — cells confirmed and flipped to `full`

Cells flipped to **`full`** for 9 frameworks:
- `enum_extraction`: aspnet-core, aspnet-mvc, carter, fastendpoints, nancyfx, servicestack, blazor, blazor-server, blazor-wasm
- `interface_extraction`: same 9
- `type_extraction`: aspnet-core, aspnet-mvc, carter, fastendpoints, nancyfx, servicestack (blazor has no `type_extraction` cell)

## Cells flipped (36 total)

| Capability | Before | After | Frameworks |
|---|---|---|---|
| `request_validation` | missing | partial | ×6 backend |
| `dto_extraction` | missing | partial | ×6 backend |
| `enum_extraction` | missing | full | ×9 (incl. blazor) |
| `interface_extraction` | missing | full | ×9 (incl. blazor) |
| `type_extraction` | missing | full | ×6 backend |

## Tests

- `internal/custom/csharp/validation_test.go` — 7 tests covering FluentValidation, DataAnnotations, ApiController auto, wrong-language guard, no-match guard
- `internal/extractors/csharp/typesystem_test.go` — 5 CST-fixture tests for enum (multiline + one-line), record (positional + block), and mixed type-system

## Validation

```
go build ./internal/... ./tools/coverage/... ✓
go test ./internal/custom/csharp/... ./internal/extractors/csharp/... ./internal/types/ ./tools/coverage/... ✓ (all pass)
go run ./tools/coverage validate → exit 0 ✓
go run ./tools/coverage fmt --check → canonical ✓
gofmt -l → (empty) ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)