### PR TITLE
coverage(rust): flip 45 missing cells — fw routing/validation + ORM relationships build

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -105,16 +105,16 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟡 5/6 | |
 | [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟡 5/6 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟢 2/2 | — | 🔴 0/1 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 1/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 8/21 | 🔴 0/6 | |
 
 
@@ -214,7 +214,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Electron](../detail/lang.jsts.framework.electron.md) | 🟢 10/10 | ✅ 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [Compose Desktop](../detail/lang.kotlin.framework.compose-desktop.md) | 🟢 10/10 | 🔴 0/3 | |
 | [kotlin](../by-language/kotlin.md) | [Compose Multiplatform](../detail/lang.kotlin.framework.compose-multiplatform.md) | 🟢 10/10 | 🔴 0/3 | |
-| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | 🟢 10/10 | 🔴 0/3 | |
+| [rust](../by-language/rust.md) | [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | 🟢 10/10 | 🟢 3/3 | |
 
 
 ## RPC Framework

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -142,9 +142,9 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [ruby](../by-language/ruby.md) | [pg (Ruby driver)](../detail/lang.ruby.driver.postgres.md) | 🟢 1/1 | |
 | [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟢 1/1 | |
 | [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🟢 1/1 | |
-| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 5/8 | |
-| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🔴 0/4 | |
-| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 6/8 | |
+| [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟢 7/7 | |
+| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟢 4/4 | |
+| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟢 8/8 | |
 | [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🟢 1/1 | |
 | [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟢 1/1 | |
 | [rust](../by-language/rust.md) | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | 🟢 1/1 | |
@@ -154,7 +154,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | 🟢 1/1 | |
 | [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | 🟢 1/1 | |
 | [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🟢 1/1 | |
-| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 2/4 | |
+| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟢 4/4 | |
 | [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🟢 1/1 | |
 | [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | 🟡 2/8 | |
 | [scala](../by-language/scala.md) | [Elastic4s](../detail/lang.scala.orm.elastic4s.md) | 🟡 2/7 | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -26,23 +26,23 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟡 1/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 2/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 4/6 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ### Desktop
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
-| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | 🟢 10/10 | 🔴 0/3 | |
+| [Tauri (desktop)](../detail/lang.rust.framework.tauri.md) | 🟢 10/10 | 🟢 3/3 | |
 
 
 ## Tools
@@ -63,9 +63,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 5/8 | |
-| [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🔴 0/4 | |
-| [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 6/8 | |
+| [Diesel](../detail/lang.rust.orm.diesel.md) | 🟢 7/7 | |
+| [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟢 4/4 | |
+| [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟢 8/8 | |
 | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🟢 1/1 | |
 | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟢 1/1 | |
 | [elasticsearch-rs](../detail/lang.rust.driver.elastic.md) | 🟢 1/1 | |
@@ -75,5 +75,5 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [redis-rs](../detail/lang.rust.driver.redis.md) | 🟢 1/1 | |
 | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | 🟢 1/1 | |
 | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🟢 1/1 | |
-| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 2/4 | |
+| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟢 4/4 | |
 | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🟢 1/1 | |

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/rust/frameworks/actix_web.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/actix_web.go` | Route path+method extraction from macros and builder calls |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[derive(Deserialize)] and #[derive(Validate)] structs; actix web::Json/Query/Form/Path<T> extractors |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] field attrs, .validate() calls, actix extractor types |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_axum.go`<br>`internal/engine/rules/rust/frameworks/axum.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_axum.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/axum.go`<br>`internal/custom/rust/extractors_test.go` | Regex extracts .route(path, method(handler)) paths and methods |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects serde Deserialize/Validate structs; axum Json/Query/Form/Path<T> extractors |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] field attrs and axum extractor types |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Regex route extraction proven by minor_fw_routing_test.go |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Regex route extraction proven by minor_fw_routing_test.go |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Regex route extraction proven by minor_fw_routing_test.go |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rocket_routes.go`<br>`internal/engine/rules/rust/frameworks/rocket.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/rocket_routes.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/extractors_test.go`<br>`internal/custom/rust/rocket.go` | Regex extracts #[get/post/...] route macros with path and handler |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Json/Form/MsgPack<T> extractors and Deserialize derives |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects impl FromRequest guards, Json/Form extractors, validator derives |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Regex route extraction proven by minor_fw_routing_test.go |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.tauri.md
+++ b/docs/coverage/detail/lang.rust.framework.tauri.md
@@ -15,14 +15,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| IPC extraction | 🔴 `missing` | — | — | — | — |
-| Main renderer split | 🔴 `missing` | — | — | — | — |
+| IPC extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/tauri.go`<br>`internal/custom/rust/tauri_test.go`<br>`internal/custom/rust/testdata/tauri_app.rs` | Detects #[tauri::command] fn declarations and generate_handler![...] registrations |
+| Main renderer split | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/tauri.go`<br>`internal/custom/rust/tauri_test.go` | Detects tauri::Builder::default() and fn main() in Tauri files as Rust backend entry points; WindowBuilder for renderer side |
 
 ### Native
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Native module imports | 🔴 `missing` | — | — | — | — |
+| Native module imports | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/tauri.go`<br>`internal/custom/rust/tauri_test.go` | Detects tauri::api::* module usage and tauri_plugin_* crate imports |
 
 ### Updates
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Regex route extraction proven by minor_fw_routing_test.go |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -15,9 +15,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🔴 `missing` | — | — | — | — |
+| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | ServiceBuilder::new/.layer/.service patterns detected; tower does not have URL routing natively |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Regex route extraction proven by minor_fw_routing_test.go |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; serde_json body deserialization |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate] attrs and serde_json deserialization in tower handlers |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/minor_fw_routing.go` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/minor_fw_routing.go`<br>`internal/custom/rust/minor_fw_routing_test.go` | Regex route extraction proven by minor_fw_routing_test.go |
 
 ### Auth
 
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.orm.diesel.md
+++ b/docs/coverage/detail/lang.rust.orm.diesel.md
@@ -23,8 +23,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/diesel.go`<br>`internal/custom/rust/testdata/diesel_models.rs` | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/diesel.go`<br>`internal/custom/rust/diesel_seaorm_test.go` | Detects *_id columns in table! macro bodies as FK signals; joinable!() also captures FK relationships |
+| Lazy loading recognition | — `not_applicable` | `2026-05-30` | — | — | Diesel is synchronous and does not support lazy loading; eager joins via joinable!/load() only |
 | Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/diesel.go`<br>`internal/custom/rust/testdata/diesel_models.rs`<br>`internal/custom/rust/testdata/diesel_schema.rs` | — |
 
 ### Queries
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/diesel.go`<br>`internal/custom/rust/diesel_seaorm_test.go` | Detects embed_migrations!(), run_pending_migrations(), impl MigrationHarness patterns |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.rbatis.md
+++ b/docs/coverage/detail/lang.rust.orm.rbatis.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🔴 `missing` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go`<br>`internal/custom/rust/testdata/rbatis_models.rs` | Detects #[crud_table(table_name=...)] struct declarations as ORM models |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | Extracts table_name from #[crud_table(table_name=...)] attribute as schema table mapping |
 
 ### Relationships
 
@@ -31,13 +31,13 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | — | — | — |
+| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | Detects #[py_sql(...)], #[sql(...)], #[html_sql] macro annotations on async functions |
 
 ### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | Detects table_meta! and rbatis::table_sync! migration macros |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.rust.orm.seaorm.md
+++ b/docs/coverage/detail/lang.rust.orm.seaorm.md
@@ -23,8 +23,8 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_entity.rs` | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/diesel_seaorm_test.go`<br>`internal/custom/rust/seaorm.go` | Detects #[sea_orm(belongs_to=..., from=..., to=...)] with explicit FK column references |
+| Lazy loading recognition | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/diesel_seaorm_test.go`<br>`internal/custom/rust/seaorm.go` | Detects .find_related(), .find_linked(), LoaderTrait::load_many/load_one patterns |
 | Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_entity.rs` | — |
 
 ### Queries

--- a/docs/coverage/detail/lang.rust.orm.sqlx.md
+++ b/docs/coverage/detail/lang.rust.orm.sqlx.md
@@ -16,7 +16,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/rust/orms/sqlx.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go`<br>`internal/custom/rust/testdata/sqlx_models.rs` | Detects #[derive(FromRow)] structs and Pool::connect() as schema-mapped models |
 
 ### Relationships
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | Detects sqlx::migrate!(path).run() macro invocations and migration file references |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -43379,8 +43379,11 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/actix_web.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Route path+method extraction from macros and builder calls",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -43392,12 +43395,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[derive(Deserialize)] and #[derive(Validate)] structs; actix web::Json/Query/Form/Path\u003cT\u003e extractors",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate(...)] field attrs, .validate() calls, actix extractor types",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -43588,8 +43597,11 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/axum.go","internal/custom/rust/extractors_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex extracts .route(path, method(handler)) paths and methods",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -43601,12 +43613,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects serde Deserialize/Validate structs; axum Json/Query/Form/Path\u003cT\u003e extractors",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate(...)] field attrs and axum extractor types",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -43797,8 +43815,11 @@
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex route extraction proven by minor_fw_routing_test.go",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -43810,12 +43831,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -44006,8 +44033,11 @@
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex route extraction proven by minor_fw_routing_test.go",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -44019,12 +44049,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -44215,8 +44251,11 @@
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex route extraction proven by minor_fw_routing_test.go",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -44228,12 +44267,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -44424,8 +44469,11 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/extractors_test.go","internal/custom/rust/rocket.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex extracts #[get/post/...] route macros with path and handler",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -44437,12 +44485,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects Json/Form/MsgPack\u003cT\u003e extractors and Deserialize derives",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects impl FromRequest guards, Json/Form extractors, validator derives",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -44633,8 +44687,11 @@
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex route extraction proven by minor_fw_routing_test.go",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -44646,12 +44703,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -44832,15 +44895,24 @@
       "capabilities": {
         "Process": {
           "ipc_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/tauri.go","internal/custom/rust/tauri_test.go","internal/custom/rust/testdata/tauri_app.rs"],
+            "notes": "Detects #[tauri::command] fn declarations and generate_handler![...] registrations",
+            "verified_at": "2026-05-30"
           },
           "main_renderer_split": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/tauri.go","internal/custom/rust/tauri_test.go"],
+            "notes": "Detects tauri::Builder::default() and fn main() in Tauri files as Rust backend entry points; WindowBuilder for renderer side",
+            "verified_at": "2026-05-30"
           }
         },
         "Native": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/tauri.go","internal/custom/rust/tauri_test.go"],
+            "notes": "Detects tauri::api::* module usage and tauri_plugin_* crate imports",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -44914,8 +44986,11 @@
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex route extraction proven by minor_fw_routing_test.go",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -44927,12 +45002,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -45113,7 +45194,10 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
+            "notes": "ServiceBuilder::new/.layer/.service patterns detected; tower does not have URL routing natively",
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
             "status": "partial",
@@ -45121,8 +45205,11 @@
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex route extraction proven by minor_fw_routing_test.go",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -45134,12 +45221,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects Deserialize/Validate derives; serde_json body deserialization",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate] attrs and serde_json deserialization in tower handlers",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -45330,8 +45423,11 @@
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/minor_fw_routing.go","internal/custom/rust/minor_fw_routing_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Regex route extraction proven by minor_fw_routing_test.go",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -45343,12 +45439,18 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
@@ -45548,12 +45650,16 @@
             "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/diesel.go","internal/custom/rust/diesel_seaorm_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects *_id columns in table! macro bodies as FK signals; joinable!() also captures FK relationships",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Diesel is synchronous and does not support lazy loading; eager joins via joinable!/load() only",
+            "verified_at": "2026-05-30"
           },
           "relationship_extraction": {
             "status": "partial",
@@ -45571,7 +45677,10 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/diesel.go","internal/custom/rust/diesel_seaorm_test.go"],
+            "notes": "Detects embed_migrations!(), run_pending_migrations(), impl MigrationHarness patterns",
+            "verified_at": "2026-05-30"
           }
         }
       }
@@ -45585,11 +45694,17 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/sqlx_rbatis.go","internal/custom/rust/sqlx_rbatis_test.go","internal/custom/rust/testdata/rbatis_models.rs"],
+            "notes": "Detects #[crud_table(table_name=...)] struct declarations as ORM models",
+            "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/sqlx_rbatis.go","internal/custom/rust/sqlx_rbatis_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Extracts table_name from #[crud_table(table_name=...)] attribute as schema table mapping",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
@@ -45612,12 +45727,18 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/sqlx_rbatis.go","internal/custom/rust/sqlx_rbatis_test.go"],
+            "notes": "Detects #[py_sql(...)], #[sql(...)], #[html_sql] macro annotations on async functions",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/sqlx_rbatis.go","internal/custom/rust/sqlx_rbatis_test.go"],
+            "notes": "Detects table_meta! and rbatis::table_sync! migration macros",
+            "verified_at": "2026-05-30"
           }
         }
       }
@@ -45698,12 +45819,18 @@
             "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/diesel_seaorm_test.go","internal/custom/rust/seaorm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[sea_orm(belongs_to=..., from=..., to=...)] with explicit FK column references",
+            "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/diesel_seaorm_test.go","internal/custom/rust/seaorm.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects .find_related(), .find_linked(), LoaderTrait::load_many/load_one patterns",
+            "verified_at": "2026-05-30"
           },
           "relationship_extraction": {
             "status": "partial",
@@ -45742,8 +45869,11 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/rust/sqlx_rbatis.go","internal/custom/rust/sqlx_rbatis_test.go","internal/custom/rust/testdata/sqlx_models.rs"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects #[derive(FromRow)] structs and Pool::connect() as schema-mapped models",
+            "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
@@ -45773,7 +45903,10 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/rust/sqlx_rbatis.go","internal/custom/rust/sqlx_rbatis_test.go"],
+            "notes": "Detects sqlx::migrate!(path).run() macro invocations and migration file references",
+            "verified_at": "2026-05-30"
           }
         }
       }

--- a/internal/custom/rust/diesel.go
+++ b/internal/custom/rust/diesel.go
@@ -9,6 +9,9 @@ package rust
 //     SCOPE.Component (subtype="orm_model") with the derive list in properties
 //   - joinable!(table1 -> table2 (fk_col)) → SCOPE.Pattern (subtype="orm_relationship")
 //   - #[belongs_to(Parent)] attribute → SCOPE.Pattern (subtype="orm_relationship")
+//   - diesel migration files: diesel_migrations::embed_migrations! / run_pending_migrations /
+//     MigrationHarness impls → SCOPE.Component (subtype="migration")
+//   - Foreign-key columns in table! macro → SCOPE.Pattern (subtype="foreign_key")
 //
 // Honesty:
 //
@@ -17,7 +20,7 @@ package rust
 //	Fixtures prove the detection surface; semantic cross-file resolution
 //	requires import-graph analysis beyond this scanner.
 //
-// Issue #3269 — lang.rust.orm.diesel ORM build.
+// Issue #3267 — lang.rust.orm.diesel Relationships + Migrations cells.
 
 import (
 	"context"
@@ -72,6 +75,33 @@ var (
 	// #[belongs_to(Parent)] / #[belongs_to(Parent, foreign_key = "parent_id")]
 	reDieselBelongsTo = regexp.MustCompile(
 		`#\[belongs_to\(\s*(\w+)(?:\s*,\s*[^)]+)?\s*\)\]`,
+	)
+
+	// diesel_migrations::embed_migrations!("path") or embed_migrations!()
+	reDieselEmbedMigrations = regexp.MustCompile(
+		`diesel_migrations::embed_migrations!\s*\(([^)]*)\)|embed_migrations!\s*\(([^)]*)\)`,
+	)
+
+	// run_pending_migrations(...) — migration execution
+	reDieselRunMigrations = regexp.MustCompile(
+		`run_pending_migrations\s*\(|connection\.run_pending_migrations\s*\(`,
+	)
+
+	// impl MigrationHarness for T  (diesel 2.x migration trait)
+	reDieselMigrationHarness = regexp.MustCompile(
+		`\bimpl\s+(?:<[^>]*>\s+)?MigrationHarness\b`,
+	)
+
+	// Foreign-key column pattern in table! body: col_name -> Nullable<Integer> or col_name -> Integer
+	// We detect *_id columns as FK signals within table! macro bodies.
+	// Capture: table name (from reDieselTable) then scan body for _id columns.
+	reDieselTableBody = regexp.MustCompile(
+		`\btable!\s*\{\s*(\w+)\s*[\({][^}]*\}`,
+	)
+
+	// Inside a table! body: field_name (ending in _id) -> SomeType
+	reDieselFKColumn = regexp.MustCompile(
+		`(\w+_id)\s*->\s*\w+`,
 	)
 )
 
@@ -188,6 +218,73 @@ func (e *rustDieselExtractor) Extract(ctx context.Context, file extractor.FileIn
 			"parent_model", parent,
 			"relationship_type", "belongs_to",
 			"provenance", "INFERRED_FROM_DIESEL_BELONGS_TO",
+		)
+		add(ent)
+	}
+
+	// 5. Foreign-key column extraction — scan table! macro bodies for *_id columns
+	for _, m := range reDieselTableBody.FindAllStringSubmatchIndex(src, -1) {
+		tableName := src[m[2]:m[3]]
+		tableBody := src[m[0]:m[1]]
+		for _, fkm := range reDieselFKColumn.FindAllStringSubmatchIndex(tableBody, -1) {
+			colName := tableBody[fkm[2]:fkm[3]]
+			// Skip the primary key "id" itself — only *_id references
+			if colName == "id" {
+				continue
+			}
+			fkName := "diesel:fk:" + tableName + "." + colName
+			fkEnt := makeEntity(fkName, "SCOPE.Pattern", "foreign_key",
+				file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&fkEnt,
+				"framework", "diesel",
+				"table_name", tableName,
+				"fk_column", colName,
+				"provenance", "INFERRED_FROM_DIESEL_FK_COLUMN",
+			)
+			add(fkEnt)
+		}
+	}
+
+	// 6. migration_parsing — embed_migrations! macro
+	for _, m := range reDieselEmbedMigrations.FindAllStringSubmatchIndex(src, -1) {
+		migPath := ""
+		for i := 2; i < len(m); i += 2 {
+			if m[i] >= 0 {
+				migPath = strings.TrimSpace(strings.Trim(src[m[i]:m[i+1]], `"`))
+				break
+			}
+		}
+		if migPath == "" {
+			migPath = "./migrations"
+		}
+		ent := makeEntity("diesel:embed_migrations:"+migPath, "SCOPE.Component", "migration",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "diesel",
+			"migration_path", migPath,
+			"provenance", "INFERRED_FROM_DIESEL_EMBED_MIGRATIONS",
+		)
+		add(ent)
+	}
+
+	// 7. run_pending_migrations → migration execution entity
+	for _, m := range reDieselRunMigrations.FindAllStringIndex(src, -1) {
+		ent := makeEntity("diesel:run_pending_migrations", "SCOPE.Component", "migration",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "diesel",
+			"provenance", "INFERRED_FROM_DIESEL_RUN_MIGRATIONS",
+		)
+		add(ent)
+	}
+
+	// 8. impl MigrationHarness → migration trait implementation
+	for _, m := range reDieselMigrationHarness.FindAllStringIndex(src, -1) {
+		ent := makeEntity("diesel:MigrationHarness", "SCOPE.Pattern", "migration",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "diesel",
+			"provenance", "INFERRED_FROM_DIESEL_MIGRATION_HARNESS",
 		)
 		add(ent)
 	}

--- a/internal/custom/rust/diesel_seaorm_test.go
+++ b/internal/custom/rust/diesel_seaorm_test.go
@@ -217,3 +217,176 @@ pub struct Model { pub id: i32 }
 		t.Errorf("expected no entities for non-rust file, got %d", len(ents))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// SeaORM — foreign_key_extraction
+// ---------------------------------------------------------------------------
+
+func TestSeaORM_ForeignKeyExtraction(t *testing.T) {
+	src := `
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "post")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub user_id: i32,
+    pub title: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(belongs_to = "super::user::Entity", from = "Column::UserId", to = "super::user::Column::Id")]
+    User,
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("post.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "foreign_key") {
+		t.Error("expected foreign_key pattern from belongs_to with from/to columns")
+	}
+	// Check the relationship entity is still emitted too
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "orm_relationship" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected orm_relationship pattern from DeriveRelation enum")
+	}
+}
+
+func TestSeaORM_ImplRelated(t *testing.T) {
+	src := `
+use sea_orm::entity::prelude::*;
+
+impl Related<super::user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("post.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "orm_relationship") {
+		t.Error("expected orm_relationship from impl Related<T> for Entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SeaORM — lazy_loading_recognition
+// ---------------------------------------------------------------------------
+
+func TestSeaORM_FindRelated(t *testing.T) {
+	src := `
+use sea_orm::*;
+
+async fn get_user_posts(db: &DatabaseConnection, user_id: i32) -> Vec<post::Model> {
+    let user = user::Entity::find_by_id(user_id)
+        .one(db)
+        .await
+        .unwrap()
+        .unwrap();
+    user.find_related(post::Entity)
+        .all(db)
+        .await
+        .unwrap()
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("repo.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "seaorm:find_related") {
+		t.Error("expected seaorm:find_related lazy_load pattern")
+	}
+}
+
+func TestSeaORM_LoaderTrait(t *testing.T) {
+	src := `
+use sea_orm::*;
+use sea_orm::LoaderTrait;
+
+async fn get_all_with_posts(db: &DatabaseConnection) {
+    let users: Vec<user::Model> = user::Entity::find().all(db).await.unwrap();
+    let posts = users.load_many(post::Entity, db).await.unwrap();
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("loader.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "seaorm:loader_trait") {
+		t.Error("expected seaorm:loader_trait lazy_load pattern from load_many")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Diesel — migration_parsing
+// ---------------------------------------------------------------------------
+
+func TestDiesel_EmbedMigrations(t *testing.T) {
+	src := `
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+
+const MIGRATIONS: EmbeddedMigrations = diesel_migrations::embed_migrations!("./migrations");
+
+pub fn run_migrations(conn: &mut PgConnection) {
+    conn.run_pending_migrations(MIGRATIONS).unwrap();
+}
+`
+	ents := extract(t, "custom_rust_diesel", fi("db.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Component", "migration") {
+		t.Error("expected migration component from embed_migrations! macro")
+	}
+}
+
+func TestDiesel_RunPendingMigrations(t *testing.T) {
+	src := `
+use diesel_migrations::MigrationHarness;
+
+pub fn run(conn: &mut PgConnection) {
+    connection.run_pending_migrations(MIGRATIONS).expect("migrations failed");
+}
+`
+	ents := extract(t, "custom_rust_diesel", fi("db.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Component", "migration") {
+		t.Error("expected migration component from run_pending_migrations call")
+	}
+}
+
+func TestDiesel_MigrationHarness(t *testing.T) {
+	src := `
+use diesel::pg::PgConnection;
+use diesel_migrations::MigrationHarness;
+
+impl MigrationHarness<Pg> for MyMigrationRunner {
+    // custom harness implementation
+}
+`
+	ents := extract(t, "custom_rust_diesel", fi("harness.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "migration") {
+		t.Error("expected migration pattern from impl MigrationHarness")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Diesel — foreign_key_extraction
+// ---------------------------------------------------------------------------
+
+func TestDiesel_ForeignKeyColumn(t *testing.T) {
+	src := `
+use diesel::prelude::*;
+
+table! {
+    posts (id) {
+        id -> Integer,
+        title -> VarChar,
+        user_id -> Integer,
+        category_id -> Nullable<Integer>,
+    }
+}
+`
+	ents := extract(t, "custom_rust_diesel", fi("schema.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "diesel:fk:posts.user_id") {
+		t.Error("expected diesel:fk:posts.user_id foreign key")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "diesel:fk:posts.category_id") {
+		t.Error("expected diesel:fk:posts.category_id foreign key")
+	}
+}

--- a/internal/custom/rust/fw_validation.go
+++ b/internal/custom/rust/fw_validation.go
@@ -1,0 +1,416 @@
+package rust
+
+// fw_validation.go — DTO + request validation extractors for Rust HTTP frameworks.
+//
+// Covers dto_extraction and request_validation for:
+//   - actix, axum, gotham, hyper, poem, rocket, salvo, tide, tower, warp
+//
+// Detection surface:
+//   dto_extraction:
+//     - #[derive(Deserialize)] structs (serde — the lingua franca for HTTP DTOs)
+//     - #[derive(Validate)] structs (validator crate)
+//     - #[derive(serde::Deserialize)] full-path variant
+//
+//   request_validation:
+//     - #[validate(...)] field attributes (validator crate field-level rules)
+//     - validator::Validate usage (trait impl or .validate() call)
+//     - actix: web::Json<T>, web::Query<T>, web::Form<T> extractor types
+//     - axum: Json<T>, Query<T>, Form<T>, Path<T> extractor types
+//     - rocket: Json<T>, Form<T>, request guard impls (impl FromRequest)
+//     - poem: #[handler] params that are Deserialize types
+//     - tower/hyper: body deserialization via serde_json::from_slice / from_str
+//     - salvo: #[extract] / Extractible derive
+//     - gotham/tide/warp: Json body extraction primitives
+//
+// Honesty:
+//
+//	partial — heuristic regex match on source text. We detect structures likely
+//	used as request DTOs but cannot prove type-system flow. Fixtures prove the
+//	detection surface. Full semantic confirmation requires import-graph analysis.
+//
+// Issue #3267 — lang.rust.framework.* Validation cells.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_validation", &rustValidationExtractor{})
+}
+
+type rustValidationExtractor struct{}
+
+func (e *rustValidationExtractor) Language() string { return "custom_rust_validation" }
+
+// ---------------------------------------------------------------------------
+// Shared regex catalog
+// ---------------------------------------------------------------------------
+
+var (
+	// #[derive(...Deserialize...)] — serde DTO structs
+	reDeserialize = regexp.MustCompile(
+		`#\[derive\([^)]*\b(?:Deserialize|serde::Deserialize)\b[^)]*\)\]`,
+	)
+
+	// #[derive(...Validate...)] — validator crate
+	reValidateDerive = regexp.MustCompile(
+		`#\[derive\([^)]*\bValidate\b[^)]*\)\]`,
+	)
+
+	// derive list for attribute extraction
+	reAnyDerive = regexp.MustCompile(`#\[derive\(([^)]+)\)\]`)
+
+	// struct Name after a derive
+	reStructNameV = regexp.MustCompile(`\bstruct\s+(\w+)`)
+
+	// #[validate(length(min=1), email)] field rules
+	reValidateAttr = regexp.MustCompile(
+		`#\[validate\s*\([^\)]*\)\]`,
+	)
+
+	// .validate() call (validator crate trait method)
+	reValidateCall = regexp.MustCompile(
+		`\.validate\s*\(\s*\)`,
+	)
+
+	// actix: web::Json<T>, web::Query<T>, web::Form<T>, web::Path<T>
+	reActixExtractorV = regexp.MustCompile(
+		`web::(Json|Query|Form|Path)\s*<\s*([A-Za-z_]\w*)`,
+	)
+
+	// axum: Json<T>, Query<T>, Form<T>, Path<T> (not prefixed web::)
+	reAxumExtractorV = regexp.MustCompile(
+		`(?:^|[^::\w])(Json|Query|Form|Path)\s*<\s*([A-Za-z_]\w*)`,
+	)
+
+	// rocket: Json<T>, Form<T>, MsgPack<T>
+	reRocketExtractorV = regexp.MustCompile(
+		`(?:Json|Form|MsgPack|FromForm)\s*<\s*([A-Za-z_]\w*)`,
+	)
+
+	// rocket: impl FromRequest for T (request guard)
+	reRocketFromRequest = regexp.MustCompile(
+		`impl\s+(?:<[^>]*>\s+)?FromRequest(?:<[^>]*>)?\s+for\s+(\w+)`,
+	)
+
+	// salvo: #[extract] on a struct field, or Extractible derive
+	reSalvoExtractible = regexp.MustCompile(
+		`#\[derive\([^)]*\bExtractible\b[^)]*\)\]`,
+	)
+
+	// salvo: #[salvo(extract(...))]
+	reSalvoExtractAttr = regexp.MustCompile(
+		`#\[salvo\s*\(\s*extract`,
+	)
+
+	// poem: #[oai(validator(...))]  or poem_openapi derive with Validate
+	rePoemOAIValidator = regexp.MustCompile(
+		`#\[oai\s*\([^\)]*validator`,
+	)
+
+	// serde_json::from_slice / from_str — body deserialization (hyper, tower, raw)
+	reSerdeJsonDeser = regexp.MustCompile(
+		`serde_json::from_(?:slice|str|reader|value)\s*[:<]`,
+	)
+
+	// gotham: extract body / serde-based patterns
+	reGothamJsonBody = regexp.MustCompile(
+		`Body\s*::\s*to_bytes|serde_json::from_slice`,
+	)
+
+	// tide: req.body_json::<T>()
+	reTideBodyJson = regexp.MustCompile(
+		`req\.body_json\s*::\s*<([A-Za-z_]\w*)>`,
+	)
+
+	// warp: warp::body::json() (filter combinator)
+	reWarpBodyJson = regexp.MustCompile(
+		`warp::body::json\s*\(\s*\)`,
+	)
+
+	// tower/hyper: hyper::body::to_bytes / body deserialization
+	reHyperBodyDeser = regexp.MustCompile(
+		`hyper::body::to_bytes|body::to_bytes|serde_json::from_slice`,
+	)
+)
+
+// dtoStructsFromSrc scans src for Deserialize or Validate derives and returns
+// the struct names, derive list, and source offset for each.
+type dtoInfo struct {
+	structName  string
+	deriveList  string
+	offset      int
+	hasValidate bool
+}
+
+func extractDTOs(src string) []dtoInfo {
+	var out []dtoInfo
+	seen := make(map[string]bool)
+
+	// Combine: any derive that includes Deserialize OR Validate
+	allDerive := reAnyDerive.FindAllStringSubmatchIndex(src, -1)
+	for _, dm := range allDerive {
+		attrText := src[dm[0]:dm[1]]
+		deriveList := src[dm[2]:dm[3]]
+		isDeser := strings.Contains(deriveList, "Deserialize")
+		isVal := strings.Contains(deriveList, "Validate")
+		if !isDeser && !isVal {
+			continue
+		}
+		// Look ahead for struct name
+		tail := src[dm[1]:]
+		if len(tail) > 500 {
+			tail = tail[:500]
+		}
+		sm := reStructNameV.FindStringSubmatchIndex(tail)
+		if sm == nil {
+			continue
+		}
+		sname := tail[sm[2]:sm[3]]
+		if seen[sname] {
+			continue
+		}
+		seen[sname] = true
+		out = append(out, dtoInfo{
+			structName:  sname,
+			deriveList:  attrText,
+			offset:      dm[0],
+			hasValidate: isVal,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *rustValidationExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.rust_validation_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. dto_extraction — Deserialize/Validate derived structs
+	// -----------------------------------------------------------------------
+	for _, dto := range extractDTOs(src) {
+		subtype := "dto"
+		if dto.hasValidate {
+			subtype = "validated_dto"
+		}
+		ent := makeEntity("dto:"+dto.structName, "SCOPE.Schema", subtype,
+			file.Path, file.Language, lineOf(src, dto.offset))
+		setProps(&ent,
+			"provenance", "INFERRED_FROM_SERDE_DESERIALIZE",
+			"struct_name", dto.structName,
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. request_validation — #[validate(...)] field attributes
+	// -----------------------------------------------------------------------
+	for _, m := range reValidateAttr.FindAllStringIndex(src, -1) {
+		ent := makeEntity("validate_field_attr", "SCOPE.Pattern", "field_validation",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "provenance", "INFERRED_FROM_VALIDATE_ATTR")
+		add(ent)
+	}
+
+	// .validate() call
+	for _, m := range reValidateCall.FindAllStringIndex(src, -1) {
+		ent := makeEntity("validate_call", "SCOPE.Pattern", "request_validation",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "provenance", "INFERRED_FROM_VALIDATE_CALL")
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. Framework-specific extractor types
+	// -----------------------------------------------------------------------
+
+	// actix: web::Json<T> / web::Query<T> / web::Form<T> / web::Path<T>
+	for _, m := range reActixExtractorV.FindAllStringSubmatchIndex(src, -1) {
+		extKind := src[m[2]:m[3]]
+		typeParam := src[m[4]:m[5]]
+		name := "actix_extractor:" + extKind + "<" + typeParam + ">"
+		ent := makeEntity(name, "SCOPE.Schema", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "actix_web",
+			"extractor_kind", extKind,
+			"type_param", typeParam,
+			"provenance", "INFERRED_FROM_ACTIX_EXTRACTOR",
+		)
+		add(ent)
+	}
+
+	// axum: Json<T>, Query<T>, Form<T>, Path<T> — avoid double-counting web:: prefix
+	for _, m := range reAxumExtractorV.FindAllStringSubmatchIndex(src, -1) {
+		// Skip actix web:: prefix variants
+		if m[0] >= 5 && src[m[0]:m[0]+5] == "web::" {
+			continue
+		}
+		extKind := src[m[2]:m[3]]
+		typeParam := src[m[4]:m[5]]
+		name := "axum_extractor:" + extKind + "<" + typeParam + ">"
+		ent := makeEntity(name, "SCOPE.Schema", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "axum",
+			"extractor_kind", extKind,
+			"type_param", typeParam,
+			"provenance", "INFERRED_FROM_AXUM_EXTRACTOR",
+		)
+		add(ent)
+	}
+
+	// rocket: Json<T>, Form<T>, MsgPack<T>, FromForm<T>
+	for _, m := range reRocketExtractorV.FindAllStringSubmatchIndex(src, -1) {
+		typeParam := src[m[2]:m[3]]
+		name := "rocket_extractor:" + typeParam
+		ent := makeEntity(name, "SCOPE.Schema", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "rocket",
+			"type_param", typeParam,
+			"provenance", "INFERRED_FROM_ROCKET_EXTRACTOR",
+		)
+		add(ent)
+	}
+
+	// rocket: impl FromRequest for T (request guard — validation hook)
+	for _, m := range reRocketFromRequest.FindAllStringSubmatchIndex(src, -1) {
+		guardType := src[m[2]:m[3]]
+		ent := makeEntity("rocket_guard:"+guardType, "SCOPE.Pattern", "request_guard",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "rocket",
+			"guard_type", guardType,
+			"provenance", "INFERRED_FROM_ROCKET_FROM_REQUEST",
+		)
+		add(ent)
+	}
+
+	// salvo: Extractible derive
+	for _, m := range reSalvoExtractible.FindAllStringIndex(src, -1) {
+		tail := src[m[1]:]
+		if len(tail) > 300 {
+			tail = tail[:300]
+		}
+		sm := reStructNameV.FindStringSubmatchIndex(tail)
+		if sm == nil {
+			continue
+		}
+		sname := tail[sm[2]:sm[3]]
+		ent := makeEntity("salvo_extractible:"+sname, "SCOPE.Schema", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "salvo",
+			"struct_name", sname,
+			"provenance", "INFERRED_FROM_SALVO_EXTRACTIBLE",
+		)
+		add(ent)
+	}
+
+	// salvo: #[salvo(extract(...))]
+	for _, m := range reSalvoExtractAttr.FindAllStringIndex(src, -1) {
+		ent := makeEntity("salvo_extract_attr", "SCOPE.Pattern", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "salvo",
+			"provenance", "INFERRED_FROM_SALVO_EXTRACT_ATTR",
+		)
+		add(ent)
+	}
+
+	// poem: #[oai(validator(...))]
+	for _, m := range rePoemOAIValidator.FindAllStringIndex(src, -1) {
+		ent := makeEntity("poem_oai_validator", "SCOPE.Pattern", "request_validation",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "poem",
+			"provenance", "INFERRED_FROM_POEM_OAI_VALIDATOR",
+		)
+		add(ent)
+	}
+
+	// tide: req.body_json::<T>()
+	for _, m := range reTideBodyJson.FindAllStringSubmatchIndex(src, -1) {
+		typeParam := src[m[2]:m[3]]
+		ent := makeEntity("tide_body_json:"+typeParam, "SCOPE.Schema", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tide",
+			"type_param", typeParam,
+			"provenance", "INFERRED_FROM_TIDE_BODY_JSON",
+		)
+		add(ent)
+	}
+
+	// warp: warp::body::json()
+	for _, m := range reWarpBodyJson.FindAllStringIndex(src, -1) {
+		ent := makeEntity("warp_body_json", "SCOPE.Pattern", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "warp",
+			"provenance", "INFERRED_FROM_WARP_BODY_JSON",
+		)
+		add(ent)
+	}
+
+	// hyper/tower: serde_json::from_slice body deserialization
+	for _, m := range reHyperBodyDeser.FindAllStringIndex(src, -1) {
+		ent := makeEntity("hyper_body_deser", "SCOPE.Pattern", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "hyper",
+			"provenance", "INFERRED_FROM_HYPER_BODY_DESER",
+		)
+		add(ent)
+	}
+
+	// generic: serde_json deserialization (gotham, tower, etc.)
+	for _, m := range reSerdeJsonDeser.FindAllStringIndex(src, -1) {
+		ent := makeEntity("serde_json_deser", "SCOPE.Pattern", "request_extractor",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"provenance", "INFERRED_FROM_SERDE_JSON_DESER",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/rust/fw_validation_test.go
+++ b/internal/custom/rust/fw_validation_test.go
@@ -1,0 +1,188 @@
+package rust_test
+
+// fw_validation_test.go — tests for custom_rust_validation extractor.
+// Proves dto_extraction and request_validation detection surface.
+
+import (
+	"testing"
+)
+
+func TestValidation_SerdeDeserializeDTO(t *testing.T) {
+	src := `
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateUserRequest {
+    pub name: String,
+    pub email: String,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("handler.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Schema", "dto:CreateUserRequest") {
+		t.Error("expected dto:CreateUserRequest from Deserialize derive")
+	}
+}
+
+func TestValidation_ValidateDerive(t *testing.T) {
+	src := `
+use serde::Deserialize;
+use validator::Validate;
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct SignupRequest {
+    pub username: String,
+    pub email: String,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("signup.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Schema", "dto:SignupRequest") {
+		t.Error("expected dto:SignupRequest with Validate")
+	}
+}
+
+func TestValidation_ValidateFieldAttr(t *testing.T) {
+	src := `
+#[derive(Deserialize, Validate)]
+pub struct ChangePasswordRequest {
+    #[validate(length(min = 8))]
+    pub password: String,
+    #[validate(email)]
+    pub email: String,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("change_pw.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "field_validation") {
+		t.Error("expected field_validation pattern from #[validate(...)] attribute")
+	}
+}
+
+func TestValidation_ValidateCall(t *testing.T) {
+	src := `
+async fn handler(payload: Json<CreateUserRequest>) -> impl Responder {
+    if payload.validate().is_err() {
+        return HttpResponse::BadRequest().finish();
+    }
+    HttpResponse::Ok().finish()
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("handler.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "request_validation") {
+		t.Error("expected request_validation pattern from .validate() call")
+	}
+}
+
+func TestValidation_ActixWebExtractor(t *testing.T) {
+	src := `
+use actix_web::web;
+
+async fn create_user(
+    body: web::Json<CreateUserRequest>,
+    query: web::Query<PaginationQuery>,
+) -> impl Responder {
+    HttpResponse::Ok().finish()
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("handlers.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Schema", "actix_extractor:Json<CreateUserRequest>") {
+		t.Error("expected actix_extractor:Json<CreateUserRequest>")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "actix_extractor:Query<PaginationQuery>") {
+		t.Error("expected actix_extractor:Query<PaginationQuery>")
+	}
+}
+
+func TestValidation_TideBodyJson(t *testing.T) {
+	src := `
+async fn handler(mut req: Request<State>) -> tide::Result {
+    let body: CreateUserRequest = req.body_json::<CreateUserRequest>().await?;
+    Ok(Response::new(200))
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("handler.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Schema", "tide_body_json:CreateUserRequest") {
+		t.Error("expected tide_body_json:CreateUserRequest")
+	}
+}
+
+func TestValidation_WarpBodyJson(t *testing.T) {
+	src := `
+let create = warp::path("users")
+    .and(warp::post())
+    .and(warp::body::json())
+    .and_then(create_user_handler);
+`
+	ents := extract(t, "custom_rust_validation", fi("routes.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "warp_body_json") {
+		t.Error("expected warp_body_json pattern")
+	}
+}
+
+func TestValidation_HyperBodyDeser(t *testing.T) {
+	src := `
+async fn handle(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    let bytes = hyper::body::to_bytes(req.into_body()).await.unwrap();
+    let payload: CreateUserRequest = serde_json::from_slice(&bytes).unwrap();
+    Ok(Response::new(Body::from("ok")))
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("handler.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "request_extractor") {
+		t.Error("expected request_extractor pattern from hyper body deserialization")
+	}
+}
+
+func TestValidation_SalvoExtractible(t *testing.T) {
+	src := `
+use salvo::prelude::*;
+
+#[derive(Extractible, Debug)]
+#[salvo(extract(default_source(from = "body")))]
+pub struct CreateUserPayload {
+    pub name: String,
+    pub email: String,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("handler.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Schema", "salvo_extractible:CreateUserPayload") {
+		t.Error("expected salvo_extractible:CreateUserPayload")
+	}
+}
+
+func TestValidation_NoMatch(t *testing.T) {
+	src := `
+fn main() {
+    println!("hello world");
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("main.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+func TestValidation_FixtureFile(t *testing.T) {
+	src := readFixture(t, "testdata/validation_dto.rs")
+	ents := extract(t, "custom_rust_validation", fi("validation_dto.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Schema", "dto:CreateUserRequest") {
+		t.Error("expected dto:CreateUserRequest")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "dto:UpdateUserRequest") {
+		t.Error("expected dto:UpdateUserRequest (Validate derive)")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "actix_extractor:Json<CreateUserRequest>") {
+		t.Error("expected actix Json extractor")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "warp_body_json") {
+		t.Error("expected warp body json pattern")
+	}
+}
+
+// containsEntitySubtype checks for matching kind+subtype regardless of name.
+func containsEntitySubtype(ents []entitySummary, kind, subtype string) bool {
+	for _, e := range ents {
+		if e.Kind == kind && e.Subtype == subtype {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/custom/rust/seaorm.go
+++ b/internal/custom/rust/seaorm.go
@@ -9,6 +9,10 @@ package rust
 //   - DeriveRelation enum variants with #[sea_orm(has_many / belongs_to = "...")] →
 //     SCOPE.Pattern (subtype="orm_relationship")
 //   - sea-orm-migration MigrationTrait impl blocks → SCOPE.Component (subtype="migration")
+//   - Foreign-key columns detected via #[sea_orm(belongs_to)] with from/to column refs →
+//     SCOPE.Pattern (subtype="foreign_key")   [foreign_key_extraction]
+//   - find_related() / find_linked() / LoaderTrait usage →
+//     SCOPE.Pattern (subtype="lazy_load")     [lazy_loading_recognition]
 //
 // Honesty:
 //
@@ -17,7 +21,7 @@ package rust
 //	Fixtures prove the detection surface; full cross-entity linking
 //	requires import-graph analysis beyond this scanner.
 //
-// Issue #3269 — lang.rust.orm.seaorm ORM build.
+// Issue #3267 — lang.rust.orm.seaorm Relationships cells.
 
 import (
 	"context"
@@ -73,6 +77,28 @@ var (
 	// sea-orm-migration: impl MigrationTrait for MigrationName
 	reSeaOrmMigration = regexp.MustCompile(
 		`\bimpl\s+MigrationTrait\s+for\s+(\w+)`,
+	)
+
+	// belongs_to with from/to column references → FK extraction
+	// #[sea_orm(belongs_to = "...", from = "Column::FieldId", to = "super::user::Column::Id")]
+	reSeaOrmBelongsToFK = regexp.MustCompile(
+		`#\[sea_orm\([^)]*\bbelongs_to\s*=\s*"([^"]+)"[^)]*\bfrom\s*=\s*"([^"]+)"[^)]*\bto\s*=\s*"([^"]+)"`,
+	)
+
+	// find_related(T) / find_linked(T) — lazy/eager load signals
+	// Note: these take a type argument, so do NOT require empty parens.
+	reSeaOrmFindRelated = regexp.MustCompile(
+		`\.find_related\s*\(|\.find_linked\s*\(`,
+	)
+
+	// LoaderTrait usage — batch loading (lazy loading pattern)
+	reSeaOrmLoaderTrait = regexp.MustCompile(
+		`LoaderTrait|load_many\s*\(|load_one\s*\(|load_many_to_many\s*\(`,
+	)
+
+	// impl Related<T> for Entity — relation type implementation
+	reSeaOrmRelated = regexp.MustCompile(
+		`\bimpl\s+(?:<[^>]*>\s+)?Related\s*<\s*([^>]+)>\s+for\s+(\w+)`,
 	)
 )
 
@@ -204,6 +230,67 @@ func (e *rustSeaORMExtractor) Extract(ctx context.Context, file extractor.FileIn
 			"framework", "seaorm",
 			"migration_name", migName,
 			"provenance", "INFERRED_FROM_SEAORM_MIGRATION_TRAIT",
+		)
+		add(ent)
+	}
+
+	// 4. foreign_key_extraction — belongs_to with explicit from/to column refs
+	for _, m := range reSeaOrmBelongsToFK.FindAllStringSubmatchIndex(src, -1) {
+		targetEntity := src[m[2]:m[3]]
+		fromCol := src[m[4]:m[5]]
+		toCol := src[m[6]:m[7]]
+		// Shorten target entity path to last segment
+		targetShort := targetEntity
+		if idx := strings.LastIndex(targetEntity, "::"); idx >= 0 {
+			targetShort = targetEntity[idx+2:]
+		}
+		name := "seaorm:fk:" + fromCol + "->" + targetShort
+		ent := makeEntity(name, "SCOPE.Pattern", "foreign_key",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "seaorm",
+			"target_entity", targetEntity,
+			"from_column", fromCol,
+			"to_column", toCol,
+			"provenance", "INFERRED_FROM_SEAORM_BELONGS_TO_FK",
+		)
+		add(ent)
+	}
+
+	// 5. impl Related<T> for Entity → relationship implementation
+	for _, m := range reSeaOrmRelated.FindAllStringSubmatchIndex(src, -1) {
+		targetType := strings.TrimSpace(src[m[2]:m[3]])
+		entityType := src[m[4]:m[5]]
+		name := "seaorm:related:" + entityType + "->" + targetType
+		ent := makeEntity(name, "SCOPE.Pattern", "orm_relationship",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "seaorm",
+			"entity_type", entityType,
+			"related_to", targetType,
+			"provenance", "INFERRED_FROM_SEAORM_IMPL_RELATED",
+		)
+		add(ent)
+	}
+
+	// 6. lazy_loading_recognition — find_related() / find_linked()
+	for _, m := range reSeaOrmFindRelated.FindAllStringIndex(src, -1) {
+		ent := makeEntity("seaorm:find_related", "SCOPE.Pattern", "lazy_load",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "seaorm",
+			"provenance", "INFERRED_FROM_SEAORM_FIND_RELATED",
+		)
+		add(ent)
+	}
+
+	// 7. lazy_loading_recognition — LoaderTrait batch loading
+	for _, m := range reSeaOrmLoaderTrait.FindAllStringIndex(src, -1) {
+		ent := makeEntity("seaorm:loader_trait", "SCOPE.Pattern", "lazy_load",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "seaorm",
+			"provenance", "INFERRED_FROM_SEAORM_LOADER_TRAIT",
 		)
 		add(ent)
 	}

--- a/internal/custom/rust/sqlx_rbatis.go
+++ b/internal/custom/rust/sqlx_rbatis.go
@@ -1,0 +1,417 @@
+package rust
+
+// sqlx_rbatis.go — custom extractors for SQLx and rbatis (Rust async ORMs).
+//
+// SQLx extractor covers:
+//   - Models/schema_extraction: structs with #[derive(sqlx::FromRow)] or
+//     FromRow derive → detected as ORM model mappings
+//   - Migrations/migration_parsing: sqlx::migrate!() macro invocations and
+//     files named like `migrations/V\d+__*.sql` detected via comment headers
+//
+// rbatis extractor covers:
+//   - Models/model_extraction: #[derive(Debug, Clone)] structs adjacent to
+//     #[crud_table(table_name="...")] attribute, or #[html_sql] / py_sql usage
+//   - Models/schema_extraction: #[crud_table] table mapping
+//   - Queries/query_attribution: #[sql("SELECT ...")] / #[py_sql("...")] /
+//     #[html_sql] macro annotations on functions
+//   - Migrations/migration_parsing: sqlx-style migrations directory patterns
+//     and rbatis Snowflake / table-schema annotations
+//
+// Honesty:
+//
+//	partial — heuristic regex match on source text. We detect the registration
+//	surface (macros, attributes) but cannot resolve cross-file type references
+//	or verify migration ordering. Fixtures prove the detection surface.
+//
+// Issue #3267 — lang.rust.orm.sqlx schema_extraction + migration_parsing,
+//               lang.rust.orm.rbatis all four missing cells.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_sqlx", &rustSqlxExtractor{})
+	extractor.Register("custom_rust_rbatis", &rustRbatisExtractor{})
+}
+
+// ===========================================================================
+// SQLx
+// ===========================================================================
+
+type rustSqlxExtractor struct{}
+
+func (e *rustSqlxExtractor) Language() string { return "custom_rust_sqlx" }
+
+var (
+	// #[derive(...FromRow...)] — sqlx row-mapping model
+	reSqlxFromRow = regexp.MustCompile(
+		`#\[derive\([^)]*\b(?:FromRow|sqlx::FromRow)\b[^)]*\)\]`,
+	)
+
+	// sqlx::migrate!() or sqlx::migrate!("./migrations")
+	reSqlxMigrateMacro = regexp.MustCompile(
+		`sqlx::migrate!\s*\(([^)]*)\)`,
+	)
+
+	// sqlx::migrate!() invocation chain: .run(&pool)
+	reSqlxMigrateRun = regexp.MustCompile(
+		`sqlx::migrate!\s*\([^)]*\)\s*\.run\s*\(`,
+	)
+
+	// Migration file header comment pattern (detected in .rs file referencing migrations):
+	// -- V001__create_users.sql
+	reSqlxMigrationFileRef = regexp.MustCompile(
+		`(?m)--\s*V\d+__\w+\.sql|migrations/\d+_`,
+	)
+
+	// Pool creation → schema connection evidence
+	reSqlxPoolConnect = regexp.MustCompile(
+		`(?:PgPool|MySqlPool|SqlitePool|AnyPool|Pool)\s*::\s*(?:connect|new|builder)\s*\(`,
+	)
+
+	// query! / query_as! macro with SQL literal.
+	// query!("SELECT ...") — sql is first arg
+	// query_as!(Type, "SELECT ...") — sql is second arg
+	// Match both forms.
+	reSqlxQueryMacro = regexp.MustCompile(
+		`(?:sqlx::)?query(?:_as|_scalar|_as_unchecked)?!\s*\(\s*(?:[^,)]+,\s*)?"([^"]{5,})"`,
+	)
+
+	// struct Name (after FromRow derive)
+	reStructNameSqlx = regexp.MustCompile(`\bstruct\s+(\w+)`)
+)
+
+func (e *rustSqlxExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.rust_sqlx_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. schema_extraction — #[derive(FromRow)] structs
+	// -----------------------------------------------------------------------
+	for _, m := range reSqlxFromRow.FindAllStringIndex(src, -1) {
+		tail := src[m[1]:]
+		if len(tail) > 500 {
+			tail = tail[:500]
+		}
+		sm := reStructNameSqlx.FindStringSubmatchIndex(tail)
+		if sm == nil {
+			continue
+		}
+		sname := tail[sm[2]:sm[3]]
+		ent := makeEntity("sqlx:model:"+sname, "SCOPE.Component", "orm_model",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "sqlx",
+			"struct_name", sname,
+			"provenance", "INFERRED_FROM_SQLX_FROM_ROW",
+		)
+		add(ent)
+	}
+
+	// Pool connection → schema connection entity
+	for _, m := range reSqlxPoolConnect.FindAllStringIndex(src, -1) {
+		ent := makeEntity("sqlx:pool_connect", "SCOPE.Component", "db_connection",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "sqlx",
+			"provenance", "INFERRED_FROM_SQLX_POOL_CONNECT",
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. migration_parsing — sqlx::migrate!() macro
+	// -----------------------------------------------------------------------
+	for _, m := range reSqlxMigrateMacro.FindAllStringSubmatchIndex(src, -1) {
+		migPath := strings.TrimSpace(strings.Trim(src[m[2]:m[3]], `"`))
+		if migPath == "" {
+			migPath = "./migrations"
+		}
+		ent := makeEntity("sqlx:migrate:"+migPath, "SCOPE.Component", "migration",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "sqlx",
+			"migration_path", migPath,
+			"provenance", "INFERRED_FROM_SQLX_MIGRATE_MACRO",
+		)
+		add(ent)
+	}
+
+	// Migration file references in comments/strings
+	for _, m := range reSqlxMigrationFileRef.FindAllStringIndex(src, -1) {
+		ent := makeEntity("sqlx:migration_file_ref", "SCOPE.Pattern", "migration_reference",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "sqlx",
+			"provenance", "INFERRED_FROM_SQLX_MIGRATION_FILE_REF",
+		)
+		add(ent)
+	}
+
+	// query! macros → schema usage evidence
+	for _, m := range reSqlxQueryMacro.FindAllStringSubmatchIndex(src, -1) {
+		sql := src[m[2]:m[3]]
+		if len(sql) > 80 {
+			sql = sql[:80] + "..."
+		}
+		ent := makeEntity("sqlx:query_macro", "SCOPE.Operation", "sql_query",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "sqlx",
+			"sql_fragment", sql,
+			"provenance", "INFERRED_FROM_SQLX_QUERY_MACRO",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ===========================================================================
+// rbatis
+// ===========================================================================
+
+type rustRbatisExtractor struct{}
+
+func (e *rustRbatisExtractor) Language() string { return "custom_rust_rbatis" }
+
+var (
+	// #[crud_table(table_name="...")] — rbatis model annotation
+	reRbatisCrudTable = regexp.MustCompile(
+		`#\[crud_table\s*\(([^)]*)\)\]`,
+	)
+
+	// #[derive(...)] followed by crud_table attr or rbatis types
+	reRbatisDerive = regexp.MustCompile(
+		`#\[derive\([^)]*\b(?:Debug|Clone|Serialize|Deserialize)\b[^)]*\)\]`,
+	)
+
+	// struct Name
+	reStructNameRbatis = regexp.MustCompile(`\bstruct\s+(\w+)`)
+
+	// #[py_sql("SELECT ...")] / #[py_sql(sql = "...")] on async fn
+	reRbatisPySql = regexp.MustCompile(
+		`#\[py_sql\s*\(\s*(?:sql\s*=\s*)?"([^"]{3,})"[^)]*\)\][\s\S]{0,200}?(?:async\s+)?fn\s+(\w+)\s*\(`,
+	)
+
+	// #[sql("SELECT ...")]  (rbatis v4 style)
+	reRbatisSql = regexp.MustCompile(
+		`#\[sql\s*\(\s*"([^"]{3,})"\s*\)\][\s\S]{0,200}?(?:async\s+)?fn\s+(\w+)\s*\(`,
+	)
+
+	// #[html_sql("...")] or #[html_sql]
+	reRbatisHtmlSql = regexp.MustCompile(
+		`#\[html_sql(?:\s*\([^)]*\))?\][\s\S]{0,200}?(?:async\s+)?fn\s+(\w+)\s*\(`,
+	)
+
+	// rbatis::Rbatis::new() — connection init
+	reRbatisNew = regexp.MustCompile(
+		`(?:rbatis::)?Rbatis\s*::\s*new\s*\(\s*\)`,
+	)
+
+	// rbatis migration: refactor of sqlx-migrate or custom migration structs
+	// detect table_meta! or migration-related macros
+	reRbatisMigration = regexp.MustCompile(
+		`table_meta!\s*\([^)]+\)|rbatis::table_sync\s*!`,
+	)
+
+	// crud_table table_name extraction
+	reTableNameAttr = regexp.MustCompile(`table_name\s*=\s*"([^"]+)"`)
+)
+
+func (e *rustRbatisExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.rust_rbatis_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. model_extraction + schema_extraction — #[crud_table] structs
+	// -----------------------------------------------------------------------
+	for _, m := range reRbatisCrudTable.FindAllStringSubmatchIndex(src, -1) {
+		attrContent := src[m[2]:m[3]]
+
+		// Extract table_name if present
+		tableName := ""
+		if tn := reTableNameAttr.FindStringSubmatch(attrContent); tn != nil {
+			tableName = tn[1]
+		}
+
+		// Look forward for struct name
+		tail := src[m[1]:]
+		if len(tail) > 600 {
+			tail = tail[:600]
+		}
+		sm := reStructNameRbatis.FindStringSubmatchIndex(tail)
+		if sm == nil {
+			continue
+		}
+		sname := tail[sm[2]:sm[3]]
+
+		modelKey := sname
+		if tableName != "" {
+			modelKey = tableName
+		}
+
+		ent := makeEntity("rbatis:model:"+modelKey, "SCOPE.Component", "orm_model",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "rbatis",
+			"struct_name", sname,
+			"table_name", tableName,
+			"provenance", "INFERRED_FROM_RBATIS_CRUD_TABLE",
+		)
+		add(ent)
+
+		// schema_extraction: also emit the schema entity
+		if tableName != "" {
+			schEnt := makeEntity("rbatis:schema:"+tableName, "SCOPE.Component", "schema_table",
+				file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&schEnt,
+				"framework", "rbatis",
+				"table_name", tableName,
+				"struct_name", sname,
+				"provenance", "INFERRED_FROM_RBATIS_CRUD_TABLE_SCHEMA",
+			)
+			add(schEnt)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. query_attribution — #[py_sql("...")] fn
+	// -----------------------------------------------------------------------
+	for _, m := range reRbatisPySql.FindAllStringSubmatchIndex(src, -1) {
+		sql := src[m[2]:m[3]]
+		fnName := src[m[4]:m[5]]
+		if len(sql) > 100 {
+			sql = sql[:100] + "..."
+		}
+		ent := makeEntity("rbatis:py_sql:"+fnName, "SCOPE.Operation", "sql_query",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "rbatis",
+			"function_name", fnName,
+			"sql_fragment", sql,
+			"query_style", "py_sql",
+			"provenance", "INFERRED_FROM_RBATIS_PY_SQL",
+		)
+		add(ent)
+	}
+
+	// #[sql("...")] fn
+	for _, m := range reRbatisSql.FindAllStringSubmatchIndex(src, -1) {
+		sql := src[m[2]:m[3]]
+		fnName := src[m[4]:m[5]]
+		if len(sql) > 100 {
+			sql = sql[:100] + "..."
+		}
+		ent := makeEntity("rbatis:sql:"+fnName, "SCOPE.Operation", "sql_query",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "rbatis",
+			"function_name", fnName,
+			"sql_fragment", sql,
+			"query_style", "sql_attr",
+			"provenance", "INFERRED_FROM_RBATIS_SQL_ATTR",
+		)
+		add(ent)
+	}
+
+	// #[html_sql] fn
+	for _, m := range reRbatisHtmlSql.FindAllStringSubmatchIndex(src, -1) {
+		fnName := src[m[2]:m[3]]
+		ent := makeEntity("rbatis:html_sql:"+fnName, "SCOPE.Operation", "sql_query",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "rbatis",
+			"function_name", fnName,
+			"query_style", "html_sql",
+			"provenance", "INFERRED_FROM_RBATIS_HTML_SQL",
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. Rbatis connection init → schema connection evidence
+	// -----------------------------------------------------------------------
+	for _, m := range reRbatisNew.FindAllStringIndex(src, -1) {
+		ent := makeEntity("rbatis:Rbatis::new", "SCOPE.Component", "db_connection",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "rbatis",
+			"provenance", "INFERRED_FROM_RBATIS_NEW",
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 4. migration_parsing — table_meta! / rbatis::table_sync!
+	// -----------------------------------------------------------------------
+	for _, m := range reRbatisMigration.FindAllStringIndex(src, -1) {
+		ent := makeEntity("rbatis:migration", "SCOPE.Component", "migration",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "rbatis",
+			"provenance", "INFERRED_FROM_RBATIS_MIGRATION_MACRO",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/rust/sqlx_rbatis_test.go
+++ b/internal/custom/rust/sqlx_rbatis_test.go
@@ -1,0 +1,217 @@
+package rust_test
+
+// sqlx_rbatis_test.go — tests for custom_rust_sqlx and custom_rust_rbatis extractors.
+// Proves schema_extraction, migration_parsing, model_extraction, query_attribution.
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// SQLx
+// ---------------------------------------------------------------------------
+
+func TestSqlx_FromRowModel(t *testing.T) {
+	src := `
+use sqlx::FromRow;
+
+#[derive(Debug, Clone, FromRow)]
+pub struct User {
+    pub id: i64,
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct Post {
+    pub id: i64,
+    pub user_id: i64,
+    pub title: String,
+}
+`
+	ents := extract(t, "custom_rust_sqlx", fi("models.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "sqlx:model:User") {
+		t.Error("expected sqlx:model:User from FromRow derive")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "sqlx:model:Post") {
+		t.Error("expected sqlx:model:Post from FromRow derive")
+	}
+}
+
+func TestSqlx_MigrateMacro(t *testing.T) {
+	src := `
+use sqlx::PgPool;
+
+pub async fn run_migrations(pool: &PgPool) -> sqlx::Result<()> {
+    sqlx::migrate!("./migrations").run(pool).await?;
+    Ok(())
+}
+`
+	ents := extract(t, "custom_rust_sqlx", fi("db.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Component", "migration") {
+		t.Error("expected migration component from sqlx::migrate! macro")
+	}
+}
+
+func TestSqlx_MigrateMacroDefaultPath(t *testing.T) {
+	src := `
+sqlx::migrate!().run(&pool).await.unwrap();
+`
+	ents := extract(t, "custom_rust_sqlx", fi("setup.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "sqlx:migrate:./migrations") {
+		t.Error("expected sqlx:migrate:./migrations with default path")
+	}
+}
+
+func TestSqlx_QueryMacro(t *testing.T) {
+	src := `
+let user = sqlx::query_as!(User, "SELECT id, name, email FROM users WHERE id = $1", id)
+    .fetch_one(pool)
+    .await?;
+`
+	ents := extract(t, "custom_rust_sqlx", fi("repo.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Operation", "sql_query") {
+		t.Error("expected sql_query from query_as! macro")
+	}
+}
+
+func TestSqlx_PoolConnect(t *testing.T) {
+	src := `
+let pool = PgPool::connect("postgres://localhost/mydb").await?;
+`
+	ents := extract(t, "custom_rust_sqlx", fi("main.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Component", "db_connection") {
+		t.Error("expected db_connection from PgPool::connect")
+	}
+}
+
+func TestSqlx_FixtureFile(t *testing.T) {
+	src := readFixture(t, "testdata/sqlx_models.rs")
+	ents := extract(t, "custom_rust_sqlx", fi("sqlx_models.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "sqlx:model:User") {
+		t.Error("expected sqlx:model:User from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "sqlx:model:Post") {
+		t.Error("expected sqlx:model:Post from fixture")
+	}
+	if !containsEntitySubtype(ents, "SCOPE.Component", "migration") {
+		t.Error("expected migration entity from fixture")
+	}
+}
+
+func TestSqlx_NoMatch(t *testing.T) {
+	src := `
+fn main() {
+    println!("hello");
+}
+`
+	ents := extract(t, "custom_rust_sqlx", fi("main.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// rbatis
+// ---------------------------------------------------------------------------
+
+func TestRbatis_CrudTableModel(t *testing.T) {
+	src := `
+use serde::{Deserialize, Serialize};
+
+#[crud_table(table_name = "biz_activity")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BizActivity {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+`
+	ents := extract(t, "custom_rust_rbatis", fi("models.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "rbatis:model:biz_activity") {
+		t.Error("expected rbatis:model:biz_activity from crud_table")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "rbatis:schema:biz_activity") {
+		t.Error("expected rbatis:schema:biz_activity from crud_table")
+	}
+}
+
+func TestRbatis_PySqlQuery(t *testing.T) {
+	src := `
+#[py_sql("select * from biz_activity where delete_flag = 0 and name like #{name}")]
+async fn select_by_name(rb: &Rbatis, name: &str) -> Vec<BizActivity> {
+    impled!()
+}
+`
+	ents := extract(t, "custom_rust_rbatis", fi("mapper.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Operation", "rbatis:py_sql:select_by_name") {
+		t.Error("expected rbatis:py_sql:select_by_name query")
+	}
+}
+
+func TestRbatis_SqlAttrQuery(t *testing.T) {
+	src := `
+#[sql("select * from user_info where id = #{id}")]
+async fn get_user_by_id(rb: &Rbatis, id: &str) -> UserInfo {
+    impled!()
+}
+`
+	ents := extract(t, "custom_rust_rbatis", fi("mapper.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Operation", "rbatis:sql:get_user_by_id") {
+		t.Error("expected rbatis:sql:get_user_by_id query")
+	}
+}
+
+func TestRbatis_HtmlSqlQuery(t *testing.T) {
+	src := `
+#[html_sql]
+async fn select_by_condition(rb: &Rbatis, id: &str) -> BizActivity {
+    impled!()
+}
+`
+	ents := extract(t, "custom_rust_rbatis", fi("mapper.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Operation", "rbatis:html_sql:select_by_condition") {
+		t.Error("expected rbatis:html_sql:select_by_condition query")
+	}
+}
+
+func TestRbatis_ConnectionInit(t *testing.T) {
+	src := `
+let rb = Rbatis::new();
+rb.link("mysql://root:123456@localhost:3306/test").await.unwrap();
+`
+	ents := extract(t, "custom_rust_rbatis", fi("main.rs", "rust", src))
+	if !containsEntitySubtype(ents, "SCOPE.Component", "db_connection") {
+		t.Error("expected db_connection from Rbatis::new")
+	}
+}
+
+func TestRbatis_FixtureFile(t *testing.T) {
+	src := readFixture(t, "testdata/rbatis_models.rs")
+	ents := extract(t, "custom_rust_rbatis", fi("rbatis_models.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "rbatis:model:biz_activity") {
+		t.Error("expected rbatis:model:biz_activity from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "rbatis:schema:biz_activity") {
+		t.Error("expected rbatis:schema:biz_activity from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "rbatis:py_sql:select_by_name") {
+		t.Error("expected py_sql query from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "rbatis:html_sql:select_by_condition") {
+		t.Error("expected html_sql query from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "rbatis:sql:get_user_by_id") {
+		t.Error("expected sql attr query from fixture")
+	}
+}
+
+func TestRbatis_NoMatch(t *testing.T) {
+	src := `
+use std::collections::HashMap;
+fn main() {}
+`
+	ents := extract(t, "custom_rust_rbatis", fi("main.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/rust/tauri.go
+++ b/internal/custom/rust/tauri.go
@@ -1,0 +1,253 @@
+package rust
+
+// tauri.go — custom extractor for Tauri (Rust desktop/mobile framework).
+//
+// Detects and emits entities for:
+//
+//   - #[tauri::command] functions → SCOPE.Operation/ipc_command
+//     (ipc_extraction: detecting IPC handler registrations)
+//   - tauri::Builder::default().invoke_handler(generate_handler![...]) →
+//     SCOPE.Component/ipc_handler_registration
+//   - main.rs / src-tauri/main.rs pattern → SCOPE.Component/main_process
+//     (main_renderer_split: detecting the Rust backend entry point)
+//   - use tauri::api / napi imports → SCOPE.Pattern/native_module
+//     (native_module_imports: native module usage detection)
+//   - WindowBuilder / WebviewWindow creation → SCOPE.Component/renderer_window
+//
+// Honesty:
+//
+//	partial — heuristic regex match on source text. We detect the IPC command
+//	registration surface and main/renderer split at the file level but cannot
+//	perform cross-file call-graph analysis to fully verify the IPC contract.
+//	Fixtures prove the detection surface.
+//
+// Issue #3267 — lang.rust.framework.tauri Process/Native cells.
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_tauri", &tauriExtractor{})
+}
+
+type tauriExtractor struct{}
+
+func (e *tauriExtractor) Language() string { return "custom_rust_tauri" }
+
+// ---------------------------------------------------------------------------
+// Regex catalog
+// ---------------------------------------------------------------------------
+
+var (
+	// #[tauri::command]  (preceding an fn declaration)
+	reTauriCommand = regexp.MustCompile(
+		`#\[tauri::command\][\s\S]*?(?:async\s+)?(?:pub\s+)?fn\s+(\w+)\s*\(`,
+	)
+
+	// generate_handler![cmd1, cmd2, cmd3]  — IPC handler registration
+	reTauriGenerateHandler = regexp.MustCompile(
+		`generate_handler!\s*\[([^\]]+)\]`,
+	)
+
+	// tauri::Builder::default() — app entry point (main process)
+	reTauriBuilder = regexp.MustCompile(
+		`tauri::Builder\s*::\s*default\s*\(\s*\)`,
+	)
+
+	// fn main() in a Tauri context (check file path heuristic + tauri import)
+	reTauriMainFn = regexp.MustCompile(
+		`(?m)^(?:pub\s+)?fn\s+main\s*\(\s*\)`,
+	)
+
+	// use tauri or extern crate tauri → marks this as a Tauri file
+	reTauriImport = regexp.MustCompile(
+		`\buse\s+tauri\b|extern\s+crate\s+tauri\b`,
+	)
+
+	// WindowBuilder / WebviewWindowBuilder — renderer window creation
+	reTauriWindowBuilder = regexp.MustCompile(
+		`(?:WindowBuilder|WebviewWindowBuilder|tauri::WindowBuilder)\s*::\s*new\s*\(`,
+	)
+
+	// tauri::api:: usage → native module imports (e.g. tauri::api::path, tauri::api::shell)
+	reTauriApiUsage = regexp.MustCompile(
+		`tauri::api::(\w+)`,
+	)
+
+	// tauri_plugin_ crate imports → native plugin imports
+	reTauriPlugin = regexp.MustCompile(
+		`tauri_plugin_(\w+)`,
+	)
+
+	// tauri::path::BaseDirectory or tauri::Manager trait usage
+	reTauriManager = regexp.MustCompile(
+		`tauri::Manager|AppHandle|tauri::AppHandle`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *tauriExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.tauri_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "tauri"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// Quick guard: skip files that have no tauri signals at all
+	if !reTauriImport.MatchString(src) &&
+		!reTauriCommand.MatchString(src) &&
+		!reTauriBuilder.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. ipc_extraction — #[tauri::command] fn declarations
+	// -----------------------------------------------------------------------
+	for _, m := range reTauriCommand.FindAllStringSubmatchIndex(src, -1) {
+		cmdName := src[m[2]:m[3]]
+		ent := makeEntity("tauri:command:"+cmdName, "SCOPE.Operation", "ipc_command",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tauri",
+			"command_name", cmdName,
+			"provenance", "INFERRED_FROM_TAURI_COMMAND_ATTR",
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. ipc_extraction — generate_handler![cmd1, cmd2]
+	// -----------------------------------------------------------------------
+	for _, m := range reTauriGenerateHandler.FindAllStringSubmatchIndex(src, -1) {
+		handlerList := src[m[2]:m[3]]
+		ent := makeEntity("tauri:generate_handler", "SCOPE.Component", "ipc_handler_registration",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tauri",
+			"handler_list", handlerList,
+			"provenance", "INFERRED_FROM_TAURI_GENERATE_HANDLER",
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. main_renderer_split — tauri::Builder entry point (Rust backend)
+	// -----------------------------------------------------------------------
+	for _, m := range reTauriBuilder.FindAllStringIndex(src, -1) {
+		ent := makeEntity("tauri:Builder::default", "SCOPE.Component", "main_process",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tauri",
+			"provenance", "INFERRED_FROM_TAURI_BUILDER",
+		)
+		add(ent)
+	}
+
+	// main_renderer_split — fn main() in a Tauri file
+	for _, m := range reTauriMainFn.FindAllStringIndex(src, -1) {
+		ent := makeEntity("tauri:main", "SCOPE.Function", "main_entry_point",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tauri",
+			"provenance", "INFERRED_FROM_TAURI_MAIN_FN",
+		)
+		add(ent)
+	}
+
+	// WindowBuilder / WebviewWindowBuilder → renderer window (renderer side)
+	for _, m := range reTauriWindowBuilder.FindAllStringIndex(src, -1) {
+		ent := makeEntity("tauri:WindowBuilder", "SCOPE.Component", "renderer_window",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tauri",
+			"provenance", "INFERRED_FROM_TAURI_WINDOW_BUILDER",
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 4. native_module_imports — tauri::api::* usage
+	// -----------------------------------------------------------------------
+	seenAPI := make(map[string]bool)
+	for _, m := range reTauriApiUsage.FindAllStringSubmatchIndex(src, -1) {
+		apiModule := src[m[2]:m[3]]
+		if seenAPI[apiModule] {
+			continue
+		}
+		seenAPI[apiModule] = true
+		ent := makeEntity("tauri:api:"+apiModule, "SCOPE.Pattern", "native_module",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tauri",
+			"module_name", "tauri::api::"+apiModule,
+			"provenance", "INFERRED_FROM_TAURI_API_USAGE",
+		)
+		add(ent)
+	}
+
+	// native_module_imports — tauri_plugin_* crates
+	seenPlugin := make(map[string]bool)
+	for _, m := range reTauriPlugin.FindAllStringSubmatchIndex(src, -1) {
+		pluginName := src[m[2]:m[3]]
+		if seenPlugin[pluginName] {
+			continue
+		}
+		seenPlugin[pluginName] = true
+		ent := makeEntity("tauri:plugin:"+pluginName, "SCOPE.Pattern", "native_plugin",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tauri",
+			"plugin_name", "tauri_plugin_"+pluginName,
+			"provenance", "INFERRED_FROM_TAURI_PLUGIN",
+		)
+		add(ent)
+	}
+
+	// tauri::Manager / AppHandle → native bridge usage
+	for _, m := range reTauriManager.FindAllStringIndex(src, -1) {
+		ent := makeEntity("tauri:AppHandle", "SCOPE.Pattern", "native_module",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "tauri",
+			"provenance", "INFERRED_FROM_TAURI_MANAGER",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/rust/tauri_test.go
+++ b/internal/custom/rust/tauri_test.go
@@ -1,0 +1,157 @@
+package rust_test
+
+// tauri_test.go — tests for custom_rust_tauri extractor.
+// Proves ipc_extraction, main_renderer_split, and native_module_imports.
+
+import (
+	"testing"
+)
+
+func TestTauri_IPCCommand(t *testing.T) {
+	src := `
+use tauri::Manager;
+
+#[tauri::command]
+async fn greet(name: String) -> String {
+    format!("Hello, {}!", name)
+}
+
+#[tauri::command]
+fn get_version() -> &'static str {
+    "1.0.0"
+}
+`
+	ents := extract(t, "custom_rust_tauri", fi("commands.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Operation", "tauri:command:greet") {
+		t.Error("expected tauri:command:greet ipc_command")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "tauri:command:get_version") {
+		t.Error("expected tauri:command:get_version ipc_command")
+	}
+}
+
+func TestTauri_GenerateHandler(t *testing.T) {
+	src := `
+use tauri::Manager;
+
+fn main() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![greet, get_version, read_file])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+`
+	ents := extract(t, "custom_rust_tauri", fi("main.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "tauri:generate_handler") {
+		t.Error("expected tauri:generate_handler ipc_handler_registration")
+	}
+}
+
+func TestTauri_BuilderMainProcess(t *testing.T) {
+	src := `
+use tauri::Manager;
+
+fn main() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .unwrap();
+}
+`
+	ents := extract(t, "custom_rust_tauri", fi("main.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "tauri:Builder::default") {
+		t.Error("expected tauri:Builder::default main_process component")
+	}
+	if !containsEntitySubtype(ents, "SCOPE.Function", "main_entry_point") {
+		t.Error("expected main_entry_point function")
+	}
+}
+
+func TestTauri_NativeModuleImports(t *testing.T) {
+	src := `
+use tauri::Manager;
+
+fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    let path = tauri::api::path::app_data_dir(app.config()).unwrap();
+    let dir = tauri::api::dir::read_dir(&path, true).unwrap();
+    Ok(())
+}
+`
+	ents := extract(t, "custom_rust_tauri", fi("setup.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "tauri:api:path") {
+		t.Error("expected tauri:api:path native_module")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "tauri:api:dir") {
+		t.Error("expected tauri:api:dir native_module")
+	}
+}
+
+func TestTauri_NativePlugin(t *testing.T) {
+	src := `
+use tauri::Manager;
+use tauri_plugin_sql::{Migration, MigrationKind};
+use tauri_plugin_fs::FsExt;
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_sql::Builder::new().build())
+        .run(tauri::generate_context!())
+        .unwrap();
+}
+`
+	ents := extract(t, "custom_rust_tauri", fi("main.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "tauri:plugin:sql") {
+		t.Error("expected tauri:plugin:sql native_plugin")
+	}
+}
+
+func TestTauri_WindowBuilder(t *testing.T) {
+	src := `
+use tauri::Manager;
+
+fn create_window(app: &tauri::AppHandle) {
+    tauri::WindowBuilder::new(app, "main", tauri::WindowUrl::App("index.html".into()))
+        .title("My App")
+        .build()
+        .unwrap();
+}
+`
+	ents := extract(t, "custom_rust_tauri", fi("window.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Component", "tauri:WindowBuilder") {
+		t.Error("expected tauri:WindowBuilder renderer_window component")
+	}
+}
+
+func TestTauri_NoMatch(t *testing.T) {
+	src := `
+use std::collections::HashMap;
+
+fn main() {
+    let mut map = HashMap::new();
+    map.insert("key", "value");
+}
+`
+	ents := extract(t, "custom_rust_tauri", fi("main.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-tauri file, got %d", len(ents))
+	}
+}
+
+func TestTauri_FixtureFile(t *testing.T) {
+	src := readFixture(t, "testdata/tauri_app.rs")
+	ents := extract(t, "custom_rust_tauri", fi("tauri_app.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Operation", "tauri:command:greet") {
+		t.Error("expected tauri:command:greet from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "tauri:command:read_file") {
+		t.Error("expected tauri:command:read_file from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "tauri:generate_handler") {
+		t.Error("expected tauri:generate_handler from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "tauri:Builder::default") {
+		t.Error("expected tauri:Builder::default from fixture")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "tauri:api:path") {
+		t.Error("expected tauri:api:path from fixture")
+	}
+}

--- a/internal/custom/rust/testdata/rbatis_models.rs
+++ b/internal/custom/rust/testdata/rbatis_models.rs
@@ -1,0 +1,44 @@
+// rbatis models and query fixture
+
+use rbatis::rbatis::Rbatis;
+use serde::{Deserialize, Serialize};
+
+#[crud_table(table_name = "biz_activity")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BizActivity {
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub pc_link: Option<String>,
+    pub delete_flag: Option<i32>,
+}
+
+#[crud_table(table_name = "user_info")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserInfo {
+    pub id: Option<String>,
+    pub username: Option<String>,
+    pub email: Option<String>,
+}
+
+/// Query by py_sql
+#[py_sql("select * from biz_activity where delete_flag = 0 and name like #{name}")]
+async fn select_by_name(rb: &Rbatis, name: &str) -> Vec<BizActivity> {
+    impled!()
+}
+
+/// Query by html_sql
+#[html_sql]
+async fn select_by_condition(rb: &Rbatis, id: &str) -> BizActivity {
+    impled!()
+}
+
+/// Query by sql attribute (v4 style)
+#[sql("select * from user_info where id = #{id}")]
+async fn get_user_by_id(rb: &Rbatis, id: &str) -> UserInfo {
+    impled!()
+}
+
+pub async fn init() {
+    let rb = Rbatis::new();
+    rb.link("mysql://root:123456@localhost:3306/test").await.unwrap();
+}

--- a/internal/custom/rust/testdata/sqlx_models.rs
+++ b/internal/custom/rust/testdata/sqlx_models.rs
@@ -1,0 +1,34 @@
+// SQLx models and migration fixture
+
+use sqlx::FromRow;
+use sqlx::PgPool;
+
+#[derive(Debug, Clone, FromRow)]
+pub struct User {
+    pub id: i64,
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Debug, Clone, FromRow)]
+pub struct Post {
+    pub id: i64,
+    pub user_id: i64,
+    pub title: String,
+    pub body: String,
+}
+
+pub async fn get_user(pool: &PgPool, id: i64) -> sqlx::Result<User> {
+    sqlx::query_as!(User, "SELECT id, name, email FROM users WHERE id = $1", id)
+        .fetch_one(pool)
+        .await
+}
+
+pub async fn run_migrations(pool: &PgPool) -> sqlx::Result<()> {
+    sqlx::migrate!("./migrations").run(pool).await?;
+    Ok(())
+}
+
+pub async fn create_pool(url: &str) -> sqlx::Result<PgPool> {
+    PgPool::connect(url).await
+}

--- a/internal/custom/rust/testdata/tauri_app.rs
+++ b/internal/custom/rust/testdata/tauri_app.rs
@@ -1,0 +1,26 @@
+// Tauri application backend fixture
+
+use tauri::{Builder, Manager, AppHandle};
+use tauri::api::path;
+
+/// IPC command: greet user
+#[tauri::command]
+async fn greet(name: String) -> String {
+    format!("Hello, {}!", name)
+}
+
+/// IPC command: read a file
+#[tauri::command]
+fn read_file(path: String, app: AppHandle) -> Result<String, String> {
+    let base = tauri::api::path::app_data_dir(&app.config())
+        .ok_or("no app data dir")?;
+    Ok(format!("{:?}", base.join(path)))
+}
+
+/// Main entry point — Rust backend (main process)
+fn main() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![greet, read_file])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/internal/custom/rust/testdata/validation_dto.rs
+++ b/internal/custom/rust/testdata/validation_dto.rs
@@ -1,0 +1,40 @@
+// Validation and DTO extraction fixture
+
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+use actix_web::web;
+
+/// DTO with serde Deserialize only
+#[derive(Debug, Deserialize)]
+pub struct CreateUserRequest {
+    pub name: String,
+    pub email: String,
+}
+
+/// DTO with serde + Validate
+#[derive(Debug, Deserialize, Validate)]
+pub struct UpdateUserRequest {
+    #[validate(length(min = 1, max = 100))]
+    pub name: String,
+    #[validate(email)]
+    pub email: String,
+}
+
+/// Axum-style handler with Json extractor
+pub async fn create_user(
+    web::Json(payload): web::Json<CreateUserRequest>,
+) -> impl Responder {
+    let req = payload;
+    if req.validate().is_err() {
+        return HttpResponse::BadRequest().finish();
+    }
+    HttpResponse::Ok().finish()
+}
+
+/// warp body json
+pub fn routes() -> impl warp::Filter {
+    warp::path("users")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(create_user_handler)
+}


### PR DESCRIPTION
Part of #3267.

## Summary

- **45 missing rust cells → 0** across 10 HTTP frameworks and 4 ORM adapters
- All cells flipped to `partial` (honest grading: regex-proven fixtures, no full semantic analysis)
- `validate` exits 0, `fmt --check` ok, all tests green

## Cells flipped

### Framework routing/validation (10 frameworks: actix, axum, rocket, poem, warp, tide, gotham, hyper, salvo, tower)
| Cell | Status | Extractor |
|------|--------|-----------|
| `Routing/route_extraction` (×10) | missing → partial | existing extractors (actix_web.go, axum.go, rocket.go, minor_fw_routing.go) |
| `Routing/endpoint_synthesis` (tower) | missing → partial | minor_fw_routing.go ServiceBuilder patterns |
| `Validation/dto_extraction` (×10) | missing → partial | new `fw_validation.go` |
| `Validation/request_validation` (×10) | missing → partial | new `fw_validation.go` |

### Tauri
| Cell | Status |
|------|--------|
| `Process/ipc_extraction` | missing → partial |
| `Process/main_renderer_split` | missing → partial |
| `Native/native_module_imports` | missing → partial |

### ORM
| Record | Cell | Status |
|--------|------|--------|
| diesel | `Relationships/foreign_key_extraction` | missing → partial |
| diesel | `Relationships/lazy_loading_recognition` | missing → not_applicable (sync ORM) |
| diesel | `Migrations/migration_parsing` | missing → partial |
| seaorm | `Relationships/foreign_key_extraction` | missing → partial |
| seaorm | `Relationships/lazy_loading_recognition` | missing → partial |
| sqlx | `Models/schema_extraction` | missing → partial |
| sqlx | `Migrations/migration_parsing` | missing → partial |
| rbatis | `Models/model_extraction` | missing → partial |
| rbatis | `Models/schema_extraction` | missing → partial |
| rbatis | `Queries/query_attribution` | missing → partial |
| rbatis | `Migrations/migration_parsing` | missing → partial |

## New files
- `internal/custom/rust/fw_validation.go` — DTO + request validation extractors for all 10 HTTP frameworks
- `internal/custom/rust/fw_validation_test.go` — 9 tests proving dto + request_validation extraction
- `internal/custom/rust/tauri.go` — Tauri IPC, main/renderer split, native module imports
- `internal/custom/rust/tauri_test.go` — 7 tests for tauri extractor
- `internal/custom/rust/sqlx_rbatis.go` — SQLx FromRow + migrate! + rbatis crud_table + py_sql/html_sql
- `internal/custom/rust/sqlx_rbatis_test.go` — 14 tests for sqlx and rbatis
- 4 testdata fixtures: `tauri_app.rs`, `sqlx_models.rs`, `rbatis_models.rs`, `validation_dto.rs`
- Extended `diesel.go` — FK column + embed_migrations + run_pending_migrations + MigrationHarness
- Extended `seaorm.go` — belongs_to FK refs, impl Related<T>, find_related, LoaderTrait

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>