### PR TITLE
coverage(kotlin): validation extractor + Compose/KMP state/nav/platform — 22 cells

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -136,12 +136,12 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/15 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 9/15 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 9/15 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 12/15 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/15 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 14/15 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
 | [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
@@ -197,8 +197,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 19/19 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🔴 0/9 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🔴 0/9 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🟡 5/9 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🟡 5/9 | |
 
 
 ## Desktop

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -27,12 +27,12 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/15 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/15 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 9/15 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 9/15 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 12/15 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/15 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 14/15 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
 | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
 
 
@@ -40,8 +40,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🔴 0/9 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🔴 0/9 | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🟡 5/9 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🟡 5/9 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -22,14 +22,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Deep link extraction | 🔴 `missing` | — | — | — | — |
-| Navigation extraction | 🔴 `missing` | — | — | — | — |
-| Screen detection | 🔴 `missing` | — | — | — | — |
+| Navigation extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
+| Screen detection | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
 
 ### Platform
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Platform branching | 🔴 `missing` | — | — | — | — |
+| Platform branching | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
 
 ### Native Bridge
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Branch conditions | 🔴 `missing` | — | — | — | — |
-| State management | 🔴 `missing` | — | — | — | — |
+| State management | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
 
 ### Type System
 
@@ -56,7 +56,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| State setter emission | 🔴 `missing` | — | — | — | — |
+| State setter emission | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -22,14 +22,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Deep link extraction | 🔴 `missing` | — | — | — | — |
-| Navigation extraction | 🔴 `missing` | — | — | — | — |
-| Screen detection | 🔴 `missing` | — | — | — | — |
+| Navigation extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
+| Screen detection | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
 
 ### Platform
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Platform branching | 🔴 `missing` | — | — | — | — |
+| Platform branching | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
 
 ### Native Bridge
 
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Branch conditions | 🔴 `missing` | — | — | — | — |
-| State management | 🔴 `missing` | — | — | — | — |
+| State management | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
 
 ### Type System
 
@@ -56,7 +56,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| State setter emission | 🔴 `missing` | — | — | — | — |
+| State setter emission | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/compose.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -29016,15 +29016,21 @@
             "status": "missing"
           },
           "navigation_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           },
           "screen_detection": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Platform": {
           "platform_branching": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Native Bridge": {
@@ -29037,7 +29043,9 @@
             "status": "missing"
           },
           "state_management": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -29059,7 +29067,9 @@
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -29589,12 +29599,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -29830,12 +29844,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -30057,15 +30075,21 @@
             "status": "missing"
           },
           "navigation_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           },
           "screen_detection": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Platform": {
           "platform_branching": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Native Bridge": {
@@ -30078,7 +30102,9 @@
             "status": "missing"
           },
           "state_management": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -30100,7 +30126,9 @@
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/compose.go"],
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -30246,12 +30274,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -30486,12 +30518,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -30735,12 +30771,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -30986,12 +31026,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {

--- a/internal/custom/kotlin/compose.go
+++ b/internal/custom/kotlin/compose.go
@@ -24,6 +24,9 @@ var (
 	reComposableFun = regexp.MustCompile(
 		`@Composable\s+(?:(?:private|internal|public)\s+)?fun\s+([A-Z][A-Za-z0-9_]*)\s*\(`,
 	)
+	reComposableScreen = regexp.MustCompile(
+		`@Composable\s+(?:(?:private|internal|public)\s+)?fun\s+([A-Z][A-Za-z0-9_]*Screen)\s*\(`,
+	)
 	reNavHostStart  = regexp.MustCompile(`(?m)\bNavHost\s*\(`)
 	reNavComposable = regexp.MustCompile(
 		`composable\s*\(\s*(?:route\s*=\s*)?["']([^"']+)["']\s*(?:,|\))`,
@@ -36,6 +39,31 @@ var (
 	)
 	reViewModelAssign = regexp.MustCompile(
 		`val\s+\w+\s*:\s*([A-Z][A-Za-z0-9_]*)\s*=\s*(?:viewModel|hiltViewModel)\s*\(`,
+	)
+
+	// State management: StateFlow<T>, MutableStateFlow<T>, collectAsState, collectAsStateWithLifecycle
+	reStateFlow = regexp.MustCompile(
+		`\b(?:Mutable)?StateFlow\s*<([A-Za-z0-9_?<>, ]+)>`,
+	)
+	// remember { } and rememberSaveable { } calls
+	reRemember = regexp.MustCompile(
+		`\b(remember(?:Saveable)?)\s*(?:<[^>]*>)?\s*\{`,
+	)
+	// mutableStateOf / mutableStateListOf / mutableStateMapOf
+	reMutableStateOf = regexp.MustCompile(
+		`\b(mutableState(?:Of|ListOf|MapOf))\s*\(`,
+	)
+	// collectAsState() / collectAsStateWithLifecycle()
+	reCollectAsState = regexp.MustCompile(
+		`\.collect(?:AsState|AsStateWithLifecycle)\s*\(`,
+	)
+
+	// KMP expect/actual declarations
+	reKmpExpect = regexp.MustCompile(
+		`(?m)^\s*expect\s+(?:fun|class|val|var|object|interface)\s+(\w+)`,
+	)
+	reKmpActual = regexp.MustCompile(
+		`(?m)^\s*actual\s+(?:fun|class|val|var|object|interface)\s+(\w+)`,
 	)
 )
 
@@ -98,6 +126,20 @@ func (e *composeExtractor) Extract(ctx context.Context, file extractor.FileInput
 		entities = append(entities, ent)
 	}
 
+	// 1b. @Composable XxxScreen functions -> SCOPE.UIComponent/screen (screen_detection)
+	for _, m := range reComposableScreen.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		key := "compose:screen:" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ent := makeEntity(name, "SCOPE.UIComponent", "screen", file.Path, lang, lineOf(src, m[0]))
+		setProps(&ent, "framework", "compose", "provenance", "INFERRED_FROM_COMPOSE_SCREEN",
+			"screen_name", name)
+		entities = append(entities, ent)
+	}
+
 	// 2. NavHost routes -> SCOPE.Operation/endpoint
 	for _, nm := range reNavHostStart.FindAllStringIndex(src, -1) {
 		// Extract brace block after NavHost(
@@ -154,6 +196,91 @@ func (e *composeExtractor) Extract(ctx context.Context, file extractor.FileInput
 		ent := makeEntity(vmType, "SCOPE.Component", "", file.Path, lang, lineOf(src, m[0]))
 		setProps(&ent, "framework", "compose", "provenance", "INFERRED_FROM_COMPOSE_VIEWMODEL",
 			"injection_kind", "viewmodel_assign")
+		entities = append(entities, ent)
+	}
+
+	// 4. StateFlow<T> / MutableStateFlow<T> -> SCOPE.Pattern/state_management
+	for _, m := range reStateFlow.FindAllStringSubmatchIndex(src, -1) {
+		typeParam := src[m[2]:m[3]]
+		key := "stateflow:" + typeParam
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ent := makeEntity("StateFlow<"+typeParam+">", "SCOPE.Pattern", "state_management", file.Path, lang, lineOf(src, m[0]))
+		setProps(&ent, "framework", "compose", "provenance", "INFERRED_FROM_STATEFLOW",
+			"state_type", typeParam)
+		entities = append(entities, ent)
+	}
+
+	// 5. remember{} / rememberSaveable{} -> SCOPE.Pattern/state_management
+	for _, m := range reRemember.FindAllStringSubmatchIndex(src, -1) {
+		fnName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		key := "remember:" + fnName + ":" + lang + ":" + src[m[0]:m[1]]
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ent := makeEntity(fnName, "SCOPE.Pattern", "state_management", file.Path, lang, line)
+		setProps(&ent, "framework", "compose", "provenance", "INFERRED_FROM_REMEMBER",
+			"remember_kind", fnName)
+		entities = append(entities, ent)
+	}
+
+	// 6. mutableStateOf / mutableStateListOf / mutableStateMapOf -> SCOPE.Pattern/state_setter
+	for _, m := range reMutableStateOf.FindAllStringSubmatchIndex(src, -1) {
+		fnName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		key := "mutable_state:" + fnName + ":" + lang + ":" + src[m[0]:m[1]]
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ent := makeEntity(fnName, "SCOPE.Pattern", "state_setter", file.Path, lang, line)
+		setProps(&ent, "framework", "compose", "provenance", "INFERRED_FROM_MUTABLE_STATE",
+			"setter_kind", fnName)
+		entities = append(entities, ent)
+	}
+
+	// 7. collectAsState() / collectAsStateWithLifecycle() -> SCOPE.Pattern/state_management
+	for _, m := range reCollectAsState.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		key := "collect_as_state:" + src[m[0]:m[1]]
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ent := makeEntity("collectAsState", "SCOPE.Pattern", "state_management", file.Path, lang, line)
+		setProps(&ent, "framework", "compose", "provenance", "INFERRED_FROM_COLLECT_AS_STATE")
+		entities = append(entities, ent)
+	}
+
+	// 8. KMP expect declarations -> SCOPE.Pattern/platform_branching
+	for _, m := range reKmpExpect.FindAllStringSubmatchIndex(src, -1) {
+		declName := src[m[2]:m[3]]
+		key := "kmp:expect:" + declName
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ent := makeEntity("expect:"+declName, "SCOPE.Pattern", "platform_branching", file.Path, lang, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kmp", "provenance", "INFERRED_FROM_KMP_EXPECT",
+			"declaration_name", declName, "branching_kind", "expect")
+		entities = append(entities, ent)
+	}
+
+	// 9. KMP actual declarations -> SCOPE.Pattern/platform_branching
+	for _, m := range reKmpActual.FindAllStringSubmatchIndex(src, -1) {
+		declName := src[m[2]:m[3]]
+		key := "kmp:actual:" + declName
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ent := makeEntity("actual:"+declName, "SCOPE.Pattern", "platform_branching", file.Path, lang, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kmp", "provenance", "INFERRED_FROM_KMP_ACTUAL",
+			"declaration_name", declName, "branching_kind", "actual")
 		entities = append(entities, ent)
 	}
 

--- a/internal/custom/kotlin/compose_ext_test.go
+++ b/internal/custom/kotlin/compose_ext_test.go
@@ -1,0 +1,188 @@
+package kotlin_test
+
+// ---------------------------------------------------------------------------
+// Compose extension tests: screen_detection, state_management, state_setter,
+// platform_branching (KMP expect/actual)
+// ---------------------------------------------------------------------------
+
+import (
+	"testing"
+)
+
+func TestComposeScreenDetection(t *testing.T) {
+	src := `
+@Composable
+fun HomeScreen(viewModel: HomeViewModel) {
+    Text("Home")
+}
+
+@Composable
+fun DetailScreen(id: Int) {
+    Text("Detail $id")
+}
+`
+	ents := extract(t, "custom_kotlin_compose", fi("Screens.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.UIComponent", "HomeScreen") {
+		t.Error("expected HomeScreen UIComponent")
+	}
+	if !containsEntity(ents, "SCOPE.UIComponent", "DetailScreen") {
+		t.Error("expected DetailScreen UIComponent")
+	}
+	// Check screen subtype specifically
+	foundScreen := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.UIComponent" && e.Subtype == "screen" && e.Name == "HomeScreen" {
+			foundScreen = true
+		}
+	}
+	if !foundScreen {
+		t.Error("expected HomeScreen with subtype=screen")
+	}
+}
+
+func TestComposeStateFlow(t *testing.T) {
+	src := `
+class HomeViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+}
+`
+	ents := extract(t, "custom_kotlin_compose", fi("HomeViewModel.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "state_management" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected state_management entity from StateFlow")
+	}
+}
+
+func TestComposeMutableStateOf(t *testing.T) {
+	src := `
+@Composable
+fun CounterScreen() {
+    var count by remember { mutableStateOf(0) }
+    Text("Count: $count")
+}
+`
+	ents := extract(t, "custom_kotlin_compose", fi("Counter.kt", "kotlin", src))
+	foundSetter := false
+	for _, e := range ents {
+		if e.Subtype == "state_setter" {
+			foundSetter = true
+		}
+	}
+	if !foundSetter {
+		t.Error("expected state_setter entity from mutableStateOf")
+	}
+}
+
+func TestComposeRemember(t *testing.T) {
+	src := `
+@Composable
+fun SettingsScreen() {
+    val navController = remember { NavController() }
+    val state = rememberSaveable { SaveableState() }
+}
+`
+	ents := extract(t, "custom_kotlin_compose", fi("Settings.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "state_management" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected state_management entity from remember{}")
+	}
+}
+
+func TestComposeCollectAsState(t *testing.T) {
+	src := `
+@Composable
+fun FeedScreen(viewModel: FeedViewModel) {
+    val uiState by viewModel.uiState.collectAsState()
+    LazyColumn {  }
+}
+`
+	ents := extract(t, "custom_kotlin_compose", fi("Feed.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "state_management" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected state_management entity from collectAsState()")
+	}
+}
+
+func TestKmpExpectActual(t *testing.T) {
+	expectSrc := `
+package com.example
+
+expect fun getPlatformName(): String
+
+expect class PlatformContext {
+    fun getSystemProperty(key: String): String?
+}
+`
+	actualSrc := `
+package com.example
+
+actual fun getPlatformName(): String = "Android"
+
+actual class PlatformContext {
+    actual fun getSystemProperty(key: String): String? = System.getProperty(key)
+}
+`
+	expectEnts := extract(t, "custom_kotlin_compose", fi("Platform.kt", "kotlin", expectSrc))
+	actualEnts := extract(t, "custom_kotlin_compose", fi("PlatformAndroid.kt", "kotlin", actualSrc))
+
+	foundExpect := false
+	for _, e := range expectEnts {
+		if e.Subtype == "platform_branching" {
+			foundExpect = true
+			break
+		}
+	}
+	if !foundExpect {
+		t.Error("expected platform_branching entity from expect declaration")
+	}
+
+	foundActual := false
+	for _, e := range actualEnts {
+		if e.Subtype == "platform_branching" {
+			foundActual = true
+			break
+		}
+	}
+	if !foundActual {
+		t.Error("expected platform_branching entity from actual declaration")
+	}
+}
+
+func TestKmpExpectFunction(t *testing.T) {
+	src := `
+expect fun httpClient(): HttpClient
+`
+	ents := extract(t, "custom_kotlin_compose", fi("HttpClient.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "expect:httpClient") {
+		t.Error("expected platform_branching entity for expect:httpClient")
+	}
+}
+
+func TestKmpActualFunction(t *testing.T) {
+	src := `
+actual fun httpClient(): HttpClient = OkHttpClient()
+`
+	ents := extract(t, "custom_kotlin_compose", fi("HttpClientAndroid.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "actual:httpClient") {
+		t.Error("expected platform_branching entity for actual:httpClient")
+	}
+}

--- a/internal/custom/kotlin/validation.go
+++ b/internal/custom/kotlin/validation.go
@@ -1,0 +1,199 @@
+// Package kotlin — validation extractor for Kotlin source files.
+//
+// Detects two validation styles:
+//
+//  1. Bean Validation (javax.validation / jakarta.validation):
+//     @Valid/@Validated on handler/controller function parameters.
+//     @NotNull/@Size/@Pattern/@Email/@Min/@Max/@NotBlank/@NotEmpty on data-class
+//     fields or constructor parameters.
+//     Emits SCOPE.Pattern (subtype="request_validation") per annotation site
+//     and SCOPE.Schema (subtype="dto") per data class bearing annotations.
+//
+//  2. Dry::Validation-style contract objects:
+//     Kotlin "contract" DSLs (Valiktor / Arrow Validation contract blocks).
+//     Emits SCOPE.Pattern (subtype="request_validation") for contract schemas
+//     and SCOPE.Schema (subtype="dto") for the parameterised type.
+//
+// These entities cause request_validation and dto_extraction coverage cells to
+// light up for the 6 Kotlin backend framework records:
+// spring-boot, ktor, micronaut, quarkus, http4k, javalin.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_validation", &kotlinValidationExtractor{})
+}
+
+type kotlinValidationExtractor struct{}
+
+func (e *kotlinValidationExtractor) Language() string { return "custom_kotlin_validation" }
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// @Valid or @Validated on a function parameter (handler/controller style).
+	// Matches: @Valid FooRequest, @Validated @RequestBody BarDto, etc.
+	reValidAnnotationParam = regexp.MustCompile(
+		`@(?:Valid|Validated)\b`,
+	)
+
+	// Field-level Bean Validation annotations on data-class constructor params
+	// or body properties.
+	reFieldAnnotation = regexp.MustCompile(
+		`@(?:NotNull|NotBlank|NotEmpty|Size|Pattern|Email|Min|Max|Positive|PositiveOrZero|Negative|NegativeOrZero|DecimalMin|DecimalMax|Digits|Future|Past|FutureOrPresent|PastOrPresent|AssertTrue|AssertFalse)\b`,
+	)
+
+	// data class FooRequest(...) or data class FooDto(...)
+	reDataClass = regexp.MustCompile(
+		`(?m)^\s*(?:data\s+class|class)\s+([A-Z][A-Za-z0-9_]*)\s*[(:@]`,
+	)
+
+	// Valiktor / Arrow-style: validate(foo) { ... } or Validator { ... }
+	// Also matches dry-validation Contract blocks.
+	reValidationContract = regexp.MustCompile(
+		`\b(?:validate|Validator)\s*(?:<\s*([A-Z][A-Za-z0-9_]*)\s*>)?\s*\(`,
+	)
+)
+
+// kotlinPrimitives are Kotlin built-in types that should not be emitted as schema entities.
+var kotlinPrimitives = map[string]bool{
+	"String": true, "Int": true, "Long": true, "Double": true, "Float": true,
+	"Boolean": true, "Char": true, "Byte": true, "Short": true, "Unit": true,
+	"Any": true, "Nothing": true, "Number": true, "List": true, "Map": true,
+	"Set": true, "Collection": true, "Iterable": true, "Sequence": true,
+	"Array": true, "Pair": true, "Triple": true,
+}
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *kotlinValidationExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_validation_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "kotlin" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. @Valid / @Validated on handler parameters → request_validation
+	// -----------------------------------------------------------------------
+	if reValidAnnotationParam.MatchString(src) {
+		for _, m := range reValidAnnotationParam.FindAllStringIndex(src, -1) {
+			attrText := src[m[0]:m[1]]
+			line := lineOf(src, m[0])
+			name := "validation:handler:" + attrText + ":" + file.Path + ":" + strconv.Itoa(line)
+			ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "kotlin", line)
+			setProps(&ent,
+				"validation_framework", "BeanValidation",
+				"annotation", attrText,
+				"provenance", "INFERRED_FROM_VALID_ANNOTATION",
+			)
+			add(ent)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. Field-level annotations (@NotNull, @Size, @Email, etc.) → request_validation
+	//    + emit DTO schema for data classes in the file
+	// -----------------------------------------------------------------------
+	if reFieldAnnotation.MatchString(src) {
+		for _, m := range reFieldAnnotation.FindAllStringIndex(src, -1) {
+			attrText := src[m[0]:m[1]]
+			line := lineOf(src, m[0])
+			name := "validation:field:" + attrText + ":" + file.Path + ":" + strconv.Itoa(line)
+			ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "kotlin", line)
+			setProps(&ent,
+				"validation_framework", "BeanValidation",
+				"annotation", attrText,
+				"provenance", "INFERRED_FROM_FIELD_ANNOTATION",
+			)
+			add(ent)
+		}
+
+		// Emit DTO schema entities for data classes in this file.
+		for _, m := range reDataClass.FindAllStringSubmatchIndex(src, -1) {
+			className := src[m[2]:m[3]]
+			if kotlinPrimitives[className] {
+				continue
+			}
+			line := lineOf(src, m[0])
+			dtoEnt := makeEntity(className, "SCOPE.Schema", "dto", file.Path, "kotlin", line)
+			setProps(&dtoEnt,
+				"validation_framework", "BeanValidation",
+				"provenance", "INFERRED_FROM_FIELD_ANNOTATION",
+			)
+			add(dtoEnt)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. Valiktor / Arrow contract blocks → request_validation + dto
+	// -----------------------------------------------------------------------
+	for _, m := range reValidationContract.FindAllStringSubmatchIndex(src, -1) {
+		line := lineOf(src, m[0])
+		typeName := ""
+		if m[2] >= 0 {
+			typeName = src[m[2]:m[3]]
+		}
+		name := "validation:contract:" + file.Path + ":" + strconv.Itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "kotlin", line)
+		setProps(&ent,
+			"validation_framework", "Valiktor",
+			"provenance", "INFERRED_FROM_VALIDATION_CONTRACT",
+		)
+		if typeName != "" {
+			setProps(&ent, "validated_type", typeName)
+		}
+		add(ent)
+
+		if typeName != "" && !kotlinPrimitives[typeName] {
+			dtoEnt := makeEntity(typeName, "SCOPE.Schema", "dto", file.Path, "kotlin", line)
+			setProps(&dtoEnt,
+				"validation_framework", "Valiktor",
+				"provenance", "INFERRED_FROM_VALIDATION_CONTRACT",
+			)
+			add(dtoEnt)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/kotlin/validation_test.go
+++ b/internal/custom/kotlin/validation_test.go
@@ -1,0 +1,156 @@
+package kotlin_test
+
+// ---------------------------------------------------------------------------
+// Validation extractor tests
+// ---------------------------------------------------------------------------
+
+import (
+	"testing"
+)
+
+func TestValidationAtValid(t *testing.T) {
+	src := `
+@RestController
+class UserController {
+    @PostMapping("/users")
+    fun createUser(@Valid @RequestBody req: CreateUserRequest): ResponseEntity<User> {
+        return ResponseEntity.ok(userService.create(req))
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_validation", fi("UserController.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "request_validation" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected request_validation entity from @Valid annotation")
+	}
+}
+
+func TestValidationAtValidated(t *testing.T) {
+	src := `
+@Controller
+class AccountController {
+    @PostMapping("/accounts")
+    fun createAccount(@Validated body: AccountRequest): String {
+        return "ok"
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_validation", fi("AccountController.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "request_validation" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected request_validation entity from @Validated annotation")
+	}
+}
+
+func TestValidationFieldAnnotations(t *testing.T) {
+	src := `
+data class CreateUserRequest(
+    @NotNull val name: String,
+    @Size(min = 1, max = 100) val username: String,
+    @Email val email: String,
+    @Pattern(regexp = "\\d+") val phone: String,
+    @NotBlank val password: String
+)
+`
+	ents := extract(t, "custom_kotlin_validation", fi("CreateUserRequest.kt", "kotlin", src))
+	hasValidation := false
+	hasDTO := false
+	for _, e := range ents {
+		if e.Subtype == "request_validation" {
+			hasValidation = true
+		}
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "dto" && e.Name == "CreateUserRequest" {
+			hasDTO = true
+		}
+	}
+	if !hasValidation {
+		t.Error("expected request_validation entities from field annotations")
+	}
+	if !hasDTO {
+		t.Error("expected DTO schema entity for CreateUserRequest")
+	}
+}
+
+func TestValidationNotNullEmitsDTO(t *testing.T) {
+	src := `
+data class LoginRequest(
+    @NotNull val username: String,
+    @NotNull val password: String
+)
+`
+	ents := extract(t, "custom_kotlin_validation", fi("LoginRequest.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Schema", "LoginRequest") {
+		t.Error("expected LoginRequest DTO schema entity")
+	}
+}
+
+func TestValidationContractBlock(t *testing.T) {
+	src := `
+class UserRequestValidator {
+    fun validate(request: UserRequest) {
+        validate<UserRequest>(request) {
+            validate(UserRequest::name).hasSize(min = 1, max = 100)
+            validate(UserRequest::email).isEmail()
+        }
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_validation", fi("UserValidator.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "request_validation" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected request_validation entity from validate() contract block")
+	}
+}
+
+func TestValidationContractWithTypeEmitsDTO(t *testing.T) {
+	src := `
+fun validateOrder(order: OrderRequest) = validate<OrderRequest>(order) {
+    validate(OrderRequest::amount).isPositive()
+}
+`
+	ents := extract(t, "custom_kotlin_validation", fi("OrderValidator.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Schema", "OrderRequest") {
+		t.Error("expected OrderRequest DTO schema entity from contract block")
+	}
+}
+
+func TestValidationWrongLanguage(t *testing.T) {
+	src := `@Valid @NotNull String name;`
+	ents := extract(t, "custom_kotlin_validation", fi("Test.java", "java", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}
+
+func TestValidationNoMatch(t *testing.T) {
+	src := `data class User(val name: String, val age: Int)`
+	ents := extract(t, "custom_kotlin_validation", fi("User.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for plain data class, got %d", len(ents))
+	}
+}
+
+func TestValidationEmptyFile(t *testing.T) {
+	ents := extract(t, "custom_kotlin_validation", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("empty file should return no entities, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Summary

- **New**: `internal/custom/kotlin/validation.go` — Bean Validation (`@Valid`/`@Validated` on handler params, `@NotNull`/`@Size`/`@Pattern`/`@Email`/`@Min`/`@Max`/`@NotBlank`/`@NotEmpty` on data-class fields) + Valiktor/Arrow `validate<T>()` contract blocks → `SCOPE.Pattern/request_validation` + `SCOPE.Schema/dto`
- **Extended**: `internal/custom/kotlin/compose.go` — `StateFlow`/`MutableStateFlow`/`collectAsState` → `state_management`; `remember{}`/`rememberSaveable{}` → `state_management`; `mutableStateOf`/`mutableStateListOf`/`mutableStateMapOf` → `state_setter`; KMP `expect`/`actual` declarations → `platform_branching`; `@Composable XxxScreen` → `screen_detection`
- 22 cells flipped `missing → partial`: `request_validation` + `dto_extraction` × 6 frameworks (spring-boot, ktor, micronaut, quarkus, http4k, javalin); `navigation_extraction`, `state_management`, `state_setter_emission`, `platform_branching`, `screen_detection` × 2 (compose, kmp)
- Kotlin missing cells: **140 → 118**
- All tests pass, `validate` exits 0, `fmt --check` clean, `gofmt -l` empty

## Test plan
- [ ] `go test ./internal/custom/kotlin/... ./internal/types/ ./tools/coverage/...` all green
- [ ] `go run ./tools/coverage validate` exits 0
- [ ] `go run ./tools/coverage fmt --check` exits 0
- [ ] `gofmt -l ./internal/custom/kotlin/` empty output
- [ ] New `validation_test.go`: 9 tests covering @Valid, @Validated, field annotations, data-class DTO emission, Valiktor contracts, wrong-language, no-match, empty-file
- [ ] New `compose_ext_test.go`: 8 tests covering screen_detection, StateFlow, mutableStateOf, remember, collectAsState, KMP expect/actual

Part of #3275

🤖 Generated with [Claude Code](https://claude.com/claude-code)