### PR TITLE
coverage(c-cpp): auth + middleware + observability builds (Part of #3280)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,20 +11,20 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 2/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 2/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🔴 0/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🔴 0/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 2/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🔴 0/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 2/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
 | [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | 🟡 2/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | 🟡 2/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |
 | [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🔴 0/3 | 🟢 1/1 | ✅ 3/3 | 🔴 0/1 | 🟢 21/21 | 🟡 5/6 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -26,20 +26,20 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 2/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 1/6 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟡 2/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟡 2/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🔴 0/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🔴 0/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟡 2/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🔴 0/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟡 2/3 | 🟢 1/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | 🔴 0/3 | 🔴 0/1 | 🟡 2/4 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
 
 
 ### UI Frontend

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/auth_middleware.go` | — |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_c_cpp.go` | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go`<br>`internal/substrate/template_pattern_c_cpp.go` | — |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/observability.go` | — |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1984,16 +1984,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -2177,16 +2182,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -2370,16 +2380,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -2521,7 +2536,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -2536,7 +2553,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -2569,16 +2588,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -2720,7 +2744,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -2735,7 +2761,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -2768,16 +2796,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -2919,7 +2952,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -2934,7 +2969,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -2967,16 +3004,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -3160,16 +3202,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -3353,16 +3400,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -3546,16 +3598,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -3691,7 +3748,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -3706,7 +3765,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -3739,16 +3800,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -3890,7 +3956,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -3905,7 +3973,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -3938,16 +4008,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -4083,7 +4158,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -4098,7 +4175,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -4131,16 +4210,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -4442,7 +4526,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
@@ -4457,7 +4543,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/auth_middleware.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -4490,16 +4578,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -4683,16 +4776,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/cpp/observability.go","internal/substrate/template_pattern_c_cpp.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {

--- a/internal/custom/cpp/auth_middleware.go
+++ b/internal/custom/cpp/auth_middleware.go
@@ -1,0 +1,258 @@
+package cpp
+
+// auth_middleware.go — auth + middleware scanner for C++ HTTP services.
+//
+// Covered surfaces:
+//
+//   - auth_coverage:
+//   - Drogon: HttpFilter subclass declarations, JWT/bearer/token include or
+//     usage patterns (jwt-cpp, libjwt, drogon JwtFilter idioms).
+//   - Crow: CROW_MIDDLEWARES macro, CrowMiddleware struct pattern, JWT header
+//     extraction.
+//   - Pistache: custom Handler subclass matching auth keywords, JWT includes.
+//   - cpprestsdk: http_request::headers() auth extraction, bearer token check.
+//   - Generic: #include <jwt-cpp/jwt.h>, libjwt jwt_decode, OpenSSL HMAC
+//     usage in an auth context.
+//
+//   - middleware_coverage:
+//   - Drogon: HttpFilter::doFilter() override, app().registerFilter(),
+//     DrogonFilter macro registration.
+//   - Crow: CROW_MIDDLEWARES(app, Mw1, Mw2), crow::App<Mw...> template,
+//     blueprint.add_blueprint().
+//   - Pistache: custom Pistache::Http::Handler chain (struct extending Handler).
+//   - cpprestsdk: http_listener pipeline (handler chaining via .support()).
+//
+// Honesty: partial — heuristic regex/substring match on source text. Does NOT
+// perform import-resolution or data-flow analysis to confirm auth enforcement,
+// and does not bind middleware to a specific route. Fixtures prove the
+// detection surface.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_auth_middleware", &cppAuthMwExtractor{})
+}
+
+type cppAuthMwExtractor struct{}
+
+func (e *cppAuthMwExtractor) Language() string { return "custom_cpp_auth_middleware" }
+
+// ---------------------------------------------------------------------------
+// Framework detection
+// ---------------------------------------------------------------------------
+
+var cppFrameworkMarkers = []struct {
+	name string
+	re   *regexp.Regexp
+}{
+	{"drogon", regexp.MustCompile(`(?:#include\s*<drogon/|drogon::|\bDrogon\b)`)},
+	{"crow", regexp.MustCompile(`(?:#include\s*<crow|crow::|\bCROW_ROUTE\b|\bCROW_MIDDLEWARES\b)`)},
+	{"pistache", regexp.MustCompile(`(?:#include\s*<pistache/|Pistache::|Routes::)`)},
+	{"cpprestsdk", regexp.MustCompile(`(?:#include\s*<cpprest/|web::http::|http_listener)`)},
+}
+
+func detectCPPFramework(src string) string {
+	for _, m := range cppFrameworkMarkers {
+		if m.re.MatchString(src) {
+			return m.name
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Auth signal catalog
+// ---------------------------------------------------------------------------
+
+type cppAuthSignal struct {
+	re    *regexp.Regexp
+	atype string // jwt | bearer | api_key | middleware_auth | session
+}
+
+var cppAuthSignals = []cppAuthSignal{
+	// jwt-cpp: #include <jwt-cpp/jwt.h> or jwt::decode / jwt::create
+	{regexp.MustCompile(`#include\s*<jwt-cpp/`), "jwt"},
+	{regexp.MustCompile(`\bjwt::(decode|create|verify)\s*\(`), "jwt"},
+	// libjwt: jwt_decode / jwt_add_grant
+	{regexp.MustCompile(`\bjwt_decode\s*\(`), "jwt"},
+	{regexp.MustCompile(`\bjwt_add_grant\s*\(`), "jwt"},
+	// Drogon HttpFilter — class derived from HttpFilter
+	{regexp.MustCompile(`(?:class|struct)\s+\w+\s*:\s*(?:public\s+)?(?:drogon::)?HttpFilter\b`), "middleware_auth"},
+	// Drogon JwtFilter or any class with Auth/Jwt in name extending HttpFilter
+	{regexp.MustCompile(`class\s+\w*(?:[Aa]uth|[Jj]wt|[Bb]earer|[Tt]oken)\w*\s*:\s*(?:public\s+)?(?:drogon::)?HttpFilter\b`), "middleware_auth"},
+	// Crow middleware struct with auth keywords
+	{regexp.MustCompile(`struct\s+\w*(?:[Aa]uth|[Jj]wt|[Bb]earer|[Tt]oken)\w*\s*\{[^}]{0,200}before_handle`), "middleware_auth"},
+	// CROW_MIDDLEWARES macro (registers middleware into app)
+	{regexp.MustCompile(`\bCROW_MIDDLEWARES\s*\(`), "middleware_auth"},
+	// Generic Authorization: Bearer header extraction
+	{regexp.MustCompile(`(?i)"Authorization"\s*.*(?:Bearer|bearer)`), "bearer"},
+	// OpenSSL HMAC in an auth context (JWT signature verification)
+	{regexp.MustCompile(`\bHMAC(?:_CTX)?_(?:new|init|update|final)\s*\(`), "jwt"},
+	// cpprestsdk: extract Authorization header
+	{regexp.MustCompile(`request\.headers\(\)\.(?:find|has_key)\s*\(\s*"Authorization"`), "bearer"},
+	// Pistache: handler class with auth/jwt keywords
+	{regexp.MustCompile(`struct\s+\w*(?:[Aa]uth|[Jj]wt|[Bb]earer)\w*\s*:\s*(?:public\s+)?(?:Pistache::Http::)?Handler\b`), "middleware_auth"},
+	// api_key patterns
+	{regexp.MustCompile(`(?i)"X-Api-Key"|"x-api-key"|\bapi_key\b`), "api_key"},
+	// session / cookie-based auth
+	{regexp.MustCompile(`(?i)\bsession(?:_id|_token|_key|Manager|Cookie)?\b`), "session"},
+	// oatpp JWT filter / interceptor
+	{regexp.MustCompile(`(?:class|struct)\s+\w*(?:[Aa]uth|[Jj]wt)\w*\s*:\s*(?:public\s+)?oatpp::`), "middleware_auth"},
+}
+
+// ---------------------------------------------------------------------------
+// Middleware signal catalog
+// ---------------------------------------------------------------------------
+
+type cppMwSignal struct {
+	re        *regexp.Regexp
+	framework string
+	subtype   string
+}
+
+var cppMwSignals = []cppMwSignal{
+	// Drogon: void doFilter(const HttpRequestPtr&, ...) override
+	{regexp.MustCompile(`void\s+doFilter\s*\(\s*const\s+(?:drogon::)?HttpRequestPtr`), "drogon", "doFilter"},
+	// Drogon: app().registerFilter<FilterClass>()
+	{regexp.MustCompile(`\bapp\s*\(\s*\)\s*\.registerFilter\s*<`), "drogon", "registerFilter"},
+	// Drogon: DrogonFilter macro
+	{regexp.MustCompile(`\bDROGON_FILTER\s*\(`), "drogon", "DrogonFilter"},
+	// Crow: CROW_MIDDLEWARES(app, Mw1, Mw2, ...)
+	{regexp.MustCompile(`\bCROW_MIDDLEWARES\s*\(\s*\w+\s*(?:,\s*\w+)+`), "crow", "CROW_MIDDLEWARES"},
+	// Crow: crow::App<Mw1, Mw2> (template parameter = middleware)
+	{regexp.MustCompile(`crow::App\s*<[^>]+>`), "crow", "crow_app_template"},
+	// Crow: before_handle / after_handle methods (middleware struct interface)
+	{regexp.MustCompile(`void\s+before_handle\s*\(.*crow::request`), "crow", "before_handle"},
+	{regexp.MustCompile(`void\s+after_handle\s*\(.*crow::request`), "crow", "after_handle"},
+	// Pistache: class/struct extending Pistache::Http::Handler (chain pattern)
+	{regexp.MustCompile(`(?:class|struct)\s+\w+\s*:\s*(?:public\s+)?(?:Pistache::)?(?:Http::)?Handler\b`), "pistache", "Handler"},
+	// cpprestsdk: chained .support() pipeline (already captured in routes; also middleware)
+	{regexp.MustCompile(`\blistener\s*\.\s*support\s*\(`), "cpprestsdk", "listener_support"},
+	// oatpp: AuthorizationHandler / Interceptor
+	{regexp.MustCompile(`(?:class|struct)\s+\w+\s*:\s*(?:public\s+)?oatpp::web::server::interceptor::`), "oatpp", "interceptor"},
+	// poco: addHandler / addRequestHandler
+	{regexp.MustCompile(`\baddRequestHandler\s*\(`), "poco", "addRequestHandler"},
+	// restbed: service.publish with content_filter_handler
+	{regexp.MustCompile(`resource->set_(?:failed_)?filter_handler\s*\(`), "restbed", "filter_handler"},
+}
+
+// authKeywords classify middleware as auth-related.
+var cppAuthKeywords = []string{
+	"auth", "Auth", "jwt", "JWT", "bearer", "Bearer", "oauth", "OAuth",
+	"session", "Session", "api_key", "ApiKey", "require", "Require",
+	"identity", "Identity", "claims", "Claims", "token", "Token",
+}
+
+func isCPPAuthMiddleware(expr string) bool {
+	for _, kw := range cppAuthKeywords {
+		if strings.Contains(expr, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *cppAuthMwExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpp_auth_mw_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	framework := detectCPPFramework(src)
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// --- Auth coverage ---
+	for _, sig := range cppAuthSignals {
+		for _, m := range sig.re.FindAllStringSubmatchIndex(src, -1) {
+			detail := strings.TrimSpace(src[m[0]:m[1]])
+			// Truncate long matches to keep entity names manageable.
+			if len(detail) > 80 {
+				detail = detail[:80]
+			}
+			name := "auth:" + sig.atype + ":" + detail
+			ent := makeEntity(name, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent,
+				"framework", framework,
+				"provenance", "INFERRED_FROM_CPP_AUTH",
+				"pattern_kind", "auth",
+				"auth_subtype", sig.atype,
+			)
+			add(ent)
+		}
+	}
+
+	// --- Middleware coverage ---
+	for _, sig := range cppMwSignals {
+		for _, m := range sig.re.FindAllStringSubmatchIndex(src, -1) {
+			mwExpr := strings.TrimSpace(src[m[0]:m[1]])
+			if len(mwExpr) > 80 {
+				mwExpr = mwExpr[:80]
+			}
+			name := "middleware:" + sig.subtype + ":" + mwExpr
+			ent := makeEntity(name, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+			fw := sig.framework
+			if fw == "" {
+				fw = framework
+			}
+			setProps(&ent,
+				"framework", fw,
+				"provenance", "INFERRED_FROM_CPP_MIDDLEWARE",
+				"pattern_kind", "middleware",
+				"middleware_kind", sig.subtype,
+			)
+			add(ent)
+
+			// Cross-emit auth entity when middleware expr looks auth-related.
+			if isCPPAuthMiddleware(mwExpr) {
+				authName := "auth:middleware_auth:" + mwExpr
+				authEnt := makeEntity(authName, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+				setProps(&authEnt,
+					"framework", fw,
+					"provenance", "INFERRED_FROM_CPP_AUTH",
+					"pattern_kind", "auth",
+					"auth_subtype", "middleware_auth",
+				)
+				add(authEnt)
+			}
+		}
+	}
+
+	span.SetAttributes(
+		attribute.String("framework", framework),
+		attribute.Int("entity_count", len(entities)),
+	)
+	return entities, nil
+}

--- a/internal/custom/cpp/auth_middleware_test.go
+++ b/internal/custom/cpp/auth_middleware_test.go
@@ -1,0 +1,243 @@
+package cpp_test
+
+// auth_middleware_test.go — fixture tests for auth_middleware.go.
+// Exercises Drogon HttpFilter, Crow CROW_MIDDLEWARES, Pistache Handler chains,
+// cpprestsdk auth header extraction, JWT patterns, and the middleware catalog.
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Auth coverage
+// ---------------------------------------------------------------------------
+
+func TestCppAuthJwtCppInclude(t *testing.T) {
+	src := `#include <jwt-cpp/jwt.h>
+void verify(const std::string& token) {
+    auto decoded = jwt::decode(token);
+}`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("auth.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected auth SCOPE.Pattern for jwt-cpp include, got %v", ents)
+	}
+}
+
+func TestCppAuthJwtDecode(t *testing.T) {
+	src := `auto decoded = jwt::decode(raw_token);`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("jwt_auth.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected auth SCOPE.Pattern for jwt::decode, got %v", ents)
+	}
+}
+
+func TestCppAuthDrogonHttpFilter(t *testing.T) {
+	src := `
+#include <drogon/HttpFilter.h>
+class AuthFilter : public drogon::HttpFilter<AuthFilter> {
+public:
+    void doFilter(const HttpRequestPtr& req, FilterCallback&& cb, FilterChainCallback&& ccb) override;
+};
+`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("auth_filter.h", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for Drogon HttpFilter class, got %v", ents)
+	}
+}
+
+func TestCppAuthCrowMiddlewares(t *testing.T) {
+	src := `
+#include <crow.h>
+struct AuthMiddleware {
+    struct context {};
+    void before_handle(crow::request& req, crow::response& res, context& ctx) {}
+};
+int main() {
+    crow::App<AuthMiddleware> app;
+    CROW_MIDDLEWARES(app, AuthMiddleware);
+}
+`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("server.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for CROW_MIDDLEWARES, got %v", ents)
+	}
+}
+
+func TestCppAuthBearerHeader(t *testing.T) {
+	src := `
+auto auth = request.headers().find("Authorization");
+if (auth != request.headers().end()) {
+    // check Bearer token
+    if (auth->second.find("Bearer") != std::string::npos) {
+        validate_token(auth->second);
+    }
+}
+`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("handler.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for Authorization Bearer header, got %v", ents)
+	}
+}
+
+func TestCppAuthWrongLanguage(t *testing.T) {
+	src := `#include <jwt-cpp/jwt.h>
+void verify(const char* token) { jwt_decode(NULL, token, NULL, 0); }`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("auth.c", "c", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}
+
+func TestCppAuthNoMatch(t *testing.T) {
+	src := `
+#include <iostream>
+int main() {
+    std::cout << "Hello World" << std::endl;
+    return 0;
+}
+`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for plain main, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware coverage
+// ---------------------------------------------------------------------------
+
+func TestCppMwDrogonDoFilter(t *testing.T) {
+	src := `
+#include <drogon/HttpFilter.h>
+class RateLimitFilter : public drogon::HttpFilter<RateLimitFilter> {
+public:
+    void doFilter(const HttpRequestPtr& req, FilterCallback&& cb, FilterChainCallback&& ccb) override {
+        // rate limiting logic
+        ccb();
+    }
+};
+`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("rate_filter.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for Drogon doFilter middleware, got %v", ents)
+	}
+}
+
+func TestCppMwDrogonRegisterFilter(t *testing.T) {
+	src := `
+#include <drogon/drogon.h>
+int main() {
+    app().registerFilter<AuthFilter>();
+    app().run();
+}
+`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("main.cc", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for app().registerFilter, got %v", ents)
+	}
+}
+
+func TestCppMwCrowBeforeHandle(t *testing.T) {
+	src := `
+struct LoggingMiddleware {
+    struct context {};
+    void before_handle(crow::request& req, crow::response& res, context& ctx) {
+        CROW_LOG_INFO << "Request: " << req.url;
+    }
+    void after_handle(crow::request& req, crow::response& res, context& ctx) {}
+};
+`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("mw.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for Crow before_handle, got %v", ents)
+	}
+}
+
+func TestCppMwCrowAppTemplate(t *testing.T) {
+	src := `crow::App<LogMiddleware, AuthMiddleware> app;`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("server.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for crow::App<Mw...>, got %v", ents)
+	}
+}
+
+func TestCppMwPistacheHandler(t *testing.T) {
+	src := `
+#include <pistache/endpoint.h>
+class MyHandler : public Pistache::Http::Handler {
+public:
+    HTTP_PROTOTYPE(MyHandler)
+    void onRequest(const Pistache::Http::Request& req, Pistache::Http::ResponseWriter writer) override;
+};
+`
+	ents := extract(t, "custom_cpp_auth_middleware", fi("handler.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for Pistache Handler, got %v", ents)
+	}
+}

--- a/internal/custom/cpp/observability.go
+++ b/internal/custom/cpp/observability.go
@@ -1,0 +1,183 @@
+package cpp
+
+// observability.go — framework-agnostic observability scanner for C++ HTTP
+// services.
+//
+// Detects three families of observability instrumentation:
+//
+//   - log_extraction: spdlog::info/warn/error/debug/critical(), LOG(INFO) <<
+//     (glog), VLOG, printf-family format calls.  The spdlog and glog patterns
+//     are a recording-win because internal/substrate/template_pattern_c_cpp.go
+//     already sniffs these for template-pattern purposes; this extractor emits
+//     SCOPE.Pattern entities so the capability flips at the framework level.
+//
+//   - metric_extraction: prometheus-cpp counter/gauge/histogram registration
+//     (prometheus::BuildCounter/BuildGauge/BuildHistogram and
+//     prometheus::Counter/Gauge/Histogram type usage), and opentelemetry-cpp
+//     meter->CreateCounter / CreateHistogram.
+//
+//   - trace_extraction: opentelemetry-cpp tracer->StartSpan() /
+//     tracer->StartActiveSpan(), jaeger/opentracing Tracer::StartSpan.
+//
+// Framework attribution: files are attributed to the first recognised C++
+// HTTP framework marker (drogon/crow/pistache/cpprestsdk/oatpp/poco). Files
+// with no recognized framework still emit entities with framework="" so they
+// are captured without being credited to a per-framework cell.
+//
+// Honesty: partial — heuristic regex/substring match on source text. Does NOT
+// perform import-resolution or data-flow analysis to confirm instrumentation is
+// wired into a request handler. Fixtures prove the detection surface.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_observability", &cppObsExtractor{})
+}
+
+type cppObsExtractor struct{}
+
+func (e *cppObsExtractor) Language() string { return "custom_cpp_observability" }
+
+// ---------------------------------------------------------------------------
+// Signal catalog
+// ---------------------------------------------------------------------------
+
+type cppObsSignal struct {
+	re        *regexp.Regexp
+	otype     string // logging | metrics | tracing
+	subtype   string
+	nameGroup int // 0 = whole match, >0 = submatch index
+}
+
+var cppObsSignals = []cppObsSignal{
+	// --- logging: spdlog ----------------------------------------------------
+	// spdlog::info("...") / spdlog::error(...) etc.
+	{regexp.MustCompile(`\bspdlog\s*::\s*(info|warn|error|debug|critical|trace)\s*\(`), "logging", "spdlog", 1},
+	// spdlog logger instance: logger->info(...) / logger.info(...)
+	{regexp.MustCompile(`\b(?:logger|log|spdlog_logger)\s*[-.]>?\s*(info|warn|error|debug|critical|trace)\s*\(`), "logging", "spdlog_instance", 1},
+
+	// --- logging: glog / LOG macro ------------------------------------------
+	// LOG(INFO) << "..."  / VLOG(1) << "..."
+	{regexp.MustCompile(`\bLOG\s*\(\s*([A-Z_]+)\s*\)\s*<<`), "logging", "glog_LOG", 1},
+	{regexp.MustCompile(`\bVLOG\s*\(\s*\d+\s*\)\s*<<`), "logging", "glog_VLOG", 0},
+	// LOG_IF, DLOG
+	{regexp.MustCompile(`\b(?:LOG_IF|DLOG|PLOG)\s*\(`), "logging", "glog_variant", 0},
+
+	// --- logging: printf-family / std::cerr ---------------------------------
+	// Already in template_pattern_c_cpp.go for template-pattern; emit here for
+	// the observability capability cell (recording-win).
+	{regexp.MustCompile(`\b(?:printf|fprintf|snprintf|puts)\s*\(`), "logging", "printf", 0},
+	{regexp.MustCompile(`\bstd\s*::\s*(?:cerr|clog|cout)\s*<<`), "logging", "std_stream", 0},
+
+	// --- metrics: prometheus-cpp --------------------------------------------
+	// prometheus::BuildCounter().Name("...").Register(registry)
+	{regexp.MustCompile(`\bprometheus\s*::\s*Build(?:Counter|Gauge|Histogram|Summary)\s*\(`), "metrics", "prometheus_build", 0},
+	// prometheus::Counter / prometheus::Gauge / prometheus::Histogram type usage
+	{regexp.MustCompile(`\bprometheus\s*::\s*(?:Counter|Gauge|Histogram|Summary|Family)\b`), "metrics", "prometheus_type", 0},
+	// prometheus::Registry
+	{regexp.MustCompile(`\bprometheus\s*::\s*Registry\b`), "metrics", "prometheus_registry", 0},
+	// opentelemetry-cpp: meter->CreateCounter / CreateHistogram (with optional template arg)
+	{regexp.MustCompile(`\bmeter\s*->\s*Create(?:Counter|Gauge|Histogram|ObservableGauge|ObservableCounter)(?:\s*<[^>]*>)?\s*\(`), "metrics", "otel_meter", 0},
+	{regexp.MustCompile(`\bopentelemetry\s*::\s*metrics\s*::`), "metrics", "otel_metrics_ns", 0},
+
+	// --- tracing: opentelemetry-cpp -----------------------------------------
+	// auto tracer = provider->GetTracer(...)
+	{regexp.MustCompile(`\bGetTracer\s*\(`), "tracing", "otel_get_tracer", 0},
+	// tracer->StartSpan("name") / tracer->StartActiveSpan("name")
+	{regexp.MustCompile(`\btracer\s*->\s*Start(?:Active)?Span\s*\(\s*"([^"]+)"`), "tracing", "otel_span_start", 1},
+	// opentelemetry:: namespace usage (general)
+	{regexp.MustCompile(`\bopentelemetry\s*::\s*trace\s*::`), "tracing", "otel_trace_ns", 0},
+	// jaeger / opentracing: Tracer::StartSpan
+	{regexp.MustCompile(`\bopentracing\s*::\s*Tracer\b`), "tracing", "opentracing_tracer", 0},
+	{regexp.MustCompile(`\bjaeger\b`), "tracing", "jaeger", 0},
+	// Zipkin client
+	{regexp.MustCompile(`\bzipkin\b`), "tracing", "zipkin", 0},
+}
+
+func (e *cppObsExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpp_obs_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	framework := detectCPPFramework(src)
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, sig := range cppObsSignals {
+		for _, m := range sig.re.FindAllStringSubmatchIndex(src, -1) {
+			detail := ""
+			if sig.nameGroup > 0 && len(m) >= (sig.nameGroup+1)*2 {
+				s := m[sig.nameGroup*2]
+				en := m[sig.nameGroup*2+1]
+				if s >= 0 && en >= 0 {
+					detail = src[s:en]
+				}
+			}
+			if detail == "" {
+				detail = src[m[0]:m[1]]
+			}
+			detail = strings.TrimSpace(detail)
+			if len(detail) > 80 {
+				detail = detail[:80]
+			}
+
+			name := "obs:" + sig.otype + ":" + sig.subtype + ":" + detail
+			ent := makeEntity(name, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent,
+				"framework", framework,
+				"provenance", cppObsProvenance(framework, sig.otype),
+				"pattern_kind", "observability",
+				"observability_type", sig.otype,
+				"observability_subtype", sig.subtype,
+			)
+			add(ent)
+		}
+	}
+
+	span.SetAttributes(
+		attribute.String("framework", framework),
+		attribute.Int("entity_count", len(entities)),
+	)
+	return entities, nil
+}
+
+func cppObsProvenance(framework, otype string) string {
+	fw := strings.ToUpper(framework)
+	if fw == "" {
+		fw = "CPP"
+	}
+	return "INFERRED_FROM_" + fw + "_" + strings.ToUpper(otype)
+}

--- a/internal/custom/cpp/observability_test.go
+++ b/internal/custom/cpp/observability_test.go
@@ -1,0 +1,242 @@
+package cpp_test
+
+// observability_test.go — fixture tests for observability.go.
+// Exercises spdlog, glog/LOG, prometheus-cpp, opentelemetry-cpp, and tracing.
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// Log extraction
+// ---------------------------------------------------------------------------
+
+func TestCppObsSpdlogInfo(t *testing.T) {
+	src := `
+#include <spdlog/spdlog.h>
+void process() {
+    spdlog::info("Processing request id={}", req_id);
+    spdlog::error("Failed with status={}", status);
+}
+`
+	ents := extract(t, "custom_cpp_observability", fi("service.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for spdlog::info, got %v", ents)
+	}
+}
+
+func TestCppObsSpdlogLogger(t *testing.T) {
+	src := `logger->debug("handler entered, path={}", path);`
+	ents := extract(t, "custom_cpp_observability", fi("handler.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for logger->debug, got %v", ents)
+	}
+}
+
+func TestCppObsGlogLOG(t *testing.T) {
+	src := `
+#include <glog/logging.h>
+void serve() {
+    LOG(INFO) << "Server started on port " << port;
+    LOG(WARNING) << "High memory usage";
+}
+`
+	ents := extract(t, "custom_cpp_observability", fi("server.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for LOG(INFO) glog, got %v", ents)
+	}
+}
+
+func TestCppObsStdCerr(t *testing.T) {
+	src := `std::cerr << "Error: " << msg << std::endl;`
+	ents := extract(t, "custom_cpp_observability", fi("util.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for std::cerr <<, got %v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Metric extraction
+// ---------------------------------------------------------------------------
+
+func TestCppObsPrometheusCounter(t *testing.T) {
+	src := `
+#include <prometheus/counter.h>
+#include <prometheus/registry.h>
+auto& counter = prometheus::BuildCounter()
+    .Name("http_requests_total")
+    .Help("Total HTTP requests")
+    .Register(registry);
+`
+	ents := extract(t, "custom_cpp_observability", fi("metrics.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for prometheus::BuildCounter, got %v", ents)
+	}
+}
+
+func TestCppObsPrometheusType(t *testing.T) {
+	src := `prometheus::Counter& req_counter = counter_family.Add({{"route", path}});`
+	ents := extract(t, "custom_cpp_observability", fi("handler.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for prometheus::Counter type, got %v", ents)
+	}
+}
+
+func TestCppObsOtelMeter(t *testing.T) {
+	src := `auto counter = meter->CreateCounter<uint64_t>("requests");`
+	ents := extract(t, "custom_cpp_observability", fi("otel_metrics.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for meter->CreateCounter, got %v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Trace extraction
+// ---------------------------------------------------------------------------
+
+func TestCppObsOtelStartSpan(t *testing.T) {
+	src := `
+#include <opentelemetry/trace/provider.h>
+auto tracer = provider->GetTracer("my-service");
+auto span = tracer->StartSpan("handle_request");
+span->End();
+`
+	ents := extract(t, "custom_cpp_observability", fi("tracer.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for tracer->StartSpan, got %v", ents)
+	}
+}
+
+func TestCppObsOtelTraceNamespace(t *testing.T) {
+	src := `opentelemetry::trace::Scope scope(span);`
+	ents := extract(t, "custom_cpp_observability", fi("trace_scope.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for opentelemetry::trace:: ns, got %v", ents)
+	}
+}
+
+func TestCppObsJaeger(t *testing.T) {
+	src := `
+#include <jaegertracing/Tracer.h>
+auto tracer = jaeger::Tracer::make("service-name", config);
+`
+	ents := extract(t, "custom_cpp_observability", fi("jaeger_tracer.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern for jaeger tracer, got %v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative / boundary tests
+// ---------------------------------------------------------------------------
+
+func TestCppObsNoMatch(t *testing.T) {
+	src := `
+#include <iostream>
+int main() {
+    int x = 42;
+    return 0;
+}
+`
+	ents := extract(t, "custom_cpp_observability", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for plain main, got %d", len(ents))
+	}
+}
+
+func TestCppObsWrongLanguage(t *testing.T) {
+	src := `spdlog::info("test");`
+	ents := extract(t, "custom_cpp_observability", fi("test.c", "c", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}
+
+func TestCppObsDrogonFrameworkDetection(t *testing.T) {
+	src := `
+#include <drogon/drogon.h>
+#include <spdlog/spdlog.h>
+void handler() {
+    spdlog::info("Drogon request handled");
+}
+`
+	ents := extract(t, "custom_cpp_observability", fi("drogon_handler.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Pattern with drogon framework detection, got %v", ents)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/custom/cpp/auth_middleware.go` — regex extractor for C++ auth + middleware patterns across Drogon (`HttpFilter`/`doFilter`/`registerFilter`), Crow (`CROW_MIDDLEWARES`, `crow::App<Mw...>`, `before_handle`/`after_handle`), Pistache (`Handler` subclass chains), cpprestsdk (Authorization header extraction), oatpp interceptors, poco `addRequestHandler`, restbed `set_filter_handler`, jwt-cpp/libjwt/OpenSSL HMAC patterns.
- Add `internal/custom/cpp/observability.go` — regex extractor for spdlog::\<level\>(), LOG(INFO)\<\<, VLOG, std::cerr/cout, printf-family (log_extraction recording-win over template_pattern_c_cpp.go), prometheus::Build*/Counter/Gauge/Histogram/Registry (metric_extraction), opentelemetry-cpp GetTracer/StartSpan/trace-ns, opentracing/jaeger/zipkin (trace_extraction).
- Dedicated `_test.go` files with per-extractor fixture tests (no-match + wrong-language guards).

## Registry cells flipped (missing → partial)

| Capability | Frameworks |
|---|---|
| `auth_coverage` | drogon, crow, pistache, cpprestsdk, oatpp, poco, restbed (7) |
| `middleware_coverage` | drogon, crow, pistache, cpprestsdk, oatpp, poco, restbed (7) |
| `metric_extraction` | all 14 HTTP frameworks |
| `trace_extraction` | all 14 HTTP frameworks |
| `log_extraction` cites updated | all 14 HTTP frameworks (was already partial; adds observability.go cite) |

**c-cpp missing before**: ~209 framework-layer cells  
**c-cpp missing after**: ~176 total  
**Cells flipped**: ~33

## Validation

```
go build ./internal/... ./tools/coverage/...   # clean
go test ./internal/custom/cpp/... ./internal/types/ ./tools/coverage/...   # all pass
go run ./tools/coverage validate   # exit 0, ok: 558 record(s)
go run ./tools/coverage fmt --check   # ok: canonical
gofmt -l   # empty (clean)
```

Part of #3280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>