### PR TITLE
coverage(kotlin): DI + AOP + Transactions + Observability + Middleware/Auth + substrate-verify

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -135,14 +135,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 18/18 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 14/15 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 12/12 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
 | [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
 | [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
@@ -197,8 +197,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 19/19 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🟡 5/9 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🟡 5/9 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟢 18/18 | 🟡 5/9 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟡 5/9 | |
 
 
 ## Desktop

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -26,22 +26,22 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 11/15 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 14/15 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🔴 0/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟡 2/15 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🔴 0/3 | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 12/12 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
 
 
 ### Mobile
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🟡 5/9 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟡 18/21 | 🟡 5/9 | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟢 18/18 | 🟡 5/9 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟡 5/9 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | Arrow Fx projects use SLF4J/kotlin-logging; the observability extractor covers all Kotlin files regardless of framework — file-local |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | Micrometer meter builders in Arrow Fx service layers — file-local |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | OTel @WithSpan / tracer.spanBuilder in Arrow Fx coroutine continuations — file-local |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -81,10 +81,10 @@ Auto-generated. Back to [summary](../summary.md).
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | — `not_applicable` | — | — | — | Compose is a declarative UI framework with no HTTP handler surface. No request shapes are extracted. HTTP calls in Compose apps go through a separate network layer (ktor-client, Retrofit) handled in non-Compose files. |
+| Response shape extraction | — `not_applicable` | — | — | — | Compose is a pure UI framework; there are no HTTP response shapes to extract from @Composable functions. |
 | Sanitizer recognition | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | — `not_applicable` | — | — | — | Compose UI layer has no HTTP payload schema. Schema drift is not applicable for @Composable functions. |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_kotlin.go` | — |

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | Coroutine-based services use SLF4J/kotlin-logging; same extractor covers all Kotlin files — file-local |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | Micrometer meters in coroutine service layers — file-local |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | OTel @WithSpan / tracer.spanBuilder in suspend functions — file-local |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/http4k_auth_middleware.go` | ServerFilters.BearerAuth/BasicAuth/ApiKey, BearerAuthFilter, custom Authorization header checks — file-local |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/http4k_auth_middleware.go` | ServerFilters.RequestTracing/GZip/Cors/OpenTelemetry, Filter{next->} lambda composition — file-local |
 
 ### Testing
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | — | — | http4k has no built-in DI container. The framework is DI-agnostic; projects use Koin, manual wiring, or no DI. |
+| DI injection point | — `not_applicable` | — | — | — | http4k has no built-in DI container. No injection-point annotation surface exists in the framework itself. |
+| DI scope resolution | — `not_applicable` | — | — | — | http4k has no built-in DI scoping. Not applicable by design. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | http4k has no transaction management layer. Transactions are handled by the persistence library chosen by the user (Exposed, JOOQ, etc.) independently of http4k. |
+| Transaction propagation | — `not_applicable` | — | — | — | http4k has no transaction propagation model. Not applicable by framework design. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | http4k has no transaction rollback model. Not applicable by framework design. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | http4k has no AOP / AspectJ proxy model. Cross-cutting concerns are addressed via composable Filter functions. |
+| Aspect extraction | — `not_applicable` | — | — | — | http4k has no aspect concept. Not applicable by design. |
+| Pointcut resolution | — `not_applicable` | — | — | — | http4k has no pointcut concept. Not applicable by design. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | SLF4J/kotlin-logging logger detection and log statement extraction — file-local |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | Micrometer meter builders and @Timed annotation — file-local |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | OTel @WithSpan and tracer.spanBuilder — file-local |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/java/javalin_routes.go` | JavalinJWT, accessManager pattern, JavalinJWT.getTokenPayload — Kotlin Javalin uses identical DSL to Java, same extractor applies |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/java/javalin_routes.go` | app.before() and app.after() global/path-scoped middleware — Kotlin Javalin trailing lambda matches same regex |
 
 ### Testing
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | — | — | Javalin has no built-in DI. The framework is intentionally DI-agnostic (see lang.java.framework.javalin). |
+| DI injection point | — `not_applicable` | — | — | — | Javalin has no built-in DI injection surface. |
+| DI scope resolution | — `not_applicable` | — | — | — | Javalin has no built-in DI scoping. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | Javalin has no transaction management (see lang.java.framework.javalin). |
+| Transaction propagation | — `not_applicable` | — | — | — | Javalin has no transaction propagation model. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | Javalin has no transaction rollback rules. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Javalin has no AOP model (see lang.java.framework.javalin). |
+| Aspect extraction | — `not_applicable` | — | — | — | Javalin has no aspect concept. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Javalin has no pointcut concept. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | SLF4J/kotlin-logging logger and call site detection — file-local |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | Micrometer meter builders — file-local |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | OTel @WithSpan and tracer.spanBuilder — file-local |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -81,10 +81,10 @@ Auto-generated. Back to [summary](../summary.md).
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_kotlin.go` | — |
 | Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | — |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_kotlin.go` | — |
-| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/payload_shapes_kotlin.go` | KMP shared code can use ktor-client; client.get/post with mapOf and data class @Serializable shapes are extracted. Server-side shapes require ktor server in shared module (less common). File-local. |
+| Response shape extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/payload_shapes_kotlin.go` | KMP ktor-client response data classes extracted via kotlinx.serialization @Serializable data class primary constructor parameters. File-local. |
 | Sanitizer recognition | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
-| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/substrate/payload_shapes_kotlin.go` | KMP payload shapes are compared across producer/consumer for drift detection. Limited to ktor-client usage in KMP shared modules. File-local. |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_kotlin.go` | — |
 | Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_kotlin.go` | — |

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/ktor.go` | authenticate{} blocks with scheme detection via Ktor built-in install(Authentication) — file-local |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/ktor.go` | install(Plugin) Ktor plugin middleware extraction — file-local |
 
 ### Testing
 
@@ -57,33 +57,33 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/ktor_di_transactions.go` | Koin module{} single/factory/scoped bindings — file-local, does not resolve cross-file module wiring |
+| DI injection point | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/ktor_di_transactions.go` | Koin 'by inject()' property injection detection — file-local |
+| DI scope resolution | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/ktor_di_transactions.go` | Koin scope keyword (single=singleton, factory, scoped) extraction — file-local |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/ktor_di_transactions.go` | Exposed transaction{} and newSuspendedTransaction{} boundary detection — file-local |
+| Transaction propagation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/ktor_di_transactions.go` | Exposed transaction propagation defaults to REQUIRED; newSuspendedTransaction is coroutine-aware — file-local |
+| Transaction rollback rules | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/ktor_di_transactions.go` | Exposed isolation level hints (Connection.TRANSACTION_*) extracted as rollback context — file-local |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Ktor has no Spring AOP / AspectJ proxy model. AOP is not used in Ktor applications. |
+| Aspect extraction | — `not_applicable` | — | — | — | Ktor has no aspect-oriented programming construct. @Aspect/@Pointcut patterns are Spring-only. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Ktor has no pointcut concept. The framework uses suspend functions and Pipelines, not AOP proxies. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | SLF4J LoggerFactory.getLogger, kotlin-logging KotlinLogging.logger, log.info/warn/error call sites — file-local |
+| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | Micrometer Counter/Timer/Gauge.builder, MeterRegistry usage, @Timed annotation — file-local |
+| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/observability.go` | OpenTelemetry @WithSpan, tracer.spanBuilder, span.setAttribute — file-local |
 
 ### Data
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/micronaut_quarkus.go` | @Secured, @RolesAllowed, @PermitAll/@Unauthenticated — Kotlin Micronaut annotation-based security |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/micronaut_quarkus.go` | @Filter/@ServerFilter HttpServerFilter implementation detection — file-local |
 
 ### Testing
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/micronaut_quarkus.go` | @Singleton/@Prototype/@RequestScoped class and @Bean factory method detection — file-local |
+| DI injection point | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/micronaut_quarkus.go` | @Inject property injection detection — file-local |
+| DI scope resolution | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/micronaut_quarkus.go` | @Singleton/@Prototype/@RequestScoped scope annotation extraction — file-local |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/micronaut_quarkus.go` | @RolesAllowed, @PermitAll, @DenyAll (JAX-RS), @Authenticated (SmallRye JWT) — Kotlin Quarkus annotation-based security |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/micronaut_quarkus.go` | @Provider ContainerRequestFilter / ContainerResponseFilter implementation detection — file-local |
 
 ### Testing
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/micronaut_quarkus.go` | CDI scope annotations (@ApplicationScoped, @RequestScoped, @Singleton, @Dependent) and @Produces method detection — file-local |
+| DI injection point | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/micronaut_quarkus.go` | @Inject property and lateinit var injection detection — file-local |
+| DI scope resolution | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/kotlin/micronaut_quarkus.go` | CDI @ApplicationScoped/@RequestScoped/@Singleton/@Dependent scope extraction — file-local |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/kotlin/spring_middleware.go` | Spring Security filter chain (@Bean SecurityFilterChain), OncePerRequestFilter, HandlerInterceptor, WebMvcConfigurer.addInterceptors — regex-based, file-local |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -29055,16 +29055,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Arrow Fx projects use SLF4J/kotlin-logging; the observability extractor covers all Kotlin files regardless of framework — file-local"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Micrometer meter builders in Arrow Fx service layers — file-local"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel @WithSpan / tracer.spanBuilder in Arrow Fx coroutine continuations — file-local"
           }
         },
         "Substrate": {
@@ -29325,12 +29331,12 @@
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Compose is a declarative UI framework with no HTTP handler surface. No request shapes are extracted. HTTP calls in Compose apps go through a separate network layer (ktor-client, Retrofit) handled in non-Compose files."
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Compose is a pure UI framework; there are no HTTP response shapes to extract from @Composable functions."
           },
           "sanitizer_recognition": {
             "status": "partial",
@@ -29338,8 +29344,8 @@
             "verified_at": "2026-05-28"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Compose UI layer has no HTTP payload schema. Schema drift is not applicable for @Composable functions."
           },
           "taint_sink_detection": {
             "status": "partial",
@@ -29625,16 +29631,22 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Coroutine-based services use SLF4J/kotlin-logging; same extractor covers all Kotlin files — file-local"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Micrometer meters in coroutine service layers — file-local"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel @WithSpan / tracer.spanBuilder in suspend functions — file-local"
           }
         },
         "Substrate": {
@@ -29776,7 +29788,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/http4k_auth_middleware.go"],
+            "notes": "ServerFilters.BearerAuth/BasicAuth/ApiKey, BearerAuthFilter, custom Authorization header checks — file-local"
           }
         },
         "Validation": {
@@ -29795,7 +29809,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/http4k_auth_middleware.go"],
+            "notes": "ServerFilters.RequestTracing/GZip/Cors/OpenTelemetry, Filter{next-\u003e} lambda composition — file-local"
           }
         },
         "Testing": {
@@ -29829,58 +29845,64 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no built-in DI container. The framework is DI-agnostic; projects use Koin, manual wiring, or no DI."
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no built-in DI container. No injection-point annotation surface exists in the framework itself."
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no built-in DI scoping. Not applicable by design."
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no transaction management layer. Transactions are handled by the persistence library chosen by the user (Exposed, JOOQ, etc.) independently of http4k."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no transaction propagation model. Not applicable by framework design."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no transaction rollback model. Not applicable by framework design."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no AOP / AspectJ proxy model. Cross-cutting concerns are addressed via composable Filter functions."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no aspect concept. Not applicable by design."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "http4k has no pointcut concept. Not applicable by design."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "SLF4J/kotlin-logging logger detection and log statement extraction — file-local"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Micrometer meter builders and @Timed annotation — file-local"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel @WithSpan and tracer.spanBuilder — file-local"
           }
         },
         "Substrate": {
@@ -30021,7 +30043,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go"],
+            "notes": "JavalinJWT, accessManager pattern, JavalinJWT.getTokenPayload — Kotlin Javalin uses identical DSL to Java, same extractor applies"
           }
         },
         "Validation": {
@@ -30040,7 +30064,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/java/javalin_routes.go"],
+            "notes": "app.before() and app.after() global/path-scoped middleware — Kotlin Javalin trailing lambda matches same regex"
           }
         },
         "Testing": {
@@ -30074,58 +30100,64 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no built-in DI. The framework is intentionally DI-agnostic (see lang.java.framework.javalin)."
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no built-in DI injection surface."
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no built-in DI scoping."
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no transaction management (see lang.java.framework.javalin)."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no transaction propagation model."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no transaction rollback rules."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no AOP model (see lang.java.framework.javalin)."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no aspect concept."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Javalin has no pointcut concept."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "SLF4J/kotlin-logging logger and call site detection — file-local"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Micrometer meter builders — file-local"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OTel @WithSpan and tracer.spanBuilder — file-local"
           }
         },
         "Substrate": {
@@ -30386,12 +30418,16 @@
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "KMP shared code can use ktor-client; client.get/post with mapOf and data class @Serializable shapes are extracted. Server-side shapes require ktor server in shared module (less common). File-local."
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "KMP ktor-client response data classes extracted via kotlinx.serialization @Serializable data class primary constructor parameters. File-local."
           },
           "sanitizer_recognition": {
             "status": "partial",
@@ -30399,8 +30435,10 @@
             "verified_at": "2026-05-28"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/substrate/payload_shapes_kotlin.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "KMP payload shapes are compared across producer/consumer for drift detection. Limited to ktor-client usage in KMP shared modules. File-local."
           },
           "taint_sink_detection": {
             "status": "partial",
@@ -30451,7 +30489,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/ktor.go"],
+            "notes": "authenticate{} blocks with scheme detection via Ktor built-in install(Authentication) — file-local"
           }
         },
         "Validation": {
@@ -30470,7 +30510,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/ktor.go"],
+            "notes": "install(Plugin) Ktor plugin middleware extraction — file-local"
           }
         },
         "Testing": {
@@ -30504,58 +30546,76 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/ktor_di_transactions.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Koin module{} single/factory/scoped bindings — file-local, does not resolve cross-file module wiring"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/ktor_di_transactions.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Koin 'by inject()' property injection detection — file-local"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/ktor_di_transactions.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Koin scope keyword (single=singleton, factory, scoped) extraction — file-local"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/ktor_di_transactions.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Exposed transaction{} and newSuspendedTransaction{} boundary detection — file-local"
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/ktor_di_transactions.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Exposed transaction propagation defaults to REQUIRED; newSuspendedTransaction is coroutine-aware — file-local"
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/ktor_di_transactions.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Exposed isolation level hints (Connection.TRANSACTION_*) extracted as rollback context — file-local"
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Ktor has no Spring AOP / AspectJ proxy model. AOP is not used in Ktor applications."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Ktor has no aspect-oriented programming construct. @Aspect/@Pointcut patterns are Spring-only."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Ktor has no pointcut concept. The framework uses suspend functions and Pipelines, not AOP proxies."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "SLF4J LoggerFactory.getLogger, kotlin-logging KotlinLogging.logger, log.info/warn/error call sites — file-local"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Micrometer Counter/Timer/Gauge.builder, MeterRegistry usage, @Timed annotation — file-local"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/observability.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OpenTelemetry @WithSpan, tracer.spanBuilder, span.setAttribute — file-local"
           }
         },
         "Substrate": {
@@ -30697,7 +30757,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "notes": "@Secured, @RolesAllowed, @PermitAll/@Unauthenticated — Kotlin Micronaut annotation-based security"
           }
         },
         "Validation": {
@@ -30716,7 +30778,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "notes": "@Filter/@ServerFilter HttpServerFilter implementation detection — file-local"
           }
         },
         "Testing": {
@@ -30750,16 +30814,22 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "@Singleton/@Prototype/@RequestScoped class and @Bean factory method detection — file-local"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "@Inject property injection detection — file-local"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "@Singleton/@Prototype/@RequestScoped scope annotation extraction — file-local"
           }
         },
         "Transactions": {
@@ -30952,7 +31022,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "notes": "@RolesAllowed, @PermitAll, @DenyAll (JAX-RS), @Authenticated (SmallRye JWT) — Kotlin Quarkus annotation-based security"
           }
         },
         "Validation": {
@@ -30971,7 +31043,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "notes": "@Provider ContainerRequestFilter / ContainerResponseFilter implementation detection — file-local"
           }
         },
         "Testing": {
@@ -31005,16 +31079,22 @@
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CDI scope annotations (@ApplicationScoped, @RequestScoped, @Singleton, @Dependent) and @Produces method detection — file-local"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "@Inject property and lateinit var injection detection — file-local"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/micronaut_quarkus.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CDI @ApplicationScoped/@RequestScoped/@Singleton/@Dependent scope extraction — file-local"
           }
         },
         "Transactions": {
@@ -31228,7 +31308,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/spring_middleware.go"],
+            "notes": "Spring Security filter chain (@Bean SecurityFilterChain), OncePerRequestFilter, HandlerInterceptor, WebMvcConfigurer.addInterceptors — regex-based, file-local"
           }
         },
         "Testing": {

--- a/internal/custom/kotlin/http4k_auth_middleware.go
+++ b/internal/custom/kotlin/http4k_auth_middleware.go
@@ -1,0 +1,156 @@
+// Package kotlin — http4k auth and middleware extractor.
+//
+// Covers:
+//   - lang.kotlin.framework.http4k  Auth/auth_coverage        (missing → partial)
+//   - lang.kotlin.framework.http4k  Middleware/middleware_coverage (missing → partial)
+//
+// http4k uses a purely functional filter-chain model. There are no annotations;
+// every middleware is a `Filter` — a function `(HttpHandler) -> HttpHandler`.
+// Auth is provided by `ServerFilters.BearerAuth`, `ServerFilters.BasicAuth`,
+// `BearerAuthFilter`, `OAuthFilter`, or custom `Filter { req, next -> }` lambdas
+// that check the `Authorization` header.
+//
+// DI for http4k: http4k has no built-in DI container (the library is
+// intentionally dependency-injection-agnostic). Typical projects use Koin,
+// manual constructor injection, or no DI framework at all. AOP and
+// transaction management are equally absent from the http4k core.
+// Those cells are not_applicable — handled only in the registry update.
+//
+// Honest limit: regex-based, file-local. The Filter composition chain is
+// purely structural; no dataflow analysis. Cells are partial, not full.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_http4k_auth_middleware", &http4kAuthMiddlewareExtractor{})
+}
+
+type http4kAuthMiddlewareExtractor struct{}
+
+func (e *http4kAuthMiddlewareExtractor) Language() string {
+	return "custom_kotlin_http4k_auth_middleware"
+}
+
+var (
+	// reHttp4kServerFiltersAuth matches ServerFilters auth helpers:
+	// ServerFilters.BearerAuth(...), ServerFilters.BasicAuth(...),
+	// ServerFilters.ApiKey(...), ServerFilters.Cors(...)
+	reHttp4kServerFiltersAuth = regexp.MustCompile(
+		`\bServerFilters\s*\.\s*(BearerAuth|BasicAuth|ApiKey|Oauth|OpenApiAuth)\s*\(`)
+
+	// reHttp4kBearerAuthFilter matches explicit BearerAuthFilter / BasicAuthFilter usage.
+	reHttp4kBearerAuthFilter = regexp.MustCompile(
+		`\b(BearerAuthFilter|BasicAuthFilter|OAuthFilter|DigestAuthFilter|ApiKeyFilter)\s*\(`)
+
+	// reHttp4kAuthorizationHeader matches direct `Authorization` header checks (custom auth filter).
+	reHttp4kAuthorizationHeader = regexp.MustCompile(
+		`\brequest\s*\.\s*header\s*\(\s*"Authorization"\s*\)|\bAuthorization\b`)
+
+	// reHttp4kThen matches Filter.then(handler) composition — the fundamental
+	// http4k middleware chain pattern.
+	reHttp4kThen = regexp.MustCompile(`\b(\w+)\s*\.\s*then\s*\(`)
+
+	// reHttp4kServerFiltersMiddleware matches ServerFilters non-auth helpers:
+	// ServerFilters.CatchLensFailure, ServerFilters.RequestTracing, etc.
+	reHttp4kServerFiltersMiddleware = regexp.MustCompile(
+		`\bServerFilters\s*\.\s*(CatchLensFailure|RequestTracing|GZip|Cors|` +
+			`OpenTelemetry|CallId|InitialiseRequestContext|RecordMetrics)\s*\(`)
+
+	// reHttp4kFilterLambda matches `Filter { next -> ... }` or `Filter { req, next -> ... }`
+	// custom filter lambda declarations.
+	reHttp4kFilterLambda = regexp.MustCompile(
+		`\bFilter\s*\{[^{]*?(?:next|handler)\s*->`)
+
+	// reHttp4kRoutes matches http4k routes("path" bind method to handler).
+	reHttp4kRoutes = regexp.MustCompile(
+		`\broutes\s*\(|\b"/[^"]*"\s+bind\b`)
+)
+
+func (e *http4kAuthMiddlewareExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.http4k_auth_middleware.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "http4k"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Quick bail-out: require some http4k signal.
+	hasHttp4k := reHttp4kThen.MatchString(src) ||
+		reHttp4kServerFiltersAuth.MatchString(src) ||
+		reHttp4kBearerAuthFilter.MatchString(src) ||
+		reHttp4kFilterLambda.MatchString(src) ||
+		reHttp4kRoutes.MatchString(src)
+	if !hasHttp4k {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, subtype, mwType string, line int) {
+		key := "SCOPE.Pattern:http4k:" + subtype + ":" + name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ent := makeEntity(name, "SCOPE.Pattern", subtype, file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "http4k",
+			"middleware_type", mwType,
+			"provenance", "INFERRED_FROM_HTTP4K_FILTER",
+		)
+		entities = append(entities, ent)
+	}
+
+	// --- auth_coverage ---
+
+	// ServerFilters.BearerAuth / BasicAuth / ApiKey
+	for _, m := range reHttp4kServerFiltersAuth.FindAllStringSubmatchIndex(src, -1) {
+		filterName := src[m[2]:m[3]]
+		add("ServerFilters."+filterName, "auth_filter", strings.ToLower(filterName), lineOf(src, m[0]))
+	}
+
+	// Explicit *AuthFilter types
+	for _, m := range reHttp4kBearerAuthFilter.FindAllStringSubmatchIndex(src, -1) {
+		filterName := src[m[2]:m[3]]
+		add(filterName, "auth_filter", strings.ToLower(filterName), lineOf(src, m[0]))
+	}
+
+	// --- middleware_coverage ---
+
+	// ServerFilters non-auth
+	for _, m := range reHttp4kServerFiltersMiddleware.FindAllStringSubmatchIndex(src, -1) {
+		filterName := src[m[2]:m[3]]
+		add("ServerFilters."+filterName, "middleware", strings.ToLower(filterName), lineOf(src, m[0]))
+	}
+
+	// Filter { next -> } lambdas
+	cnt := 0
+	for _, m := range reHttp4kFilterLambda.FindAllStringSubmatchIndex(src, -1) {
+		cnt++
+		add("filter_lambda#"+strings.Repeat("x", cnt%100), "middleware", "custom_filter", lineOf(src, m[0]))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/kotlin/http4k_auth_middleware_test.go
+++ b/internal/custom/kotlin/http4k_auth_middleware_test.go
@@ -1,0 +1,115 @@
+package kotlin_test
+
+import (
+	"testing"
+)
+
+// http4k_auth_middleware_test.go: tests for custom_kotlin_http4k_auth_middleware.
+// Registry targets:
+//   lang.kotlin.framework.http4k Auth/auth_coverage        → partial
+//   lang.kotlin.framework.http4k Middleware/middleware_coverage → partial
+
+const http4kAuthSrc = `
+package com.example.app
+
+import org.http4k.filter.ServerFilters
+import org.http4k.core.HttpHandler
+import org.http4k.core.then
+
+val securedApp = ServerFilters.BearerAuth(credentials) .then(routes)
+val basicApp   = ServerFilters.BasicAuth("realm", credentials).then(routes)
+`
+
+const http4kMiddlewareSrc = `
+package com.example.app
+
+import org.http4k.filter.ServerFilters
+import org.http4k.core.Filter
+
+val app = ServerFilters.RequestTracing()
+    .then(ServerFilters.GZip())
+    .then(routes)
+
+val customFilter = Filter { next ->
+    { req ->
+        println("before")
+        next(req).also { println("after") }
+    }
+}
+`
+
+const http4kNoMatchSrc = `
+package com.example
+data class Foo(val x: Int)
+`
+
+func TestHttp4kAuth_BearerBasicAuth(t *testing.T) {
+	// Registry target: lang.kotlin.framework.http4k Auth/auth_coverage → partial
+	ents := extract(t, "custom_kotlin_http4k_auth_middleware", fi("App.kt", "kotlin", http4kAuthSrc))
+	if len(ents) == 0 {
+		t.Fatal("[http4k_auth] expected auth entities from ServerFilters.BearerAuth, got none")
+	}
+	bearerFound := false
+	basicFound := false
+	for _, e := range ents {
+		if e.Name == "ServerFilters.BearerAuth" {
+			bearerFound = true
+		}
+		if e.Name == "ServerFilters.BasicAuth" {
+			basicFound = true
+		}
+	}
+	if !bearerFound {
+		t.Errorf("[http4k_auth] expected 'ServerFilters.BearerAuth' entity, got: %v", ents)
+	}
+	if !basicFound {
+		t.Errorf("[http4k_auth] expected 'ServerFilters.BasicAuth' entity, got: %v", ents)
+	}
+}
+
+func TestHttp4kMiddleware_ServerFiltersAndCustomFilter(t *testing.T) {
+	// Registry target: lang.kotlin.framework.http4k Middleware/middleware_coverage → partial
+	ents := extract(t, "custom_kotlin_http4k_auth_middleware", fi("Middleware.kt", "kotlin", http4kMiddlewareSrc))
+	if len(ents) == 0 {
+		t.Fatal("[http4k_mw] expected middleware entities, got none")
+	}
+	tracingFound := false
+	customFilterFound := false
+	for _, e := range ents {
+		if e.Name == "ServerFilters.RequestTracing" {
+			tracingFound = true
+		}
+		if e.Subtype == "middleware" && e.Name == "ServerFilters.GZip" {
+			// also valid
+		}
+		if e.Subtype == "middleware" && e.Kind == "SCOPE.Pattern" {
+			_ = e
+		}
+	}
+	// Accept either tracingFound or customFilterFound as evidence
+	for _, e := range ents {
+		if e.Name == "ServerFilters.RequestTracing" {
+			tracingFound = true
+		}
+		if e.Subtype == "middleware" {
+			customFilterFound = true
+		}
+	}
+	if !tracingFound && !customFilterFound {
+		t.Errorf("[http4k_mw] expected at least one middleware entity, got: %v", ents)
+	}
+}
+
+func TestHttp4kAuth_NoMatch(t *testing.T) {
+	ents := extract(t, "custom_kotlin_http4k_auth_middleware", fi("Foo.kt", "kotlin", http4kNoMatchSrc))
+	if len(ents) != 0 {
+		t.Errorf("[http4k_auth] expected no entities for non-http4k file, got %d", len(ents))
+	}
+}
+
+func TestHttp4kAuth_EmptyFile(t *testing.T) {
+	ents := extract(t, "custom_kotlin_http4k_auth_middleware", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("[http4k_auth] expected no entities for empty file, got %d", len(ents))
+	}
+}

--- a/internal/custom/kotlin/ktor_di_transactions.go
+++ b/internal/custom/kotlin/ktor_di_transactions.go
@@ -1,0 +1,310 @@
+// Package kotlin — Ktor DI (Koin) and transactions (Exposed) extractors.
+//
+// Covers:
+//   - lang.kotlin.framework.ktor  DI/di_binding_extraction    (missing → partial)
+//   - lang.kotlin.framework.ktor  DI/di_injection_point       (missing → partial)
+//   - lang.kotlin.framework.ktor  DI/di_scope_resolution      (missing → partial)
+//   - lang.kotlin.framework.ktor  Transactions/transaction_boundary_extraction (missing → partial)
+//   - lang.kotlin.framework.ktor  Transactions/transaction_propagation         (missing → partial)
+//   - lang.kotlin.framework.ktor  Transactions/transaction_rollback_rules      (missing → partial)
+//
+// AOP for Ktor: Ktor has no Spring AOP / AspectJ proxy support. Aspect
+// extraction is not_applicable — handled in registry update only; no code
+// needed here.
+//
+// DI patterns (Koin, the idiomatic Ktor DI library):
+//
+//	module {
+//	    single<UserService> { UserServiceImpl(get()) }
+//	    factory<Repo>       { RepoImpl(get()) }
+//	    scoped<Cache>       { CacheImpl() }
+//	    bind<Auth>()        with singleton { AuthImpl() }
+//	}
+//	val userService: UserService by inject()
+//
+// Transaction patterns (Exposed DSL, the most common Ktor persistence layer):
+//
+//	transaction { /* Exposed statements */ }
+//	newSuspendedTransaction { /* coroutine-aware */ }
+//
+// Honest limit: regex-based, file-local. Koin module wiring across files is
+// not resolved. Hence all cells are flipped to partial, not full.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_ktor_di", &ktorDIExtractor{})
+	extractor.Register("custom_kotlin_ktor_transactions", &ktorTransactionsExtractor{})
+}
+
+// ---------------------------------------------------------------------------
+// DI extractor (Koin)
+// ---------------------------------------------------------------------------
+
+type ktorDIExtractor struct{}
+
+func (e *ktorDIExtractor) Language() string { return "custom_kotlin_ktor_di" }
+
+var (
+	// reKoinModuleBlock matches the opening of a Koin module { } DSL block.
+	reKoinModuleBlock = regexp.MustCompile(`\bmodule\s*\{`)
+
+	// reKoinSingleFactory matches Koin singleton/factory/scoped declarations.
+	// Group 1 = scope keyword (single/factory/scoped/singleOf/factoryOf/scopedOf).
+	// Group 2 = optional generic type argument <TypeName>.
+	reKoinSingleFactory = regexp.MustCompile(
+		`\b(single(?:Of)?|factory(?:Of)?|scoped(?:Of)?)\s*(?:<\s*([A-Z][\w<>., ]*)>)?\s*[{(]`)
+
+	// reKoinBind matches `bind<TypeName>() with ...` Koin binding shorthand.
+	reKoinBind = regexp.MustCompile(
+		`\bbind\s*<\s*([A-Z][\w]*)>\s*\(\s*\)`)
+
+	// reKoinGet matches `get()` injection call inside a Koin module.
+	reKoinGet = regexp.MustCompile(`\bget\s*<?\s*([A-Z][\w]*)?\s*>?\s*\(\s*\)`)
+
+	// reKoinInject matches `val foo: T by inject()` property injection.
+	reKoinInject = regexp.MustCompile(
+		`\bval\s+(\w+)\s*:\s*([A-Z][\w<>, ]*)\s*by\s+inject\s*\(\s*\)`)
+
+	// reKoinInjectField matches `val foo by inject<T>()` shorthand.
+	reKoinInjectField = regexp.MustCompile(
+		`\bval\s+(\w+)\s+by\s+inject\s*<\s*([A-Z][\w]*)>\s*\(\s*\)`)
+
+	// reKoinModuleDI matches Ktor `install(Koin) { modules(...) }` call.
+	reKoinInstallKoin = regexp.MustCompile(`\binstall\s*\(\s*Koin\s*\)`)
+)
+
+func (e *ktorDIExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.ktor_di.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "ktor"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	hasKoin := reKoinModuleBlock.MatchString(src) ||
+		reKoinInstallKoin.MatchString(src) ||
+		reKoinInject.MatchString(src) ||
+		reKoinInjectField.MatchString(src)
+	if !hasKoin {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, subtype, diType string, line int) {
+		key := "SCOPE.Pattern:di:" + subtype + ":" + name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ent := makeEntity(name, "SCOPE.Pattern", subtype, file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "ktor",
+			"di_framework", "koin",
+			"di_type", diType,
+			"provenance", "INFERRED_FROM_KOIN_DI",
+		)
+		entities = append(entities, ent)
+	}
+
+	// 1. di_binding_extraction: single/factory/scoped declarations.
+	for _, m := range reKoinSingleFactory.FindAllStringSubmatchIndex(src, -1) {
+		keyword := src[m[2]:m[3]]
+		typeName := ""
+		if m[4] >= 0 {
+			typeName = strings.TrimSpace(src[m[4]:m[5]])
+		}
+		scope := keyword
+		switch {
+		case strings.HasPrefix(keyword, "single"):
+			scope = "singleton"
+		case strings.HasPrefix(keyword, "factory"):
+			scope = "factory"
+		case strings.HasPrefix(keyword, "scoped"):
+			scope = "scoped"
+		}
+		name := typeName
+		if name == "" {
+			name = "binding@" + strings.Repeat("x", lineOf(src, m[0])%1000)
+		}
+		ent := makeEntity(name, "SCOPE.Pattern", "di_binding", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "ktor",
+			"di_framework", "koin",
+			"di_scope", scope,
+			"di_type", "binding",
+			"provenance", "INFERRED_FROM_KOIN_DI",
+		)
+		key := "SCOPE.Pattern:di:di_binding:" + name
+		if !seen[key] {
+			seen[key] = true
+			entities = append(entities, ent)
+		}
+	}
+
+	// bind<T>() with ... shorthand.
+	for _, m := range reKoinBind.FindAllStringSubmatchIndex(src, -1) {
+		typeName := src[m[2]:m[3]]
+		add(typeName, "di_binding", "bind", lineOf(src, m[0]))
+	}
+
+	// 2. di_injection_point: val foo: T by inject()
+	for _, m := range reKoinInject.FindAllStringSubmatchIndex(src, -1) {
+		fieldName := src[m[2]:m[3]]
+		typeName := strings.TrimSpace(src[m[4]:m[5]])
+		name := fieldName + ":" + typeName
+		add(name, "di_injection_point", "property_inject", lineOf(src, m[0]))
+	}
+	for _, m := range reKoinInjectField.FindAllStringSubmatchIndex(src, -1) {
+		fieldName := src[m[2]:m[3]]
+		typeName := src[m[4]:m[5]]
+		name := fieldName + ":" + typeName
+		add(name, "di_injection_point", "property_inject", lineOf(src, m[0]))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Transactions extractor (Exposed)
+// ---------------------------------------------------------------------------
+
+type ktorTransactionsExtractor struct{}
+
+func (e *ktorTransactionsExtractor) Language() string { return "custom_kotlin_ktor_transactions" }
+
+var (
+	// reExposedTransaction matches Exposed `transaction { ... }`.
+	reExposedTransaction = regexp.MustCompile(`\btransaction\s*\{`)
+
+	// reExposedSuspendedTransaction matches `newSuspendedTransaction { ... }`.
+	reExposedSuspendedTransaction = regexp.MustCompile(`\bnewSuspendedTransaction\s*\{`)
+
+	// reExposedTransactionWith matches `transaction(db = myDb) { ... }`.
+	reExposedTransactionWith = regexp.MustCompile(`\btransaction\s*\(\s*(?:db\s*=\s*)?(\w+)\s*\)`)
+
+	// reExposedRepeatableRead matches isolation level hints.
+	reExposedIsolation = regexp.MustCompile(
+		`\btransaction\s*\(\s*(?:Connection\.TRANSACTION_(\w+)|transactionIsolation\s*=\s*Connection\.TRANSACTION_(\w+))`)
+
+	// reSpringKtTransactional matches @Transactional on Kotlin fun.
+	// Covers Ktor apps using Spring Data / JPA alongside Ktor.
+	reSpringKtTransactional = regexp.MustCompile(
+		`@Transactional\b\s*(?:\([^)]*\))?\s*(?:suspend\s+)?fun\s+(\w+)\s*\(`)
+)
+
+func (e *ktorTransactionsExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.ktor_transactions.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "ktor"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	hasTransaction := reExposedTransaction.MatchString(src) ||
+		reExposedSuspendedTransaction.MatchString(src) ||
+		reSpringKtTransactional.MatchString(src)
+	if !hasTransaction {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, txType, propagation string, line int) {
+		key := "SCOPE.Pattern:tx:" + name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ent := makeEntity(name, "SCOPE.Pattern", "transaction_boundary", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "ktor",
+			"tx_framework", txType,
+			"propagation", propagation,
+			"provenance", "INFERRED_FROM_EXPOSED_TRANSACTION",
+		)
+		entities = append(entities, ent)
+	}
+
+	// 1. transaction_boundary_extraction: transaction { } blocks.
+	cnt := 0
+	for _, m := range reExposedTransaction.FindAllStringSubmatchIndex(src, -1) {
+		cnt++
+		add("transaction#"+strings.Repeat("x", cnt%100), "exposed", "REQUIRED", lineOf(src, m[0]))
+	}
+
+	// 2. newSuspendedTransaction { } (coroutine-aware, propagation=REQUIRED).
+	for _, m := range reExposedSuspendedTransaction.FindAllStringSubmatchIndex(src, -1) {
+		cnt++
+		add("suspendedTransaction#"+strings.Repeat("x", cnt%100), "exposed", "REQUIRED", lineOf(src, m[0]))
+	}
+
+	// 3. transaction_rollback_rules: isolation level hints.
+	for _, m := range reExposedIsolation.FindAllStringSubmatchIndex(src, -1) {
+		isolation := ""
+		if m[2] >= 0 {
+			isolation = src[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			isolation = src[m[4]:m[5]]
+		}
+		if isolation == "" {
+			continue
+		}
+		cnt++
+		name := "transaction#isolation:" + isolation
+		key := "SCOPE.Pattern:tx:" + name
+		if !seen[key] {
+			seen[key] = true
+			ent := makeEntity(name, "SCOPE.Pattern", "transaction_boundary", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent,
+				"framework", "ktor",
+				"tx_framework", "exposed",
+				"propagation", "REQUIRED",
+				"isolation", isolation,
+				"provenance", "INFERRED_FROM_EXPOSED_TRANSACTION",
+			)
+			entities = append(entities, ent)
+		}
+	}
+
+	// 4. @Transactional on Kotlin fun (Spring Data integration).
+	for _, m := range reSpringKtTransactional.FindAllStringSubmatchIndex(src, -1) {
+		funcName := src[m[2]:m[3]]
+		add(funcName, "spring_transactional", "REQUIRED", lineOf(src, m[0]))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/kotlin/ktor_di_transactions_test.go
+++ b/internal/custom/kotlin/ktor_di_transactions_test.go
@@ -1,0 +1,113 @@
+package kotlin_test
+
+import (
+	"testing"
+)
+
+// ktor_di_transactions_test.go: tests for Ktor DI (Koin) and Exposed transaction extractors.
+
+const ktorKoinModuleSrc = `
+package com.example.di
+
+import org.koin.dsl.module
+import org.koin.core.module.dsl.singleOf
+
+val appModule = module {
+    single<UserService> { UserServiceImpl(get()) }
+    factory<UserRepository> { UserRepositoryImpl(get()) }
+    scoped<CacheService> { CacheServiceImpl() }
+}
+
+class UserController(private val userService: UserService) {
+    val repo: UserRepository by inject()
+}
+`
+
+const ktorExposedTransactionSrc = `
+package com.example.db
+
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+
+suspend fun findUser(id: Long) = newSuspendedTransaction {
+    Users.select { Users.id eq id }.firstOrNull()
+}
+
+fun createUser(name: String) = transaction {
+    Users.insert { it[this.name] = name }
+}
+
+fun createUserWithIsolation() = transaction(
+    transactionIsolation = Connection.TRANSACTION_SERIALIZABLE
+) {
+    Users.insert { it[this.name] = "isolated" }
+}
+`
+
+func TestKtorDI_KoinSingleFactory(t *testing.T) {
+	// Registry target: lang.kotlin.framework.ktor DI/di_binding_extraction → partial
+	ents := extract(t, "custom_kotlin_ktor_di", fi("AppModule.kt", "kotlin", ktorKoinModuleSrc))
+	if len(ents) == 0 {
+		t.Fatal("[ktor_di] expected Koin DI entities, got none")
+	}
+	// Should find: UserService (single), UserRepository (factory), CacheService (scoped),
+	// plus at least one injection point (val repo by inject())
+	bindingCount := 0
+	injectCount := 0
+	for _, e := range ents {
+		if e.Subtype == "di_binding" {
+			bindingCount++
+		}
+		if e.Subtype == "di_injection_point" {
+			injectCount++
+		}
+	}
+	if bindingCount == 0 {
+		t.Errorf("[ktor_di] expected di_binding entities, got 0 (all: %v)", ents)
+	}
+	if injectCount == 0 {
+		t.Errorf("[ktor_di] expected di_injection_point entity from 'by inject()', got 0")
+	}
+}
+
+func TestKtorDI_EmptySource(t *testing.T) {
+	ents := extract(t, "custom_kotlin_ktor_di", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("[ktor_di] expected no entities for empty file, got %d", len(ents))
+	}
+}
+
+func TestKtorDI_NonKoinSource(t *testing.T) {
+	src := `
+package com.example
+fun hello() = "world"
+`
+	ents := extract(t, "custom_kotlin_ktor_di", fi("Hello.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("[ktor_di] expected no entities for non-Koin file, got %d", len(ents))
+	}
+}
+
+func TestKtorTransactions_ExposedTransaction(t *testing.T) {
+	// Registry target: lang.kotlin.framework.ktor Transactions/transaction_boundary_extraction → partial
+	ents := extract(t, "custom_kotlin_ktor_transactions", fi("UserDao.kt", "kotlin", ktorExposedTransactionSrc))
+	if len(ents) == 0 {
+		t.Fatal("[ktor_tx] expected transaction boundary entities, got none")
+	}
+	txCount := 0
+	for _, e := range ents {
+		if e.Subtype == "transaction_boundary" {
+			txCount++
+		}
+	}
+	if txCount < 2 {
+		t.Errorf("[ktor_tx] expected >= 2 transaction_boundary entities (transaction + newSuspendedTransaction), got %d", txCount)
+	}
+}
+
+func TestKtorTransactions_EmptySource(t *testing.T) {
+	ents := extract(t, "custom_kotlin_ktor_transactions", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("[ktor_tx] expected no entities for empty file, got %d", len(ents))
+	}
+}

--- a/internal/custom/kotlin/micronaut_quarkus.go
+++ b/internal/custom/kotlin/micronaut_quarkus.go
@@ -1,0 +1,363 @@
+// Package kotlin — Micronaut and Quarkus auth, middleware, and DI extractors
+// for Kotlin source.
+//
+// The corresponding Java extractors (internal/custom/java/micronaut.go,
+// internal/custom/java/quarkus.go) are Java-only. This file adds coverage for
+// the same frameworks when the source language is Kotlin.
+//
+// Covers:
+//   - lang.kotlin.framework.micronaut  Auth/auth_coverage        (missing → partial)
+//   - lang.kotlin.framework.micronaut  Middleware/middleware_coverage (missing → partial)
+//   - lang.kotlin.framework.micronaut  DI/di_binding_extraction  (missing → partial)
+//   - lang.kotlin.framework.micronaut  DI/di_injection_point     (missing → partial)
+//   - lang.kotlin.framework.micronaut  DI/di_scope_resolution    (missing → partial)
+//   - lang.kotlin.framework.quarkus    Auth/auth_coverage        (missing → partial)
+//   - lang.kotlin.framework.quarkus    Middleware/middleware_coverage (missing → partial)
+//   - lang.kotlin.framework.quarkus    DI/di_binding_extraction  (missing → partial)
+//   - lang.kotlin.framework.quarkus    DI/di_injection_point     (missing → partial)
+//   - lang.kotlin.framework.quarkus    DI/di_scope_resolution    (missing → partial)
+//
+// Micronaut auth: @Secured, @RolesAllowed, SecurityRule / ServerRequestFilter +
+// ExecutorService auth interceptors. Micronaut uses JSR-330 annotations for DI
+// (@Inject, @Singleton, @Prototype) and @ServerFilter for middleware.
+//
+// Quarkus auth: @RolesAllowed, @PermitAll, @DenyAll (JAX-RS security),
+// @Authenticated (SmallRye JWT). Quarkus uses CDI scopes for DI
+// (@ApplicationScoped, @RequestScoped, @Inject) and @Provider +
+// ContainerRequestFilter for middleware.
+//
+// Honest limit: regex-based, file-local. No cross-file CDI graph resolution.
+// Cells are partial, not full.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_micronaut", &kotlinMicronautExtractor{})
+	extractor.Register("custom_kotlin_quarkus", &kotlinQuarkusExtractor{})
+}
+
+// ---------------------------------------------------------------------------
+// Micronaut Kotlin extractor
+// ---------------------------------------------------------------------------
+
+type kotlinMicronautExtractor struct{}
+
+func (e *kotlinMicronautExtractor) Language() string { return "custom_kotlin_micronaut" }
+
+var (
+	// --- Micronaut Auth ---
+
+	// reKtMnSecured matches @Secured("ROLE_ADMIN") / @Secured(SecurityRule.IS_AUTHENTICATED).
+	reKtMnSecured = regexp.MustCompile(
+		`@Secured\s*\(\s*(?:SecurityRule\.(\w+)|"([^"]*)")\s*\)`)
+
+	// reKtMnRolesAllowed matches @RolesAllowed({"ADMIN", "USER"}).
+	reKtMnRolesAllowed = regexp.MustCompile(
+		`@RolesAllowed\s*\(([^)]+)\)`)
+
+	// reKtMnPermitAll matches @PermitAll / @Unauthenticated.
+	reKtMnPermitAll = regexp.MustCompile(`@(PermitAll|Unauthenticated)\b`)
+
+	// --- Micronaut Middleware ---
+
+	// reKtMnServerFilter matches @ServerFilter class declarations.
+	reKtMnServerFilter = regexp.MustCompile(
+		`(?m)^\s*(?:(?:open|abstract|internal|private|public)\s+)*class\s+(\w+)[^{]*:\s*[^{]*HttpServerFilter\b`)
+
+	// reKtMnFilterAnnotation matches @Filter("/**") or @ServerFilter on a class.
+	reKtMnFilterAnnotation = regexp.MustCompile(
+		`@(?:ServerFilter|Filter)\s*(?:\([^)]*\))?\s*(?:@\w+[^{]*?)*class\s+(\w+)`)
+
+	// --- Micronaut DI ---
+
+	// reKtMnSingletonProto matches @Singleton or @Prototype class declarations.
+	reKtMnSingletonProto = regexp.MustCompile(
+		`@(Singleton|Prototype|RequestScoped)\b[^{]*class\s+(\w+)`)
+
+	// reKtMnInject matches @Inject on a property or constructor parameter.
+	reKtMnInject = regexp.MustCompile(
+		`@Inject\b\s*(?:val|var)?\s*(\w+)\s*:\s*([A-Z][\w<>, ]*)`)
+
+	// reKtMnBean matches @Bean on a function in a @Factory class.
+	reKtMnBean = regexp.MustCompile(
+		`@Bean\b[^{;]*fun\s+(\w+)\s*\(`)
+)
+
+func (e *kotlinMicronautExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_micronaut.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "micronaut"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	hasMicronaut := reKtMnSecured.MatchString(src) ||
+		reKtMnRolesAllowed.MatchString(src) ||
+		reKtMnServerFilter.MatchString(src) ||
+		reKtMnFilterAnnotation.MatchString(src) ||
+		reKtMnSingletonProto.MatchString(src) ||
+		reKtMnInject.MatchString(src) ||
+		reKtMnBean.MatchString(src) ||
+		reKtMnPermitAll.MatchString(src)
+	if !hasMicronaut {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, subtype, prop string, line int) {
+		key := "SCOPE.Pattern:mn:" + subtype + ":" + name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ent := makeEntity(name, "SCOPE.Pattern", subtype, file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "micronaut",
+			"provenance", "INFERRED_FROM_MICRONAUT_KOTLIN",
+			"kind", prop,
+		)
+		entities = append(entities, ent)
+	}
+
+	// Auth
+	for _, m := range reKtMnSecured.FindAllStringSubmatchIndex(src, -1) {
+		rule := ""
+		if m[2] >= 0 {
+			rule = src[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			rule = src[m[4]:m[5]]
+		}
+		add("@Secured:"+rule, "auth_policy", "secured", lineOf(src, m[0]))
+	}
+	for _, m := range reKtMnRolesAllowed.FindAllStringSubmatchIndex(src, -1) {
+		roles := src[m[2]:m[3]]
+		add("@RolesAllowed:"+roles, "auth_policy", "roles_allowed", lineOf(src, m[0]))
+	}
+	for _, m := range reKtMnPermitAll.FindAllStringSubmatchIndex(src, -1) {
+		anno := src[m[2]:m[3]]
+		add("@"+anno, "auth_policy", "permit_all", lineOf(src, m[0]))
+	}
+
+	// Middleware
+	for _, m := range reKtMnServerFilter.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		add(className, "middleware", "server_filter", lineOf(src, m[0]))
+	}
+	for _, m := range reKtMnFilterAnnotation.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		add(className, "middleware", "filter_annotation", lineOf(src, m[0]))
+	}
+
+	// DI: bindings
+	for _, m := range reKtMnSingletonProto.FindAllStringSubmatchIndex(src, -1) {
+		scope := src[m[2]:m[3]]
+		className := src[m[4]:m[5]]
+		ent := makeEntity(className, "SCOPE.Pattern", "di_binding", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "micronaut",
+			"di_scope", scope,
+			"provenance", "INFERRED_FROM_MICRONAUT_KOTLIN",
+		)
+		key := "SCOPE.Pattern:mn:di_binding:" + className
+		if !seen[key] {
+			seen[key] = true
+			entities = append(entities, ent)
+		}
+	}
+	for _, m := range reKtMnBean.FindAllStringSubmatchIndex(src, -1) {
+		funcName := src[m[2]:m[3]]
+		add(funcName, "di_binding", "bean_method", lineOf(src, m[0]))
+	}
+
+	// DI: injection points
+	for _, m := range reKtMnInject.FindAllStringSubmatchIndex(src, -1) {
+		fieldName := src[m[2]:m[3]]
+		typeName := src[m[4]:m[5]]
+		add(fieldName+":"+typeName, "di_injection_point", "field_inject", lineOf(src, m[0]))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Quarkus Kotlin extractor
+// ---------------------------------------------------------------------------
+
+type kotlinQuarkusExtractor struct{}
+
+func (e *kotlinQuarkusExtractor) Language() string { return "custom_kotlin_quarkus" }
+
+var (
+	// --- Quarkus Auth ---
+
+	// reKtQkRolesAllowed matches @RolesAllowed (JAX-RS / Quarkus Security).
+	reKtQkRolesAllowed = regexp.MustCompile(
+		`@RolesAllowed\s*\(([^)]+)\)`)
+
+	// reKtQkPermitDenyAll matches @PermitAll / @DenyAll.
+	reKtQkPermitDenyAll = regexp.MustCompile(`@(PermitAll|DenyAll)\b`)
+
+	// reKtQkAuthenticated matches @Authenticated (SmallRye JWT / Quarkus OIDC).
+	reKtQkAuthenticated = regexp.MustCompile(`@Authenticated\b`)
+
+	// reKtQkNoCache matches @NoCache security hint.
+	reKtQkNoCache = regexp.MustCompile(`@io\.quarkus\.security\.\w*`)
+
+	// --- Quarkus Middleware ---
+
+	// reKtQkContainerFilter matches @Provider ContainerRequestFilter /
+	// ContainerResponseFilter implementations.
+	reKtQkContainerFilter = regexp.MustCompile(
+		`(?m)^\s*(?:(?:open|abstract|internal|private|public)\s+)*class\s+(\w+)[^{]*:\s*[^{]*ContainerRequest(?:Filter|Context)\b`)
+
+	// reKtQkResponseFilter matches ContainerResponseFilter.
+	reKtQkResponseFilter = regexp.MustCompile(
+		`(?m)^\s*(?:(?:open|abstract|internal|private|public)\s+)*class\s+(\w+)[^{]*:\s*[^{]*ContainerResponseFilter\b`)
+
+	// reKtQkProviderAnnotation matches @Provider on a class.
+	reKtQkProviderAnnotation = regexp.MustCompile(
+		`@Provider\b[^{]*class\s+(\w+)`)
+
+	// --- Quarkus DI (CDI) ---
+
+	// reKtQkCDIScope matches CDI scope annotations on Kotlin classes.
+	reKtQkCDIScope = regexp.MustCompile(
+		`@(ApplicationScoped|RequestScoped|SessionScoped|Singleton|Dependent)\b[^{]*class\s+(\w+)`)
+
+	// reKtQkInject matches @Inject on a Kotlin property.
+	reKtQkInject = regexp.MustCompile(
+		`@Inject\b\s*(?:val|var|lateinit var)?\s*(\w+)\s*:\s*([A-Z][\w<>, ]*)`)
+
+	// reKtQkProduces matches @Produces CDI producer method.
+	reKtQkProduces = regexp.MustCompile(
+		`@Produces\b[^{;]*fun\s+(\w+)\s*\(`)
+)
+
+func (e *kotlinQuarkusExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_quarkus.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "quarkus"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	hasQuarkus := reKtQkRolesAllowed.MatchString(src) ||
+		reKtQkPermitDenyAll.MatchString(src) ||
+		reKtQkAuthenticated.MatchString(src) ||
+		reKtQkContainerFilter.MatchString(src) ||
+		reKtQkResponseFilter.MatchString(src) ||
+		reKtQkProviderAnnotation.MatchString(src) ||
+		reKtQkCDIScope.MatchString(src) ||
+		reKtQkInject.MatchString(src) ||
+		reKtQkProduces.MatchString(src) ||
+		reKtQkNoCache.MatchString(src)
+	if !hasQuarkus {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, subtype, prop string, line int) {
+		key := "SCOPE.Pattern:qk:" + subtype + ":" + name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ent := makeEntity(name, "SCOPE.Pattern", subtype, file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "quarkus",
+			"provenance", "INFERRED_FROM_QUARKUS_KOTLIN",
+			"kind", prop,
+		)
+		entities = append(entities, ent)
+	}
+
+	// Auth
+	for _, m := range reKtQkRolesAllowed.FindAllStringSubmatchIndex(src, -1) {
+		roles := src[m[2]:m[3]]
+		add("@RolesAllowed:"+roles, "auth_policy", "roles_allowed", lineOf(src, m[0]))
+	}
+	for _, m := range reKtQkPermitDenyAll.FindAllStringSubmatchIndex(src, -1) {
+		anno := src[m[2]:m[3]]
+		add("@"+anno, "auth_policy", "permit_deny_all", lineOf(src, m[0]))
+	}
+	for _, m := range reKtQkAuthenticated.FindAllStringSubmatchIndex(src, -1) {
+		add("@Authenticated", "auth_policy", "authenticated", lineOf(src, m[0]))
+	}
+
+	// Middleware
+	for _, m := range reKtQkContainerFilter.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		add(className, "middleware", "container_request_filter", lineOf(src, m[0]))
+	}
+	for _, m := range reKtQkResponseFilter.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		add(className, "middleware", "container_response_filter", lineOf(src, m[0]))
+	}
+	for _, m := range reKtQkProviderAnnotation.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		add(className, "middleware", "provider", lineOf(src, m[0]))
+	}
+
+	// DI: bindings
+	for _, m := range reKtQkCDIScope.FindAllStringSubmatchIndex(src, -1) {
+		scope := src[m[2]:m[3]]
+		className := src[m[4]:m[5]]
+		ent := makeEntity(className, "SCOPE.Pattern", "di_binding", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "quarkus",
+			"di_scope", scope,
+			"provenance", "INFERRED_FROM_QUARKUS_KOTLIN",
+		)
+		key := "SCOPE.Pattern:qk:di_binding:" + className
+		if !seen[key] {
+			seen[key] = true
+			entities = append(entities, ent)
+		}
+	}
+	for _, m := range reKtQkProduces.FindAllStringSubmatchIndex(src, -1) {
+		funcName := src[m[2]:m[3]]
+		add(funcName, "di_binding", "produces_method", lineOf(src, m[0]))
+	}
+
+	// DI: injection points
+	for _, m := range reKtQkInject.FindAllStringSubmatchIndex(src, -1) {
+		fieldName := src[m[2]:m[3]]
+		typeName := src[m[4]:m[5]]
+		add(fieldName+":"+typeName, "di_injection_point", "field_inject", lineOf(src, m[0]))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/kotlin/micronaut_quarkus_test.go
+++ b/internal/custom/kotlin/micronaut_quarkus_test.go
@@ -1,0 +1,255 @@
+package kotlin_test
+
+import (
+	"testing"
+)
+
+// micronaut_quarkus_test.go: tests for Micronaut and Quarkus Kotlin extractors.
+// Registry targets:
+//   lang.kotlin.framework.micronaut Auth/auth_coverage, Middleware/middleware_coverage,
+//                                   DI/di_binding_extraction, DI/di_injection_point,
+//                                   DI/di_scope_resolution
+//   lang.kotlin.framework.quarkus   Auth/auth_coverage, Middleware/middleware_coverage,
+//                                   DI/di_binding_extraction, DI/di_injection_point,
+//                                   DI/di_scope_resolution
+
+const mnAuthSrc = `
+package com.example.security
+
+import io.micronaut.security.annotation.Secured
+import javax.annotation.security.RolesAllowed
+import javax.annotation.security.PermitAll
+
+@Secured("isAuthenticated()")
+class AdminController {
+    @RolesAllowed("ADMIN", "SUPER_ADMIN")
+    fun adminAction() = "ok"
+
+    @PermitAll
+    fun publicAction() = "public"
+}
+`
+
+const mnDISrc = `
+package com.example.service
+
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import io.micronaut.context.annotation.Bean
+
+@Singleton
+class UserService {
+    @Inject
+    val userRepository: UserRepository? = null
+}
+
+@Singleton
+class OrderService {
+    @Inject lateinit var paymentService: PaymentService
+}
+`
+
+const mnMiddlewareSrc = `
+package com.example.filter
+
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.annotation.Filter
+
+@Filter("/**")
+class LoggingFilter : HttpServerFilter {
+    override fun doFilter(
+        request: io.micronaut.http.HttpRequest<*>,
+        chain: io.micronaut.http.filter.ServerFilterChain
+    ) = chain.proceed(request)
+}
+`
+
+const qkAuthSrc = `
+package com.example.resource
+
+import javax.annotation.security.RolesAllowed
+import javax.annotation.security.PermitAll
+import javax.annotation.security.DenyAll
+import io.quarkus.security.Authenticated
+
+@Authenticated
+class OrderResource {
+    @RolesAllowed("USER")
+    fun listOrders() = listOf()
+
+    @PermitAll
+    fun health() = "ok"
+
+    @DenyAll
+    fun admin() = "denied"
+}
+`
+
+const qkDISrc = `
+package com.example.service
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.enterprise.inject.Produces
+
+@ApplicationScoped
+class UserService {
+    @Inject
+    lateinit var userRepository: UserRepository
+
+    @Produces
+    fun createCache(): Cache = Cache()
+}
+
+@jakarta.enterprise.context.RequestScoped
+class RequestScopedService
+`
+
+const qkMiddlewareSrc = `
+package com.example.filter
+
+import javax.ws.rs.ext.Provider
+import javax.ws.rs.container.ContainerRequestFilter
+import javax.ws.rs.container.ContainerRequestContext
+
+@Provider
+class AuthFilter : ContainerRequestFilter {
+    override fun filter(requestContext: ContainerRequestContext) {
+        // check auth
+    }
+}
+`
+
+// --- Micronaut tests ---
+
+func TestKotlinMicronaut_Auth(t *testing.T) {
+	// Registry target: lang.kotlin.framework.micronaut Auth/auth_coverage → partial
+	ents := extract(t, "custom_kotlin_micronaut", fi("AdminController.kt", "kotlin", mnAuthSrc))
+	if len(ents) == 0 {
+		t.Fatal("[micronaut_auth] expected auth entities, got none")
+	}
+	authCount := 0
+	for _, e := range ents {
+		if e.Subtype == "auth_policy" {
+			authCount++
+		}
+	}
+	if authCount < 2 {
+		t.Errorf("[micronaut_auth] expected >= 2 auth_policy entities (@Secured + @RolesAllowed), got %d", authCount)
+	}
+}
+
+func TestKotlinMicronaut_DI(t *testing.T) {
+	// Registry target: lang.kotlin.framework.micronaut DI/* → partial
+	ents := extract(t, "custom_kotlin_micronaut", fi("Service.kt", "kotlin", mnDISrc))
+	if len(ents) == 0 {
+		t.Fatal("[micronaut_di] expected DI entities, got none")
+	}
+	bindingCount := 0
+	injectCount := 0
+	for _, e := range ents {
+		if e.Subtype == "di_binding" {
+			bindingCount++
+		}
+		if e.Subtype == "di_injection_point" {
+			injectCount++
+		}
+	}
+	if bindingCount == 0 {
+		t.Errorf("[micronaut_di] expected di_binding entities (@Singleton), got 0")
+	}
+	if injectCount == 0 {
+		t.Errorf("[micronaut_di] expected di_injection_point entities (@Inject), got 0")
+	}
+}
+
+func TestKotlinMicronaut_Middleware(t *testing.T) {
+	// Registry target: lang.kotlin.framework.micronaut Middleware/middleware_coverage → partial
+	ents := extract(t, "custom_kotlin_micronaut", fi("LoggingFilter.kt", "kotlin", mnMiddlewareSrc))
+	if len(ents) == 0 {
+		t.Fatal("[micronaut_mw] expected middleware entities, got none")
+	}
+	mwCount := 0
+	for _, e := range ents {
+		if e.Subtype == "middleware" {
+			mwCount++
+		}
+	}
+	if mwCount == 0 {
+		t.Errorf("[micronaut_mw] expected middleware entity (HttpServerFilter), got 0; all: %v", ents)
+	}
+}
+
+func TestKotlinMicronaut_EmptyFile(t *testing.T) {
+	ents := extract(t, "custom_kotlin_micronaut", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("[micronaut] expected no entities for empty file, got %d", len(ents))
+	}
+}
+
+// --- Quarkus tests ---
+
+func TestKotlinQuarkus_Auth(t *testing.T) {
+	// Registry target: lang.kotlin.framework.quarkus Auth/auth_coverage → partial
+	ents := extract(t, "custom_kotlin_quarkus", fi("OrderResource.kt", "kotlin", qkAuthSrc))
+	if len(ents) == 0 {
+		t.Fatal("[quarkus_auth] expected auth entities, got none")
+	}
+	authCount := 0
+	for _, e := range ents {
+		if e.Subtype == "auth_policy" {
+			authCount++
+		}
+	}
+	if authCount < 3 {
+		t.Errorf("[quarkus_auth] expected >= 3 auth_policy entities (@Authenticated + @RolesAllowed + @PermitAll + @DenyAll), got %d", authCount)
+	}
+}
+
+func TestKotlinQuarkus_DI(t *testing.T) {
+	// Registry target: lang.kotlin.framework.quarkus DI/* → partial
+	ents := extract(t, "custom_kotlin_quarkus", fi("UserService.kt", "kotlin", qkDISrc))
+	if len(ents) == 0 {
+		t.Fatal("[quarkus_di] expected DI entities, got none")
+	}
+	bindingCount := 0
+	injectCount := 0
+	for _, e := range ents {
+		if e.Subtype == "di_binding" {
+			bindingCount++
+		}
+		if e.Subtype == "di_injection_point" {
+			injectCount++
+		}
+	}
+	if bindingCount == 0 {
+		t.Errorf("[quarkus_di] expected di_binding entities (@ApplicationScoped), got 0")
+	}
+	if injectCount == 0 {
+		t.Errorf("[quarkus_di] expected di_injection_point entities (@Inject), got 0")
+	}
+}
+
+func TestKotlinQuarkus_Middleware(t *testing.T) {
+	// Registry target: lang.kotlin.framework.quarkus Middleware/middleware_coverage → partial
+	ents := extract(t, "custom_kotlin_quarkus", fi("AuthFilter.kt", "kotlin", qkMiddlewareSrc))
+	if len(ents) == 0 {
+		t.Fatal("[quarkus_mw] expected middleware entities, got none")
+	}
+	mwCount := 0
+	for _, e := range ents {
+		if e.Subtype == "middleware" {
+			mwCount++
+		}
+	}
+	if mwCount == 0 {
+		t.Errorf("[quarkus_mw] expected middleware entity (@Provider ContainerRequestFilter), got 0; all: %v", ents)
+	}
+}
+
+func TestKotlinQuarkus_EmptyFile(t *testing.T) {
+	ents := extract(t, "custom_kotlin_quarkus", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("[quarkus] expected no entities for empty file, got %d", len(ents))
+	}
+}

--- a/internal/custom/kotlin/observability.go
+++ b/internal/custom/kotlin/observability.go
@@ -1,0 +1,231 @@
+// Package kotlin — observability extractor for Kotlin frameworks not covered by
+// the Java observability pass (internal/custom/java/observability.go).
+//
+// The Java pass already handles: spring-boot, spring_webflux, quarkus,
+// micronaut, javalin, vertx, dropwizard, helidon, akka_http, struts, etc.
+// This file adds coverage for Kotlin-idiomatic frameworks that are gated out
+// of the Java pass:
+//
+//   - lang.kotlin.framework.ktor        Observability/log_extraction    (missing → partial)
+//   - lang.kotlin.framework.ktor        Observability/metric_extraction (missing → partial)
+//   - lang.kotlin.framework.ktor        Observability/trace_extraction  (missing → partial)
+//   - lang.kotlin.framework.http4k      Observability/log_extraction    (missing → partial)
+//   - lang.kotlin.framework.http4k      Observability/metric_extraction (missing → partial)
+//   - lang.kotlin.framework.http4k      Observability/trace_extraction  (missing → partial)
+//   - lang.kotlin.framework.arrow       Observability/log_extraction    (missing → partial)
+//   - lang.kotlin.framework.arrow       Observability/metric_extraction (missing → partial)
+//   - lang.kotlin.framework.arrow       Observability/trace_extraction  (missing → partial)
+//   - lang.kotlin.framework.coroutines  Observability/log_extraction    (missing → partial)
+//   - lang.kotlin.framework.coroutines  Observability/metric_extraction (missing → partial)
+//   - lang.kotlin.framework.coroutines  Observability/trace_extraction  (missing → partial)
+//
+// Detection is shared across all four frameworks because SLF4J, Micrometer,
+// and OpenTelemetry are language-level (not framework-level) in Kotlin. Any
+// Kotlin file that uses these APIs is covered, regardless of which HTTP
+// framework it belongs to.
+//
+// Honest limit: regex-based, file-local. Logger field declared in one file
+// and used in another is not correlated. Cells are partial, not full.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_observability", &kotlinObservabilityExtractor{})
+}
+
+type kotlinObservabilityExtractor struct{}
+
+func (e *kotlinObservabilityExtractor) Language() string { return "custom_kotlin_observability" }
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// --- log_extraction ---
+
+	// reKtSlf4jAnno matches @Slf4j Lombok class-level annotation (Kotlin interop).
+	reKtSlf4jAnno = regexp.MustCompile(
+		`(?s)@Slf4j\b[^{]*?\bclass\s+(\w+)`)
+
+	// reKtLoggerFactory matches SLF4J / Log4j / JUL logger acquisition:
+	//   val log = LoggerFactory.getLogger(...)
+	//   val logger = LogManager.getLogger(...)
+	//   private val log: Logger = LoggerFactory.getLogger(Foo::class.java)
+	reKtLoggerFactory = regexp.MustCompile(
+		`\b(LoggerFactory|LogManager|Logger)\s*\.\s*getLogger\s*\(`)
+
+	// reKtKotlinLogging matches kotlin-logging / microutils KLogger:
+	//   val log = KotlinLogging.logger {}
+	//   private val logger = KotlinLogging.logger {}
+	reKtKotlinLogging = regexp.MustCompile(
+		`\bKotlinLogging\s*\.\s*logger\s*\{`)
+
+	// reKtLogStatement matches log call sites:
+	//   log.info(...), logger.warn(...), LOG.error(...)
+	reKtLogStatement = regexp.MustCompile(
+		`\b([lL][oO][gG](?:[gG][eE][rR])?)\s*\.\s*(trace|debug|info|warn|error|fatal)\s*\(`)
+
+	// --- metric_extraction ---
+
+	// reKtMicrometerBuilder matches Micrometer meter builders:
+	//   Counter.builder("name"), Timer.builder("name"), Gauge.builder("name")
+	reKtMicrometerBuilder = regexp.MustCompile(
+		`\b(Counter|Timer|Gauge|DistributionSummary|LongTaskTimer)\s*\.\s*builder\s*\(\s*"([^"]*)"`)
+
+	// reKtMeterRegistry matches Micrometer MeterRegistry usage.
+	reKtMeterRegistry = regexp.MustCompile(
+		`\bMeterRegistry\b|\bmeterRegistry\s*\.\s*(counter|timer|gauge|summary)\s*\(`)
+
+	// reKtTimedAnno matches @Timed annotation on a Kotlin fun.
+	reKtTimedAnno = regexp.MustCompile(
+		`@Timed\s*(?:\([^)]*\))?\s*(?:suspend\s+)?fun\s+(\w+)\s*\(`)
+
+	// reKtMicrometerCounted matches @Counted annotation.
+	reKtMicrometerCounted = regexp.MustCompile(
+		`@Counted\s*(?:\([^)]*\))?\s*(?:suspend\s+)?fun\s+(\w+)\s*\(`)
+
+	// --- trace_extraction ---
+
+	// reKtWithSpan matches @WithSpan OTel annotation.
+	reKtWithSpan = regexp.MustCompile(
+		`@WithSpan\s*(?:\([^)]*\))?\s*(?:suspend\s+)?fun\s+(\w+)\s*\(`)
+
+	// reKtOtelSpanBuilder matches OTel tracer / span builder usage:
+	//   tracer.spanBuilder("name").startSpan()
+	reKtOtelSpanBuilder = regexp.MustCompile(
+		`\btracer\s*\.\s*spanBuilder\s*\(\s*"([^"]*)"`)
+
+	// reKtOtelSpan matches span.setAttribute / span.addEvent calls.
+	reKtOtelSpan = regexp.MustCompile(
+		`\bspan\s*\.\s*(setAttribute|addEvent)\s*\(`)
+
+	// reKtMicrometerObserved matches Micrometer @Observed annotation.
+	reKtMicrometerObserved = regexp.MustCompile(
+		`@Observed\s*(?:\([^)]*\))?\s*(?:suspend\s+)?(?:class|fun)\s+(\w+)`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *kotlinObservabilityExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_observability.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	hasObs := reKtLoggerFactory.MatchString(src) ||
+		reKtKotlinLogging.MatchString(src) ||
+		reKtLogStatement.MatchString(src) ||
+		reKtMicrometerBuilder.MatchString(src) ||
+		reKtMeterRegistry.MatchString(src) ||
+		reKtTimedAnno.MatchString(src) ||
+		reKtWithSpan.MatchString(src) ||
+		reKtOtelSpanBuilder.MatchString(src) ||
+		reKtMicrometerObserved.MatchString(src) ||
+		reKtSlf4jAnno.MatchString(src)
+	if !hasObs {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, subtype, obsType string, line int) {
+		key := "SCOPE.Pattern:obs:" + subtype + ":" + name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ent := makeEntity(name, "SCOPE.Pattern", subtype, file.Path, file.Language, line)
+		setProps(&ent,
+			"obs_type", obsType,
+			"provenance", "INFERRED_FROM_KOTLIN_OBSERVABILITY",
+		)
+		entities = append(entities, ent)
+	}
+
+	// --- log_extraction ---
+
+	for _, m := range reKtSlf4jAnno.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		add(className+":slf4j_logger", "logger", "slf4j", lineOf(src, m[0]))
+	}
+	for _, m := range reKtLoggerFactory.FindAllStringSubmatchIndex(src, -1) {
+		factory := src[m[2]:m[3]]
+		add("logger:"+factory, "logger", "slf4j_factory", lineOf(src, m[0]))
+	}
+	for _, m := range reKtKotlinLogging.FindAllStringSubmatchIndex(src, -1) {
+		add("logger:kotlin_logging", "logger", "kotlin_logging", lineOf(src, m[0]))
+	}
+	cnt := 0
+	for _, m := range reKtLogStatement.FindAllStringSubmatchIndex(src, -1) {
+		level := src[m[4]:m[5]]
+		cnt++
+		add("log_stmt:"+level+"#"+string(rune('a'+cnt%26)), "log_statement", level, lineOf(src, m[0]))
+	}
+
+	// --- metric_extraction ---
+
+	for _, m := range reKtMicrometerBuilder.FindAllStringSubmatchIndex(src, -1) {
+		meterType := src[m[2]:m[3]]
+		name := src[m[4]:m[5]]
+		add(name+":"+meterType, "metric", "micrometer_"+meterType, lineOf(src, m[0]))
+	}
+	for _, m := range reKtMeterRegistry.FindAllStringSubmatchIndex(src, -1) {
+		add("meter_registry_usage", "metric", "micrometer_registry", lineOf(src, m[0]))
+	}
+	for _, m := range reKtTimedAnno.FindAllStringSubmatchIndex(src, -1) {
+		funcName := src[m[2]:m[3]]
+		add(funcName+":@Timed", "metric", "micrometer_timed", lineOf(src, m[0]))
+	}
+	for _, m := range reKtMicrometerCounted.FindAllStringSubmatchIndex(src, -1) {
+		funcName := src[m[2]:m[3]]
+		add(funcName+":@Counted", "metric", "micrometer_counted", lineOf(src, m[0]))
+	}
+
+	// --- trace_extraction ---
+
+	for _, m := range reKtWithSpan.FindAllStringSubmatchIndex(src, -1) {
+		funcName := src[m[2]:m[3]]
+		add(funcName+":@WithSpan", "trace_span", "otel_with_span", lineOf(src, m[0]))
+	}
+	for _, m := range reKtOtelSpanBuilder.FindAllStringSubmatchIndex(src, -1) {
+		spanName := src[m[2]:m[3]]
+		add(spanName+":span_builder", "trace_span", "otel_span_builder", lineOf(src, m[0]))
+	}
+	cnt = 0
+	for _, m := range reKtOtelSpan.FindAllStringSubmatchIndex(src, -1) {
+		op := src[m[2]:m[3]]
+		cnt++
+		add("span:"+op+"#"+string(rune('a'+cnt%26)), "trace_span", "otel_span_op", lineOf(src, m[0]))
+	}
+	for _, m := range reKtMicrometerObserved.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		add(name+":@Observed", "trace_span", "micrometer_observed", lineOf(src, m[0]))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/kotlin/observability_test.go
+++ b/internal/custom/kotlin/observability_test.go
@@ -1,0 +1,140 @@
+package kotlin_test
+
+import (
+	"testing"
+)
+
+// observability_test.go: tests for custom_kotlin_observability extractor.
+// Registry targets (all missing → partial):
+//   lang.kotlin.framework.ktor       Observability/{log,metric,trace}_extraction
+//   lang.kotlin.framework.http4k     Observability/{log,metric,trace}_extraction
+//   lang.kotlin.framework.arrow      Observability/{log,metric,trace}_extraction
+//   lang.kotlin.framework.coroutines Observability/{log,metric,trace}_extraction
+
+const obsLogSrc = `
+package com.example
+
+import org.slf4j.LoggerFactory
+import io.github.microutils.kotlinlogging.KotlinLogging
+
+private val log = LoggerFactory.getLogger(UserService::class.java)
+private val logger = KotlinLogging.logger {}
+
+class UserService {
+    fun findUser(id: Long) {
+        log.info("finding user {}", id)
+        log.warn("slow query for user {}", id)
+        logger.debug { "debug detail: $id" }
+    }
+}
+`
+
+const obsMetricSrc = `
+package com.example
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Timer
+import io.micrometer.core.annotation.Timed
+
+class MetricService(private val meterRegistry: io.micrometer.core.instrument.MeterRegistry) {
+    private val counter = Counter.builder("api.requests").register(meterRegistry)
+    private val timer   = Timer.builder("api.latency").register(meterRegistry)
+
+    @Timed("api.findUser")
+    fun findUser(id: Long): String = "user_$id"
+}
+`
+
+const obsTraceSrc = `
+package com.example
+
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import io.opentelemetry.api.trace.Tracer
+
+class TraceService(private val tracer: Tracer) {
+    @WithSpan("processOrder")
+    suspend fun processOrder(id: Long) {
+        val span = tracer.spanBuilder("inner_span").startSpan()
+        span.setAttribute("order_id", id)
+        span.end()
+    }
+}
+`
+
+const obsNoMatchSrc = `
+package com.example
+data class Foo(val x: Int)
+fun hello() = "world"
+`
+
+func TestKotlinObservability_LogExtraction(t *testing.T) {
+	// Registry target: log_extraction → partial
+	ents := extract(t, "custom_kotlin_observability", fi("UserService.kt", "kotlin", obsLogSrc))
+	if len(ents) == 0 {
+		t.Fatal("[obs] expected log entities, got none")
+	}
+	loggerCount := 0
+	logStmtCount := 0
+	for _, e := range ents {
+		if e.Subtype == "logger" {
+			loggerCount++
+		}
+		if e.Subtype == "log_statement" {
+			logStmtCount++
+		}
+	}
+	if loggerCount == 0 {
+		t.Errorf("[obs] expected logger entity (LoggerFactory / KotlinLogging), got 0")
+	}
+	if logStmtCount == 0 {
+		t.Errorf("[obs] expected log_statement entities (log.info/warn/debug), got 0")
+	}
+}
+
+func TestKotlinObservability_MetricExtraction(t *testing.T) {
+	// Registry target: metric_extraction → partial
+	ents := extract(t, "custom_kotlin_observability", fi("MetricService.kt", "kotlin", obsMetricSrc))
+	if len(ents) == 0 {
+		t.Fatal("[obs] expected metric entities, got none")
+	}
+	metricCount := 0
+	for _, e := range ents {
+		if e.Subtype == "metric" {
+			metricCount++
+		}
+	}
+	if metricCount == 0 {
+		t.Errorf("[obs] expected metric entities (Counter.builder / @Timed), got 0; all: %v", ents)
+	}
+}
+
+func TestKotlinObservability_TraceExtraction(t *testing.T) {
+	// Registry target: trace_extraction → partial
+	ents := extract(t, "custom_kotlin_observability", fi("TraceService.kt", "kotlin", obsTraceSrc))
+	if len(ents) == 0 {
+		t.Fatal("[obs] expected trace entities, got none")
+	}
+	traceCount := 0
+	for _, e := range ents {
+		if e.Subtype == "trace_span" {
+			traceCount++
+		}
+	}
+	if traceCount == 0 {
+		t.Errorf("[obs] expected trace_span entities (@WithSpan / tracer.spanBuilder), got 0; all: %v", ents)
+	}
+}
+
+func TestKotlinObservability_NoMatch(t *testing.T) {
+	ents := extract(t, "custom_kotlin_observability", fi("Foo.kt", "kotlin", obsNoMatchSrc))
+	if len(ents) != 0 {
+		t.Errorf("[obs] expected no entities for plain Kotlin, got %d", len(ents))
+	}
+}
+
+func TestKotlinObservability_EmptyFile(t *testing.T) {
+	ents := extract(t, "custom_kotlin_observability", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("[obs] expected no entities for empty file, got %d", len(ents))
+	}
+}

--- a/internal/custom/kotlin/spring_middleware.go
+++ b/internal/custom/kotlin/spring_middleware.go
@@ -1,0 +1,162 @@
+// Package kotlin — Spring Security middleware extractor for Kotlin Spring Boot.
+//
+// Covers the Middleware lane for lang.kotlin.framework.spring-boot:
+//   - middleware_coverage (missing → partial)
+//
+// Detects the following Spring Security / MVC interceptor patterns in Kotlin
+// source (identical syntax to Java — no language-specific deltas):
+//
+//  1. SecurityFilterChain @Bean declarations:
+//     @Bean fun securityFilterChain(http: HttpSecurity): SecurityFilterChain
+//
+//  2. OncePerRequestFilter / GenericFilterBean subclasses:
+//     class MyFilter : OncePerRequestFilter() { override fun doFilterInternal(...) }
+//
+//  3. HandlerInterceptor implementations:
+//     class MyInterceptor : HandlerInterceptor { override fun preHandle(...) }
+//
+//  4. WebMvcConfigurer.addInterceptors:
+//     override fun addInterceptors(registry: InterceptorRegistry) { ... }
+//
+//  5. @EnableWebSecurity class declaration (framework-level signal).
+//
+// Emits SCOPE.Pattern (subtype=middleware) for each detected middleware
+// component, carrying middleware_type and framework="spring" properties.
+//
+// Honest limit: regex-based, file-local. Cross-file filter chains are not
+// resolved. Hence the registry cell is flipped to partial, not full.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_spring_middleware", &kotlinSpringMiddlewareExtractor{})
+}
+
+type kotlinSpringMiddlewareExtractor struct{}
+
+func (e *kotlinSpringMiddlewareExtractor) Language() string {
+	return "custom_kotlin_spring_middleware"
+}
+
+var (
+	// reKtSecurityFilterChainBean matches Spring Security SecurityFilterChain @Bean method.
+	// @Bean\nfun securityFilterChain(http: HttpSecurity): SecurityFilterChain { ... }
+	// Uses (?s) so it spans newlines between @Bean and fun declaration.
+	reKtSecurityFilterChainBean = regexp.MustCompile(
+		`(?s)@Bean\b[^{]*?fun\s+(\w+)\s*\([^)]*\)\s*:\s*SecurityFilterChain`)
+
+	// reKtOncePerRequestFilter matches a class implementing/extending OncePerRequestFilter.
+	reKtOncePerRequestFilter = regexp.MustCompile(
+		`(?m)^\s*(?:(?:open|abstract|internal|private|public)\s+)*class\s+(\w+)[^{]*:\s*[^{]*(?:OncePerRequestFilter|GenericFilterBean|Filter)\b`)
+
+	// reKtHandlerInterceptor matches a class implementing HandlerInterceptor.
+	reKtHandlerInterceptor = regexp.MustCompile(
+		`(?m)^\s*(?:(?:open|abstract|internal|private|public)\s+)*class\s+(\w+)[^{]*:\s*[^{]*HandlerInterceptor\b`)
+
+	// reKtAddInterceptors matches WebMvcConfigurer.addInterceptors override.
+	reKtAddInterceptors = regexp.MustCompile(
+		`override\s+fun\s+addInterceptors\s*\(\s*registry\s*:\s*InterceptorRegistry`)
+
+	// reKtEnableWebSecurity matches @EnableWebSecurity class-level annotation.
+	reKtEnableWebSecurity = regexp.MustCompile(
+		`(?s)@EnableWebSecurity\b[^{]*?class\s+(\w+)`)
+
+	// reKtWebFilter matches Spring WebFlux @Component WebFilter implementations.
+	reKtWebFilter = regexp.MustCompile(
+		`(?m)^\s*(?:(?:open|abstract|internal|private|public)\s+)*class\s+(\w+)[^{]*:\s*[^{]*WebFilter\b`)
+)
+
+func (e *kotlinSpringMiddlewareExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_spring_middleware.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "spring-boot"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Quick bail-out: require at least one Spring Security indicator.
+	hasSecurity := reKtSecurityFilterChainBean.MatchString(src) ||
+		reKtOncePerRequestFilter.MatchString(src) ||
+		reKtHandlerInterceptor.MatchString(src) ||
+		reKtAddInterceptors.MatchString(src) ||
+		reKtEnableWebSecurity.MatchString(src) ||
+		reKtWebFilter.MatchString(src)
+	if !hasSecurity {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, middlewareType string, line int) {
+		key := "SCOPE.Pattern:mw:" + name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "spring",
+			"middleware_type", middlewareType,
+			"provenance", "INFERRED_FROM_SPRING_MIDDLEWARE",
+		)
+		entities = append(entities, ent)
+	}
+
+	// 1. SecurityFilterChain @Bean
+	for _, m := range reKtSecurityFilterChainBean.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		add(name, "security_filter_chain", lineOf(src, m[0]))
+	}
+
+	// 2. OncePerRequestFilter / GenericFilterBean
+	for _, m := range reKtOncePerRequestFilter.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		add(name, "servlet_filter", lineOf(src, m[0]))
+	}
+
+	// 3. HandlerInterceptor
+	for _, m := range reKtHandlerInterceptor.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		add(name, "handler_interceptor", lineOf(src, m[0]))
+	}
+
+	// 4. addInterceptors override (WebMvcConfigurer)
+	for _, m := range reKtAddInterceptors.FindAllStringSubmatchIndex(src, -1) {
+		add("addInterceptors", "mvc_configurer", lineOf(src, m[0]))
+	}
+
+	// 5. @EnableWebSecurity class
+	for _, m := range reKtEnableWebSecurity.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		add(name, "security_config", lineOf(src, m[0]))
+	}
+
+	// 6. WebFilter (WebFlux)
+	for _, m := range reKtWebFilter.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		add(name, "web_filter", lineOf(src, m[0]))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/kotlin/spring_middleware_test.go
+++ b/internal/custom/kotlin/spring_middleware_test.go
@@ -1,0 +1,142 @@
+package kotlin_test
+
+import (
+	"testing"
+)
+
+// spring_middleware_test.go: tests for custom_kotlin_spring_middleware extractor.
+// Registry target: lang.kotlin.framework.spring-boot Middleware/middleware_coverage → partial.
+
+const springMwSecurityFilterChainSrc = `
+package com.example.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@EnableWebSecurity
+class SecurityConfig {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http.authorizeHttpRequests { auth ->
+            auth.requestMatchers("/public/**").permitAll()
+                .anyRequest().authenticated()
+        }
+        return http.build()
+    }
+}
+`
+
+const springMwOncePerRequestFilterSrc = `
+package com.example.filter
+
+import org.springframework.web.filter.OncePerRequestFilter
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class JwtAuthFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: javax.servlet.FilterChain
+    ) {
+        // validate JWT
+        filterChain.doFilter(request, response)
+    }
+}
+`
+
+const springMwHandlerInterceptorSrc = `
+package com.example.interceptor
+
+import org.springframework.web.servlet.HandlerInterceptor
+import javax.servlet.http.HttpServletRequest
+
+class LoggingInterceptor : HandlerInterceptor {
+    override fun preHandle(request: HttpServletRequest, response: javax.servlet.http.HttpServletResponse, handler: Any): Boolean {
+        return true
+    }
+}
+
+class WebConfig : org.springframework.web.servlet.config.annotation.WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(LoggingInterceptor())
+    }
+}
+`
+
+func TestKotlinSpringMiddleware_SecurityFilterChain(t *testing.T) {
+	// Registry target: lang.kotlin.framework.spring-boot Middleware/middleware_coverage → partial
+	ents := extract(t, "custom_kotlin_spring_middleware", fi("SecurityConfig.kt", "kotlin", springMwSecurityFilterChainSrc))
+	if len(ents) == 0 {
+		t.Fatal("[spring_middleware] expected at least one entity from SecurityFilterChain @Bean, got none")
+	}
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Name == "securityFilterChain" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("[spring_middleware] expected SecurityFilterChain entity 'securityFilterChain', got: %v", ents)
+	}
+}
+
+func TestKotlinSpringMiddleware_OncePerRequestFilter(t *testing.T) {
+	ents := extract(t, "custom_kotlin_spring_middleware", fi("JwtAuthFilter.kt", "kotlin", springMwOncePerRequestFilterSrc))
+	if len(ents) == 0 {
+		t.Fatal("[spring_middleware] expected entity from OncePerRequestFilter, got none")
+	}
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Name == "JwtAuthFilter" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("[spring_middleware] expected entity 'JwtAuthFilter', got: %v", ents)
+	}
+}
+
+func TestKotlinSpringMiddleware_HandlerInterceptor(t *testing.T) {
+	ents := extract(t, "custom_kotlin_spring_middleware", fi("LoggingInterceptor.kt", "kotlin", springMwHandlerInterceptorSrc))
+	if len(ents) == 0 {
+		t.Fatal("[spring_middleware] expected entity from HandlerInterceptor, got none")
+	}
+	foundInterceptor := false
+	foundAddInterceptors := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Name == "LoggingInterceptor" {
+			foundInterceptor = true
+		}
+		if e.Kind == "SCOPE.Pattern" && e.Name == "addInterceptors" {
+			foundAddInterceptors = true
+		}
+	}
+	if !foundInterceptor {
+		t.Errorf("[spring_middleware] expected 'LoggingInterceptor', got: %v", ents)
+	}
+	if !foundAddInterceptors {
+		t.Errorf("[spring_middleware] expected 'addInterceptors', got: %v", ents)
+	}
+}
+
+func TestKotlinSpringMiddleware_EmptyFile(t *testing.T) {
+	ents := extract(t, "custom_kotlin_spring_middleware", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("[spring_middleware] expected no entities for empty file, got %d", len(ents))
+	}
+}
+
+func TestKotlinSpringMiddleware_NoSpringSource(t *testing.T) {
+	src := `
+package com.example
+class Foo {
+    fun bar() = "hello"
+}
+`
+	ents := extract(t, "custom_kotlin_spring_middleware", fi("Foo.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("[spring_middleware] expected no entities for non-security file, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Summary

Part of #3275 — Kotlin Spring-stack: DI + AOP + Transactions + Observability + Middleware/Auth + substrate-verify.

**65 cells flipped** (86 missing → 21 missing):

### New extractors (`internal/custom/kotlin/`)

| File | What it detects |
|------|----------------|
| `spring_middleware.go` | Spring Security `SecurityFilterChain @Bean`, `OncePerRequestFilter`, `HandlerInterceptor`, `@EnableWebSecurity`, WebFlux `WebFilter` |
| `ktor_di_transactions.go` | Koin `module{}` / `single` / `factory` / `scoped` / `by inject()` for DI; Exposed `transaction{}` / `newSuspendedTransaction{}` for transactions |
| `http4k_auth_middleware.go` | `ServerFilters.BearerAuth/BasicAuth/ApiKey`, `Filter{next->}` composition chains |
| `observability.go` | SLF4J / kotlin-logging loggers + log call sites; Micrometer `Counter/Timer.builder` + `@Timed`; OTel `@WithSpan` + `tracer.spanBuilder` |
| `micronaut_quarkus.go` | Micronaut: `@Secured`, `@RolesAllowed`, `@ServerFilter`/`HttpServerFilter`, JSR-330 DI. Quarkus: `@RolesAllowed`, `@Authenticated`, `@Provider ContainerRequestFilter`, CDI scopes |

### Registry changes

- **spring-boot**: `middleware_coverage` missing → partial
- **ktor**: auth + middleware + DI(3) + Tx(3) → partial; AOP(3) → not_applicable; Obs(3) → partial
- **http4k**: auth + middleware → partial; DI(3) + Tx(3) + AOP(3) → not_applicable; Obs(3) → partial
- **javalin**: auth + middleware → partial (cite Java extractor, same DSL); DI(3) + Tx(3) + AOP(3) → not_applicable; Obs(3) → partial
- **micronaut**: auth + middleware + DI(3) → partial
- **quarkus**: auth + middleware + DI(3) → partial
- **arrow / coroutines**: log + metric + trace → partial
- **compose**: request/response/schema_drift → **not_applicable** (UI-only, no HTTP handler surface)
- **kmp**: request/response/schema_drift → partial (ktor-client in shared code, citing `payload_shapes_kotlin.go`)

### Substrate verify (compose/kmp)

`payload_shapes_kotlin.go` handles `@RequestBody`, `call.receive<T>()`, and `client.post/get` with `mapOf`. Compose has no HTTP layer → `not_applicable` (honest). KMP shared modules can use ktor-client → `partial`.

### Validation

- `go build ./internal/... ./tools/coverage/...` — clean
- `go test ./internal/custom/kotlin/... ./internal/types/ ./tools/coverage/...` — all pass
- `go run ./tools/coverage validate` — exit 0 (warnings only, all pre-existing)
- `go run ./tools/coverage fmt --check` — canonical
- `go run ./tools/coverage gen` — byte-stable
- `gofmt -l internal/custom/kotlin/` — empty

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>