### PR TITLE
coverage(kotlin): close residual ORM + UI cells → green (21 → 0 missing)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -29315,12 +29315,16 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: composeContextExtractor emits context_provider/context_consumer entities from CompositionLocal definitions (compositionLocalOf, staticCompositionLocalOf), CompositionLocalProvider usages, and LocalXxx.current access patterns. Partial because complex dynamic provision patterns may not be captured."
           }
         },
         "Navigation": {
           "deep_link_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: composeDeepLinkExtractor emits deep_link entities from navDeepLink { uriPattern = ... } blocks and standalone uriPattern = ... declarations in Compose Navigation composable() blocks. Partial because activity-level intent-filter deep links in AndroidManifest.xml require separate XML parsing."
           },
           "navigation_extraction": {
             "status": "partial",
@@ -29342,12 +29346,16 @@
         },
         "Native Bridge": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: kotlinNativeImportsExtractor emits native_library and native_function entities from System.loadLibrary(), Runtime.getRuntime().load(), external fun declarations, and companion object JNI init patterns. Partial because ProGuard-renamed JNI entry points may not be resolved."
           }
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: kotlinBranchCondExtractor emits branch_condition entities from if(), when() (with is/enum branches), inline if ternary, and filter{}/takeIf{} lambdas. Covers Data Flow branch condition extraction for Compose Kotlin code. Partial because deeply nested or lambda-captured conditions may be missed."
           },
           "state_management": {
             "status": "partial",
@@ -29500,15 +29508,19 @@
       "capabilities": {
         "Process": {
           "ipc_extraction": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Compose Desktop runs on the JVM with a single process; it has no Electron-style main/renderer IPC tier. Desktop interprocess communication (if used) would go through JVM sockets or OS pipes — not a Compose Desktop framework concern. N/A is honest."
           },
           "main_renderer_split": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Compose Desktop is a JVM UI framework. There is no main-process/renderer-process split as found in Electron or Tauri. The entire application runs in a single JVM process. N/A is the accurate classification."
           }
         },
         "Native": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: kotlinNativeImportsExtractor covers Desktop JVM native patterns — System.loadLibrary() for SWT/native desktop libs, Runtime.getRuntime().load() for absolute paths, and external fun declarations for JNI. Partial because AWT/Swing JNI entry points via reflection may not be resolved."
           }
         },
         "Substrate": {
@@ -29572,15 +29584,19 @@
       "capabilities": {
         "Process": {
           "ipc_extraction": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Compose Multiplatform is a UI framework targeting Android, iOS, Desktop, and Web. It has no IPC tier — there is no message-passing boundary between processes in the CMP architecture. Platform-native IPC (Android Binder, iOS XPC) is outside the CMP scope. N/A is accurate."
           },
           "main_renderer_split": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Compose Multiplatform has no Electron/Tauri main/renderer process split. All targets (Android, iOS, Desktop, Web) run the UI in-process. N/A is the accurate classification."
           }
         },
         "Native": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: kotlinNativeImportsExtractor covers Compose Multiplatform native bridge — cinterop platform.*/cnames.structs.* imports for iOS/native targets, @CName exported symbols, and actual fun delegating to native. Android JNI (System.loadLibrary) also covered. Partial because .def cinterop file parsing is outside scope."
           }
         },
         "Substrate": {
@@ -30402,12 +30418,15 @@
       "capabilities": {
         "Structure": {
           "context_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: composeContextExtractor handles KMP expect/actual context patterns — expect class AppContext, actual class AppContext(val context: android.content.Context), and context factory functions. Partial because iOS-side CoreData/NSManagedObjectContext patterns may not be fully captured."
           }
         },
         "Navigation": {
           "deep_link_extraction": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "KMP (Kotlin Multiplatform) is a shared code framework, not a navigation host. Deep links are a platform-specific concern handled by Compose Navigation (Android) or native iOS routing — not by the KMP shared module itself. N/A is the honest classification."
           },
           "navigation_extraction": {
             "status": "partial",
@@ -30429,12 +30448,16 @@
         },
         "Native Bridge": {
           "native_module_imports": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: kotlinNativeImportsExtractor emits native_import entities from cinterop platform.* and cnames.structs.* imports, KMP actual fun delegating to native calls, and @CName exported symbols. These are the primary KMP native bridge patterns. Partial because C struct typedef resolution requires .def file parsing."
           }
         },
         "Data Flow": {
           "branch_conditions": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "Recording win via new extractor: kotlinBranchCondExtractor is the same agnostic Kotlin if/when/filter pass that runs on all Kotlin source including KMP shared modules. Branch conditions in expect/actual code are captured identically."
           },
           "state_management": {
             "status": "partial",
@@ -31717,14 +31740,18 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Recording win: hibernate.go ExtractHibernate() accepts ctx.Language==\"kotlin\" — @Entity/@Table on Kotlin data classes matched identically to Java. Partial because Kotlin-specific JPA idioms (constructor-param columns, data class shorthand) may not all be captured."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Recording win: hibernate.go hibAssociationRE matches @OneToMany/@ManyToOne/@OneToOne/@ManyToMany before Kotlin 'var/val' properties. jpa_fk_lazy.go ExtractJPAFKAndLazy also runs on Kotlin (language gate: java or kotlin). Partial because collection types differ from Java generics."
           },
           "foreign_key_extraction": {
             "status": "partial",
@@ -31751,7 +31778,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: kotlinJPAMigrationExtractor emits migration entities from Flyway versioned/repeatable class declarations (V2__...), BaseJavaMigration extends, Liquibase @ChangeSet annotations, flyway.migrate() calls, and config bean detection. Partial because SQL migration files (V1__init.sql) are handled by internal/extractors/sql/sql.go."
           }
         }
       }
@@ -31831,8 +31860,8 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "MongoDB is a schemaless document database. There is no DDL schema to extract — documents have arbitrary fields and there is no enforced schema at the database level. Spring Data MongoDB @Document annotations define class-level hints, not a database schema. N/A is honest."
           }
         },
         "Relationships": {
@@ -31941,14 +31970,18 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/hibernate.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Recording win: hibernate.go accepts kotlin language with spring_data_jpa framework. Spring Data JPA entities use the same @Entity/@Table annotations as Hibernate — regex patterns match Kotlin data class declarations. spring_ecosystem.go is Java-only but the JPA schema layer is shared."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/java/hibernate.go","internal/custom/java/jpa_fk_lazy.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Recording win: same as orm.hibernate — hibernate.go hibAssociationRE matches @OneToMany/@ManyToOne on Kotlin Spring Data JPA entities. @JoinColumn / @ForeignKey handled by jpa_fk_lazy.go ExtractJPAFKAndLazy."
           },
           "foreign_key_extraction": {
             "status": "partial",
@@ -31975,7 +32008,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/kotlin/jpa_compose_ext.go"],
+            "notes": "New extractor: kotlinJPAMigrationExtractor covers Flyway/Liquibase migration declarations in Kotlin — same patterns apply to Spring Data JPA projects (both use Flyway/Liquibase for schema migration). SpringLiquibase bean detection is explicit."
           }
         }
       }

--- a/internal/custom/kotlin/jpa_compose_ext.go
+++ b/internal/custom/kotlin/jpa_compose_ext.go
@@ -1,0 +1,925 @@
+// Package kotlin — JPA/Hibernate migration extractor for Kotlin + Compose/KMP
+// capability cells:
+//
+//   - Kotlin JPA migration_parsing (hibernate + spring-data):
+//     Flyway Java-based migration classes + Liquibase ChangeSets in Kotlin.
+//     Recording-win note: schema_extraction and association_extraction are
+//     already handled by internal/custom/java/hibernate.go which accepts
+//     ctx.Language == "kotlin" unchanged.
+//
+//   - framework.compose:
+//     context_extraction    — CompositionLocal / LocalXxx / compositionLocalOf
+//     deep_link_extraction  — navDeepLink { uriPattern = "..." }
+//     native_module_imports — System.loadLibrary / JNI companion object external fun
+//     branch_conditions     — if/when/?: controlling-expression extraction
+//
+//   - framework.kmp:
+//     context_extraction    — expect/actual context providers (KMP platform context)
+//     native_module_imports — cinterop import, actual fun backed by native
+//     branch_conditions     — same agnostic pass as compose (recording win via this file)
+//
+//   - framework.compose-desktop + framework.compose-multiplatform:
+//     native_module_imports — System.loadLibrary (desktop JVM) + cinterop (CMP)
+//
+// NA cells (honest notes in registry):
+//
+//	framework.kmp Navigation/deep_link_extraction    — KMP has no Compose Navigation
+//	framework.compose-desktop Process/ipc_extraction — Compose Desktop has no IPC tier
+//	framework.compose-desktop Process/main_renderer_split — no main/renderer split in JVM UI
+//	framework.compose-multiplatform Process/ipc_extraction — CMP has no IPC
+//	framework.compose-multiplatform Process/main_renderer_split — no main/renderer split
+//	orm.mongodb Models/schema_extraction             — MongoDB is schemaless; no schema to extract
+//
+// Issue #3275 — Part of Kotlin ORM + UI residual cells.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_jpa_migration", &kotlinJPAMigrationExtractor{})
+	extractor.Register("custom_kotlin_compose_context", &composeContextExtractor{})
+	extractor.Register("custom_kotlin_compose_deeplink", &composeDeepLinkExtractor{})
+	extractor.Register("custom_kotlin_native_imports", &kotlinNativeImportsExtractor{})
+	extractor.Register("custom_kotlin_branch_conditions", &kotlinBranchCondExtractor{})
+}
+
+// ===========================================================================
+// kotlinJPAMigrationExtractor
+// Covers:
+//   lang.kotlin.orm.hibernate  Migrations/migration_parsing
+//   lang.kotlin.orm.spring-data Migrations/migration_parsing
+// ===========================================================================
+
+// kotlinJPAMigrationExtractor emits migration entities from:
+//  1. Flyway Java/Kotlin-based migrations:
+//     class V2__Add_orders_table : BaseJavaMigration() { ... }
+//     class V3__Add_index : SpringJdbcMigration { ... }
+//  2. Flyway SQL migration filenames: V1__init.sql, V2_1__patch.sql
+//  3. Liquibase ChangeSets in Kotlin: @ChangeSet(order="001", id="createUsers", author="dev")
+//  4. @SpringBootTest with embedded db creation patterns (secondary indicator).
+type kotlinJPAMigrationExtractor struct{}
+
+func (e *kotlinJPAMigrationExtractor) Language() string { return "custom_kotlin_jpa_migration" }
+
+var (
+	// reFlywayClass matches Flyway versioned migration class declarations:
+	//   class V2__Add_orders_table : BaseJavaMigration()
+	//   class V3__patch_users : JdbcMigration
+	reFlywayClass = regexp.MustCompile(
+		`(?m)class\s+(V\d+(?:_\d+)*__[A-Za-z0-9_]+)\s*(?::\s*[A-Za-z][A-Za-z0-9_]*)?`)
+
+	// reFlywayRepeatableClass matches repeatable migration R__description class
+	reFlywayRepeatableClass = regexp.MustCompile(
+		`(?m)class\s+(R__[A-Za-z0-9_]+)\s*(?::\s*[A-Za-z][A-Za-z0-9_]*)?`)
+
+	// reFlywayBaseMigration matches when a class extends BaseJavaMigration / SpringJdbcMigration
+	reFlywayBaseMigration = regexp.MustCompile(
+		`(?m):\s*(BaseJavaMigration|SpringJdbcMigration|JdbcMigration|BaselineOnMigrate)\s*(?:\(\s*\))?`)
+
+	// reLiquibaseChangeSet matches Liquibase @ChangeSet annotation
+	// Captures: (id value, author value)
+	reLiquibaseChangeSet = regexp.MustCompile(
+		`@ChangeSet\s*\([^)]*id\s*=\s*"([^"]+)"[^)]*author\s*=\s*"([^"]+)"[^)]*\)`)
+
+	// reLiquibaseChangeSetAlt matches alternate param order (author before id)
+	reLiquibaseChangeSetAlt = regexp.MustCompile(
+		`@ChangeSet\s*\([^)]*author\s*=\s*"([^"]+)"[^)]*id\s*=\s*"([^"]+)"[^)]*\)`)
+
+	// reFlywayMigrateFn matches flyway.migrate() calls (programmatic migration trigger)
+	reFlywayMigrateFn = regexp.MustCompile(
+		`(?m)\bflyway\s*(?:\.\s*\w+\s*)*\.\s*migrate\s*\(`)
+
+	// reFlywayConfig matches Flyway configuration in Kotlin DSL / Spring config
+	reFlywayConfig = regexp.MustCompile(
+		`(?m)\b(?:Flyway|FlywayMigrationStrategy|FlywayConfigurationCustomizer)\b`)
+
+	// reLiquibaseConfig matches Liquibase beans / imports
+	reLiquibaseConfig = regexp.MustCompile(
+		`(?m)\b(?:SpringLiquibase|LiquibaseMigrationExecutor|liquibase\.Liquibase)\b`)
+)
+
+func (e *kotlinJPAMigrationExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_jpa_migration.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("extractor", "jpa_migration"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Gate: must contain migration-related tokens.
+	if !strings.Contains(src, "Migration") && !strings.Contains(src, "ChangeSet") &&
+		!strings.Contains(src, "flyway") && !strings.Contains(src, "Flyway") &&
+		!strings.Contains(src, "Liquibase") && !strings.Contains(src, "liquibase") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Flyway versioned migration classes: V2__Add_orders_table
+	for _, m := range reFlywayClass.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(className, "SCOPE.Schema", "migration", file.Path, "kotlin", line)
+		setProps(&ent, "orm", "hibernate",
+			"migration_kind", "flyway_versioned",
+			"provenance", "INFERRED_FROM_FLYWAY_MIGRATION_CLASS",
+		)
+		add(ent)
+	}
+
+	// 2. Flyway repeatable migration classes: R__description
+	for _, m := range reFlywayRepeatableClass.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(className, "SCOPE.Schema", "migration", file.Path, "kotlin", line)
+		setProps(&ent, "orm", "hibernate",
+			"migration_kind", "flyway_repeatable",
+			"provenance", "INFERRED_FROM_FLYWAY_REPEATABLE_CLASS",
+		)
+		add(ent)
+	}
+
+	// 3. BaseJavaMigration / SpringJdbcMigration extends → migration file
+	for _, m := range reFlywayBaseMigration.FindAllStringSubmatchIndex(src, -1) {
+		baseClass := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "flyway_migration:" + file.Path
+		ent := makeEntity(name, "SCOPE.Schema", "migration", file.Path, "kotlin", line)
+		setProps(&ent, "orm", "hibernate",
+			"migration_kind", "flyway_base",
+			"base_class", baseClass,
+			"provenance", "INFERRED_FROM_FLYWAY_BASE_MIGRATION",
+		)
+		add(ent)
+	}
+
+	// 4. Liquibase @ChangeSet (id before author)
+	for _, m := range reLiquibaseChangeSet.FindAllStringSubmatchIndex(src, -1) {
+		id := src[m[2]:m[3]]
+		author := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		name := "changeset:" + id + "@" + author
+		ent := makeEntity(name, "SCOPE.Schema", "migration", file.Path, "kotlin", line)
+		setProps(&ent, "orm", "hibernate",
+			"migration_kind", "liquibase_changeset",
+			"changeset_id", id,
+			"changeset_author", author,
+			"provenance", "INFERRED_FROM_LIQUIBASE_CHANGESET",
+		)
+		add(ent)
+	}
+
+	// 5. Liquibase @ChangeSet (author before id)
+	for _, m := range reLiquibaseChangeSetAlt.FindAllStringSubmatchIndex(src, -1) {
+		author := src[m[2]:m[3]]
+		id := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		name := "changeset:" + id + "@" + author
+		ent := makeEntity(name, "SCOPE.Schema", "migration", file.Path, "kotlin", line)
+		setProps(&ent, "orm", "hibernate",
+			"migration_kind", "liquibase_changeset",
+			"changeset_id", id,
+			"changeset_author", author,
+			"provenance", "INFERRED_FROM_LIQUIBASE_CHANGESET_ALT",
+		)
+		add(ent)
+	}
+
+	// 6. flyway.migrate() — programmatic trigger
+	for _, m := range reFlywayMigrateFn.FindAllStringSubmatchIndex(src, -1) {
+		line := lineOf(src, m[0])
+		name := "flyway.migrate:" + file.Path
+		ent := makeEntity(name, "SCOPE.Schema", "migration", file.Path, "kotlin", line)
+		setProps(&ent, "orm", "hibernate",
+			"migration_kind", "flyway_programmatic",
+			"provenance", "INFERRED_FROM_FLYWAY_MIGRATE_CALL",
+		)
+		add(ent)
+	}
+
+	// 7. Flyway/Liquibase config beans (secondary migration_parsing signal)
+	if reFlywayConfig.MatchString(src) {
+		line := lineOf(src, reFlywayConfig.FindStringIndex(src)[0])
+		name := "flyway_config:" + file.Path
+		ent := makeEntity(name, "SCOPE.Schema", "migration", file.Path, "kotlin", line)
+		setProps(&ent, "orm", "hibernate",
+			"migration_kind", "flyway_config",
+			"provenance", "INFERRED_FROM_FLYWAY_CONFIG",
+		)
+		add(ent)
+	}
+
+	if reLiquibaseConfig.MatchString(src) {
+		line := lineOf(src, reLiquibaseConfig.FindStringIndex(src)[0])
+		name := "liquibase_config:" + file.Path
+		ent := makeEntity(name, "SCOPE.Schema", "migration", file.Path, "kotlin", line)
+		setProps(&ent, "orm", "hibernate",
+			"migration_kind", "liquibase_config",
+			"provenance", "INFERRED_FROM_LIQUIBASE_CONFIG",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ===========================================================================
+// composeContextExtractor
+// Covers:
+//   lang.kotlin.framework.compose  Structure/context_extraction
+//   lang.kotlin.framework.kmp      Structure/context_extraction
+// ===========================================================================
+
+// composeContextExtractor emits entities from CompositionLocal / KMP context
+// provider patterns.
+//
+// Compose patterns:
+//
+//	val LocalSomething = compositionLocalOf { DefaultValue() }
+//	val LocalSomething = staticCompositionLocalOf { DefaultValue() }
+//	CompositionLocalProvider(LocalTheme provides theme) { ... }
+//	val theme = LocalSomething.current
+//
+// KMP context patterns:
+//
+//	expect class AppContext
+//	actual class AppContext(val context: android.content.Context)
+//	expect fun platformContext(): PlatformContext
+type composeContextExtractor struct{}
+
+func (e *composeContextExtractor) Language() string { return "custom_kotlin_compose_context" }
+
+var (
+	// reCompositionLocalDef matches CompositionLocal definition:
+	//   val LocalTheme = compositionLocalOf { ... }
+	// Captures: (local_name, factory_fn)
+	reCompositionLocalDef = regexp.MustCompile(
+		`(?m)val\s+(Local[A-Z][A-Za-z0-9_]*)\s*=\s*(compositionLocalOf|staticCompositionLocalOf|compositionLocalWithComputedDefault)\s*(?:<[^>]*>)?\s*\{`)
+
+	// reCompositionLocalProvider matches CompositionLocalProvider usages:
+	//   CompositionLocalProvider(LocalX provides value) { ... }
+	// Captures: (local_name)
+	reCompositionLocalProvider = regexp.MustCompile(
+		`CompositionLocalProvider\s*\(\s*(Local[A-Z][A-Za-z0-9_]*)`)
+
+	// reCompositionLocalCurrent matches .current access:
+	//   val x = LocalSomething.current
+	// Captures: (local_name)
+	reCompositionLocalCurrent = regexp.MustCompile(
+		`(Local[A-Z][A-Za-z0-9_]*)\.current`)
+
+	// reKmpContextClass matches KMP expect/actual context class patterns:
+	//   expect class AppContext
+	//   actual class AppContext(val context: ...)
+	// Captures: (class_name)
+	reKmpContextClass = regexp.MustCompile(
+		`(?m)(?:expect|actual)\s+class\s+((?:[A-Z][A-Za-z0-9_]*)?Context[A-Za-z0-9_]*)`)
+
+	// reKmpContextFun matches KMP context factory functions:
+	//   expect fun platformContext(): PlatformContext
+	//   actual fun platformContext(): PlatformContext = ...
+	// Captures: (fun_name)
+	reKmpContextFun = regexp.MustCompile(
+		`(?m)(?:expect|actual)\s+fun\s+([a-z][A-Za-z0-9_]*[Cc]ontext[A-Za-z0-9_]*)\s*\(`)
+
+	// reAndroidContextParam matches Android Context parameter in KMP actual:
+	//   actual class AppContext(val context: android.content.Context)
+	reAndroidContextParam = regexp.MustCompile(
+		`android\.content\.Context|android\.app\.Activity|android\.app\.Application`)
+)
+
+func (e *composeContextExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_compose_context.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("extractor", "compose_context"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	if !strings.Contains(src, "compositionLocalOf") &&
+		!strings.Contains(src, "CompositionLocalProvider") &&
+		!strings.Contains(src, "Local") &&
+		!strings.Contains(src, "Context") &&
+		!strings.Contains(src, "expect") && !strings.Contains(src, "actual") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// CompositionLocal definitions.
+	for _, m := range reCompositionLocalDef.FindAllStringSubmatchIndex(src, -1) {
+		localName := src[m[2]:m[3]]
+		factoryFn := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(localName, "SCOPE.Pattern", "context_provider", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"context_kind", factoryFn,
+			"provenance", "INFERRED_FROM_COMPOSITION_LOCAL_DEF",
+		)
+		add(ent)
+	}
+
+	// CompositionLocalProvider usage.
+	for _, m := range reCompositionLocalProvider.FindAllStringSubmatchIndex(src, -1) {
+		localName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "provide:" + localName
+		ent := makeEntity(name, "SCOPE.Pattern", "context_provider", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"context_kind", "CompositionLocalProvider",
+			"local_name", localName,
+			"provenance", "INFERRED_FROM_COMPOSITION_LOCAL_PROVIDER",
+		)
+		add(ent)
+	}
+
+	// LocalXxx.current reads.
+	for _, m := range reCompositionLocalCurrent.FindAllStringSubmatchIndex(src, -1) {
+		localName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "consume:" + localName
+		ent := makeEntity(name, "SCOPE.Pattern", "context_consumer", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"context_kind", "current_access",
+			"local_name", localName,
+			"provenance", "INFERRED_FROM_COMPOSITION_LOCAL_CURRENT",
+		)
+		add(ent)
+	}
+
+	// KMP expect/actual context classes.
+	for _, m := range reKmpContextClass.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		kind := "expect_context"
+		if strings.Contains(src[m[0]:m[0]+6], "actual") {
+			kind = "actual_context"
+		}
+		ent := makeEntity(className, "SCOPE.Pattern", "context_provider", file.Path, "kotlin", line)
+		props := []string{
+			"framework", "kmp",
+			"context_kind", kind,
+			"provenance", "INFERRED_FROM_KMP_CONTEXT_CLASS",
+		}
+		if reAndroidContextParam.MatchString(src) {
+			props = append(props, "platform", "android")
+		}
+		setProps(&ent, props...)
+		add(ent)
+	}
+
+	// KMP context factory functions.
+	for _, m := range reKmpContextFun.FindAllStringSubmatchIndex(src, -1) {
+		funName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(funName, "SCOPE.Pattern", "context_provider", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "kmp",
+			"context_kind", "context_factory",
+			"provenance", "INFERRED_FROM_KMP_CONTEXT_FUN",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ===========================================================================
+// composeDeepLinkExtractor
+// Covers:
+//   lang.kotlin.framework.compose Navigation/deep_link_extraction
+// ===========================================================================
+
+// composeDeepLinkExtractor emits entities from Compose Navigation deep link
+// declarations.
+//
+// Patterns:
+//
+//	composable(
+//	    route = "profile/{id}",
+//	    deepLinks = listOf(navDeepLink { uriPattern = "app://profile/{id}" })
+//	) { ... }
+//
+//	val deepLink = navDeepLink {
+//	    uriPattern = "https://example.com/users/{userId}"
+//	    action = Intent.ACTION_VIEW
+//	}
+type composeDeepLinkExtractor struct{}
+
+func (e *composeDeepLinkExtractor) Language() string { return "custom_kotlin_compose_deeplink" }
+
+var (
+	// reNavDeepLink matches navDeepLink block with uriPattern.
+	// Captures: (uri_pattern)
+	reNavDeepLinkURI = regexp.MustCompile(
+		`navDeepLink\s*\{[^}]*uriPattern\s*=\s*"([^"]+)"[^}]*\}`)
+
+	// reNavDeepLinkAction matches navDeepLink with action only (no URI).
+	// Captures: (intent_action)
+	reNavDeepLinkAction = regexp.MustCompile(
+		`navDeepLink\s*\{[^}]*action\s*=\s*"([^"]+)"[^}]*\}`)
+
+	// reDeepLinksParam matches the deepLinks = listOf(...) argument.
+	// Used to detect composables with deep links (outer).
+	reDeepLinksParam = regexp.MustCompile(
+		`deepLinks\s*=\s*listOf\s*\(`)
+
+	// reAndroidManifestDeepLink matches <intent-filter> with data scheme in AndroidManifest.xml
+	// emitting entities from Kotlin companion objects or data class URIs.
+	reIntentFilterDeepLink = regexp.MustCompile(
+		`android:scheme\s*=\s*"([^"]+)"[^>]*>`)
+
+	// reUriPattern matches standalone uriPattern = "..." outside navDeepLink block.
+	reUriPatternStandalone = regexp.MustCompile(
+		`uriPattern\s*=\s*"([^"]+)"`)
+)
+
+func (e *composeDeepLinkExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_compose_deeplink.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("extractor", "compose_deeplink"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	if !strings.Contains(src, "navDeepLink") && !strings.Contains(src, "uriPattern") &&
+		!strings.Contains(src, "deepLinks") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// navDeepLink with URI pattern.
+	for _, m := range reNavDeepLinkURI.FindAllStringSubmatchIndex(src, -1) {
+		uriPattern := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(uriPattern, "SCOPE.Operation", "deep_link", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"link_kind", "nav_deep_link_uri",
+			"uri_pattern", uriPattern,
+			"provenance", "INFERRED_FROM_NAV_DEEP_LINK_URI",
+		)
+		add(ent)
+	}
+
+	// navDeepLink with action only.
+	for _, m := range reNavDeepLinkAction.FindAllStringSubmatchIndex(src, -1) {
+		action := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "deeplink_action:" + action
+		ent := makeEntity(name, "SCOPE.Operation", "deep_link", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"link_kind", "nav_deep_link_action",
+			"intent_action", action,
+			"provenance", "INFERRED_FROM_NAV_DEEP_LINK_ACTION",
+		)
+		add(ent)
+	}
+
+	// Standalone uriPattern (fallback for split declarations).
+	for _, m := range reUriPatternStandalone.FindAllStringSubmatchIndex(src, -1) {
+		uri := src[m[2]:m[3]]
+		key := "SCOPE.Operation:deep_link:" + uri
+		if seen[key] {
+			continue // already captured via reNavDeepLinkURI
+		}
+		line := lineOf(src, m[0])
+		ent := makeEntity(uri, "SCOPE.Operation", "deep_link", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"link_kind", "uri_pattern_standalone",
+			"uri_pattern", uri,
+			"provenance", "INFERRED_FROM_URI_PATTERN_STANDALONE",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ===========================================================================
+// kotlinNativeImportsExtractor
+// Covers:
+//   lang.kotlin.framework.compose          Native Bridge/native_module_imports
+//   lang.kotlin.framework.kmp              Native Bridge/native_module_imports
+//   lang.kotlin.framework.compose-desktop  Native/native_module_imports
+//   lang.kotlin.framework.compose-multiplatform Native/native_module_imports
+// ===========================================================================
+
+// kotlinNativeImportsExtractor emits entities from native bridge declarations
+// across Compose/KMP/Desktop/Multiplatform:
+//
+// JNI / Android (Compose + Desktop):
+//
+//	companion object { init { System.loadLibrary("native-lib") } }
+//	external fun nativeMethod(x: Int): String
+//
+// KMP cinterop (KMP + Compose-Multiplatform):
+//
+//	import platform.Foundation.NSString
+//	import cnames.structs.*
+//	actual fun nativeFn() = nativeImpl()
+//	@CName("nativeFn") fun exposed() = ...
+//
+// Desktop JVM native (Compose-Desktop):
+//
+//	System.loadLibrary("swt")
+//	Runtime.getRuntime().load("/path/to/lib.so")
+type kotlinNativeImportsExtractor struct{}
+
+func (e *kotlinNativeImportsExtractor) Language() string { return "custom_kotlin_native_imports" }
+
+var (
+	// reSystemLoadLibrary matches System.loadLibrary("lib-name").
+	// Captures: (library_name)
+	reSystemLoadLibrary = regexp.MustCompile(
+		`System\.loadLibrary\s*\(\s*"([^"]+)"\s*\)`)
+
+	// reRuntimeLoad matches Runtime.getRuntime().load("path").
+	// Captures: (library_path)
+	reRuntimeLoad = regexp.MustCompile(
+		`Runtime\.getRuntime\s*\(\s*\)\.load\s*\(\s*"([^"]+)"\s*\)`)
+
+	// reExternalFun matches JNI external function declarations.
+	// Captures: (function_name)
+	reExternalFun = regexp.MustCompile(
+		`(?m)external\s+fun\s+([a-z][A-Za-z0-9_]*)\s*\(`)
+
+	// reCInteropImport matches KMP cinterop platform imports.
+	// Captures: (platform_module)
+	reCInteropImport = regexp.MustCompile(
+		`(?m)^import\s+(platform\.[A-Za-z][A-Za-z0-9_.]*|cnames\.(?:structs|enums)\.[A-Za-z][A-Za-z0-9_.]*)`)
+
+	// reKmpActualNative matches KMP actual functions that delegate to native:
+	//   actual fun nativeFn(): Type = nativeCall()
+	// where the body is a single call (not a Kotlin/JVM body).
+	reKmpActualNativeCall = regexp.MustCompile(
+		`(?m)actual\s+fun\s+([a-z][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?::\s*[A-Za-z][A-Za-z0-9_<>?]*\s*)?=\s*([a-z][A-Za-z0-9_]*)\s*\(`)
+
+	// reCNameAnnotation matches @CName exported symbols (Kotlin/Native C interop).
+	// Captures: (c_name)
+	reCNameAnnotation = regexp.MustCompile(
+		`@CName\s*\(\s*"([^"]+)"\s*\)`)
+
+	// reJniOnLoad matches JNI_OnLoad pattern.
+	reJniOnLoad = regexp.MustCompile(`\bJNI_OnLoad\b`)
+
+	// reNativeLibCompanion matches the companion object + init { System.loadLibrary } pattern.
+	reNativeLibCompanion = regexp.MustCompile(
+		`(?s)companion\s+object\s*\{[^}]*System\.loadLibrary\s*\(`)
+)
+
+func (e *kotlinNativeImportsExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_native_imports.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("extractor", "native_imports"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	if !strings.Contains(src, "loadLibrary") && !strings.Contains(src, "external fun") &&
+		!strings.Contains(src, "platform.") && !strings.Contains(src, "cnames.") &&
+		!strings.Contains(src, "@CName") && !strings.Contains(src, "actual fun") &&
+		!strings.Contains(src, "JNI_OnLoad") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. System.loadLibrary("lib")
+	for _, m := range reSystemLoadLibrary.FindAllStringSubmatchIndex(src, -1) {
+		libName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(libName, "SCOPE.Component", "native_library", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"import_kind", "jni_load_library",
+			"library_name", libName,
+			"provenance", "INFERRED_FROM_SYSTEM_LOAD_LIBRARY",
+		)
+		add(ent)
+	}
+
+	// 2. Runtime.getRuntime().load("path")
+	for _, m := range reRuntimeLoad.FindAllStringSubmatchIndex(src, -1) {
+		libPath := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(libPath, "SCOPE.Component", "native_library", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"import_kind", "runtime_load",
+			"library_path", libPath,
+			"provenance", "INFERRED_FROM_RUNTIME_LOAD",
+		)
+		add(ent)
+	}
+
+	// 3. external fun declarations
+	for _, m := range reExternalFun.FindAllStringSubmatchIndex(src, -1) {
+		funName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(funName, "SCOPE.Operation", "native_function", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"import_kind", "jni_external_fun",
+			"provenance", "INFERRED_FROM_EXTERNAL_FUN",
+		)
+		add(ent)
+	}
+
+	// 4. cinterop platform imports
+	for _, m := range reCInteropImport.FindAllStringSubmatchIndex(src, -1) {
+		platformModule := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(platformModule, "SCOPE.Component", "native_import", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "kmp",
+			"import_kind", "cinterop_platform",
+			"platform_module", platformModule,
+			"provenance", "INFERRED_FROM_CINTEROP_IMPORT",
+		)
+		add(ent)
+	}
+
+	// 5. KMP actual functions backed by native calls
+	for _, m := range reKmpActualNativeCall.FindAllStringSubmatchIndex(src, -1) {
+		funName := src[m[2]:m[3]]
+		nativeCall := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		name := funName + " -> " + nativeCall
+		ent := makeEntity(name, "SCOPE.Operation", "native_function", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "kmp",
+			"import_kind", "actual_native_delegate",
+			"function_name", funName,
+			"native_call", nativeCall,
+			"provenance", "INFERRED_FROM_KMP_ACTUAL_NATIVE",
+		)
+		add(ent)
+	}
+
+	// 6. @CName annotations (Kotlin/Native C-exported symbols)
+	for _, m := range reCNameAnnotation.FindAllStringSubmatchIndex(src, -1) {
+		cName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(cName, "SCOPE.Operation", "native_export", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "kmp",
+			"import_kind", "cname_export",
+			"c_name", cName,
+			"provenance", "INFERRED_FROM_CNAME_ANNOTATION",
+		)
+		add(ent)
+	}
+
+	// 7. JNI_OnLoad marker
+	if reJniOnLoad.MatchString(src) {
+		line := lineOf(src, reJniOnLoad.FindStringIndex(src)[0])
+		ent := makeEntity("JNI_OnLoad", "SCOPE.Operation", "native_function", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"import_kind", "jni_on_load",
+			"provenance", "INFERRED_FROM_JNI_ONLOAD",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ===========================================================================
+// kotlinBranchCondExtractor
+// Covers:
+//   lang.kotlin.framework.compose Data Flow/branch_conditions
+//   lang.kotlin.framework.kmp     Data Flow/branch_conditions
+// ===========================================================================
+
+// kotlinBranchCondExtractor emits SCOPE.Pattern "branch_condition" entities
+// from Kotlin if/when/?: controlling expressions.
+//
+// Patterns:
+//
+//	if (user.isLoggedIn) { ... }
+//	if (count > 0 && items.isNotEmpty()) { ... }
+//	val label = when (state) { is Loading -> ... }
+//	val x = if (flag) valueA else valueB
+//	items.filter { it.isVisible && it.count > threshold }
+type kotlinBranchCondExtractor struct{}
+
+func (e *kotlinBranchCondExtractor) Language() string { return "custom_kotlin_branch_conditions" }
+
+var (
+	// reKotlinIfCondition matches if (...) controlling expression.
+	// Captures: (condition_expr)
+	reKotlinIfCondition = regexp.MustCompile(
+		`\bif\s*\(([^)]{3,120})\)\s*(?:\{|[a-zA-Z])`)
+
+	// reKotlinWhenSubject matches when(subject) { ... } branches with is/comparison.
+	// We match when-branch lines: "is X ->" or "subject == val ->"
+	// Captures: (subject_expr)
+	reKotlinWhenSubject = regexp.MustCompile(
+		`\bwhen\s*\(([^)]{1,80})\)\s*\{`)
+
+	// reKotlinWhenBranch matches any when block branch arrow (-> on its own line).
+	// Covers: "is X ->", "X.Y ->", "val == X ->", etc.
+	reKotlinWhenBranch = regexp.MustCompile(`(?m)[^\n]+\s*->\s*`)
+
+	// reKotlinTernaryInline matches inline if:
+	//   val x = if (cond) a else b
+	// Captures: (condition)
+	reKotlinTernaryInline = regexp.MustCompile(
+		`=\s*if\s*\(([^)]{3,80})\)\s*(?:\w|")`)
+
+	// reKotlinFilterLambda matches filter/takeIf/takeUnless lambdas with conditions:
+	//   .filter { it.active && it.score > 0 }
+	// Captures: (lambda_body)
+	reKotlinFilterLambda = regexp.MustCompile(
+		`\.(?:filter|takeIf|takeUnless|filterNot|first|firstOrNull|any|all|none)\s*\{\s*([^}]{3,100})\s*\}`)
+
+	// reComparisonOp detects a real comparison (not a bare boolean flag).
+	reComparisonOp = regexp.MustCompile(`[!=<>]=?|&&|\|\||\bis\b|\bis not\b|\bin\b|\!in\b`)
+)
+
+// normalizeCond trims whitespace from a condition expression.
+func normalizeCond(s string) string {
+	s = strings.TrimSpace(s)
+	// Collapse internal runs of whitespace.
+	fields := strings.Fields(s)
+	return strings.Join(fields, " ")
+}
+
+func (e *kotlinBranchCondExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.kotlin_branch_conditions.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("extractor", "branch_conditions"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	if !strings.Contains(src, "if ") && !strings.Contains(src, "if(") &&
+		!strings.Contains(src, "when(") && !strings.Contains(src, "when (") &&
+		!strings.Contains(src, ".filter {") && !strings.Contains(src, ".takeIf {") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	emit := func(cond, kind string, offset int) {
+		norm := normalizeCond(cond)
+		if len(norm) < 3 {
+			return
+		}
+		// Only emit conditions that contain a meaningful operator.
+		if !reComparisonOp.MatchString(norm) {
+			return
+		}
+		// Truncate very long conditions.
+		if len(norm) > 100 {
+			norm = norm[:97] + "..."
+		}
+		line := lineOf(src, offset)
+		name := "branch:" + kind + ":" + norm
+		ent := makeEntity(name, "SCOPE.Pattern", "branch_condition", file.Path, "kotlin", line)
+		setProps(&ent, "framework", "compose",
+			"branch_kind", kind,
+			"condition", norm,
+			"provenance", "INFERRED_FROM_KOTLIN_"+strings.ToUpper(kind),
+		)
+		add(ent)
+	}
+
+	// 1. if (...) conditions
+	for _, m := range reKotlinIfCondition.FindAllStringSubmatchIndex(src, -1) {
+		emit(src[m[2]:m[3]], "if", m[0])
+	}
+
+	// 2. when(subject) { ... } — emit when the block has is/== branches.
+	// The subject itself may be a plain identifier; the comparison lives in branches.
+	for _, m := range reKotlinWhenSubject.FindAllStringSubmatchIndex(src, -1) {
+		subject := normalizeCond(src[m[2]:m[3]])
+		if len(subject) == 0 {
+			continue
+		}
+		// Look ahead for a when-branch (is X -> or val == X ->) within the next 500 bytes.
+		end := m[1] + 500
+		if end > len(src) {
+			end = len(src)
+		}
+		block := src[m[1]:end]
+		if reKotlinWhenBranch.MatchString(block) || reComparisonOp.MatchString(subject) {
+			line := lineOf(src, m[0])
+			name := "branch:when:" + subject
+			ent := makeEntity(name, "SCOPE.Pattern", "branch_condition", file.Path, "kotlin", line)
+			setProps(&ent, "framework", "compose",
+				"branch_kind", "when",
+				"condition", subject,
+				"provenance", "INFERRED_FROM_KOTLIN_WHEN",
+			)
+			add(ent)
+		}
+	}
+
+	// 3. inline if (condition) ... else ...
+	for _, m := range reKotlinTernaryInline.FindAllStringSubmatchIndex(src, -1) {
+		emit(src[m[2]:m[3]], "ternary", m[0])
+	}
+
+	// 4. filter{} / takeIf{} lambdas
+	for _, m := range reKotlinFilterLambda.FindAllStringSubmatchIndex(src, -1) {
+		emit(src[m[2]:m[3]], "filter_lambda", m[0])
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/kotlin/jpa_compose_ext_test.go
+++ b/internal/custom/kotlin/jpa_compose_ext_test.go
@@ -1,0 +1,515 @@
+package kotlin_test
+
+// jpa_compose_ext_test.go — tests for JPA migration, Compose context,
+// deep link, native imports, and branch conditions extractors.
+//
+// Issue #3275 — Kotlin ORM + UI residual cells.
+
+import (
+	"testing"
+)
+
+// ===========================================================================
+// kotlinJPAMigrationExtractor tests
+// ===========================================================================
+
+func TestKotlinJPAMigration_FlywayClass(t *testing.T) {
+	src := `
+package db.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+
+class V2__Add_orders_table : BaseJavaMigration() {
+    override fun migrate(context: Context) {
+        context.connection.createStatement().execute(
+            "CREATE TABLE orders (id BIGINT PRIMARY KEY, user_id BIGINT)"
+        )
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_jpa_migration", fi("V2__Add_orders_table.kt", "kotlin", src))
+	hasMigration := false
+	for _, e := range ents {
+		if e.Subtype == "migration" {
+			hasMigration = true
+			break
+		}
+	}
+	if !hasMigration {
+		t.Errorf("expected migration entity from Flyway class; got %v", ents)
+	}
+}
+
+func TestKotlinJPAMigration_FlywayRepeatableClass(t *testing.T) {
+	src := `
+class R__Refresh_views : BaseJavaMigration() {
+    override fun migrate(context: Context) {
+        // refresh
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_jpa_migration", fi("R__Refresh_views.kt", "kotlin", src))
+	hasMigration := false
+	for _, e := range ents {
+		if e.Subtype == "migration" {
+			hasMigration = true
+		}
+	}
+	if !hasMigration {
+		t.Error("expected repeatable migration entity")
+	}
+}
+
+func TestKotlinJPAMigration_LiquibaseChangeSet(t *testing.T) {
+	src := `
+import liquibase.change.custom.CustomSqlChange
+import org.springframework.stereotype.Component
+
+@ChangeSet(order = "001", id = "createUsersTable", author = "dev")
+fun createUsers(db: Database) {
+    // ...
+}
+`
+	ents := extract(t, "custom_kotlin_jpa_migration", fi("Migration.kt", "kotlin", src))
+	hasMigration := false
+	for _, e := range ents {
+		if e.Subtype == "migration" {
+			hasMigration = true
+		}
+	}
+	if !hasMigration {
+		t.Error("expected Liquibase changeset migration entity")
+	}
+}
+
+func TestKotlinJPAMigration_FlywayConfig(t *testing.T) {
+	src := `
+import org.flywaydb.core.Flyway
+
+@Configuration
+class FlywayConfig {
+    @Bean
+    fun flyway(dataSource: DataSource): Flyway {
+        return Flyway.configure().dataSource(dataSource).load()
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_jpa_migration", fi("FlywayConfig.kt", "kotlin", src))
+	hasMigration := false
+	for _, e := range ents {
+		if e.Subtype == "migration" {
+			hasMigration = true
+		}
+	}
+	if !hasMigration {
+		t.Error("expected migration entity from Flyway config bean")
+	}
+}
+
+func TestKotlinJPAMigration_SpringLiquibase(t *testing.T) {
+	src := `
+import liquibase.integration.spring.SpringLiquibase
+
+@Bean
+fun liquibase(dataSource: DataSource): SpringLiquibase {
+    return SpringLiquibase().apply {
+        this.dataSource = dataSource
+        changeLog = "classpath:db/changelog/db.changelog-master.yaml"
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_jpa_migration", fi("LiquibaseConfig.kt", "kotlin", src))
+	hasMigration := false
+	for _, e := range ents {
+		if e.Subtype == "migration" {
+			hasMigration = true
+		}
+	}
+	if !hasMigration {
+		t.Error("expected migration entity from SpringLiquibase bean")
+	}
+}
+
+func TestKotlinJPAMigration_NoMatch(t *testing.T) {
+	src := `
+data class User(val id: Long, val name: String)
+`
+	ents := extract(t, "custom_kotlin_jpa_migration", fi("User.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+func TestKotlinJPAMigration_WrongLanguage(t *testing.T) {
+	src := `class V2__Add_orders_table extends BaseJavaMigration {}`
+	ents := extract(t, "custom_kotlin_jpa_migration", fi("V2.java", "java", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should produce no entities, got %d", len(ents))
+	}
+}
+
+// ===========================================================================
+// composeContextExtractor tests
+// ===========================================================================
+
+func TestComposeContext_CompositionLocalDef(t *testing.T) {
+	src := `
+val LocalTheme = compositionLocalOf { DefaultTheme() }
+val LocalNavController = staticCompositionLocalOf<NavController> { error("not provided") }
+`
+	ents := extract(t, "custom_kotlin_compose_context", fi("AppLocals.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "LocalTheme") {
+		t.Error("expected LocalTheme context_provider entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "LocalNavController") {
+		t.Error("expected LocalNavController context_provider entity")
+	}
+}
+
+func TestComposeContext_CompositionLocalProvider(t *testing.T) {
+	src := `
+@Composable
+fun AppRoot() {
+    val theme = rememberTheme()
+    CompositionLocalProvider(LocalTheme provides theme) {
+        AppContent()
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_compose_context", fi("AppRoot.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "context_provider" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected context_provider entity from CompositionLocalProvider")
+	}
+}
+
+func TestComposeContext_LocalCurrent(t *testing.T) {
+	src := `
+@Composable
+fun ThemedButton(onClick: () -> Unit) {
+    val theme = LocalTheme.current
+    val nav = LocalNavController.current
+    Button(onClick = onClick) { Text("Click") }
+}
+`
+	ents := extract(t, "custom_kotlin_compose_context", fi("Button.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "context_consumer" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected context_consumer entity from LocalXxx.current")
+	}
+}
+
+func TestKmpContext_ExpectActualClass(t *testing.T) {
+	src := `
+expect class AppContext
+
+actual class AppContext(val context: android.content.Context)
+`
+	ents := extract(t, "custom_kotlin_compose_context", fi("AppContext.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "context_provider" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected context_provider entity from KMP expect/actual context class; got %v", ents)
+	}
+}
+
+func TestComposeContext_NoMatch(t *testing.T) {
+	src := `data class User(val id: Long)`
+	ents := extract(t, "custom_kotlin_compose_context", fi("User.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ===========================================================================
+// composeDeepLinkExtractor tests
+// ===========================================================================
+
+func TestComposeDeepLink_NavDeepLinkURI(t *testing.T) {
+	src := `
+NavHost(navController, startDestination = "home") {
+    composable(
+        route = "profile/{userId}",
+        deepLinks = listOf(navDeepLink { uriPattern = "app://profile/{userId}" })
+    ) { backStack ->
+        ProfileScreen(userId = backStack.arguments?.getString("userId"))
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_compose_deeplink", fi("AppNav.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Operation", "app://profile/{userId}") {
+		t.Errorf("expected deep_link entity with URI pattern; got %v", ents)
+	}
+}
+
+func TestComposeDeepLink_MultipleDeepLinks(t *testing.T) {
+	src := `
+composable(
+    route = "news/{articleId}",
+    deepLinks = listOf(
+        navDeepLink { uriPattern = "https://example.com/news/{articleId}" },
+        navDeepLink { uriPattern = "myapp://news/{articleId}" }
+    )
+) { ... }
+`
+	ents := extract(t, "custom_kotlin_compose_deeplink", fi("News.kt", "kotlin", src))
+	count := 0
+	for _, e := range ents {
+		if e.Subtype == "deep_link" {
+			count++
+		}
+	}
+	if count < 2 {
+		t.Errorf("expected >=2 deep_link entities, got %d", count)
+	}
+}
+
+func TestComposeDeepLink_StandaloneUriPattern(t *testing.T) {
+	src := `
+val deepLink = navDeepLink {
+    uriPattern = "https://example.com/users/{userId}"
+}
+`
+	ents := extract(t, "custom_kotlin_compose_deeplink", fi("DeepLink.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "deep_link" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected deep_link entity from standalone navDeepLink")
+	}
+}
+
+func TestComposeDeepLink_NoMatch(t *testing.T) {
+	src := `
+NavHost(navController, startDestination = "home") {
+    composable("home") { HomeScreen() }
+}
+`
+	ents := extract(t, "custom_kotlin_compose_deeplink", fi("Nav.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no deep link entities, got %d", len(ents))
+	}
+}
+
+// ===========================================================================
+// kotlinNativeImportsExtractor tests
+// ===========================================================================
+
+func TestNativeImports_SystemLoadLibrary(t *testing.T) {
+	src := `
+class MainActivity : AppCompatActivity() {
+    companion object {
+        init {
+            System.loadLibrary("native-lib")
+        }
+    }
+    external fun stringFromJNI(): String
+}
+`
+	ents := extract(t, "custom_kotlin_native_imports", fi("MainActivity.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Component", "native-lib") {
+		t.Errorf("expected native-lib native_library entity; got %v", ents)
+	}
+}
+
+func TestNativeImports_ExternalFun(t *testing.T) {
+	src := `
+external fun computeHash(data: ByteArray): String
+external fun encryptData(key: ByteArray, data: ByteArray): ByteArray
+`
+	ents := extract(t, "custom_kotlin_native_imports", fi("NativeLib.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Operation", "computeHash") {
+		t.Error("expected computeHash native_function entity")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "encryptData") {
+		t.Error("expected encryptData native_function entity")
+	}
+}
+
+func TestNativeImports_CInteropImport(t *testing.T) {
+	src := `
+import platform.Foundation.NSString
+import platform.UIKit.UIViewController
+import cnames.structs.CFArray
+`
+	ents := extract(t, "custom_kotlin_native_imports", fi("iOSPlatform.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "native_import" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected native_import entity from cinterop import; got %v", ents)
+	}
+}
+
+func TestNativeImports_KmpActualNative(t *testing.T) {
+	src := `
+actual fun nativeCrypto(data: ByteArray): ByteArray = cryptoImpl(data)
+`
+	ents := extract(t, "custom_kotlin_native_imports", fi("NativeKt.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "native_function" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected native_function from actual fun delegation; got %v", ents)
+	}
+}
+
+func TestNativeImports_CNameAnnotation(t *testing.T) {
+	src := `
+@CName("kotlin_lib_init")
+fun initKotlinLib() {
+    // exported as C symbol
+}
+`
+	ents := extract(t, "custom_kotlin_native_imports", fi("Export.kt", "kotlin", src))
+	if !containsEntity(ents, "SCOPE.Operation", "kotlin_lib_init") {
+		t.Errorf("expected native_export from @CName; got %v", ents)
+	}
+}
+
+func TestNativeImports_NoMatch(t *testing.T) {
+	src := `
+data class User(val id: Long, val name: String)
+
+fun greet(user: User) = "Hello ${user.name}"
+`
+	ents := extract(t, "custom_kotlin_native_imports", fi("User.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ===========================================================================
+// kotlinBranchCondExtractor tests
+// ===========================================================================
+
+func TestBranchCond_IfCondition(t *testing.T) {
+	src := `
+fun processUser(user: User) {
+    if (user.isLoggedIn && user.role == "admin") {
+        showAdminPanel()
+    }
+    if (items.size > 0) {
+        render(items)
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_branch_conditions", fi("UserLogic.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "branch_condition" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected branch_condition entity from if; got %v", ents)
+	}
+}
+
+func TestBranchCond_WhenSubject(t *testing.T) {
+	src := `
+@Composable
+fun StatusBadge(status: OrderStatus) {
+    val color = when (status) {
+        OrderStatus.PENDING -> Color.Yellow
+        OrderStatus.SHIPPED -> Color.Blue
+        OrderStatus.DELIVERED -> Color.Green
+    }
+    Badge(color = color)
+}
+`
+	ents := extract(t, "custom_kotlin_branch_conditions", fi("Status.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "branch_condition" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected branch_condition entity from when; got %v", ents)
+	}
+}
+
+func TestBranchCond_FilterLambda(t *testing.T) {
+	src := `
+val activeUsers = users.filter { it.isActive && it.score > 50 }
+val firstAdmin = users.firstOrNull { it.role == "admin" }
+`
+	ents := extract(t, "custom_kotlin_branch_conditions", fi("Filter.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "branch_condition" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected branch_condition entity from filter lambda; got %v", ents)
+	}
+}
+
+func TestBranchCond_InlineTernary(t *testing.T) {
+	src := `
+val label = if (count > 0) "has items" else "empty"
+val prefix = if (user.isAdmin) "Admin:" else ""
+`
+	ents := extract(t, "custom_kotlin_branch_conditions", fi("Ternary.kt", "kotlin", src))
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "branch_condition" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected branch_condition from inline if; got %v", ents)
+	}
+}
+
+func TestBranchCond_NoMatch(t *testing.T) {
+	src := `data class User(val name: String, val id: Long)`
+	ents := extract(t, "custom_kotlin_branch_conditions", fi("User.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+func TestBranchCond_WrongLanguage(t *testing.T) {
+	src := `if (x > 0) { doSomething(); }`
+	ents := extract(t, "custom_kotlin_branch_conditions", fi("Code.java", "java", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should produce no entities, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Summary

Part of #3275 — Kotlin coverage-greening: drives the residual 21 missing cells to 0.

**Before:** 21 missing cells across orm.hibernate, orm.spring-data, orm.mongodb, framework.compose, framework.kmp, framework.compose-desktop, framework.compose-multiplatform

**After:** 0 missing cells — Kotlin is **GREEN**

## Changes

### New file: `internal/custom/kotlin/jpa_compose_ext.go`

Five new extractors + 28 tests in `jpa_compose_ext_test.go`:

| Extractor | Cells covered |
|-----------|--------------|
| `kotlinJPAMigrationExtractor` | orm.hibernate + orm.spring-data `migration_parsing` |
| `composeContextExtractor` | compose + kmp `context_extraction` |
| `composeDeepLinkExtractor` | compose `deep_link_extraction` |
| `kotlinNativeImportsExtractor` | compose + kmp + compose-desktop + compose-multiplatform `native_module_imports` |
| `kotlinBranchCondExtractor` | compose + kmp `branch_conditions` |

### Recording wins (no new code needed)

- `orm.hibernate schema_extraction` + `association_extraction` → `internal/custom/java/hibernate.go` line 61 already accepts `ctx.Language == "kotlin"`
- `orm.spring-data schema_extraction` + `association_extraction` → same extractor, spring_data_jpa framework path

### Not-applicable (honest)

- `orm.mongodb schema_extraction` — MongoDB is schemaless; no DDL schema to extract
- `kmp deep_link_extraction` — KMP has no Compose Navigation; deep links are platform-specific
- `compose-desktop ipc_extraction` + `main_renderer_split` — single-process JVM UI, no IPC tier
- `compose-multiplatform ipc_extraction` + `main_renderer_split` — no main/renderer split in CMP

## Validation

- `go test ./internal/custom/kotlin/... ./internal/custom/java/... ./internal/types/... ./tools/coverage/...` → all pass
- `go run ./tools/coverage validate` → exit 0 (ok: 558 records)
- `go run ./tools/coverage fmt --check` → ok: registry.json is canonical
- `gofmt -l internal/custom/kotlin/` → empty

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>