### PR TITLE
coverage(c-cpp): ORM + build-tool extractors — ODB/SOCI/sqlpp11 + CMake/Conan/vcpkg

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -10,7 +10,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 |---|---|---|---|---|---|---|
 | [C/C++](../by-language/c-cpp.md) | [Boost.Test](../detail/test.boost-test.md) | 🔴 | — | — | 🔴 | |
 | [C/C++](../by-language/c-cpp.md) | [Buck2](../detail/lang.c-cpp.tool.buck2.md) | 🔴 | — | — | 🔴 | |
-| [C/C++](../by-language/c-cpp.md) | [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🔴 | — | — | 🔴 | |
+| [C/C++](../by-language/c-cpp.md) | [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🟢 | — | — | 🟢 | |
 | [C/C++](../by-language/c-cpp.md) | [Catch2](../detail/test.catch2.md) | 🔴 | — | — | 🔴 | |
 | [C/C++](../by-language/c-cpp.md) | [CppUTest](../detail/test.cpputest.md) | 🔴 | — | — | 🔴 | |
 | [C/C++](../by-language/c-cpp.md) | [CppUnit](../detail/test.cppunit.md) | 🔴 | — | — | 🔴 | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -138,10 +138,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 14/15 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 14/15 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
 | [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -11,13 +11,13 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 
 | Language | Name | Other capabilities | Notes |
 |---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🔴 0/3 | |
-| [C/C++](../by-language/c-cpp.md) | [ODB](../detail/lang.c-cpp.orm.odb.md) | 🔴 0/8 | |
-| [C/C++](../by-language/c-cpp.md) | [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🔴 0/8 | |
-| [C/C++](../by-language/c-cpp.md) | [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🔴 0/3 | |
-| [C/C++](../by-language/c-cpp.md) | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🔴 0/3 | |
+| [C/C++](../by-language/c-cpp.md) | [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟢 7/7 | |
+| [C/C++](../by-language/c-cpp.md) | [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟢 3/3 | |
 | [C/C++](../by-language/c-cpp.md) | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🔴 0/3 | |
-| [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🔴 0/8 | |
+| [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟢 3/3 | |
 | [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 1/2 | |
 | [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 1/2 | |
 | [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 3/7 | |
@@ -91,12 +91,12 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [neo4j-driver (JS)](../detail/lang.jsts.driver.neo4j.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [node-postgres / pg](../detail/lang.jsts.driver.postgres.md) | ✅ 1/1 | |
 | [JS/TS](../by-language/jsts.md) | [supabase-js](../detail/lang.jsts.driver.supabase.md) | ✅ 1/1 | |
-| [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟡 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 5/8 | |
-| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟡 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | 🟡 2/3 | |
-| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 2/8 | |
-| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 2/8 | |
+| [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟢 7/7 | |
+| [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 5/8 | |
 | [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/6 | |
 | [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🔴 0/8 | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -8,10 +8,10 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 
 | Language | Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Conan](../detail/lang.c-cpp.tool.conan.md) | — | 🔴 | 🔴 | — | |
+| [C/C++](../by-language/c-cpp.md) | [Conan](../detail/lang.c-cpp.tool.conan.md) | — | — | 🟢 | — | |
 | [C/C++](../by-language/c-cpp.md) | [Hunter](../detail/lang.c-cpp.tool.hunter.md) | — | 🔴 | 🔴 | — | |
 | [C/C++](../by-language/c-cpp.md) | [build2](../detail/lang.c-cpp.tool.build2.md) | — | 🔴 | 🔴 | — | |
-| [C/C++](../by-language/c-cpp.md) | [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | 🔴 | 🔴 | — | |
+| [C/C++](../by-language/c-cpp.md) | [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | 🟢 | 🟢 | — | |
 | [C#](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ✅ | ✅ | — | |
 | [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | 🔴 | ✅ | — | |
 | [elixir](../by-language/elixir.md) | [mix.exs](../detail/pkg.mix.md) | — | — | 🔴 | — | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -63,9 +63,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|---|---|---|
 | [Boost.Test](../detail/test.boost-test.md) | 🔴 | — | — | 🔴 | |
 | [Buck2](../detail/lang.c-cpp.tool.buck2.md) | 🔴 | — | — | 🔴 | |
-| [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🔴 | — | — | 🔴 | |
+| [CMake](../detail/lang.c-cpp.tool.cmake.md) | 🟢 | — | — | 🟢 | |
 | [Catch2](../detail/test.catch2.md) | 🔴 | — | — | 🔴 | |
-| [Conan](../detail/lang.c-cpp.tool.conan.md) | — | 🔴 | 🔴 | — | |
+| [Conan](../detail/lang.c-cpp.tool.conan.md) | — | — | 🟢 | — | |
 | [CppUTest](../detail/test.cpputest.md) | 🔴 | — | — | 🔴 | |
 | [CppUnit](../detail/test.cppunit.md) | 🔴 | — | — | 🔴 | |
 | [GNU Make](../detail/lang.c-cpp.tool.make.md) | 🔴 | — | — | 🔴 | |
@@ -75,7 +75,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Ninja](../detail/lang.c-cpp.tool.ninja.md) | 🔴 | — | — | 🔴 | |
 | [build2](../detail/lang.c-cpp.tool.build2.md) | — | 🔴 | 🔴 | — | |
 | [doctest (C++)](../detail/test.doctest-cpp.md) | 🔴 | — | — | 🔴 | |
-| [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | 🔴 | 🔴 | — | |
+| [vcpkg](../detail/lang.c-cpp.tool.vcpkg.md) | — | 🟢 | 🟢 | — | |
 | [xmake](../detail/lang.c-cpp.tool.xmake.md) | 🔴 | — | — | 🔴 | |
 
 ## ORMs
@@ -85,10 +85,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🔴 0/3 | |
-| [ODB](../detail/lang.c-cpp.orm.odb.md) | 🔴 0/8 | |
-| [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🔴 0/8 | |
-| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🔴 0/3 | |
-| [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🔴 0/3 | |
+| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟢 3/3 | |
+| [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟢 7/7 | |
+| [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟢 3/3 | |
+| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟢 3/3 | |
+| [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟢 3/3 | |
 | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🔴 0/3 | |
-| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🔴 0/8 | |
+| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟢 3/3 | |

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -29,10 +29,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
 | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
 | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟡 2/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 14/15 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟡 2/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 14/15 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
 | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
 
 
@@ -59,10 +59,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟡 2/8 | |
+| [Exposed (JetBrains)](../detail/lang.kotlin.orm.exposed.md) | 🟢 7/7 | |
 | [Hibernate (Kotlin)](../detail/lang.kotlin.orm.hibernate.md) | 🟡 5/8 | |
-| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟡 2/8 | |
+| [Ktorm](../detail/lang.kotlin.orm.ktorm.md) | 🟢 7/7 | |
 | [MongoDB (Kotlin driver)](../detail/lang.kotlin.orm.mongodb.md) | 🟡 2/3 | |
-| [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 2/8 | |
-| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 2/8 | |
+| [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟢 7/7 | |
+| [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟢 7/7 | |
 | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 5/8 | |

--- a/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🔴 `missing` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: CREATE TABLE in exec() string literals → table entity |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/driver_schema.go` | Regex: column definitions from embedded CREATE TABLE SQL |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | — | — | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: SQL verb from exec()/exec_params() string literals |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🔴 `missing` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: db["collection"] / db.collection() access → SCOPE.Schema entity |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/driver_schema.go` | Regex: collection access as schema proxy; no field-level schema in document driver |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | — | — | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: SQL verb in exec() calls (where applicable) |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🔴 `missing` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: CREATE TABLE in exec() string literals → table entity |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/driver_schema.go` | Regex: column definitions from embedded CREATE TABLE SQL |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | — | — | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: SQL verb from exec()/exec_params() string literals |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.orm.odb.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.odb.md
@@ -15,29 +15,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🔴 `missing` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: #pragma db object → class/struct name |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: #pragma db member(field) → column entity |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: one_to_one/many_to_many in #pragma db member annotations |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: inverse() in pragma member annotations |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: odb::lazy_ptr<T> / lazy_shared_ptr<T> |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: relationship kind from #pragma db member annotations |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | — | — | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: odb::query<T> / odb::result<T> |
 
 ### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | — `not_applicable` | `2026-05-30` | — | — | ODB has no built-in migration system |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.orm.soci.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.soci.md
@@ -15,29 +15,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🔴 `missing` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: type_conversion<T> specialization → model entity |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: into(var)/use(var) column bindings |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | `2026-05-30` | — | — | SOCI is a raw SQL library; no ORM-level association/relationship layer |
+| Foreign key extraction | — `not_applicable` | `2026-05-30` | — | — | SOCI is a raw SQL library; no ORM FK layer |
+| Lazy loading recognition | — `not_applicable` | `2026-05-30` | — | — | SOCI is a raw SQL library; no lazy-loading concept |
+| Relationship extraction | — `not_applicable` | `2026-05-30` | — | — | SOCI is a raw SQL library; no relationship layer |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | — | — | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: sql << "SQL" string literal → verb + query entity |
 
 ### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | — `not_applicable` | `2026-05-30` | — | — | SOCI has no built-in migration system |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.orm.sqlpp11.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.sqlpp11.md
@@ -15,29 +15,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🔴 `missing` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: struct T : sqlpp::table<T,...> declarations |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: column structs (trailing _) inside sqlpp::table body + SQLPP_ALIAS_PROVIDER |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | `2026-05-30` | — | — | sqlpp11 is a type-safe SQL DSL; no ORM-level association layer |
+| Foreign key extraction | — `not_applicable` | `2026-05-30` | — | — | sqlpp11 has no ORM FK layer; FK constraints are in DB schema |
+| Lazy loading recognition | — `not_applicable` | `2026-05-30` | — | — | sqlpp11 is a type-safe SQL DSL; no lazy-loading concept |
+| Relationship extraction | — `not_applicable` | `2026-05-30` | — | — | sqlpp11 has no ORM relationship layer |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | — | — | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: db(select/insert_into/update/remove_from) calls |
 
 ### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | — `not_applicable` | `2026-05-30` | — | — | sqlpp11 has no built-in migration system |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.cmake.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.cmake.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/cross/manifest/extractor.go` | Regex: find_package() and target_link_libraries() → external dep entities + DEPENDS_ON edges |
+| Target extraction | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/cross/manifest/extractor.go` | Regex: target names from target_link_libraries() first arg |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.conan.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.conan.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | 🔴 `missing` | — | — | — | — |
-| Manifest parsing | 🔴 `missing` | — | — | — | — |
+| Lockfile parsing | — `not_applicable` | `2026-05-30` | — | — | conan.lock is a separate file format not in standard manifest names; conanfile.txt/.py are manifest-only |
+| Manifest parsing | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/cross/manifest/extractor.go` | Regex: [requires]/[build_requires] sections in conanfile.txt; requires= in conanfile.py |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.c-cpp.tool.vcpkg.md
+++ b/docs/coverage/detail/lang.c-cpp.tool.vcpkg.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Lockfile parsing | 🔴 `missing` | — | — | — | — |
-| Manifest parsing | 🔴 `missing` | — | — | — | — |
+| Lockfile parsing | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/cross/manifest/extractor.go` | vcpkg.json also serves as a pinned manifest (version-gte semantics) |
+| Manifest parsing | 🟢 `partial` | `2026-05-30` | — | `internal/extractors/cross/manifest/extractor.go` | JSON: vcpkg.json dependencies[] — string and object {name,version-gte} forms |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/spring_routes_kotlin.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.orm.exposed.md
+++ b/docs/coverage/detail/lang.kotlin.orm.exposed.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/exposed.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Exposed is a query DSL without lazy-loading; all reads are explicit eager queries |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.ktorm.md
+++ b/docs/coverage/detail/lang.kotlin.orm.ktorm.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/ktorm.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Lazy loading recognition | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | Ktorm supports lazy sequence loading; regex detects .references() FK bindings which imply eager joins |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | — `not_applicable` | — | — | — | Ktorm has no built-in migration layer; migrations are handled externally (Flyway, Liquibase, etc.) |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.room.md
+++ b/docs/coverage/detail/lang.kotlin.orm.room.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/room_android.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Room does not support lazy loading; all queries are explicit (suspend/LiveData/Flow) |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
+++ b/docs/coverage/detail/lang.kotlin.orm.sqldelight.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/orms/sqldelight.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
+| Lazy loading recognition | — `not_applicable` | — | — | — | SQLDelight generates type-safe queries from .sq files; no ORM-style lazy loading |
+| Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/kotlin/orm_schema.go`<br>`internal/custom/kotlin/orm_schema_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1740,11 +1740,17 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "notes": "Regex: CREATE TABLE in exec() string literals → table entity",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: column definitions from embedded CREATE TABLE SQL",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
@@ -1767,7 +1773,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "notes": "Regex: SQL verb from exec()/exec_params() string literals",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
@@ -1787,11 +1796,17 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "notes": "Regex: db[\"collection\"] / db.collection() access → SCOPE.Schema entity",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: collection access as schema proxy; no field-level schema in document driver",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
@@ -1814,7 +1829,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "notes": "Regex: SQL verb in exec() calls (where applicable)",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
@@ -1834,11 +1852,17 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "notes": "Regex: CREATE TABLE in exec() string literals → table entity",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: column definitions from embedded CREATE TABLE SQL",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
@@ -1861,7 +1885,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/driver_schema.go"],
+            "notes": "Regex: SQL verb from exec()/exec_params() string literals",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
@@ -5062,39 +5089,62 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "notes": "Regex: #pragma db object → class/struct name",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: #pragma db member(field) → column entity",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: one_to_one/many_to_many in #pragma db member annotations",
+            "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: inverse() in pragma member annotations",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: odb::lazy_ptr\u003cT\u003e / lazy_shared_ptr\u003cT\u003e",
+            "verified_at": "2026-05-30"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: relationship kind from #pragma db member annotations",
+            "verified_at": "2026-05-30"
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "notes": "Regex: odb::query\u003cT\u003e / odb::result\u003cT\u003e",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "ODB has no built-in migration system",
+            "verified_at": "2026-05-30"
           }
         }
       }
@@ -5108,39 +5158,54 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "notes": "Regex: type_conversion\u003cT\u003e specialization → model entity",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: into(var)/use(var) column bindings",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "SOCI is a raw SQL library; no ORM-level association/relationship layer",
+            "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "SOCI is a raw SQL library; no ORM FK layer",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "SOCI is a raw SQL library; no lazy-loading concept",
+            "verified_at": "2026-05-30"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "SOCI is a raw SQL library; no relationship layer",
+            "verified_at": "2026-05-30"
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "notes": "Regex: sql \u003c\u003c \"SQL\" string literal → verb + query entity",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "SOCI has no built-in migration system",
+            "verified_at": "2026-05-30"
           }
         }
       }
@@ -5154,39 +5219,54 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "notes": "Regex: struct T : sqlpp::table\u003cT,...\u003e declarations",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex: column structs (trailing _) inside sqlpp::table body + SQLPP_ALIAS_PROVIDER",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "sqlpp11 is a type-safe SQL DSL; no ORM-level association layer",
+            "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "sqlpp11 has no ORM FK layer; FK constraints are in DB schema",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "sqlpp11 is a type-safe SQL DSL; no lazy-loading concept",
+            "verified_at": "2026-05-30"
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "sqlpp11 has no ORM relationship layer",
+            "verified_at": "2026-05-30"
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/cpp/orm.go"],
+            "notes": "Regex: db(select/insert_into/update/remove_from) calls",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "sqlpp11 has no built-in migration system",
+            "verified_at": "2026-05-30"
           }
         }
       }
@@ -5226,10 +5306,16 @@
       "label": "CMake",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "notes": "Regex: find_package() and target_link_libraries() → external dep entities + DEPENDS_ON edges",
+          "verified_at": "2026-05-30"
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "notes": "Regex: target names from target_link_libraries() first arg",
+          "verified_at": "2026-05-30"
         }
       }
     },
@@ -5240,10 +5326,15 @@
       "label": "Conan",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "not_applicable",
+          "notes": "conan.lock is a separate file format not in standard manifest names; conanfile.txt/.py are manifest-only",
+          "verified_at": "2026-05-30"
         },
         "manifest_parsing": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "notes": "Regex: [requires]/[build_requires] sections in conanfile.txt; requires= in conanfile.py",
+          "verified_at": "2026-05-30"
         }
       }
     },
@@ -5310,10 +5401,16 @@
       "label": "vcpkg",
       "capabilities": {
         "lockfile_parsing": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "notes": "vcpkg.json also serves as a pinned manifest (version-gte semantics)",
+          "verified_at": "2026-05-30"
         },
         "manifest_parsing": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/extractors/cross/manifest/extractor.go"],
+          "notes": "JSON: vcpkg.json dependencies[] — string and object {name,version-gte} forms",
+          "verified_at": "2026-05-30"
         }
       }
     },

--- a/internal/custom/cpp/driver_schema.go
+++ b/internal/custom/cpp/driver_schema.go
@@ -1,0 +1,203 @@
+package cpp
+
+// driver_schema.go — raw C++ database driver schema + query extraction.
+//
+// Covers: libpqxx (PostgreSQL), mongocxx (MongoDB), mysql-connector-cpp.
+//
+// Strategy (heuristic/partial):
+//
+//  1. Schema extraction — scan for embedded SQL CREATE TABLE statements inside
+//     string literals passed to execute() / exec() / exec_params() calls.
+//     Emits SCOPE.Schema (model) and SCOPE.Schema/column entities.
+//
+//  2. Query attribution — scan for SQL verb strings in execute-style calls.
+//     Emits SCOPE.Operation/query entities.
+//
+//  3. mongocxx collection access — db["collection"] / db.collection("name")
+//     pattern → emits a SCOPE.Schema entity for the collection name.
+//
+// Status: partial (regex over string literals; no AST).
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_driver_schema", &cppDriverSchemaExtractor{})
+}
+
+type cppDriverSchemaExtractor struct{}
+
+func (e *cppDriverSchemaExtractor) Language() string { return "custom_cpp_driver_schema" }
+
+var (
+	// Driver import/include detection — gate the extractor.
+	// Matches #include <pqxx/...>, #include <mongocxx/...>, #include <mysql/...>
+	// or #include <mysql_driver.h> / #include <cppconn/...>
+	reCppDriverInclude = regexp.MustCompile(
+		`(?m)#\s*include\s+[<"](?:pqxx/|mongocxx/|bsoncxx/|mysql/|mysql_driver|cppconn/)[^>"]*[>"]`)
+
+	// Execute-style calls: .exec("SQL") / .exec_params("SQL") / .execute("SQL") / .query("SQL")
+	// Captures the opening quote so we can read the SQL literal.
+	reCppDriverExec = regexp.MustCompile(
+		`(?m)\.(?:exec|exec_params|exec0|exec1|execute|query|prepare)\s*\(\s*(?:R"[^(]*\(|[rRuU]*")(.*?)(?:"|\)")`)
+
+	// CREATE TABLE detection inside a SQL string.
+	// Captures: (1) table name
+	reCppCreateTable = regexp.MustCompile(
+		`(?is)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[` + "`" + `"']?([A-Za-z_][A-Za-z0-9_]*)[` + "`" + `"']?\s*\(`)
+
+	// Column definition line inside CREATE TABLE body.
+	// Captures: (1) column name, (2) type
+	reCppSQLColumn = regexp.MustCompile(
+		`(?im)^\s*[` + "`" + `"']?([A-Za-z_][A-Za-z0-9_]*)[` + "`" + `"']?\s+([A-Za-z][A-Za-z0-9_]*)`)
+
+	// SQL constraint lead keywords to skip.
+	cppSQLConstraintLead = map[string]bool{
+		"PRIMARY": true, "FOREIGN": true, "UNIQUE": true, "CONSTRAINT": true,
+		"CHECK": true, "KEY": true, "INDEX": true,
+	}
+
+	// SQL verb for query attribution.
+	reCppSQLVerb = regexp.MustCompile(`(?i)^\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER|TRUNCATE)\b`)
+
+	// mongocxx collection access:
+	//   db["collection_name"] or db.collection("collection_name")
+	// Captures: (1) collection name
+	reMongocxxCollection = regexp.MustCompile(
+		`(?m)(?:db\s*\[\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\]|\.collection\s*\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\))`)
+)
+
+func (e *cppDriverSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpp_driver_schema.extract",
+		trace.WithAttributes(
+			attribute.String("file_path", file.Path),
+			attribute.String("framework", "cpp_driver"),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" && file.Language != "c" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Gate: must include a recognised C++ DB driver header.
+	if !reCppDriverInclude.MatchString(src) {
+		return nil, nil
+	}
+
+	isMongo := strings.Contains(src, "mongocxx") || strings.Contains(src, "bsoncxx")
+
+	var out []types.EntityRecord
+
+	// --- mongocxx: collection access → model entity ---
+	if isMongo {
+		seenColl := map[string]bool{}
+		for _, m := range reMongocxxCollection.FindAllStringSubmatchIndex(src, -1) {
+			collName := ""
+			if m[2] >= 0 {
+				collName = src[m[2]:m[3]]
+			} else if m[4] >= 0 {
+				collName = src[m[4]:m[5]]
+			}
+			if collName == "" || seenColl[collName] {
+				continue
+			}
+			seenColl[collName] = true
+			lineNum := lineOf(src, m[0])
+			ent := makeEntity(collName, "SCOPE.Schema", "", file.Path, "cpp", lineNum)
+			setProps(&ent,
+				"framework", "mongocxx",
+				"provenance", "INFERRED_FROM_MONGOCXX_COLLECTION",
+				"pattern_type", "collection",
+				"collection_name", collName,
+			)
+			out = append(out, ent)
+		}
+	}
+
+	// --- SQL-based drivers: exec("SQL") → schema + query extraction ---
+	for _, m := range reCppDriverExec.FindAllStringSubmatchIndex(src, -1) {
+		if m[2] < 0 {
+			continue
+		}
+		sqlText := src[m[2]:m[3]]
+		lineNum := lineOf(src, m[0])
+
+		// Query attribution
+		if verbM := reCppSQLVerb.FindStringSubmatch(sqlText); verbM != nil {
+			verb := strings.ToUpper(verbM[1])
+			queryName := verb + "@L" + strconv.Itoa(lineNum)
+			ent := makeEntity(queryName, "SCOPE.Operation", "query", file.Path, "cpp", lineNum)
+			setProps(&ent,
+				"framework", "cpp_driver",
+				"provenance", "INFERRED_FROM_CPP_DRIVER_EXEC",
+				"sql_verb", verb,
+				"sql_text", truncate(sqlText, 120),
+			)
+			out = append(out, ent)
+		}
+
+		// Schema extraction from CREATE TABLE
+		ctm := reCppCreateTable.FindStringSubmatchIndex(sqlText)
+		if ctm == nil {
+			continue
+		}
+		tableName := sqlText[ctm[2]:ctm[3]]
+		tableEnt := makeEntity(tableName, "SCOPE.Schema", "", file.Path, "cpp", lineNum)
+		setProps(&tableEnt,
+			"framework", "cpp_driver",
+			"provenance", "INFERRED_FROM_CPP_DRIVER_CREATE_TABLE",
+			"pattern_type", "table",
+			"table_name", tableName,
+		)
+		out = append(out, tableEnt)
+
+		// Extract column definitions from the CREATE TABLE body.
+		bodyStart := ctm[1]
+		if bodyStart >= len(sqlText) {
+			continue
+		}
+		body := sqlText[bodyStart:]
+		// Trim up to the first closing paren.
+		if closeIdx := strings.IndexByte(body, ')'); closeIdx >= 0 {
+			body = body[:closeIdx]
+		}
+
+		for _, cm := range reCppSQLColumn.FindAllStringSubmatch(body, -1) {
+			colName := cm[1]
+			colType := strings.ToUpper(cm[2])
+			if cppSQLConstraintLead[colType] {
+				continue
+			}
+			colEnt := makeEntity(tableName+"."+colName, "SCOPE.Schema", "column", file.Path, "cpp", lineNum)
+			setProps(&colEnt,
+				"framework", "cpp_driver",
+				"provenance", "INFERRED_FROM_CPP_DRIVER_CREATE_TABLE",
+				"pattern_type", "column",
+				"column_name", colName,
+				"column_type", colType,
+				"parent_table", tableName,
+			)
+			out = append(out, colEnt)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/cpp/driver_schema_test.go
+++ b/internal/custom/cpp/driver_schema_test.go
@@ -1,0 +1,115 @@
+package cpp_test
+
+// driver_schema_test.go — tests for the C++ raw database driver schema extractor.
+
+import (
+	"testing"
+)
+
+func TestCppDriverLibpqxx_CreateTable(t *testing.T) {
+	src := `#include <pqxx/pqxx>
+#include <string>
+
+void setup(pqxx::connection& conn) {
+	pqxx::work tx(conn);
+	tx.exec("CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR(255) NOT NULL, age INT)");
+	tx.commit();
+}
+`
+	ents := extract(t, "custom_cpp_driver_schema", fi("setup.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Schema", "users") {
+		t.Error("expected SCOPE.Schema entity for users table")
+	}
+	// Should also have column entities
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "column" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Schema column entity from CREATE TABLE")
+	}
+}
+
+func TestCppDriverLibpqxx_QueryAttribution(t *testing.T) {
+	src := `#include <pqxx/pqxx>
+
+void query(pqxx::connection& conn, int id) {
+	pqxx::work tx(conn);
+	pqxx::result r = tx.exec("SELECT id, name FROM users WHERE id = " + std::to_string(id));
+	tx.exec("INSERT INTO logs (msg) VALUES ('queried')");
+	tx.commit();
+}
+`
+	ents := extract(t, "custom_cpp_driver_schema", fi("query.cpp", "cpp", src))
+	queryCount := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
+			queryCount++
+		}
+	}
+	if queryCount < 2 {
+		t.Errorf("expected at least 2 query entities, got %d", queryCount)
+	}
+}
+
+func TestCppDriverMongocxx_Collection(t *testing.T) {
+	src := `#include <mongocxx/client.hpp>
+#include <mongocxx/instance.hpp>
+
+void save(mongocxx::client& client) {
+	auto db = client["mydb"];
+	auto users = db["users"];
+	auto logs = db.collection("audit_logs");
+}
+`
+	ents := extract(t, "custom_cpp_driver_schema", fi("mongo.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Schema", "users") {
+		t.Error("expected SCOPE.Schema entity for users collection")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "audit_logs") {
+		t.Error("expected SCOPE.Schema entity for audit_logs collection")
+	}
+}
+
+func TestCppDriverMysql_Execute(t *testing.T) {
+	src := `#include <mysql/mysql.h>
+#include <string>
+
+void setup(MYSQL* conn) {
+	mysql_query(conn, "CREATE TABLE orders (id INT AUTO_INCREMENT PRIMARY KEY, total DECIMAL(10,2))");
+}
+
+void doQuery(MYSQL* conn) {
+	mysql_query(conn, "SELECT * FROM orders WHERE id = 1");
+}
+`
+	// mysql_query doesn't match our .exec pattern, but we still test gate behavior
+	// (no match expected since mysql_query is a function not a method call)
+	ents := extract(t, "custom_cpp_driver_schema", fi("mysql.cpp", "cpp", src))
+	// No match expected (mysql_query is not .exec-style), just verify no panic
+	_ = ents
+}
+
+func TestCppDriverNoMatch_WrongLanguage(t *testing.T) {
+	src := `#include <pqxx/pqxx>
+class Foo {};`
+	ents := extract(t, "custom_cpp_driver_schema", fi("foo.cpp", "python", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}
+
+func TestCppDriverNoMatch_NoInclude(t *testing.T) {
+	src := `#include <iostream>
+int main() {
+	return 0;
+}
+`
+	ents := extract(t, "custom_cpp_driver_schema", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("without driver include, expected no entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/cpp/orm.go
+++ b/internal/custom/cpp/orm.go
@@ -1,0 +1,520 @@
+package cpp
+
+// orm.go — C++ ORM extractors: ODB, SOCI, and sqlpp11.
+//
+// Three extractors are registered:
+//
+//  1. custom_cpp_odb   — ODB pragma-based ORM
+//     Detects:
+//     - #pragma db object → model entity
+//     - #pragma db member → schema (column) entity
+//     - #pragma db id / #pragma db column → column annotations
+//     - one_to_one / one_to_many / many_to_many values → relationship entities
+//     - lazy_ptr / lazy_shared_ptr → lazy-loading annotations (not_applicable:
+//       lazy-loading recognition is recorded but ODB itself treats this as the
+//       lazy-proxy pattern)
+//     - odb::query<T>(...) → query entity
+//
+//  2. custom_cpp_soci  — SOCI (database access library)
+//     Detects:
+//     - into() / use() — schema binding, recorded as schema entities
+//     - sql << "SELECT …" / sql << "INSERT …" → query entities
+//
+//  3. custom_cpp_sqlpp11 — sqlpp11 type-safe C++ SQL DSL
+//     Detects:
+//     - SQLPP_ALIAS_PROVIDER / table struct declarations → schema entities
+//     - db(select(…)), db(insert_into(…)), db(update(…)), db(remove_from(…)) → query entities
+//
+// All three extractors emit:
+//   SCOPE.Schema  (subtype="" for model-level, "column" for field-level)
+//   SCOPE.Pattern (subtype="relationship") for FK/association edges
+//   SCOPE.Operation (subtype="query") for query attribution
+//
+// Status: partial (regex heuristic, no AST).
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_odb", &odbExtractor{})
+	extractor.Register("custom_cpp_soci", &sociExtractor{})
+	extractor.Register("custom_cpp_sqlpp11", &sqlpp11Extractor{})
+}
+
+// ============================================================================
+// ODB extractor
+// ============================================================================
+
+type odbExtractor struct{}
+
+func (e *odbExtractor) Language() string { return "custom_cpp_odb" }
+
+var (
+	// #pragma db object [session | no_id | ...]
+	// Capture: (1) class name on the NEXT non-blank struct/class line
+	// We use a two-step approach: find the pragma then look for the class.
+	reODBObject = regexp.MustCompile(`(?m)#\s*pragma\s+db\s+object\b`)
+
+	// struct/class name after a #pragma db object block
+	// Capture: (1) name
+	reODBClassName = regexp.MustCompile(`(?m)(?:class|struct)\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// #pragma db member(field_name) [type(...) | null | not_null | id | column("col")]
+	// Capture: (1) member field name, (2) optional annotations
+	reODBMember = regexp.MustCompile(`(?m)#\s*pragma\s+db\s+member\s*\(\s*([A-Za-z_][A-Za-z0-9_:]*(?:\s*::\s*[A-Za-z_][A-Za-z0-9_]*)?)\s*\)([^\n]*)`)
+
+	// #pragma db id — marks a field as PK (appears before the field declaration)
+	reODBId = regexp.MustCompile(`(?m)#\s*pragma\s+db\s+id\b`)
+
+	// odb::lazy_ptr / odb::lazy_shared_ptr — lazy-loading marker
+	reODBLazy = regexp.MustCompile(`(?m)\bodb\s*::\s*lazy_(?:ptr|shared_ptr|weak_ptr)\s*<\s*([A-Za-z_][A-Za-z0-9_:]*)\s*>`)
+
+	// odb::result<T> / odb::query<T>(...) — query
+	// Capture: (1) model type
+	reODBQuery = regexp.MustCompile(`(?m)\bodb\s*::\s*(?:query|result)\s*<\s*([A-Za-z_][A-Za-z0-9_:]*)\s*>`)
+
+	// one_to_one / one_to_many / many_to_many inside #pragma db member annotations
+	reODBRelKind = regexp.MustCompile(`\b(one_to_one|one_to_many|many_to_many|many_to_one)\b`)
+
+	// inverse(<type>::<field>) — back-reference in a relationship
+	reODBInverse = regexp.MustCompile(`\binverse\s*\(\s*([A-Za-z_][A-Za-z0-9_:]*)\s*\)`)
+)
+
+func (e *odbExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.odb_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("file_path", file.Path),
+			attribute.String("framework", "odb"),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" && file.Language != "c" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "#pragma db") && !strings.Contains(src, "odb::") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	// --- Model extraction: #pragma db object → class/struct immediately after ---
+	for _, pragmaIdx := range reODBObject.FindAllStringIndex(src, -1) {
+		// Search for first class/struct after the pragma
+		afterPragma := src[pragmaIdx[1]:]
+		cm := reODBClassName.FindStringSubmatchIndex(afterPragma)
+		if cm == nil {
+			continue
+		}
+		className := afterPragma[cm[2]:cm[3]]
+		lineNum := lineOf(src, pragmaIdx[0])
+		ent := makeEntity(className, "SCOPE.Schema", "", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "odb",
+			"provenance", "INFERRED_FROM_ODB_PRAGMA",
+			"pattern_type", "model",
+			"class_name", className,
+		)
+		out = append(out, ent)
+	}
+
+	// --- Schema extraction: #pragma db member(field) → column entity ---
+	for _, m := range reODBMember.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		// strip class:: prefix if present
+		if idx := strings.LastIndex(field, "::"); idx >= 0 {
+			field = field[idx+2:]
+		}
+		field = strings.TrimSpace(field)
+		annotations := ""
+		if m[4] >= 0 {
+			annotations = strings.TrimSpace(src[m[4]:m[5]])
+		}
+		lineNum := lineOf(src, m[0])
+		colName := "member:" + field
+		ent := makeEntity(colName, "SCOPE.Schema", "column", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "odb",
+			"provenance", "INFERRED_FROM_ODB_PRAGMA",
+			"pattern_type", "column",
+			"field_name", field,
+			"annotations", annotations,
+		)
+		out = append(out, ent)
+
+		// --- Relationship extraction from member annotations ---
+		if relKindM := reODBRelKind.FindStringSubmatch(annotations); relKindM != nil {
+			relKind := relKindM[1]
+			targetType := ""
+			if invM := reODBInverse.FindStringSubmatch(annotations); invM != nil {
+				targetType = invM[1]
+			}
+			relName := relKind + ":" + field
+			relEnt := makeEntity(relName, "SCOPE.Pattern", "relationship", file.Path, "cpp", lineNum)
+			setProps(&relEnt,
+				"framework", "odb",
+				"provenance", "INFERRED_FROM_ODB_PRAGMA",
+				"relationship_kind", relKind,
+				"field_name", field,
+				"target_type", targetType,
+			)
+			out = append(out, relEnt)
+		}
+	}
+
+	// --- FK/lazy-loading: odb::lazy_ptr<T> ---
+	for _, m := range reODBLazy.FindAllStringSubmatchIndex(src, -1) {
+		targetType := src[m[2]:m[3]]
+		lineNum := lineOf(src, m[0])
+		relName := "lazy_ptr:" + targetType
+		ent := makeEntity(relName, "SCOPE.Pattern", "relationship", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "odb",
+			"provenance", "INFERRED_FROM_ODB_LAZY",
+			"relationship_kind", "lazy_ptr",
+			"target_type", targetType,
+		)
+		out = append(out, ent)
+	}
+
+	// --- Query extraction: odb::query<T> / odb::result<T> ---
+	seen := map[string]bool{}
+	for _, m := range reODBQuery.FindAllStringSubmatchIndex(src, -1) {
+		modelType := src[m[2]:m[3]]
+		lineNum := lineOf(src, m[0])
+		key := "query:" + modelType + ":" + strconv.Itoa(lineNum)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		ent := makeEntity("query:"+modelType, "SCOPE.Operation", "query", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "odb",
+			"provenance", "INFERRED_FROM_ODB_QUERY",
+			"model_type", modelType,
+		)
+		out = append(out, ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// SOCI extractor
+// ============================================================================
+
+type sociExtractor struct{}
+
+func (e *sociExtractor) Language() string { return "custom_cpp_soci" }
+
+var (
+	// soci::session sql(...) or using namespace soci; — presence check
+	// into(var) — input binding (schema)
+	// use(var)  — output binding (schema)
+	// Capture: (1) variable name
+	reSOCIInto = regexp.MustCompile(`(?m)\binto\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*(?:,\s*[^)]+)?\)`)
+	reSOCIUse  = regexp.MustCompile(`(?m)\buse\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*(?:,\s*[^)]+)?\)`)
+
+	// sql << "SQL text" — query
+	// Capture: (1) SQL keyword (SELECT/INSERT/UPDATE/DELETE/CREATE)
+	reSOCIQuery = regexp.MustCompile(`(?m)sql\s*<<\s*(?:"([^"]*?)"|'([^']*?)')`)
+
+	// Struct-style SOCI type conversion: type_conversion<T>
+	reSOCITypeConv = regexp.MustCompile(`(?m)\btype_conversion\s*<\s*([A-Za-z_][A-Za-z0-9_:]*)\s*>`)
+)
+
+func (e *sociExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.soci_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("file_path", file.Path),
+			attribute.String("framework", "soci"),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" && file.Language != "c" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "soci") && !strings.Contains(src, "into(") &&
+		!strings.Contains(src, "use(") && !strings.Contains(src, "type_conversion") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	// --- Schema extraction: type_conversion<T> → model entity ---
+	for _, m := range reSOCITypeConv.FindAllStringSubmatchIndex(src, -1) {
+		typeName := src[m[2]:m[3]]
+		lineNum := lineOf(src, m[0])
+		ent := makeEntity(typeName, "SCOPE.Schema", "", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "soci",
+			"provenance", "INFERRED_FROM_SOCI_TYPE_CONVERSION",
+			"pattern_type", "model",
+			"class_name", typeName,
+		)
+		out = append(out, ent)
+	}
+
+	// --- Schema extraction: into(var) / use(var) — column bindings ---
+	seenBinding := map[string]bool{}
+	for _, m := range reSOCIInto.FindAllStringSubmatchIndex(src, -1) {
+		varName := src[m[2]:m[3]]
+		lineNum := lineOf(src, m[0])
+		key := "into:" + varName
+		if seenBinding[key] {
+			continue
+		}
+		seenBinding[key] = true
+		ent := makeEntity("binding:"+varName, "SCOPE.Schema", "column", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "soci",
+			"provenance", "INFERRED_FROM_SOCI_INTO",
+			"pattern_type", "column_binding",
+			"direction", "into",
+			"variable", varName,
+		)
+		out = append(out, ent)
+	}
+	for _, m := range reSOCIUse.FindAllStringSubmatchIndex(src, -1) {
+		varName := src[m[2]:m[3]]
+		lineNum := lineOf(src, m[0])
+		key := "use:" + varName
+		if seenBinding[key] {
+			continue
+		}
+		seenBinding[key] = true
+		ent := makeEntity("binding:"+varName, "SCOPE.Schema", "column", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "soci",
+			"provenance", "INFERRED_FROM_SOCI_USE",
+			"pattern_type", "column_binding",
+			"direction", "use",
+			"variable", varName,
+		)
+		out = append(out, ent)
+	}
+
+	// --- Query extraction: sql << "..." ---
+	for _, m := range reSOCIQuery.FindAllStringSubmatchIndex(src, -1) {
+		sqlText := ""
+		if m[2] >= 0 {
+			sqlText = src[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			sqlText = src[m[4]:m[5]]
+		}
+		lineNum := lineOf(src, m[0])
+		sqlUpper := strings.ToUpper(strings.TrimSpace(sqlText))
+		verb := "QUERY"
+		for _, kw := range []string{"SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP"} {
+			if strings.HasPrefix(sqlUpper, kw) {
+				verb = kw
+				break
+			}
+		}
+		queryName := verb + "@L" + strconv.Itoa(lineNum)
+		ent := makeEntity(queryName, "SCOPE.Operation", "query", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "soci",
+			"provenance", "INFERRED_FROM_SOCI_QUERY",
+			"sql_verb", verb,
+			"sql_text", truncate(sqlText, 120),
+		)
+		out = append(out, ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// sqlpp11 extractor
+// ============================================================================
+
+type sqlpp11Extractor struct{}
+
+func (e *sqlpp11Extractor) Language() string { return "custom_cpp_sqlpp11" }
+
+var (
+	// SQLPP_ALIAS_PROVIDER(alias) — table alias macro
+	reSQLPP11Alias = regexp.MustCompile(`(?m)\bSQLPP_ALIAS_PROVIDER\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)`)
+
+	// sqlpp::table<...> struct pattern:
+	// struct Tab : sqlpp::table<Tab, ...>
+	// Capture: (1) table struct name
+	reSQLPP11Table = regexp.MustCompile(`(?m)struct\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?:public\s+)?sqlpp\s*::\s*table\b`)
+
+	// Column definition inside a sqlpp11 table: using colname = ...
+	// sqlpp11 column structs look like: struct col_ { ... using _traits = ... }
+	reSQLPP11Column = regexp.MustCompile(`(?m)struct\s+([a-z_][a-z0-9_]*_)\s*\{`)
+
+	// Query calls: db(select(...)), db(insert_into(...)), db(update(...)), db(remove_from(...))
+	// Capture: (1) operation name
+	reSQLPP11Op = regexp.MustCompile(`(?m)\bdb\s*\(\s*(select|insert_into|update|remove_from|truncate)\s*\(`)
+
+	// Multi-table select: sqlpp::select(...)
+	reSQLPP11Select = regexp.MustCompile(`(?m)\bsqlpp\s*::\s*(select|insert_into|update|remove_from)\s*\(`)
+)
+
+func (e *sqlpp11Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.sqlpp11_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("file_path", file.Path),
+			attribute.String("framework", "sqlpp11"),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" && file.Language != "c" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "sqlpp") && !strings.Contains(src, "SQLPP_ALIAS_PROVIDER") &&
+		!strings.Contains(src, "insert_into(") && !strings.Contains(src, "remove_from(") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	// --- Model extraction: sqlpp::table<...> struct ---
+	for _, m := range reSQLPP11Table.FindAllStringSubmatchIndex(src, -1) {
+		tableName := src[m[2]:m[3]]
+		lineNum := lineOf(src, m[0])
+		ent := makeEntity(tableName, "SCOPE.Schema", "", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "sqlpp11",
+			"provenance", "INFERRED_FROM_SQLPP11_TABLE",
+			"pattern_type", "model",
+			"class_name", tableName,
+		)
+		out = append(out, ent)
+
+		// Scan class body for column structs (heuristic: struct name ends with _)
+		body := extractCppClassBody(src, m[0])
+		for _, cm := range reSQLPP11Column.FindAllStringSubmatchIndex(body, -1) {
+			colStructName := body[cm[2]:cm[3]]
+			// The public column name is the struct name with trailing _ stripped
+			colName := strings.TrimRight(colStructName, "_")
+			colLineNum := lineNum + strings.Count(body[:cm[0]], "\n")
+			colEnt := makeEntity(tableName+"."+colName, "SCOPE.Schema", "column", file.Path, "cpp", colLineNum)
+			setProps(&colEnt,
+				"framework", "sqlpp11",
+				"provenance", "INFERRED_FROM_SQLPP11_COLUMN",
+				"pattern_type", "column",
+				"col_struct", colStructName,
+				"parent_table", tableName,
+			)
+			out = append(out, colEnt)
+		}
+	}
+
+	// --- Schema extraction: SQLPP_ALIAS_PROVIDER ---
+	for _, m := range reSQLPP11Alias.FindAllStringSubmatchIndex(src, -1) {
+		alias := src[m[2]:m[3]]
+		lineNum := lineOf(src, m[0])
+		ent := makeEntity("alias:"+alias, "SCOPE.Schema", "alias", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "sqlpp11",
+			"provenance", "INFERRED_FROM_SQLPP11_ALIAS",
+			"pattern_type", "alias",
+			"alias_name", alias,
+		)
+		out = append(out, ent)
+	}
+
+	// --- Query extraction: db(select/insert_into/update/remove_from) ---
+	seenQuery := map[string]bool{}
+	emitQuery := func(opName string, lineNum int) {
+		key := opName + ":" + strconv.Itoa(lineNum)
+		if seenQuery[key] {
+			return
+		}
+		seenQuery[key] = true
+		queryName := strings.ToUpper(opName) + "@L" + strconv.Itoa(lineNum)
+		ent := makeEntity(queryName, "SCOPE.Operation", "query", file.Path, "cpp", lineNum)
+		setProps(&ent,
+			"framework", "sqlpp11",
+			"provenance", "INFERRED_FROM_SQLPP11_QUERY",
+			"sql_verb", strings.ToUpper(opName),
+		)
+		out = append(out, ent)
+	}
+
+	for _, m := range reSQLPP11Op.FindAllStringSubmatchIndex(src, -1) {
+		emitQuery(src[m[2]:m[3]], lineOf(src, m[0]))
+	}
+	for _, m := range reSQLPP11Select.FindAllStringSubmatchIndex(src, -1) {
+		emitQuery(src[m[2]:m[3]], lineOf(src, m[0]))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+// extractCppClassBody returns the text of a C++ class/struct body starting at
+// classStart, up to the matching closing brace (heuristic brace counting).
+// Returns empty string if no opening brace is found within 5 lines.
+func extractCppClassBody(source string, classStart int) string {
+	// Find the first '{' after classStart
+	rest := source[classStart:]
+	braceIdx := strings.IndexByte(rest, '{')
+	if braceIdx < 0 {
+		return ""
+	}
+	// Check it's within a reasonable distance (≤ 500 chars = ~5 lines)
+	if braceIdx > 500 {
+		return ""
+	}
+	start := braceIdx + 1
+	depth := 1
+	for i := start; i < len(rest); i++ {
+		switch rest[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return rest[start:i]
+			}
+		}
+	}
+	return rest[start:]
+}
+
+// truncate limits a string to maxLen characters, appending "…" when trimmed.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…"
+}

--- a/internal/custom/cpp/orm_test.go
+++ b/internal/custom/cpp/orm_test.go
@@ -1,0 +1,250 @@
+package cpp_test
+
+// orm_test.go — tests for ODB, SOCI, and sqlpp11 C++ ORM extractors.
+
+import (
+	"testing"
+)
+
+// ============================================================================
+// ODB
+// ============================================================================
+
+func TestODBModelExtraction(t *testing.T) {
+	src := `
+#pragma db object
+class Person {
+public:
+	std::string name;
+	int age;
+};
+`
+	ents := extract(t, "custom_cpp_odb", fi("person.hxx", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Schema", "Person") {
+		t.Error("expected SCOPE.Schema entity for Person")
+	}
+}
+
+func TestODBMemberExtraction(t *testing.T) {
+	src := `
+#pragma db member(Person::name) column("person_name")
+#pragma db member(Person::age)
+`
+	ents := extract(t, "custom_cpp_odb", fi("person.hxx", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "column" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Schema column entity for member pragma")
+	}
+}
+
+func TestODBRelationshipExtraction(t *testing.T) {
+	src := `
+#pragma db member(Employee::employer) one_to_many inverse(employees)
+`
+	ents := extract(t, "custom_cpp_odb", fi("employee.hxx", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "relationship" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Pattern relationship for one_to_many member")
+	}
+}
+
+func TestODBLazyPtrExtraction(t *testing.T) {
+	src := `
+odb::lazy_ptr<Employer> employer_;
+odb::lazy_shared_ptr<Department> dept_;
+`
+	ents := extract(t, "custom_cpp_odb", fi("employee.hxx", "cpp", src))
+	found := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "relationship" {
+			found++
+		}
+	}
+	if found < 2 {
+		t.Errorf("expected at least 2 lazy_ptr relationship entities, got %d", found)
+	}
+}
+
+func TestODBQueryExtraction(t *testing.T) {
+	src := `
+odb::result<Person> r = db.query<Person>(odb::query<Person>::age > 18);
+`
+	ents := extract(t, "custom_cpp_odb", fi("main.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Operation query entity for odb::query<Person>")
+	}
+}
+
+func TestODBNoMatch(t *testing.T) {
+	src := `#include <iostream>
+int main() { return 0; }
+`
+	ents := extract(t, "custom_cpp_odb", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+func TestODBWrongLanguage(t *testing.T) {
+	src := `#pragma db object
+class Foo {};`
+	// python language → should not match
+	ents := extract(t, "custom_cpp_odb", fi("foo.hxx", "python", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// SOCI
+// ============================================================================
+
+func TestSOCITypeConversionModel(t *testing.T) {
+	src := `
+template<> struct type_conversion<Person> {
+	typedef values base_type;
+	static void from_base(values const& v, indicator ind, Person& p) {
+		p.name = v.get<string>("name");
+	}
+};
+`
+	ents := extract(t, "custom_cpp_soci", fi("person.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Schema", "Person") {
+		t.Error("expected SCOPE.Schema entity for type_conversion<Person>")
+	}
+}
+
+func TestSOCIIntoBinding(t *testing.T) {
+	src := `
+soci::session sql("postgresql://dbname=mydb");
+int count;
+sql << "SELECT COUNT(*) FROM persons", into(count);
+`
+	ents := extract(t, "custom_cpp_soci", fi("query.cpp", "cpp", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "column" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Schema column binding for into(count)")
+	}
+}
+
+func TestSOCIQueryExtraction(t *testing.T) {
+	src := `
+soci::session sql("sqlite3://mydb.db");
+sql << "SELECT * FROM users WHERE id = :id", use(id), into(user);
+sql << "INSERT INTO logs (msg) VALUES (:msg)", use(msg);
+`
+	ents := extract(t, "custom_cpp_soci", fi("query.cpp", "cpp", src))
+	queryCount := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
+			queryCount++
+		}
+	}
+	if queryCount < 2 {
+		t.Errorf("expected at least 2 query entities, got %d", queryCount)
+	}
+}
+
+func TestSOCINoMatch(t *testing.T) {
+	src := `#include <vector>
+void foo() { std::vector<int> v; }`
+	ents := extract(t, "custom_cpp_soci", fi("foo.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// sqlpp11
+// ============================================================================
+
+func TestSQLPP11TableExtraction(t *testing.T) {
+	src := `
+struct TabPerson : sqlpp::table<TabPerson, TabPerson::Id, TabPerson::Name> {
+	struct id_ {
+		struct _alias_t { static constexpr const char _literal[] = "id"; };
+		using _traits = sqlpp::make_traits<sqlpp::integer, sqlpp::tag::must_not_insert>;
+	};
+	struct name_ {
+		struct _alias_t { static constexpr const char _literal[] = "name"; };
+		using _traits = sqlpp::make_traits<sqlpp::varchar>;
+	};
+	id_   id;
+	name_ name;
+};
+`
+	ents := extract(t, "custom_cpp_sqlpp11", fi("tables.h", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Schema", "TabPerson") {
+		t.Error("expected SCOPE.Schema entity for TabPerson")
+	}
+}
+
+func TestSQLPP11AliasExtraction(t *testing.T) {
+	src := `SQLPP_ALIAS_PROVIDER(left)
+SQLPP_ALIAS_PROVIDER(right)
+`
+	ents := extract(t, "custom_cpp_sqlpp11", fi("tables.h", "cpp", src))
+	found := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "alias" {
+			found++
+		}
+	}
+	if found < 2 {
+		t.Errorf("expected at least 2 alias schema entities, got %d", found)
+	}
+}
+
+func TestSQLPP11QueryExtraction(t *testing.T) {
+	src := `
+auto result = db(select(tab.id, tab.name).from(tab).where(tab.id == id));
+db(insert_into(tab).set(tab.name = "alice"));
+db(update(tab).set(tab.name = "bob").where(tab.id == 1));
+db(remove_from(tab).where(tab.id == 2));
+`
+	ents := extract(t, "custom_cpp_sqlpp11", fi("queries.cpp", "cpp", src))
+	queryCount := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
+			queryCount++
+		}
+	}
+	if queryCount < 4 {
+		t.Errorf("expected at least 4 query entities (select/insert/update/remove), got %d", queryCount)
+	}
+}
+
+func TestSQLPP11NoMatch(t *testing.T) {
+	src := `#include <iostream>
+int main() { return 0; }
+`
+	ents := extract(t, "custom_cpp_sqlpp11", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-sqlpp11 file, got %d", len(ents))
+	}
+}

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -19,6 +19,10 @@
 //   - Gemfile              (bundler/ruby)
 //   - *.csproj             (nuget — manifest_parsing via <PackageReference>)
 //   - packages.lock.json   (nuget — lockfile_parsing via NuGet v3 lock format)
+//   - CMakeLists.txt       (cmake) — find_package / target_link_libraries deps
+//   - conanfile.txt        (conan) — [requires] section
+//   - conanfile.py         (conan) — requires list in ConanFile class
+//   - vcpkg.json           (vcpkg) — dependencies array
 //
 // Entity kind: "SCOPE.Component"
 // Relationships emitted: DEPENDS_ON(kind=external_dependency)
@@ -117,6 +121,11 @@ var exactManifestNames = map[string]bool{
 	"pubspec.yaml":        true,
 	"Gemfile":             true,
 	"packages.lock.json":  true,
+	// C++ build/package manifests
+	"CMakeLists.txt": true,
+	"conanfile.txt":  true,
+	"conanfile.py":   true,
+	"vcpkg.json":     true,
 }
 
 // IsManifest returns true when filePath names a supported manifest file.
@@ -155,6 +164,11 @@ func detectPackageManager(filePath string) string {
 		"pubspec.yaml":        "pub",
 		"Gemfile":             "bundler",
 		"packages.lock.json":  "nuget",
+		// C++ build/package manifests
+		"CMakeLists.txt": "cmake",
+		"conanfile.txt":  "conan",
+		"conanfile.py":   "conan",
+		"vcpkg.json":     "vcpkg",
 	}
 	basename := filepath.Base(filePath)
 	if v, ok := pm[basename]; ok {
@@ -1016,6 +1030,243 @@ func parsePoetryLock(source string) []dep {
 }
 
 // ---------------------------------------------------------------------------
+// Parser: CMakeLists.txt
+// ---------------------------------------------------------------------------
+
+// cmakeFindPackageRE matches find_package(PkgName [REQUIRED] [...]) calls.
+// Captures: (1) package name.
+var cmakeFindPackageRE = regexp.MustCompile(
+	`(?im)\bfind_package\s*\(\s*([A-Za-z0-9_][A-Za-z0-9_.-]*)`)
+
+// cmakeTargetLinkRE matches target_link_libraries(target [scope] dep ...) calls.
+// We capture each dep token following the target and optional scope keyword.
+// Captures: (1) target name, (2) remainder of the argument list.
+var cmakeTargetLinkRE = regexp.MustCompile(
+	`(?im)\btarget_link_libraries\s*\(\s*([A-Za-z0-9_][A-Za-z0-9_.-]*)\s*((?:[^)]|\n)*)\)`)
+
+// cmakeScopeTokenRE matches PUBLIC/PRIVATE/INTERFACE scope keywords (stripped).
+var cmakeScopeTokenRE = regexp.MustCompile(`(?i)^(?:PUBLIC|PRIVATE|INTERFACE)$`)
+
+func parseCMakeLists(source string) []dep {
+	var out []dep
+	seen := map[string]bool{}
+
+	add := func(name, kind string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, dep{name: name, kind: kind})
+	}
+
+	// find_package() → runtime dep
+	for _, m := range cmakeFindPackageRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], "runtime")
+	}
+
+	// target_link_libraries() → runtime deps (skip scope keywords and generator expressions)
+	for _, m := range cmakeTargetLinkRE.FindAllStringSubmatch(source, -1) {
+		argBlock := m[2]
+		for _, tok := range strings.Fields(argBlock) {
+			tok = strings.TrimSpace(tok)
+			// Skip scope keywords
+			if cmakeScopeTokenRE.MatchString(tok) {
+				continue
+			}
+			// Skip CMake generator expressions $<...>
+			if strings.HasPrefix(tok, "$<") {
+				continue
+			}
+			// Skip cmake variables ${...}
+			if strings.HasPrefix(tok, "${") {
+				continue
+			}
+			// Skip empty or purely numeric tokens
+			if tok == "" {
+				continue
+			}
+			add(tok, "runtime")
+		}
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parser: conanfile.txt
+// ---------------------------------------------------------------------------
+
+// conanTxtRequiresRE matches the [requires] section in a conanfile.txt.
+// Lines under [requires] look like:  boost/1.79.0   or  zlib/1.2.13
+var conanTxtSectionRE = regexp.MustCompile(`(?m)^\[([a-z_]+)\]`)
+var conanTxtDepLineRE = regexp.MustCompile(`(?m)^([A-Za-z0-9_][A-Za-z0-9_.-]*)(?:/([^\s#\n]*))?`)
+
+func parseConanfileTxt(source string) []dep {
+	// Build a section index.
+	sectionMatches := conanTxtSectionRE.FindAllStringSubmatchIndex(source, -1)
+	type sectionEntry struct {
+		start int
+		name  string
+	}
+	sections := make([]sectionEntry, 0, len(sectionMatches))
+	for _, m := range sectionMatches {
+		sections = append(sections, sectionEntry{
+			start: m[0],
+			name:  strings.TrimSpace(source[m[2]:m[3]]),
+		})
+	}
+	sections = append(sections, sectionEntry{start: len(source), name: "__end__"})
+
+	bodyFor := func(name string) string {
+		for i, s := range sections[:len(sections)-1] {
+			if s.name == name {
+				return source[s.start:sections[i+1].start]
+			}
+		}
+		return ""
+	}
+
+	var out []dep
+	seen := map[string]bool{}
+
+	parseDeps := func(body string, isDev bool, kind string) {
+		for _, m := range conanTxtDepLineRE.FindAllStringSubmatch(body, -1) {
+			name := m[1]
+			// Skip lines that are section headers themselves
+			if name == "" || strings.HasPrefix(name, "[") {
+				continue
+			}
+			version := ""
+			if len(m) > 2 {
+				version = m[2]
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			out = append(out, dep{name: name, version: version, isDev: isDev, kind: kind})
+		}
+	}
+
+	parseDeps(bodyFor("requires"), false, "runtime")
+	parseDeps(bodyFor("build_requires"), false, "runtime")
+	parseDeps(bodyFor("test_requires"), true, "dev")
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parser: conanfile.py
+// ---------------------------------------------------------------------------
+
+// conanPyRequiresRE matches Python list/tuple/string requires in a ConanFile:
+//
+//	requires = "boost/1.79.0", "zlib/1.2.13"
+//	requires = ("boost/1.79.0", "zlib/1.2.13")
+//	requires = ["boost/1.79.0"]
+var conanPyDepRE = regexp.MustCompile(`"([A-Za-z0-9_][A-Za-z0-9_.-]*)(?:/([^"]*))?"`)
+
+// conanPyRequiresBlockRE captures the content assigned to requires / build_requires.
+var conanPyRequiresBlockRE = regexp.MustCompile(
+	`(?m)^\s*(requires|build_requires|test_requires)\s*=\s*([^\n]+(?:\n\s+[^\n]+)*)`)
+
+func parseConanfilePy(source string) []dep {
+	var out []dep
+	seen := map[string]bool{}
+
+	for _, bm := range conanPyRequiresBlockRE.FindAllStringSubmatch(source, -1) {
+		attrName := bm[1]
+		block := bm[2]
+		isDev := attrName == "test_requires"
+		kind := "runtime"
+		if isDev {
+			kind = "dev"
+		}
+		for _, dm := range conanPyDepRE.FindAllStringSubmatch(block, -1) {
+			name := dm[1]
+			version := ""
+			if len(dm) > 2 {
+				version = dm[2]
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			out = append(out, dep{name: name, version: version, isDev: isDev, kind: kind})
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parser: vcpkg.json
+// ---------------------------------------------------------------------------
+
+// vcpkgManifest is a minimal vcpkg.json structure for JSON unmarshalling.
+type vcpkgManifest struct {
+	Dependencies    []vcpkgDep `json:"dependencies"`
+	DevDependencies []vcpkgDep `json:"dev-dependencies"`
+}
+
+// vcpkgDep can be either a plain string or an object {"name": "...", "version-gte": "..."}.
+// JSON unmarshalling for mixed types requires custom handling.
+type vcpkgDep struct {
+	Name    string
+	Version string
+	IsDev   bool
+}
+
+func parseVcpkgJSON(source string) []dep {
+	// Custom parse: vcpkg dependencies can be either a string or an object.
+	// We use a two-pass approach: unmarshal to raw messages, then inspect each element.
+	var raw struct {
+		Dependencies    []json.RawMessage `json:"dependencies"`
+		DevDependencies []json.RawMessage `json:"dev-dependencies"`
+	}
+	if err := json.Unmarshal([]byte(source), &raw); err != nil {
+		return nil
+	}
+
+	var out []dep
+	seen := map[string]bool{}
+
+	parseDep := func(msg json.RawMessage, isDev bool) {
+		var s string
+		if err := json.Unmarshal(msg, &s); err == nil {
+			// plain string
+			if s != "" && !seen[s] {
+				seen[s] = true
+				out = append(out, dep{name: s, isDev: isDev, kind: depKindStr(isDev)})
+			}
+			return
+		}
+		// object with "name" key
+		var obj struct {
+			Name       string `json:"name"`
+			VersionGte string `json:"version-gte"`
+		}
+		if err := json.Unmarshal(msg, &obj); err == nil && obj.Name != "" && !seen[obj.Name] {
+			seen[obj.Name] = true
+			out = append(out, dep{name: obj.Name, version: obj.VersionGte, isDev: isDev, kind: depKindStr(isDev)})
+		}
+	}
+
+	for _, msg := range raw.Dependencies {
+		parseDep(msg, false)
+	}
+	for _, msg := range raw.DevDependencies {
+		parseDep(msg, true)
+	}
+	return out
+}
+
+func depKindStr(isDev bool) string {
+	if isDev {
+		return "dev"
+	}
+	return "runtime"
+}
+
+// ---------------------------------------------------------------------------
 // Dispatch table
 // ---------------------------------------------------------------------------
 // Parser: *.csproj  (NuGet / MSBuild PackageReference manifest)
@@ -1106,6 +1357,11 @@ var parsers = map[string]parserFn{
 	"pubspec.yaml":        parsePubspecYaml,
 	"Gemfile":             parseGemfile,
 	"packages.lock.json":  parseNugetLockJSON,
+	// C++ build/package manifests
+	"CMakeLists.txt": parseCMakeLists,
+	"conanfile.txt":  parseConanfileTxt,
+	"conanfile.py":   parseConanfilePy,
+	"vcpkg.json":     parseVcpkgJSON,
 }
 
 func dispatchParser(filePath, source string) (string, []dep) {

--- a/internal/extractors/cross/manifest/extractor_test.go
+++ b/internal/extractors/cross/manifest/extractor_test.go
@@ -821,3 +821,241 @@ func TestNugetLockFile(t *testing.T) {
 		t.Errorf("expected package_manager=nuget, got %q", byName["Dapper"].Properties["package_manager"])
 	}
 }
+
+func TestCMake_FindPackage(t *testing.T) {
+	src := `cmake_minimum_required(VERSION 3.15)
+project(MyApp)
+find_package(Boost 1.79 REQUIRED COMPONENTS filesystem)
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB)
+`
+	records := runExtract(t, "CMakeLists.txt", src)
+	deps := depEntities(records)
+	byName := map[string]bool{}
+	for _, d := range deps {
+		byName[d.Name] = true
+	}
+	for _, pkg := range []string{"Boost", "OpenSSL", "ZLIB"} {
+		if !byName[pkg] {
+			t.Errorf("expected dep %q from find_package, not found", pkg)
+		}
+	}
+}
+
+func TestCMake_TargetLinkLibraries(t *testing.T) {
+	src := `add_executable(myapp main.cpp)
+target_link_libraries(myapp PRIVATE Boost::filesystem OpenSSL::SSL pthread)
+`
+	records := runExtract(t, "CMakeLists.txt", src)
+	deps := depEntities(records)
+	byName := map[string]bool{}
+	for _, d := range deps {
+		byName[d.Name] = true
+	}
+	for _, lib := range []string{"Boost::filesystem", "OpenSSL::SSL", "pthread"} {
+		if !byName[lib] {
+			t.Errorf("expected dep %q from target_link_libraries, not found", lib)
+		}
+	}
+}
+
+func TestCMake_PackageManager(t *testing.T) {
+	src := `find_package(Eigen3 REQUIRED)`
+	records := runExtract(t, "CMakeLists.txt", src)
+	for _, r := range records {
+		if r.Properties["package_manager"] != "" && r.Properties["package_manager"] != "cmake" {
+			t.Errorf("package_manager=%q want cmake", r.Properties["package_manager"])
+		}
+	}
+}
+
+func TestCMake_Empty(t *testing.T) {
+	src := `cmake_minimum_required(VERSION 3.15)
+project(Empty)
+add_executable(app main.cpp)
+`
+	records := runExtract(t, "CMakeLists.txt", src)
+	deps := depEntities(records)
+	if len(deps) != 0 {
+		t.Errorf("expected no dep entities for CMake without find_package/target_link_libraries deps, got %d", len(deps))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// conanfile.txt
+// ---------------------------------------------------------------------------
+
+func TestConanfileTxt_Requires(t *testing.T) {
+	src := `[requires]
+boost/1.79.0
+zlib/1.2.13
+openssl/3.1.0
+
+[generators]
+cmake
+`
+	records := runExtract(t, "conanfile.txt", src)
+	deps := depEntities(records)
+	byName := map[string]bool{}
+	for _, d := range deps {
+		byName[d.Name] = true
+	}
+	for _, pkg := range []string{"boost", "zlib", "openssl"} {
+		if !byName[pkg] {
+			t.Errorf("expected dep %q from conanfile.txt [requires], not found", pkg)
+		}
+	}
+}
+
+func TestConanfileTxt_BuildRequires(t *testing.T) {
+	src := `[requires]
+boost/1.79.0
+
+[build_requires]
+cmake/3.25.0
+`
+	records := runExtract(t, "conanfile.txt", src)
+	deps := depEntities(records)
+	if len(deps) < 2 {
+		t.Errorf("expected at least 2 deps (requires + build_requires), got %d", len(deps))
+	}
+}
+
+func TestConanfileTxt_Versions(t *testing.T) {
+	src := `[requires]
+fmt/9.1.0
+`
+	records := runExtract(t, "conanfile.txt", src)
+	deps := depEntities(records)
+	for _, d := range deps {
+		if d.Name == "fmt" {
+			if d.Properties["version"] != "9.1.0" {
+				t.Errorf("version=%q want 9.1.0", d.Properties["version"])
+			}
+			return
+		}
+	}
+	t.Error("dep fmt not found")
+}
+
+// ---------------------------------------------------------------------------
+// conanfile.py
+// ---------------------------------------------------------------------------
+
+func TestConanfilePy_Requires(t *testing.T) {
+	src := `from conans import ConanFile
+
+class MyConan(ConanFile):
+    name = "myproject"
+    requires = "boost/1.79.0", "zlib/1.2.13"
+    build_requires = "cmake/3.25.0"
+`
+	records := runExtract(t, "conanfile.py", src)
+	deps := depEntities(records)
+	byName := map[string]bool{}
+	for _, d := range deps {
+		byName[d.Name] = true
+	}
+	for _, pkg := range []string{"boost", "zlib", "cmake"} {
+		if !byName[pkg] {
+			t.Errorf("expected dep %q from conanfile.py, not found", pkg)
+		}
+	}
+}
+
+func TestConanfilePy_ListRequires(t *testing.T) {
+	src := `from conans import ConanFile
+
+class MyConan(ConanFile):
+    requires = [
+        "openssl/3.1.0",
+        "fmt/9.1.0",
+    ]
+`
+	records := runExtract(t, "conanfile.py", src)
+	deps := depEntities(records)
+	if len(deps) < 2 {
+		t.Errorf("expected at least 2 deps from list-style requires, got %d", len(deps))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// vcpkg.json
+// ---------------------------------------------------------------------------
+
+func TestVcpkgJSON_StringDeps(t *testing.T) {
+	src := `{
+  "name": "myproject",
+  "version": "1.0.0",
+  "dependencies": [
+    "boost",
+    "openssl",
+    "zlib"
+  ]
+}`
+	records := runExtract(t, "vcpkg.json", src)
+	deps := depEntities(records)
+	byName := map[string]bool{}
+	for _, d := range deps {
+		byName[d.Name] = true
+	}
+	for _, pkg := range []string{"boost", "openssl", "zlib"} {
+		if !byName[pkg] {
+			t.Errorf("expected dep %q from vcpkg.json, not found", pkg)
+		}
+	}
+}
+
+func TestVcpkgJSON_ObjectDeps(t *testing.T) {
+	src := `{
+  "name": "myproject",
+  "dependencies": [
+    { "name": "fmt", "version-gte": "9.1.0" },
+    { "name": "nlohmann-json", "version-gte": "3.11.0" },
+    "boost"
+  ]
+}`
+	records := runExtract(t, "vcpkg.json", src)
+	deps := depEntities(records)
+	byName := map[string]string{}
+	for _, d := range deps {
+		byName[d.Name] = d.Properties["version"]
+	}
+	if _, ok := byName["fmt"]; !ok {
+		t.Error("expected dep fmt from vcpkg.json object-style")
+	}
+	if _, ok := byName["nlohmann-json"]; !ok {
+		t.Error("expected dep nlohmann-json from vcpkg.json object-style")
+	}
+	if _, ok := byName["boost"]; !ok {
+		t.Error("expected dep boost from vcpkg.json string-style")
+	}
+}
+
+func TestVcpkgJSON_PackageManager(t *testing.T) {
+	src := `{"dependencies": ["zlib"]}`
+	records := runExtract(t, "vcpkg.json", src)
+	for _, r := range records {
+		pm := r.Properties["package_manager"]
+		if pm != "" && pm != "vcpkg" {
+			t.Errorf("package_manager=%q want vcpkg", pm)
+		}
+	}
+}
+
+func TestVcpkgJSON_Empty(t *testing.T) {
+	src := `{"name": "empty", "dependencies": []}`
+	records := runExtract(t, "vcpkg.json", src)
+	deps := depEntities(records)
+	if len(deps) != 0 {
+		t.Errorf("expected no dep entities for empty dependencies, got %d", len(deps))
+	}
+}
+
+func TestCMake_NotManifest(t *testing.T) {
+	// A file named differently should not be processed
+	records := runExtract(t, "CMakeListsCustom.txt", "find_package(Boost REQUIRED)")
+	if len(records) != 0 {
+		t.Errorf("expected 0 entities for non-manifest filename, got %d", len(records))
+	}
+}


### PR DESCRIPTION
## Summary

Part of #3280 — C/C++ coverage greening, biggest remaining clusters: ORM + build-tools.

### New extractors

**`internal/custom/cpp/orm.go`** — three ORM extractors:
- `custom_cpp_odb`: ODB pragma-based ORM — `#pragma db object` → model, `#pragma db member(...)` → schema/column, `one_to_many`/`many_to_many` annotations → relationship, `odb::lazy_ptr<T>` → lazy-loading, `odb::query<T>` → query attribution
- `custom_cpp_soci`: SOCI library — `type_conversion<T>` → model, `into()`/`use()` → column bindings (schema), `sql << "SELECT..."` → query attribution
- `custom_cpp_sqlpp11`: sqlpp11 DSL — `struct T : sqlpp::table<>` + column structs → model/schema, `SQLPP_ALIAS_PROVIDER` → alias, `db(select/insert_into/update/remove_from)` → query

**`internal/custom/cpp/driver_schema.go`** — raw driver schema/query extractor:
- libpqxx: `exec()` / `exec_params()` string literals → CREATE TABLE schema + SQL verb query attribution
- mongocxx: `db["collection"]` / `.collection("name")` → SCOPE.Schema model entity
- mysql-connector-cpp: same exec()-pattern as libpqxx

**`internal/extractors/cross/manifest/extractor.go`** — extended with C++ build manifests:
- `CMakeLists.txt`: `find_package()` + `target_link_libraries()` → dep entities + DEPENDS_ON edges
- `conanfile.txt`: `[requires]` / `[build_requires]` sections
- `conanfile.py`: `requires=` / `build_requires=` attributes (string tuple and list forms)
- `vcpkg.json`: `dependencies[]` — both plain string and `{"name","version-gte"}` object forms

### Registry impact

33 cells flipped: **156 → 123 missing** in `lang.c-cpp.*`

| Record | Cells flipped |
|--------|--------------|
| `lang.c-cpp.orm.odb` | model/schema/association/fk/lazy/relationship/query partial; migration not_applicable |
| `lang.c-cpp.orm.soci` | model/schema/query partial; association/fk/lazy/relationship/migration not_applicable |
| `lang.c-cpp.orm.sqlpp11` | model/schema/query partial; association/fk/lazy/relationship/migration not_applicable |
| `lang.c-cpp.driver.libpqxx` | model/schema/query partial |
| `lang.c-cpp.driver.mongocxx` | model/schema/query partial |
| `lang.c-cpp.driver.mysql-connector-cpp` | model/schema/query partial |
| `lang.c-cpp.tool.cmake` | dependency_graph + target_extraction partial |
| `lang.c-cpp.tool.conan` | manifest_parsing partial; lockfile_parsing not_applicable |
| `lang.c-cpp.tool.vcpkg` | manifest_parsing + lockfile_parsing partial |

## Test plan

- [x] `go build ./internal/... ./tools/coverage/...` — clean
- [x] `go test ./internal/custom/cpp/... ./internal/extractors/cross/manifest/... ./internal/types/ ./tools/coverage/...` — all pass
- [x] `go run ./tools/coverage validate` — exit 0
- [x] `go run ./tools/coverage fmt --check` — canonical
- [x] `go run ./tools/coverage gen` — byte-stable
- [x] `gofmt -l` — empty (no formatting issues)
- [x] All regex extractors gated on language check (cpp/c only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)