### PR TITLE
coverage(rust): Diesel/SeaORM ORM build + type_alias extraction

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -105,16 +105,16 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
 | [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟡 2/3 | 🟢 1/1 | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/6 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟡 1/2 | — | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟡 3/5 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🔴 0/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🔴 0/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🔴 0/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🔴 0/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 8/21 | 🔴 0/6 | |
 
 

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -142,9 +142,9 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🟡 1/4 | |
 | [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟡 1/4 | |
 | [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🟡 1/4 | |
-| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 2/8 | |
+| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 5/8 | |
 | [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🔴 0/8 | |
-| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 2/8 | |
+| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 6/8 | |
 | [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🟡 1/6 | |
 | [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟡 1/6 | |
 | [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | 🟡 1/6 | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -26,16 +26,16 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | 🔴 0/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🔴 0/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 2/3 | 🟢 1/1 | 🟡 3/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | 🔴 0/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🔴 0/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
 
 
 ### Desktop
@@ -63,9 +63,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 2/8 | |
+| [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 5/8 | |
 | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🔴 0/8 | |
-| [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 2/8 | |
+| [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 6/8 | |
 | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🟡 1/6 | |
 | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟡 1/6 | |
 | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | 🟡 1/6 | |

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -44,7 +44,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 | Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
 
 ### Testing

--- a/docs/coverage/detail/lang.rust.orm.diesel.md
+++ b/docs/coverage/detail/lang.rust.orm.diesel.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/diesel.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/diesel.go`<br>`internal/custom/rust/testdata/diesel_schema.rs` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/diesel.go`<br>`internal/custom/rust/testdata/diesel_models.rs` | — |
 | Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/diesel.go`<br>`internal/custom/rust/testdata/diesel_models.rs`<br>`internal/custom/rust/testdata/diesel_schema.rs` | — |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.rust.orm.seaorm.md
+++ b/docs/coverage/detail/lang.rust.orm.seaorm.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/orms/seaorm.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_entity.rs` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_entity.rs` | — |
 | Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 | Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_entity.rs` | — |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_migration.rs` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -43161,8 +43161,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -43368,8 +43370,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -43575,8 +43579,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -43782,8 +43788,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -43989,8 +43997,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -44196,8 +44206,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -44399,8 +44411,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -44678,8 +44692,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -44881,8 +44897,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -45088,8 +45106,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/extractors/rust/rust.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
             "status": "partial",
@@ -45250,14 +45270,18 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/diesel.go","internal/custom/rust/testdata/diesel_schema.rs"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/diesel.go","internal/custom/rust/testdata/diesel_models.rs"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
             "status": "missing",
@@ -45268,8 +45292,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/diesel.go","internal/custom/rust/testdata/diesel_models.rs","internal/custom/rust/testdata/diesel_schema.rs"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Queries": {
@@ -45394,14 +45420,18 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/seaorm.go","internal/custom/rust/testdata/seaorm_entity.rs"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/seaorm.go","internal/custom/rust/testdata/seaorm_entity.rs"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
             "status": "missing",
@@ -45412,8 +45442,10 @@
             "issue": "backfill:dictionary-completeness"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/seaorm.go","internal/custom/rust/testdata/seaorm_entity.rs"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Queries": {
@@ -45425,7 +45457,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/seaorm.go","internal/custom/rust/testdata/seaorm_migration.rs"],
+            "verified_at": "2026-05-30"
           }
         }
       }

--- a/internal/custom/rust/diesel.go
+++ b/internal/custom/rust/diesel.go
@@ -1,0 +1,197 @@
+package rust
+
+// diesel.go — custom extractor for the Diesel ORM (Rust).
+//
+// Detects and emits entities for:
+//
+//   - table! {} macro declarations → SCOPE.Component (subtype="schema_table")
+//   - #[derive(Queryable, Insertable, AsChangeset, ...)] struct annotations →
+//     SCOPE.Component (subtype="orm_model") with the derive list in properties
+//   - joinable!(table1 -> table2 (fk_col)) → SCOPE.Pattern (subtype="orm_relationship")
+//   - #[belongs_to(Parent)] attribute → SCOPE.Pattern (subtype="orm_relationship")
+//
+// Honesty:
+//
+//	partial — heuristic regex match on source text. Does NOT perform
+//	type-system analysis or resolve schema paths from diesel.toml.
+//	Fixtures prove the detection surface; semantic cross-file resolution
+//	requires import-graph analysis beyond this scanner.
+//
+// Issue #3269 — lang.rust.orm.diesel ORM build.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_diesel", &rustDieselExtractor{})
+}
+
+type rustDieselExtractor struct{}
+
+func (e *rustDieselExtractor) Language() string { return "custom_rust_diesel" }
+
+// ---------------------------------------------------------------------------
+// Regex catalog
+// ---------------------------------------------------------------------------
+
+var (
+	// table! { users (id) { id -> Integer, name -> Text, } }
+	// Captures table name.
+	reDieselTable = regexp.MustCompile(
+		`\btable!\s*\{\s*(\w+)\s*[\({]`,
+	)
+
+	// #[derive(Queryable)] / #[derive(Queryable, Insertable, AsChangeset)]
+	// Followed (within a few lines) by struct Name.
+	// We capture the derive list and then the struct name via a two-step scan.
+	reDieselDerive = regexp.MustCompile(
+		`#\[derive\([^)]*\b(?:Queryable|Insertable|AsChangeset|Identifiable|Associations|Selectable)\b[^)]*\)\]`,
+	)
+	reDieselDeriveList = regexp.MustCompile(
+		`#\[derive\(([^)]+)\)\]`,
+	)
+
+	// struct Name following a diesel derive
+	reStructName = regexp.MustCompile(`\bstruct\s+(\w+)`)
+
+	// joinable!(posts -> users (user_id));
+	reDieselJoinable = regexp.MustCompile(
+		`\bjoinable!\s*\(\s*(\w+)\s*->\s*(\w+)\s*\(\s*(\w+)\s*\)\s*\)`,
+	)
+
+	// #[belongs_to(Parent)] / #[belongs_to(Parent, foreign_key = "parent_id")]
+	reDieselBelongsTo = regexp.MustCompile(
+		`#\[belongs_to\(\s*(\w+)(?:\s*,\s*[^)]+)?\s*\)\]`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *rustDieselExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.rust_diesel_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. table! {} macro → schema_table entity
+	for _, m := range reDieselTable.FindAllStringSubmatchIndex(src, -1) {
+		tableName := src[m[2]:m[3]]
+		ent := makeEntity("diesel:schema:"+tableName, "SCOPE.Component", "schema_table",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "diesel",
+			"table_name", tableName,
+			"provenance", "INFERRED_FROM_DIESEL_TABLE_MACRO",
+		)
+		add(ent)
+	}
+
+	// 2. #[derive(Queryable/Insertable/...)] struct → orm_model entity.
+	//    We scan all derive attrs; for each diesel-bearing derive we look
+	//    for the next struct declaration within 10 lines.
+	deriveMatches := reDieselDerive.FindAllStringIndex(src, -1)
+	for _, dm := range deriveMatches {
+		// Full attribute text for the derive list.
+		attrText := src[dm[0]:dm[1]]
+		listMatch := reDieselDeriveList.FindStringSubmatch(attrText)
+		deriveList := ""
+		if len(listMatch) >= 2 {
+			deriveList = listMatch[1]
+		}
+
+		// Scan forward from end of derive attr for `struct Name`.
+		tail := src[dm[1]:]
+		// Limit lookahead to the next ~500 characters (roughly 10 lines).
+		if len(tail) > 500 {
+			tail = tail[:500]
+		}
+		structMatch := reStructName.FindStringSubmatchIndex(tail)
+		if structMatch == nil {
+			continue
+		}
+		structName := tail[structMatch[2]:structMatch[3]]
+		line := lineOf(src, dm[0])
+		ent := makeEntity("diesel:model:"+structName, "SCOPE.Component", "orm_model",
+			file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "diesel",
+			"struct_name", structName,
+			"derive_traits", strings.TrimSpace(deriveList),
+			"provenance", "INFERRED_FROM_DIESEL_DERIVE",
+		)
+		add(ent)
+	}
+
+	// 3. joinable!(table1 -> table2 (fk)) → orm_relationship pattern
+	for _, m := range reDieselJoinable.FindAllStringSubmatchIndex(src, -1) {
+		fromTable := src[m[2]:m[3]]
+		toTable := src[m[4]:m[5]]
+		fkCol := src[m[6]:m[7]]
+		name := "diesel:joinable:" + fromTable + "->" + toTable
+		ent := makeEntity(name, "SCOPE.Pattern", "orm_relationship",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "diesel",
+			"from_table", fromTable,
+			"to_table", toTable,
+			"foreign_key", fkCol,
+			"relationship_type", "joinable",
+			"provenance", "INFERRED_FROM_DIESEL_JOINABLE_MACRO",
+		)
+		add(ent)
+	}
+
+	// 4. #[belongs_to(Parent)] → orm_relationship pattern
+	for _, m := range reDieselBelongsTo.FindAllStringSubmatchIndex(src, -1) {
+		parent := src[m[2]:m[3]]
+		name := "diesel:belongs_to:" + parent
+		ent := makeEntity(name, "SCOPE.Pattern", "orm_relationship",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "diesel",
+			"parent_model", parent,
+			"relationship_type", "belongs_to",
+			"provenance", "INFERRED_FROM_DIESEL_BELONGS_TO",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/rust/diesel_seaorm_test.go
+++ b/internal/custom/rust/diesel_seaorm_test.go
@@ -1,0 +1,219 @@
+package rust_test
+
+// diesel_seaorm_test.go — tests for custom_rust_diesel and custom_rust_seaorm
+// extractors (issue #3269).
+//
+// Uses the fi/extract/containsEntity helpers from extractors_test.go.
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Diesel — schema extraction (table! macro)
+// ---------------------------------------------------------------------------
+
+func TestDiesel_TableMacro(t *testing.T) {
+	src := readFixture(t, "testdata/diesel_schema.rs")
+	ents := extract(t, "custom_rust_diesel", fi("schema.rs", "rust", src))
+
+	if !containsEntity(ents, "SCOPE.Component", "diesel:schema:users") {
+		t.Error("expected diesel:schema:users from table! macro")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "diesel:schema:posts") {
+		t.Error("expected diesel:schema:posts from table! macro")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Diesel — model extraction (#[derive(Queryable/Insertable/...)])
+// ---------------------------------------------------------------------------
+
+func TestDiesel_QueryableModel(t *testing.T) {
+	src := readFixture(t, "testdata/diesel_models.rs")
+	ents := extract(t, "custom_rust_diesel", fi("models.rs", "rust", src))
+
+	if !containsEntity(ents, "SCOPE.Component", "diesel:model:User") {
+		t.Error("expected diesel:model:User (Queryable)")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "diesel:model:NewUser") {
+		t.Error("expected diesel:model:NewUser (Insertable)")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "diesel:model:Post") {
+		t.Error("expected diesel:model:Post (Queryable+Associations)")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "diesel:model:UpdatePost") {
+		t.Error("expected diesel:model:UpdatePost (AsChangeset)")
+	}
+}
+
+func TestDiesel_QueryableModelInline(t *testing.T) {
+	src := `
+use diesel::prelude::*;
+
+#[derive(Queryable)]
+pub struct Product {
+    pub id: i32,
+    pub name: String,
+}
+`
+	ents := extract(t, "custom_rust_diesel", fi("product.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "diesel:model:Product") {
+		t.Error("expected diesel:model:Product")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Diesel — relationship extraction (joinable! + belongs_to)
+// ---------------------------------------------------------------------------
+
+func TestDiesel_JoinableMacro(t *testing.T) {
+	src := readFixture(t, "testdata/diesel_schema.rs")
+	ents := extract(t, "custom_rust_diesel", fi("schema.rs", "rust", src))
+
+	if !containsEntity(ents, "SCOPE.Pattern", "diesel:joinable:posts->users") {
+		t.Error("expected diesel:joinable:posts->users from joinable! macro")
+	}
+}
+
+func TestDiesel_BelongsTo(t *testing.T) {
+	src := readFixture(t, "testdata/diesel_models.rs")
+	ents := extract(t, "custom_rust_diesel", fi("models.rs", "rust", src))
+
+	if !containsEntity(ents, "SCOPE.Pattern", "diesel:belongs_to:User") {
+		t.Error("expected diesel:belongs_to:User from #[belongs_to(User)]")
+	}
+}
+
+func TestDiesel_BelongsToInline(t *testing.T) {
+	src := `
+use diesel::prelude::*;
+
+#[derive(Queryable, Associations)]
+#[belongs_to(Category, foreign_key = "category_id")]
+pub struct Article {
+    pub id: i32,
+    pub category_id: i32,
+}
+`
+	ents := extract(t, "custom_rust_diesel", fi("article.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "diesel:belongs_to:Category") {
+		t.Error("expected diesel:belongs_to:Category")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Diesel — non-rust file is ignored
+// ---------------------------------------------------------------------------
+
+func TestDiesel_IgnoresNonRust(t *testing.T) {
+	src := `table! { users (id) { id -> Integer, } }`
+	ents := extract(t, "custom_rust_diesel", fi("schema.ts", "typescript", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-rust file, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SeaORM — entity model extraction (#[derive(DeriveEntityModel)])
+// ---------------------------------------------------------------------------
+
+func TestSeaORM_EntityModel(t *testing.T) {
+	src := readFixture(t, "testdata/seaorm_entity.rs")
+	ents := extract(t, "custom_rust_seaorm", fi("user.rs", "rust", src))
+
+	if !containsEntity(ents, "SCOPE.Component", "seaorm:model:users") {
+		t.Error("expected seaorm:model:users (from table_name attribute)")
+	}
+}
+
+func TestSeaORM_EntityModelInline(t *testing.T) {
+	src := `
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "products")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub name: String,
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("product.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "seaorm:model:products") {
+		t.Error("expected seaorm:model:products")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SeaORM — relationship extraction (DeriveRelation enum)
+// ---------------------------------------------------------------------------
+
+func TestSeaORM_RelationHasMany(t *testing.T) {
+	src := readFixture(t, "testdata/seaorm_entity.rs")
+	ents := extract(t, "custom_rust_seaorm", fi("user.rs", "rust", src))
+
+	if !containsEntity(ents, "SCOPE.Pattern", "seaorm:relation:Relation:has_many:Entity") {
+		t.Error("expected seaorm:relation:Relation:has_many:Entity")
+	}
+}
+
+func TestSeaORM_RelationBelongsTo(t *testing.T) {
+	src := `
+use sea_orm::entity::prelude::*;
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(belongs_to = "super::user::Entity", from = "Column::UserId", to = "super::user::Column::Id")]
+    User,
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("post.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "seaorm:relation:Relation:belongs_to:Entity") {
+		t.Error("expected seaorm:relation:Relation:belongs_to:Entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SeaORM — migration extraction (impl MigrationTrait)
+// ---------------------------------------------------------------------------
+
+func TestSeaORM_Migration(t *testing.T) {
+	src := readFixture(t, "testdata/seaorm_migration.rs")
+	ents := extract(t, "custom_rust_seaorm", fi("migration.rs", "rust", src))
+
+	if !containsEntity(ents, "SCOPE.Component", "seaorm:migration:Migration") {
+		t.Error("expected seaorm:migration:Migration from impl MigrationTrait")
+	}
+}
+
+func TestSeaORM_MigrationInline(t *testing.T) {
+	src := `
+use sea_orm_migration::prelude::*;
+
+pub struct CreateUsersTable;
+
+impl MigrationTrait for CreateUsersTable {
+    fn name(&self) -> &str { "m20220101_create_users" }
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("mig.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "seaorm:migration:CreateUsersTable") {
+		t.Error("expected seaorm:migration:CreateUsersTable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SeaORM — non-rust file is ignored
+// ---------------------------------------------------------------------------
+
+func TestSeaORM_IgnoresNonRust(t *testing.T) {
+	src := `
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+pub struct Model { pub id: i32 }
+`
+	ents := extract(t, "custom_rust_seaorm", fi("entity.py", "python", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-rust file, got %d", len(ents))
+	}
+}

--- a/internal/custom/rust/seaorm.go
+++ b/internal/custom/rust/seaorm.go
@@ -1,0 +1,213 @@
+package rust
+
+// seaorm.go — custom extractor for the SeaORM async ORM (Rust).
+//
+// Detects and emits entities for:
+//
+//   - #[derive(Clone, Debug, PartialEq, DeriveEntityModel)] + #[sea_orm(table_name = "...")] →
+//     SCOPE.Component (subtype="orm_model")
+//   - DeriveRelation enum variants with #[sea_orm(has_many / belongs_to = "...")] →
+//     SCOPE.Pattern (subtype="orm_relationship")
+//   - sea-orm-migration MigrationTrait impl blocks → SCOPE.Component (subtype="migration")
+//
+// Honesty:
+//
+//	partial — heuristic regex match on source text. Does NOT perform
+//	full semantic analysis, import-resolution, or macro expansion.
+//	Fixtures prove the detection surface; full cross-entity linking
+//	requires import-graph analysis beyond this scanner.
+//
+// Issue #3269 — lang.rust.orm.seaorm ORM build.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_seaorm", &rustSeaORMExtractor{})
+}
+
+type rustSeaORMExtractor struct{}
+
+func (e *rustSeaORMExtractor) Language() string { return "custom_rust_seaorm" }
+
+// ---------------------------------------------------------------------------
+// Regex catalog
+// ---------------------------------------------------------------------------
+
+var (
+	// #[derive(...DeriveEntityModel...)]
+	reSeaOrmEntityDerive = regexp.MustCompile(
+		`#\[derive\([^)]*\bDeriveEntityModel\b[^)]*\)\]`,
+	)
+
+	// #[sea_orm(table_name = "users")]
+	reSeaOrmTableName = regexp.MustCompile(
+		`#\[sea_orm\([^)]*table_name\s*=\s*"([^"]+)"[^)]*\)\]`,
+	)
+
+	// Entity Model struct name (pub struct Model)
+	reSeaOrmModel = regexp.MustCompile(`\bpub\s+struct\s+(\w+)`)
+
+	// DeriveRelation enum
+	reSeaOrmRelationEnum = regexp.MustCompile(
+		`#\[derive\([^)]*\bDeriveRelation\b[^)]*\)\]\s*(?:pub\s+)?enum\s+(\w+)`,
+	)
+
+	// Relation variant annotations:
+	// #[sea_orm(has_many = "super::post::Entity")]
+	// #[sea_orm(belongs_to = "super::user::Entity", from = "Column::UserId", to = "super::user::Column::Id")]
+	reSeaOrmRelationAttr = regexp.MustCompile(
+		`#\[sea_orm\([^)]*\b(has_many|belongs_to|has_one)\s*=\s*"([^"]+)"[^)]*\)\]`,
+	)
+
+	// sea-orm-migration: impl MigrationTrait for MigrationName
+	reSeaOrmMigration = regexp.MustCompile(
+		`\bimpl\s+MigrationTrait\s+for\s+(\w+)`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *rustSeaORMExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.rust_seaorm_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. DeriveEntityModel struct → orm_model entity.
+	//    Scan for the derive attribute, then look forward for:
+	//    (a) an optional #[sea_orm(table_name = "...")] attribute,
+	//    (b) the struct declaration.
+	entityDeriveMatches := reSeaOrmEntityDerive.FindAllStringIndex(src, -1)
+	for _, dm := range entityDeriveMatches {
+		// Look ahead ~600 chars for table_name attr and struct name.
+		tail := src[dm[1]:]
+		if len(tail) > 600 {
+			tail = tail[:600]
+		}
+
+		tableName := ""
+		if tnMatch := reSeaOrmTableName.FindStringSubmatch(tail); tnMatch != nil {
+			tableName = tnMatch[1]
+		}
+
+		structMatch := reSeaOrmModel.FindStringSubmatchIndex(tail)
+		if structMatch == nil {
+			continue
+		}
+		structName := tail[structMatch[2]:structMatch[3]]
+		if structName == "" {
+			continue
+		}
+
+		modelKey := structName
+		if tableName != "" {
+			modelKey = tableName
+		}
+
+		line := lineOf(src, dm[0])
+		ent := makeEntity("seaorm:model:"+modelKey, "SCOPE.Component", "orm_model",
+			file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "seaorm",
+			"struct_name", structName,
+			"table_name", tableName,
+			"provenance", "INFERRED_FROM_SEAORM_DERIVE_ENTITY_MODEL",
+		)
+		add(ent)
+	}
+
+	// 2. DeriveRelation enum → parse each variant's sea_orm attribute
+	//    to emit orm_relationship patterns.
+	for _, m := range reSeaOrmRelationEnum.FindAllStringSubmatchIndex(src, -1) {
+		enumName := src[m[2]:m[3]]
+
+		// Find the enum body: scan forward for { ... }
+		bodyStart := strings.Index(src[m[1]:], "{")
+		if bodyStart < 0 {
+			continue
+		}
+		bodyStart += m[1]
+		// Find matching closing brace (shallow: assume no nested braces in enum body).
+		bodyEnd := strings.Index(src[bodyStart:], "}")
+		if bodyEnd < 0 {
+			continue
+		}
+		bodyEnd += bodyStart
+		body := src[bodyStart : bodyEnd+1]
+
+		// Within the enum body, find each sea_orm relation attribute.
+		for _, rm := range reSeaOrmRelationAttr.FindAllStringSubmatchIndex(body, -1) {
+			relType := body[rm[2]:rm[3]]      // has_many | belongs_to | has_one
+			targetEntity := body[rm[4]:rm[5]] // e.g. "super::post::Entity"
+			// Extract the short entity name (last segment before ::Entity or ::Model).
+			targetShort := targetEntity
+			if idx := strings.LastIndex(targetEntity, "::"); idx >= 0 {
+				targetShort = targetEntity[idx+2:]
+			}
+			name := "seaorm:relation:" + enumName + ":" + relType + ":" + targetShort
+			ent := makeEntity(name, "SCOPE.Pattern", "orm_relationship",
+				file.Path, file.Language, lineOf(src, bodyStart+rm[0]))
+			setProps(&ent,
+				"framework", "seaorm",
+				"enum_name", enumName,
+				"relation_type", relType,
+				"target_entity", targetEntity,
+				"provenance", "INFERRED_FROM_SEAORM_DERIVE_RELATION",
+			)
+			add(ent)
+		}
+	}
+
+	// 3. impl MigrationTrait for M → migration entity
+	for _, m := range reSeaOrmMigration.FindAllStringSubmatchIndex(src, -1) {
+		migName := src[m[2]:m[3]]
+		ent := makeEntity("seaorm:migration:"+migName, "SCOPE.Component", "migration",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "seaorm",
+			"migration_name", migName,
+			"provenance", "INFERRED_FROM_SEAORM_MIGRATION_TRAIT",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/rust/testdata/diesel_models.rs
+++ b/internal/custom/rust/testdata/diesel_models.rs
@@ -1,0 +1,32 @@
+use diesel::prelude::*;
+use crate::schema::{users, posts};
+
+#[derive(Queryable, Identifiable, Selectable)]
+#[diesel(table_name = users)]
+pub struct User {
+    pub id: i32,
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = users)]
+pub struct NewUser<'a> {
+    pub name: &'a str,
+    pub email: &'a str,
+}
+
+#[derive(Queryable, Identifiable, Associations)]
+#[belongs_to(User)]
+#[diesel(table_name = posts)]
+pub struct Post {
+    pub id: i32,
+    pub title: String,
+    pub user_id: i32,
+}
+
+#[derive(AsChangeset)]
+#[diesel(table_name = posts)]
+pub struct UpdatePost {
+    pub title: Option<String>,
+}

--- a/internal/custom/rust/testdata/diesel_schema.rs
+++ b/internal/custom/rust/testdata/diesel_schema.rs
@@ -1,0 +1,21 @@
+use diesel::prelude::*;
+
+table! {
+    users (id) {
+        id -> Integer,
+        name -> VarChar,
+        email -> VarChar,
+    }
+}
+
+table! {
+    posts (id) {
+        id -> Integer,
+        title -> VarChar,
+        user_id -> Integer,
+    }
+}
+
+joinable!(posts -> users (user_id));
+
+allow_tables_to_appear_in_same_query!(users, posts);

--- a/internal/custom/rust/testdata/seaorm_entity.rs
+++ b/internal/custom/rust/testdata/seaorm_entity.rs
@@ -1,0 +1,18 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(has_many = "super::post::Entity")]
+    Post,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/internal/custom/rust/testdata/seaorm_migration.rs
+++ b/internal/custom/rust/testdata/seaorm_migration.rs
@@ -1,0 +1,36 @@
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20220101_000001_create_users_table"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Users::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Users::Id).integer().not_null().auto_increment().primary_key())
+                    .col(ColumnDef::new(Users::Name).string().not_null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.drop_table(Table::drop().table(Users::Table).to_owned()).await
+    }
+}
+
+#[derive(Iden)]
+enum Users {
+    Table,
+    Id,
+    Name,
+}

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -74,6 +74,14 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 			*out = append(*out, rec)
 		}
 
+	case "type_item":
+		// Issue #3269 — type X = Y; alias declarations.
+		// tree-sitter Rust grammar: type_item has a "name" field (type_identifier)
+		// and a "type" field holding the aliased type expression.
+		if rec, ok := buildTypeAlias(node, file); ok {
+			*out = append(*out, rec)
+		}
+
 	case "trait_item":
 		rec, ok := buildComponent(node, file, "trait")
 		if !ok {
@@ -474,6 +482,35 @@ func buildOperation(node *sitter.Node, file extractor.FileInput) (types.EntityRe
 		Signature:          sig,
 		EnrichmentRequired: false,
 	}, true
+}
+
+// buildTypeAlias creates a Component entity for type alias declarations
+// (`type X = Y;`). The aliased type is captured in the "aliased_type" property.
+//
+// Issue #3269 — type_alias_extraction capability.
+func buildTypeAlias(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	name := childFieldText(node, "name", file.Content)
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	aliasedType := childFieldText(node, "type", file.Content)
+
+	rec := types.EntityRecord{
+		Name:               name,
+		Kind:               "SCOPE.Component",
+		Subtype:            "type_alias",
+		SourceFile:         file.Path,
+		Language:           "rust",
+		StartLine:          int(node.StartPoint().Row) + 1,
+		EndLine:            int(node.EndPoint().Row) + 1,
+		Signature:          buildTypeSignature(node, file.Content, name),
+		EnrichmentRequired: false,
+	}
+	if aliasedType != "" {
+		rec.Properties = map[string]string{"aliased_type": aliasedType}
+	}
+	rec.ID = rec.ComputeID()
+	return rec, true
 }
 
 // buildImport creates a Component entity for use declarations.

--- a/internal/extractors/rust/rust_test.go
+++ b/internal/extractors/rust/rust_test.go
@@ -681,3 +681,80 @@ fn method1() -> u32 { 1 }
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// type_alias_extraction — issue #3269
+// ---------------------------------------------------------------------------
+
+func TestRustExtractor_TypeAlias(t *testing.T) {
+	src := `
+type MyResult<T> = Result<T, MyError>;
+type UserId = u64;
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+`
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("rust")
+	if !ok {
+		t.Fatal("rust extractor not registered")
+	}
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "types.rs",
+		Content:  []byte(src),
+		Language: "rust",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var aliases []string
+	for _, e := range got {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "type_alias" {
+			aliases = append(aliases, e.Name)
+		}
+	}
+
+	wantAliases := []string{"MyResult", "UserId", "BoxFuture"}
+	for _, want := range wantAliases {
+		found := false
+		for _, got := range aliases {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected type_alias entity %q; got: %v", want, aliases)
+		}
+	}
+}
+
+func TestRustExtractor_TypeAlias_Properties(t *testing.T) {
+	src := `type UserId = u64;`
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("rust")
+	if !ok {
+		t.Fatal("rust extractor not registered")
+	}
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "types.rs",
+		Content:  []byte(src),
+		Language: "rust",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, e := range got {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "type_alias" && e.Name == "UserId" {
+			if e.Properties["aliased_type"] != "u64" {
+				t.Errorf("expected aliased_type=u64, got %q", e.Properties["aliased_type"])
+			}
+			return
+		}
+	}
+	t.Error("did not find UserId type_alias entity")
+}


### PR DESCRIPTION
## Summary

- **`internal/custom/rust/diesel.go`** — new custom extractor for Diesel ORM: `table! {}` macro → `schema_table` entity, `#[derive(Queryable/Insertable/AsChangeset)]` struct → `orm_model` entity, `joinable!()` macro → `orm_relationship` pattern, `#[belongs_to(...)]` attribute → `orm_relationship` pattern.
- **`internal/custom/rust/seaorm.go`** — new custom extractor for SeaORM: `#[derive(DeriveEntityModel)]` + `#[sea_orm(table_name)]` → `orm_model`, `DeriveRelation` enum with `has_many`/`belongs_to`/`has_one` attributes → `orm_relationship`, `impl MigrationTrait for M` → `migration`.
- **`internal/extractors/rust/rust.go`** — adds `type_item` case in `walk()` so `type X = Y;` declarations emit `SCOPE.Component(subtype=type_alias)` with `aliased_type` property.
- **Test fixtures** — `testdata/diesel_schema.rs`, `diesel_models.rs`, `seaorm_entity.rs`, `seaorm_migration.rs`; dedicated test file `diesel_seaorm_test.go` + two type_alias tests in `rust_test.go`.

## Registry cells flipped (missing → partial)

| Record | Capability |
|---|---|
| `lang.rust.orm.diesel` | `schema_extraction`, `association_extraction`, `relationship_extraction` |
| `lang.rust.orm.seaorm` | `schema_extraction`, `association_extraction`, `relationship_extraction`, `migration_parsing` |
| `lang.rust.framework.{actix,axum,gotham,hyper,poem,rocket,salvo,tide,tower,warp}` | `type_alias_extraction` |

## Test plan

- [x] `go build ./internal/... ./tools/coverage/...` — clean
- [x] `go test ./internal/custom/rust/... ./internal/extractors/rust/... ./internal/types/ ./tools/coverage/...` — all pass
- [x] `go run ./tools/coverage validate` — exit 0
- [x] `go run ./tools/coverage fmt --check` — ok: canonical
- [x] `gofmt -l` on new/modified files — empty (clean)

Part of #3269

🤖 Generated with [Claude Code](https://claude.com/claude-code)