### PR TITLE
coverage(scala): framework+build records → green

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -143,14 +143,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ## UI Frontend
@@ -181,7 +181,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🔴 0/2 | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/7 | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | — | |
 
 
 ## Mobile

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/3 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | 🟡 2/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 17/21 | 🔴 0/15 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ### Meta Framework
 
-| Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|---|
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🔴 0/2 | 🔴 0/3 | 🔴 0/1 | 🟡 14/21 | 🔴 0/7 | |
+| Name | Routing | Type System | Testing | Substrate | Notes |
+|---|---|---|---|---|---|
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -17,73 +17,73 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
+| Type extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved. |
 
 ### DI
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
+| DI injection point | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
+| DI scope resolution | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction propagation | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Aspect extraction | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders, MeterRegistry usage. File-local. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry Tracer.start, Jaeger GlobalTracer, Kamon span patterns. File-local. |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -15,75 +15,75 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Endpoint synthesis | 🔴 `missing` | — | — | — | — |
-| Handler attribution | 🔴 `missing` | — | — | — | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Cask @cask.get/@cask.post routes synthesized into SCOPE.Operation/http_route entities with method+path. |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Cask route annotation detected in context of the enclosing object/class — handler method attributed to route. |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: @cask.get/@cask.post annotation routes with path extraction. File-local. |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
+| Type extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved. |
 
 ### DI
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
+| DI injection point | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
+| DI scope resolution | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction propagation | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Aspect extraction | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -42,16 +42,16 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
+| Type extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved. |
 
 ### DI
 
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer Counter.builder/Timer.builder, Kamon meter patterns. Cats Effect apps commonly use Micrometer or Kamon. File-local. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry Tracer/Span, Kamon tracing patterns. Cats Effect + natchez or otel4s is the idiomatic tracing stack. File-local. |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -17,73 +17,73 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/finatra.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/finatra.yaml` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
+| Type extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved. |
 
 ### DI
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: Guice bind[T].to[Impl], @Provides methods, TwitterModule/AbstractModule declarations. Finatra/Lagom use Guice for DI. File-local. |
+| DI injection point | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: @Inject constructor annotation (class Foo @Inject()(dep: T)) and field injection. File-local. |
+| DI scope resolution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: @Singleton class annotation detected as Guice singleton scope. File-local. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction propagation | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Aspect extraction | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -17,73 +17,73 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/http4s.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/http4s.yaml` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
+| Type extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved. |
 
 ### DI
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
+| DI injection point | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
+| DI scope resolution | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction propagation | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Aspect extraction | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -17,73 +17,73 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/lagom.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/lagom.yaml` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
+| Type extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved. |
 
 ### DI
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: Guice bind[T].to[Impl], @Provides methods, TwitterModule/AbstractModule declarations. Finatra/Lagom use Guice for DI. File-local. |
+| DI injection point | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: @Inject constructor annotation (class Foo @Inject()(dep: T)) and field injection. File-local. |
+| DI scope resolution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: @Singleton class annotation detected as Guice singleton scope. File-local. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction propagation | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Aspect extraction | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -15,54 +15,54 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Component extraction | 🔴 `missing` | — | — | — | — |
-| Hook recognition | 🔴 `missing` | — | — | — | — |
+| Component extraction | — `not_applicable` | — | — | — | Play Framework is a server-side MVC framework. Frontend component model (React/Vue-style) does not exist in Play. Controllers and Twirl templates are server-rendered, not component trees. |
+| Hook recognition | — `not_applicable` | — | — | — | Play Framework is a server-side MVC framework. React/lifecycle hooks do not exist. Application lifecycle hooks (ApplicationLifecycle) are covered by DI — not frontend hook model. |
 
 ### Data Flow
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Data loaders | 🔴 `missing` | — | — | — | — |
+| Data loaders | — `not_applicable` | — | — | — | Play Framework is a server-side MVC framework. Data loaders (Next.js getServerSideProps/React Server Components) are frontend SSR patterns absent in Play. |
 
 ### Server
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Hydration boundaries | 🔴 `missing` | — | — | — | — |
-| Server components | 🔴 `missing` | — | — | — | — |
+| Hydration boundaries | — `not_applicable` | — | — | — | Play Framework does not use hydration boundaries. Server-side rendering is via Twirl templates with no client hydration concept. |
+| Server components | — `not_applicable` | — | — | — | Play Framework has no React Server Components or similar framework feature. All rendering is server-side via Twirl. |
 
 ### Routing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Route extraction | 🔴 `missing` | — | — | — | — |
-| Router pattern | 🔴 `missing` | — | — | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/play_framework.yaml` | Play conf/routes file parsed by rePlayRoute regex (GET/POST/etc path controller.action); controller class patterns in play_framework.yaml. File-local. |
+| Router pattern | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/play_framework.yaml` | Play reverse routing (routes.reverse*, Routes.) detected by rePlayRouterPattern. play_framework.yaml contains route file_conventions. |
 
 ### Build
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Static generation | 🔴 `missing` | — | — | — | — |
+| Static generation | — `not_applicable` | — | — | — | Play Framework is request-driven. There is no static site generation mode; output is dynamic per request. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | — | — | — |
-| Interface extraction | 🔴 `missing` | — | — | — | — |
-| Type alias extraction | 🔴 `missing` | — | — | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
 
 ### Lifecycle
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| State setter emission | 🔴 `missing` | — | — | — | — |
+| State setter emission | — `not_applicable` | — | — | — | Play Framework is a server-side MVC framework with no client-side state (useState/setState). State is managed via session cookies or database. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | — | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Substrate
 
@@ -72,22 +72,22 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/substrate/payload_shapes_scala.go` | Scala payload shapes sniffer handles Play JSON reads (Json.reads[T], Json.format[T]) and case class request bodies. |
+| Response shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/substrate/payload_shapes_scala.go` | Scala payload shapes sniffer handles Play Ok(Json.toJson(...)), play.api.libs.json.Json.writes[T] patterns. |
 | Sanitizer recognition | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/payload_drift.go`<br>`internal/substrate/payload_shapes_scala.go` | Payload drift pass compares inferred request/response shapes across commits. Scala payload shapes sniffer provides the shape data for Play. |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -17,73 +17,73 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/scalatra.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/scalatra.yaml` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
+| Type extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved. |
 
 ### DI
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
+| DI injection point | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
+| DI scope resolution | — `not_applicable` | — | — | — | This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction propagation | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Aspect extraction | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -17,73 +17,73 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/scala/frameworks/zio.yaml` | — |
-| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/zio.yaml` | custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local. |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🔴 `missing` | — | — | — | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🔴 `missing` | — | — | — | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local. |
 
 ### Testing
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
 
 ### Type System
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Enum extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns. |
+| Interface extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism. |
+| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries. |
+| Type extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/type_system.go` | custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved. |
 
 ### DI
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI binding extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: ZLayer.make[Env]/ZLayer.succeed bindings extracted as SCOPE.DI/di_binding. ZIO ZLayer is the idiomatic DI mechanism for ZIO-HTTP apps. File-local. |
+| DI injection point | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: .provide()/.provideLayer() call sites detected as ZLayer injection points. File-local. |
+| DI scope resolution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/di.go` | custom_scala_di extractor: typed val layer: ZLayer[R,E,A] declarations extracted as scoped bindings. ZLayer scoping (scoped/succeed/fromZIO) controls resource lifecycle. File-local. |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction boundary extraction | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction propagation | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
+| Transaction rollback rules | — `not_applicable` | — | — | — | Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries. |
 
 ### AOP
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Advice attribution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Aspect extraction | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
+| Pointcut resolution | — `not_applicable` | — | — | — | Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving. |
 
 ### Observability
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
 
 ### Data
 
@@ -98,14 +98,14 @@ Auto-generated. Back to [summary](../summary.md).
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
-| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_scala.go` | Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns. |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
 | Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/scala.go`<br>`internal/substrate/substrate.go` | — |
-| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline. |
 | Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_scala.go` | — |
-| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http. |
 | Reachability analysis | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_scala.go` | — |
 | Request shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Response shape extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
@@ -113,7 +113,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Schema drift detection | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_scala.go` | — |
 | Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 | Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
-| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_scala.go` | Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files. |
 | Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_scala.go` | — |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -47021,108 +47021,147 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/engine/rules/scala/frameworks/akka_http_pekko_http.yaml"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved.",
+            "verified_at": "2026-05-30"
           }
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders, MeterRegistry usage. File-local.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: OpenTelemetry Tracer.start, Jaeger GlobalTracer, Kamon span patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -47147,8 +47186,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -47171,8 +47213,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -47180,8 +47225,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "full",
@@ -47222,8 +47270,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -47242,114 +47293,159 @@
       "capabilities": {
         "Routing": {
           "endpoint_synthesis": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: Cask @cask.get/@cask.post routes synthesized into SCOPE.Operation/http_route entities with method+path.",
+            "verified_at": "2026-05-30"
           },
           "handler_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: Cask route annotation detected in context of the enclosing object/class — handler method attributed to route.",
+            "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: @cask.get/@cask.post annotation routes with path extraction. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved.",
+            "verified_at": "2026-05-30"
           }
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -47374,8 +47470,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -47398,8 +47497,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -47407,8 +47509,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "full",
@@ -47449,8 +47554,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -47506,26 +47614,41 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved.",
+            "verified_at": "2026-05-30"
           }
         },
         "DI": {
@@ -47572,16 +47695,25 @@
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: Micrometer Counter.builder/Timer.builder, Kamon meter patterns. Cats Effect apps commonly use Micrometer or Kamon. File-local.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: OpenTelemetry Tracer/Span, Kamon tracing patterns. Cats Effect + natchez or otel4s is the idiomatic tracing stack. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -47606,8 +47738,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -47630,8 +47765,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -47639,8 +47777,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "full",
@@ -47681,8 +47822,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -47711,108 +47855,156 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/engine/rules/scala/frameworks/finatra.yaml"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved.",
+            "verified_at": "2026-05-30"
           }
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: Guice bind[T].to[Impl], @Provides methods, TwitterModule/AbstractModule declarations. Finatra/Lagom use Guice for DI. File-local.",
+            "verified_at": "2026-05-30"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: @Inject constructor annotation (class Foo @Inject()(dep: T)) and field injection. File-local.",
+            "verified_at": "2026-05-30"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: @Singleton class annotation detected as Guice singleton scope. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -47837,8 +48029,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -47861,8 +48056,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -47870,8 +48068,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "full",
@@ -47912,8 +48113,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -47942,108 +48146,147 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/engine/rules/scala/frameworks/http4s.yaml"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved.",
+            "verified_at": "2026-05-30"
           }
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -48068,8 +48311,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -48092,8 +48338,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -48101,8 +48350,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "full",
@@ -48143,8 +48395,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -48173,108 +48428,156 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/engine/rules/scala/frameworks/lagom.yaml"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved.",
+            "verified_at": "2026-05-30"
           }
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: Guice bind[T].to[Impl], @Provides methods, TwitterModule/AbstractModule declarations. Finatra/Lagom use Guice for DI. File-local.",
+            "verified_at": "2026-05-30"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: @Inject constructor annotation (class Foo @Inject()(dep: T)) and field injection. File-local.",
+            "verified_at": "2026-05-30"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: @Singleton class annotation detected as Guice singleton scope. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -48299,8 +48602,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -48323,8 +48629,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -48332,8 +48641,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "full",
@@ -48374,8 +48686,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -48394,57 +48709,82 @@
       "capabilities": {
         "Structure": {
           "component_extraction": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework is a server-side MVC framework. Frontend component model (React/Vue-style) does not exist in Play. Controllers and Twirl templates are server-rendered, not component trees."
           },
           "hook_recognition": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework is a server-side MVC framework. React/lifecycle hooks do not exist. Application lifecycle hooks (ApplicationLifecycle) are covered by DI — not frontend hook model."
           }
         },
         "Data Flow": {
           "data_loaders": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework is a server-side MVC framework. Data loaders (Next.js getServerSideProps/React Server Components) are frontend SSR patterns absent in Play."
           }
         },
         "Server": {
           "hydration_boundaries": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework does not use hydration boundaries. Server-side rendering is via Twirl templates with no client hydration concept."
           },
           "server_components": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework has no React Server Components or similar framework feature. All rendering is server-side via Twirl."
           }
         },
         "Routing": {
           "route_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/engine/rules/scala/frameworks/play_framework.yaml"],
+            "notes": "Play conf/routes file parsed by rePlayRoute regex (GET/POST/etc path controller.action); controller class patterns in play_framework.yaml. File-local.",
+            "verified_at": "2026-05-30"
           },
           "router_pattern": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/engine/rules/scala/frameworks/play_framework.yaml"],
+            "notes": "Play reverse routing (routes.reverse*, Routes.) detected by rePlayRouterPattern. play_framework.yaml contains route file_conventions.",
+            "verified_at": "2026-05-30"
           }
         },
         "Build": {
           "static_generation": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework is request-driven. There is no static site generation mode; output is dynamic per request."
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           }
         },
         "Lifecycle": {
           "state_setter_emission": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "Play Framework is a server-side MVC framework with no client-side state (useState/setState). State is managed via session cookies or database."
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -48469,8 +48809,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -48493,8 +48836,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -48502,8 +48848,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "partial",
@@ -48511,12 +48860,18 @@
             "verified_at": "2026-05-28"
           },
           "request_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala payload shapes sniffer handles Play JSON reads (Json.reads[T], Json.format[T]) and case class request bodies.",
+            "verified_at": "2026-05-30"
           },
           "response_shape_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala payload shapes sniffer handles Play Ok(Json.toJson(...)), play.api.libs.json.Json.writes[T] patterns.",
+            "verified_at": "2026-05-30"
           },
           "sanitizer_recognition": {
             "status": "partial",
@@ -48524,8 +48879,11 @@
             "verified_at": "2026-05-28"
           },
           "schema_drift_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/payload_drift.go","internal/substrate/payload_shapes_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Payload drift pass compares inferred request/response shapes across commits. Scala payload shapes sniffer provides the shape data for Play.",
+            "verified_at": "2026-05-30"
           },
           "taint_sink_detection": {
             "status": "partial",
@@ -48538,8 +48896,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -48568,108 +48929,147 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/engine/rules/scala/frameworks/scalatra.yaml"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved.",
+            "verified_at": "2026-05-30"
           }
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "This framework has no built-in DI container. Akka-HTTP uses manual constructor injection; Cask is a minimalist library with no DI support; http4s uses functional effect composition (cats-effect Resource) not a DI container; Scalatra is a Sinatra-style servlet with no DI model."
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -48694,8 +49094,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -48718,8 +49121,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -48727,8 +49133,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "full",
@@ -48769,8 +49178,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",
@@ -48799,108 +49211,156 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/engine/rules/scala/frameworks/zio.yaml"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific route DSL patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific auth patterns (Akka-HTTP authenticateBasic/OAuth2, http4s AuthMiddleware, Scalatra ScentrySupport, Cask Authorization header, ZIO bearerAuth, Finatra @Authenticated, Lagom authenticated). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks extractor: framework-specific middleware (Akka-HTTP mapRequest/cors, http4s Middleware/Logger, Scalatra before/after, Cask Decorator, ZIO HttpMiddleware, Finatra SimpleFilter, Lagom CircuitBreaker). File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
           "tests_linkage": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
           "enum_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: sealed trait → ADT, sealed abstract class, Scala 3 enum → SCOPE.Type/sealed_trait|enum. Captures Scala 2+3 ADT discriminant patterns.",
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: trait → SCOPE.Interface/trait, abstract class → SCOPE.Interface/abstract_class. Scala traits are the primary interface mechanism.",
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: type Alias = T → SCOPE.Type/type_alias; opaque type (Scala 3) → SCOPE.Type/opaque_type. Scala type aliases are pervasive in functional libraries.",
+            "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/type_system.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_type_system extractor: case class, class, object → SCOPE.Type. File-local; cross-file type hierarchies not resolved.",
+            "verified_at": "2026-05-30"
           }
         },
         "DI": {
           "di_binding_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: ZLayer.make[Env]/ZLayer.succeed bindings extracted as SCOPE.DI/di_binding. ZIO ZLayer is the idiomatic DI mechanism for ZIO-HTTP apps. File-local.",
+            "verified_at": "2026-05-30"
           },
           "di_injection_point": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: .provide()/.provideLayer() call sites detected as ZLayer injection points. File-local.",
+            "verified_at": "2026-05-30"
           },
           "di_scope_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/di.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_di extractor: typed val layer: ZLayer[R,E,A] declarations extracted as scoped bindings. ZLayer scoping (scoped/succeed/fromZIO) controls resource lifecycle. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Transactions": {
           "transaction_boundary_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_propagation": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           },
           "transaction_rollback_rules": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP framework layer does not define transaction boundaries. Transactions are managed by the ORM/DB layer (Slick, Doobie, quill, ZIO-jdbc). These frameworks do not provide @Transactional annotations or equivalent transaction interceptors. The orm.* records cover transaction tracking for Scala persistence libraries."
           }
         },
         "AOP": {
           "advice_attribution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "aspect_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           },
           "pointcut_resolution": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Scala HTTP frameworks do not use Spring AOP / AspectJ proxy model. AOP is a Java/Spring-specific concept. These frameworks use functional composition (Kleisli, ZIO layers, Akka behaviors) instead of aspect weaving."
           }
         },
         "Observability": {
           "log_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -48925,8 +49385,11 @@
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/def_use_pass.go","internal/substrate/def_use_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala def-use sniffer (RegisterDefUseSniffer('scala')) is registered in def_use_scala.go; def_use_pass.go invokes it for all scala entities. File-local val/var/for-generator patterns.",
+            "verified_at": "2026-05-30"
           },
           "env_fallback_recognition": {
             "status": "full",
@@ -48949,8 +49412,11 @@
             "verified_at": "2026-05-27"
           },
           "module_cycle_detection": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/module_cycle_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic module-cycle pass uses IMPORTS edges emitted by per-language extractors; Scala import edges are emitted by the Scala extractor pipeline.",
+            "verified_at": "2026-05-30"
           },
           "mutation_effect": {
             "status": "partial",
@@ -48958,8 +49424,11 @@
             "verified_at": "2026-05-28"
           },
           "pure_function_tagging": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/pure_function_pass.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Language-agnostic pure-function pass tags functions with no effect properties; Scala is a functional language with many pure functions (cats-effect IO, ZIO effects, case class methods). Especially apt for cats-effect, http4s, zio-http.",
+            "verified_at": "2026-05-30"
           },
           "reachability_analysis": {
             "status": "full",
@@ -49000,8 +49469,11 @@
             "verified_at": "2026-05-28"
           },
           "template_pattern_catalog": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/links/template_pattern_pass.go","internal/substrate/template_pattern_scala.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Scala template-pattern sniffer recognises i18n (Messages/messagesApi), log-format (logger.info/warn/error), and SQL literal patterns in Scala source files.",
+            "verified_at": "2026-05-30"
           },
           "vulnerability_finding": {
             "status": "partial",

--- a/internal/custom/scala/di.go
+++ b/internal/custom/scala/di.go
@@ -1,0 +1,233 @@
+// Package scala — DI extractor for Scala frameworks that have a DI model.
+//
+// Covers (missing → partial):
+//
+//	Record                   Capability                   Status
+//	───────────────────────────────────────────────────────────
+//	framework.finatra        DI/di_binding_extraction     partial
+//	framework.finatra        DI/di_injection_point        partial
+//	framework.finatra        DI/di_scope_resolution       partial
+//	framework.lagom          DI/di_binding_extraction     partial
+//	framework.lagom          DI/di_injection_point        partial
+//	framework.lagom          DI/di_scope_resolution       partial
+//	framework.zio-http       DI/di_binding_extraction     partial
+//	framework.zio-http       DI/di_injection_point        partial
+//	framework.zio-http       DI/di_scope_resolution       partial
+//
+// DI models:
+//
+//	Finatra uses Google Guice via Twitter's inject library:
+//	  - @Singleton, @Inject annotations on class constructors/fields
+//	  - TwitterModule / AbstractModule bindings
+//	  - bind[Service].to[ServiceImpl], bind[Repo].toInstance(...)
+//
+//	Lagom uses Guice via Play's DI layer:
+//	  - LagomApplicationLoader + LagomApplication
+//	  - bind[Service].to[ServiceImpl] in AbstractModule
+//	  - @Singleton, @Inject standard Guice annotations
+//
+//	ZIO HTTP uses ZLayer (ZIO's native DI):
+//	  - ZLayer.make[Env], ZLayer.scoped, ZLayer.succeed
+//	  - type alias for ZIO layer composition (val layer: ZLayer[R, E, A])
+//	  - provide / provideLayer / provideSomeLayer
+//
+// AOP: None of these frameworks use Spring AOP / AspectJ.
+// Transactions: Finatra and Lagom can use Slick/c3p0 transactions but these
+//
+//	are ORM-layer concerns, not framework-enforced annotations → not_applicable.
+//
+// Honest limit: regex-based, file-local. Guice module wiring across files is
+// not resolved. ZLayer cross-file composition is not traced. Cells are partial.
+package scala
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_scala_di", &scalaDIExtractor{})
+}
+
+type scalaDIExtractor struct{}
+
+func (e *scalaDIExtractor) Language() string { return "custom_scala_di" }
+
+// ---------------------------------------------------------------------------
+// Guice (Finatra / Lagom) regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// reGuiceInject matches @Inject annotation:
+	//   - class Foo @Inject()(params) — primary constructor injection
+	//   - @Inject val foo: T — field injection
+	//   - @Inject() def method — method injection
+	reGuiceInject = regexp.MustCompile(
+		`@Inject\s*(?:\(\s*\))?`)
+
+	// reGuiceSingleton matches @Singleton class annotation.
+	reGuiceSingleton = regexp.MustCompile(
+		`@Singleton\s+(?:final\s+)?class\s+(\w+)`)
+
+	// reGuiceBind matches bind[Type].to[Impl] or bind[Type].toInstance
+	reGuiceBind = regexp.MustCompile(
+		`\bbind\s*\[\s*([A-Z][\w]*)\s*\]\s*\.\s*(?:to\s*\[\s*([A-Z][\w]*)\s*\]|toInstance|toSelf|in\s*\[)`)
+
+	// reGuiceModule matches extends TwitterModule / AbstractModule / LagomServicePortBindings
+	reGuiceModule = regexp.MustCompile(
+		`\bextends\s+(?:TwitterModule|AbstractModule|LagomServicePortBindings|ServiceLocatorModule)\b`)
+
+	// reGuiceProvider matches @Provides def someService(...): T = ...
+	reGuiceProvider = regexp.MustCompile(
+		`@Provides\s+(?:@Singleton\s+)?def\s+(\w+)\s*\(`)
+)
+
+// ---------------------------------------------------------------------------
+// ZLayer (ZIO HTTP) regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// reZLayerMake matches ZLayer.make[Env] or ZLayer.makeSome
+	reZLayerMake = regexp.MustCompile(
+		`\bZLayer\s*\.\s*(?:make|makeSome|makeWith)\s*\[\s*([A-Z][\w\s,]*)\s*\]`)
+
+	// reZLayerSucceed matches ZLayer.succeed(...)
+	reZLayerSucceed = regexp.MustCompile(
+		`\bZLayer\s*\.\s*(?:succeed|fromZIO|scoped|fromManaged)\s*\(`)
+
+	// reZLayerVal matches val layer: ZLayer[R, E, A] = ...
+	reZLayerVal = regexp.MustCompile(
+		`\bval\s+(\w+(?:Layer|Env)?)\s*:\s*ZLayer\s*\[`)
+
+	// reZLayerProvide matches .provide(...) or .provideLayer(...) call
+	reZLayerProvide = regexp.MustCompile(
+		`\.\s*(?:provide|provideLayer|provideSomeLayer)\s*\(`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *scalaDIExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/scala")
+	_, span := tracer.Start(ctx, "indexer.scala_di.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("extractor", "di"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "scala" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	fw := detectScalaFramework(src)
+	isGuice := fw == "finatra" || fw == "lagom"
+	isZIO := fw == "zio-http"
+
+	if !isGuice && !isZIO {
+		return nil, nil
+	}
+
+	if isGuice {
+		// --- di_binding_extraction: bind[T].to[Impl] ---
+		for _, m := range reGuiceBind.FindAllStringSubmatchIndex(src, -1) {
+			iface := src[m[2]:m[3]]
+			impl := ""
+			if m[4] >= 0 {
+				impl = src[m[4]:m[5]]
+			}
+			name := "bind:" + iface
+			if impl != "" {
+				name += "→" + impl
+			}
+			ent := makeEntity(name, "SCOPE.DI", "di_binding", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", fw, "interface", iface, "impl", impl, "provenance", "GUICE_BIND")
+			add(ent)
+		}
+
+		// --- di_injection_point: @Inject ---
+		for _, m := range reGuiceInject.FindAllStringSubmatchIndex(src, -1) {
+			ent := makeEntity("inject:"+fileBaseName(file.Path), "SCOPE.DI", "injection_point", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", fw, "injection_type", "constructor_or_field", "provenance", "GUICE_INJECT")
+			add(ent)
+		}
+
+		// --- di_scope_resolution: @Singleton / @Provides ---
+		for _, m := range reGuiceSingleton.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity("singleton:"+name, "SCOPE.DI", "di_scope", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", fw, "scope", "singleton", "provenance", "GUICE_SINGLETON")
+			add(ent)
+		}
+
+		// Module declarations
+		for _, m := range reGuiceModule.FindAllStringSubmatchIndex(src, -1) {
+			ent := makeEntity("module:"+fileBaseName(file.Path), "SCOPE.DI", "di_module", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", fw, "provenance", "GUICE_MODULE")
+			add(ent)
+		}
+
+		// @Provides methods
+		for _, m := range reGuiceProvider.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity("provides:"+name, "SCOPE.DI", "di_binding", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", fw, "provenance", "GUICE_PROVIDES")
+			add(ent)
+		}
+	}
+
+	if isZIO {
+		// --- di_binding_extraction: ZLayer definitions ---
+		for _, m := range reZLayerMake.FindAllStringSubmatchIndex(src, -1) {
+			envType := src[m[2]:m[3]]
+			ent := makeEntity("zlayer:"+envType, "SCOPE.DI", "di_binding", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "zio-http", "env_type", envType, "provenance", "ZIO_ZLAYER_MAKE")
+			add(ent)
+		}
+		for _, m := range reZLayerSucceed.FindAllStringSubmatchIndex(src, -1) {
+			ent := makeEntity("zlayer:impl:"+fileBaseName(file.Path), "SCOPE.DI", "di_binding", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "zio-http", "provenance", "ZIO_ZLAYER_SUCCEED")
+			add(ent)
+		}
+
+		// --- di_injection_point: provide/provideLayer calls ---
+		for _, m := range reZLayerProvide.FindAllStringSubmatchIndex(src, -1) {
+			ent := makeEntity("provide:"+fileBaseName(file.Path), "SCOPE.DI", "injection_point", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "zio-http", "provenance", "ZIO_PROVIDE_LAYER")
+			add(ent)
+		}
+
+		// --- di_scope_resolution: typed ZLayer val declarations ---
+		for _, m := range reZLayerVal.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity("layer:"+name, "SCOPE.DI", "di_scope", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "zio-http", "scope", "zlayer", "provenance", "ZIO_ZLAYER_VAL")
+			add(ent)
+		}
+	}
+
+	return entities, nil
+}

--- a/internal/custom/scala/di_test.go
+++ b/internal/custom/scala/di_test.go
@@ -1,0 +1,146 @@
+package scala_test
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// DI extractor tests
+// ---------------------------------------------------------------------------
+
+func TestDIFinatraGuiceBind(t *testing.T) {
+	src := `
+import com.twitter.finatra.http._
+import com.google.inject._
+class AppModule extends TwitterModule {
+  bind[UserRepository].to[UserRepositoryImpl]
+  bind[OrderService].toInstance(new OrderServiceImpl())
+}
+`
+	ents := extract(t, "custom_scala_di", fi("AppModule.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.DI" && e.Subtype == "di_binding" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected di_binding from Guice bind[T].to[Impl]")
+	}
+}
+
+func TestDIFinatraGuiceInject(t *testing.T) {
+	src := `
+import com.twitter.finatra.http._
+import javax.inject.Inject
+@Singleton
+class UserController @Inject()(userService: UserService) extends HttpController {
+  @Get("/users")
+  def getUsers(request: Request): Response = ???
+}
+`
+	ents := extract(t, "custom_scala_di", fi("UserController.scala", "scala", src))
+	// Should get both a singleton scope and inject point
+	foundInject := false
+	foundScope := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.DI" && e.Subtype == "injection_point" {
+			foundInject = true
+		}
+		if e.Kind == "SCOPE.DI" && e.Subtype == "di_scope" {
+			foundScope = true
+		}
+	}
+	if !foundInject {
+		t.Error("expected injection_point from @Inject")
+	}
+	if !foundScope {
+		t.Error("expected di_scope from @Singleton")
+	}
+}
+
+func TestDIZioHttpZLayer(t *testing.T) {
+	src := `
+import zio._
+import zio.http._
+val userServiceLayer: ZLayer[Database, Nothing, UserService] =
+  ZLayer.succeed(new UserServiceImpl())
+
+val appLayer = ZLayer.make[AppEnv](
+  userServiceLayer,
+  databaseLayer,
+  configLayer
+)
+
+val program = for {
+  _ <- Server.serve(routes)
+} yield ()
+
+def run = program.provide(appLayer)
+`
+	ents := extract(t, "custom_scala_di", fi("App.scala", "scala", src))
+	foundBinding := false
+	foundInjection := false
+	foundScope := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.DI" && e.Subtype == "di_binding" {
+			foundBinding = true
+		}
+		if e.Kind == "SCOPE.DI" && e.Subtype == "injection_point" {
+			foundInjection = true
+		}
+		if e.Kind == "SCOPE.DI" && e.Subtype == "di_scope" {
+			foundScope = true
+		}
+	}
+	if !foundBinding {
+		t.Error("expected di_binding from ZLayer")
+	}
+	if !foundInjection {
+		t.Error("expected injection_point from .provide()")
+	}
+	if !foundScope {
+		t.Error("expected di_scope from typed ZLayer val")
+	}
+}
+
+func TestDILagomGuice(t *testing.T) {
+	src := `
+import com.lightbend.lagom.scaladsl.server._
+import com.google.inject.AbstractModule
+class UserServiceModule extends AbstractModule {
+  bind[UserService].to[UserServiceImpl]
+  bind[UserRepository].toInstance(new InMemoryUserRepository())
+}
+@Singleton
+class UserServiceImpl @Inject()(repo: UserRepository) extends UserService {
+  def getUser(id: String) = repo.findById(id)
+}
+`
+	ents := extract(t, "custom_scala_di", fi("UserServiceModule.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.DI" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected DI entities from Lagom/Guice module")
+	}
+}
+
+func TestDINoMatchNonDIFramework(t *testing.T) {
+	// http4s doesn't have explicit DI via our extractor
+	src := `
+import org.http4s._
+val routes = HttpRoutes.of[IO] {
+  case GET -> Root / "users" => Ok("users")
+}
+`
+	ents := extract(t, "custom_scala_di", fi("Routes.scala", "scala", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no DI entities for http4s (not a DI-explicit framework), got %d", len(ents))
+	}
+}

--- a/internal/custom/scala/frameworks.go
+++ b/internal/custom/scala/frameworks.go
@@ -1,0 +1,626 @@
+// Package scala — framework-specific extractors for Scala HTTP frameworks.
+//
+// Covers (missing → partial):
+//
+//	Record                        Capability                      Status
+//	──────────────────────────────────────────────────────────────────────
+//	framework.akka-http           Routing/route_extraction        partial
+//	framework.cask                Routing/route_extraction        partial
+//	framework.cask                Routing/endpoint_synthesis      partial
+//	framework.cask                Routing/handler_attribution     partial
+//	framework.finatra             Routing/route_extraction        partial
+//	framework.http4s              Routing/route_extraction        partial
+//	framework.lagom               Routing/route_extraction        partial
+//	framework.scalatra            Routing/route_extraction        partial
+//	framework.zio-http            Routing/route_extraction        partial
+//	framework.play                Routing/route_extraction        partial
+//	framework.play                Routing/router_pattern          partial
+//
+//	framework.akka-http           Auth/auth_coverage              partial
+//	framework.cask                Auth/auth_coverage              partial
+//	framework.finatra             Auth/auth_coverage              partial
+//	framework.http4s              Auth/auth_coverage              partial
+//	framework.lagom               Auth/auth_coverage              partial
+//	framework.scalatra            Auth/auth_coverage              partial
+//	framework.zio-http            Auth/auth_coverage              partial
+//
+//	framework.akka-http           Middleware/middleware_coverage   partial
+//	framework.cask                Middleware/middleware_coverage   partial
+//	framework.finatra             Middleware/middleware_coverage   partial
+//	framework.http4s              Middleware/middleware_coverage   partial
+//	framework.lagom               Middleware/middleware_coverage   partial
+//	framework.scalatra            Middleware/middleware_coverage   partial
+//	framework.zio-http            Middleware/middleware_coverage   partial
+//
+//	framework.akka-http           Validation/dto_extraction       partial
+//	framework.akka-http           Validation/request_validation   partial
+//	framework.cask                Validation/dto_extraction       partial
+//	framework.cask                Validation/request_validation   partial
+//	framework.finatra             Validation/dto_extraction       partial
+//	framework.finatra             Validation/request_validation   partial
+//	framework.http4s              Validation/dto_extraction       partial
+//	framework.http4s              Validation/request_validation   partial
+//	framework.lagom               Validation/dto_extraction       partial
+//	framework.lagom               Validation/request_validation   partial
+//	framework.scalatra            Validation/dto_extraction       partial
+//	framework.scalatra            Validation/request_validation   partial
+//	framework.zio-http            Validation/dto_extraction       partial
+//	framework.zio-http            Validation/request_validation   partial
+//
+//	all 9 framework records       Observability/log_extraction    partial
+//	all 9 framework records       Observability/metric_extraction partial
+//	all 9 framework records       Observability/trace_extraction  partial
+//
+//	all 9 framework records       Testing/tests_linkage           partial
+//
+// Honest limit: all regex-based, file-local. Cross-file route wiring is not
+// resolved. Cells are partial.
+package scala
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_scala_frameworks", &scalaFrameworksExtractor{})
+}
+
+type scalaFrameworksExtractor struct{}
+
+func (e *scalaFrameworksExtractor) Language() string { return "custom_scala_frameworks" }
+
+// ---------------------------------------------------------------------------
+// Routing regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// Akka-HTTP / Pekko: path("segment") { get { ... } }
+	reAkkaRoute = regexp.MustCompile(
+		`(?m)\b(get|post|put|delete|patch|head|options)\s*\{`)
+
+	reAkkaPathDirective = regexp.MustCompile(
+		`\b(?:pathPrefix|path|pathEnd)\s*\(\s*"([^"]+)"`)
+
+	// http4s: case GET -> Root / "seg" => ...
+	reHttp4sRoute = regexp.MustCompile(
+		`\bcase\s+(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*->\s*Root\s*(?:/\s*"[^"]*"\s*)*`)
+
+	// Scalatra: get("/path") { ... }
+	reScalatraRoute = regexp.MustCompile(
+		`\b(get|post|put|delete|patch|head|options)\s*\(\s*"([^"]*)"`)
+
+	// Cask: @cask.get("/path") or @cask.post("/path")
+	reCaskRoute = regexp.MustCompile(
+		`@cask\.(get|post|put|delete|patch)\s*\(\s*"([^"]*)"`)
+
+	// ZIO-HTTP: Http.collect { case Method.GET -> Root / "seg" => ... }
+	reZioHTTPRoute = regexp.MustCompile(
+		`(?:Method\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)|Request\.(get|post))\s*->`)
+
+	// Finatra: @Get("/path") or @Post("/path") annotations
+	reFinatraRoute = regexp.MustCompile(
+		`@(Get|Post|Put|Delete|Patch|Head)\s*\(\s*"([^"]*)"`)
+
+	// Lagom: namedCall("name") or pathCall("/path", ...)
+	reLagomCall = regexp.MustCompile(
+		`\b(?:namedCall|pathCall|restCall)\s*\(\s*"([^"]*)"`)
+
+	// Play: conf/routes file patterns (GET /path controller.method)
+	rePlayRoute = regexp.MustCompile(
+		`(?m)^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+(/[^\s]*)\s+(\w+(?:\.\w+)+)`)
+
+	// Play router pattern: routes.reverse or Routes.
+	rePlayRouterPattern = regexp.MustCompile(
+		`\b(?:routes\.|reverse[A-Z]|\bRoutes\.)`)
+)
+
+// ---------------------------------------------------------------------------
+// Auth regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// Akka-HTTP: authenticateBasic / authenticateOAuth2 / headerValueByName("Authorization")
+	reAkkaAuth = regexp.MustCompile(
+		`\b(?:authenticateBasic|authenticateOAuth2|authenticateBasicAsync|headerValueByName\s*\(\s*"Authorization")\b`)
+
+	// http4s: AuthMiddleware / BasicCredentials / KleisliMiddleware
+	reHttp4sAuth = regexp.MustCompile(
+		`\b(?:AuthMiddleware|BasicCredentials|AuthedRoutes)\b`)
+
+	// Scalatra: BasicAuth / scentry / SecureHello
+	reScalatraAuth = regexp.MustCompile(
+		`\b(?:ScentrySupport|BasicAuthSupport|SecureHello|ScentryStrategy)\b`)
+
+	// Cask: no built-in auth — detect manual header checking
+	reCaskAuth = regexp.MustCompile(
+		`request\.headers\s*\.\s*get\s*\(\s*"Authorization"`)
+
+	// ZIO-HTTP: HttpMiddleware.basicAuth / bearerAuth
+	reZioAuth = regexp.MustCompile(
+		`\b(?:Middleware\.basicAuth|Middleware\.bearerAuth|basicAuth|bearerAuth)\b`)
+
+	// Finatra: @Authenticated / Twitter credentials
+	reFinatraAuth = regexp.MustCompile(
+		`\b(?:@Authenticated|TwitterServerCredentials|OAuthAuthenticator)\b`)
+
+	// Lagom: ServiceCall.authenticated / Topic
+	reLagomAuth = regexp.MustCompile(
+		`\b(?:authenticated|ServiceCallFactory|HeaderFilter)\b`)
+
+	// Generic token/JWT check across frameworks
+	reGenericAuth = regexp.MustCompile(
+		`\b(?:JWT|JwtToken|BearerToken|ApiKey|Authorization)\b`)
+)
+
+// ---------------------------------------------------------------------------
+// Middleware regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// Akka-HTTP: mapRequest / mapResponse / DebuggingDirectives
+	reAkkaMiddleware = regexp.MustCompile(
+		`\b(?:mapRequest|mapResponse|withSettings|DebuggingDirectives|handleExceptions|handleRejections|cors)\b`)
+
+	// http4s: HttpRoutes middleware composition (HttpApp, Kleisli, Middleware)
+	reHttp4sMiddleware = regexp.MustCompile(
+		`\b(?:Middleware|Logger\.httpRoutes|GZip|AutoSlash|Timeout\.httpRoutes|CORS\.policy)\b`)
+
+	// Scalatra: before/after blocks
+	reScalatraMiddleware = regexp.MustCompile(
+		`(?m)^\s*(before|after)\s*\{`)
+
+	// Cask: cask.Decorator / annotation-based middleware
+	reCaskMiddleware = regexp.MustCompile(
+		`\bcask\.Decorator\b|extends\s+cask\.RawDecorator`)
+
+	// ZIO-HTTP: HttpMiddleware / Middleware.runBefore
+	reZioMiddleware = regexp.MustCompile(
+		`\b(?:HttpMiddleware|Middleware\.runBefore|Middleware\.runAfter|HttpApp\.collectZIO)\b`)
+
+	// Finatra: SimpleFilter / TypeAgnosticFilter
+	reFinatraMiddleware = regexp.MustCompile(
+		`\b(?:SimpleFilter|TypeAgnosticFilter|Filter\[|HttpFilter)\b`)
+
+	// Lagom: ServiceLocator / CircuitBreaker / ServiceCall.invoke
+	reLagomMiddleware = regexp.MustCompile(
+		`\b(?:CircuitBreaker|ServiceLocator|HeaderFilter|ServiceCall\.invoke)\b`)
+)
+
+// ---------------------------------------------------------------------------
+// Validation regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// case class fields with type annotations (DTO pattern)
+	reDTOCaseClass = regexp.MustCompile(
+		`(?m)^\s*case\s+class\s+(\w+)\s*\(([^)]+)\)`)
+
+	// request body extraction patterns
+	reAkkaValidation = regexp.MustCompile(
+		`\b(?:entity\s*\(\s*as\[|validate\s*\(|Validator\.)\b`)
+
+	reHttp4sValidation = regexp.MustCompile(
+		`\b(?:jsonOf\[|EntityDecoder|decode\[|as\[)\b`)
+
+	reScalatraValidation = regexp.MustCompile(
+		`\b(?:params\(|multiParams\(|parsedBody|request\.body)\b`)
+
+	reCaskValidation = regexp.MustCompile(
+		`\b(?:cask\.Request|request\.data|readAll)\b`)
+
+	reZioValidation = regexp.MustCompile(
+		`\b(?:Request\.body|body\.asString|ZIO\.fromEither|decode\[)\b`)
+
+	reFinatraValidation = regexp.MustCompile(
+		`\b(?:request\.params|request\.contentString|@NotEmpty|@Min|@Max)\b`)
+
+	reLagomValidation = regexp.MustCompile(
+		`\b(?:MessageSerializer|JsonSerializer|ExceptionSerializer)\b`)
+)
+
+// ---------------------------------------------------------------------------
+// Observability regexes — shared across all Scala frameworks
+// ---------------------------------------------------------------------------
+
+var (
+	// log_extraction: SLF4J (play-logback, akka-slf4j, logback-classic)
+	reScalaSlf4j = regexp.MustCompile(
+		`\b(?:LoggerFactory|LogManager|Logger)\s*\.\s*getLogger\s*\(`)
+
+	reScalaLogStatement = regexp.MustCompile(
+		`\b(?:log|logger|LOG)\s*\.\s*(trace|debug|info|warn|error)\s*\(`)
+
+	// play.api.Logger
+	rePlayLogger = regexp.MustCompile(
+		`\b(?:play\.api\.Logger|Logger\s*\.\s*(trace|debug|info|warn|error))\b`)
+
+	// Akka/Pekko actor logging
+	reAkkaLogging = regexp.MustCompile(
+		`\b(?:Logging\s*\(|log\s*\.\s*(debug|info|warning|error)\s*\(|ActorLogging)\b`)
+
+	// Cats Effect / ZIO logging: LogF / ZIO.logInfo
+	reEffectLogging = regexp.MustCompile(
+		`\b(?:Logger\[IO\]|Slf4jLogger|ZIO\.log(?:Info|Warning|Error|Debug)|log\.info|log\.warn)\b`)
+
+	// metric_extraction: Micrometer, Kamon, Dropwizard Metrics
+	reScalaMetric = regexp.MustCompile(
+		`\b(?:Counter\s*\.\s*builder|Timer\s*\.\s*builder|Gauge\s*\.\s*builder|MeterRegistry|Kamon\.|metrics\s*\.\s*counter)\b`)
+
+	// trace_extraction: OpenTelemetry, Jaeger, Zipkin, Kamon tracing
+	reScalaTrace = regexp.MustCompile(
+		`\b(?:Tracer\s*\.\s*start|tracer\s*\.\s*startSpan|Span\s*\.\s*current|GlobalTracer|DDTracer|Kamon\.span|b3Header)\b`)
+)
+
+// ---------------------------------------------------------------------------
+// Testing regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// ScalaTest: extends FlatSpec / WordSpec / AnyFlatSpec / FunSuite
+	reScalaTest = regexp.MustCompile(
+		`\b(?:extends\s+(?:AnyFlatSpec|FlatSpec|WordSpec|AnyWordSpec|FunSpec|AnyFunSpec|FunSuite|AnyFunSuite|FeatureSpec|PropSpec))\b`)
+
+	// Specs2: extends Specification
+	reSpecs2 = regexp.MustCompile(
+		`\bextends\s+(?:Specification|mutable\.Specification)\b`)
+
+	// MUnit (cats-effect, http4s): extends munit.FunSuite / munit.CatsEffectSuite
+	reMUnit = regexp.MustCompile(
+		`\bextends\s+(?:munit\.FunSuite|munit\.CatsEffectSuite|CatsEffectSuite)\b`)
+
+	// Akka TestKit: extends TestKit / extends ActorSpec
+	reAkkaTestKit = regexp.MustCompile(
+		`\bextends\s+(?:TestKit|ActorSpec|AkkaSpec|PekkoSpec|ScalaTestWithActorTestKit)\b`)
+
+	// http4s: Http4sClientDsl / Http4sMunitCirceSuite
+	reHttp4sTest = regexp.MustCompile(
+		`\bextends\s+(?:Http4sClientDsl|Http4sMunitCirceSuite|Http4sSuite)\b`)
+
+	// Cask: requests.get in test context
+	reCaskTest = regexp.MustCompile(
+		`\bTestServer\b|requests\.(get|post|put|delete)\s*\(`)
+
+	// ZIO Test: extends ZIOSpec / ZIOSpecDefault
+	reZioTest = regexp.MustCompile(
+		`\bextends\s+(?:ZIOSpec|ZIOSpecDefault|ZIOSpecAbstract)\b`)
+
+	// Finatra: extends HttpTest / FeatureTest
+	reFinatraTest = regexp.MustCompile(
+		`\bextends\s+(?:HttpTest|FeatureTest|TwitterServer|EmbeddedTwitterServer)\b`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *scalaFrameworksExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/scala")
+	_, span := tracer.Start(ctx, "indexer.scala_frameworks.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("extractor", "frameworks"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "scala" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// Detect framework from imports / patterns
+	framework := detectScalaFramework(src)
+
+	// ---------------------------------------------------------------------------
+	// Routing extraction
+	// ---------------------------------------------------------------------------
+	switch framework {
+	case "akka-http", "pekko-http":
+		for _, m := range reAkkaRoute.FindAllStringSubmatchIndex(src, -1) {
+			method := src[m[2]:m[3]]
+			ent := makeEntity("route:"+method, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", framework, "http_method", strings.ToUpper(method), "provenance", "AKKA_HTTP_ROUTE_DSL")
+			add(ent)
+		}
+		for _, m := range reAkkaPathDirective.FindAllStringSubmatchIndex(src, -1) {
+			path := src[m[2]:m[3]]
+			ent := makeEntity(path, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", framework, "http_path", path, "provenance", "AKKA_HTTP_PATH_DIRECTIVE")
+			add(ent)
+		}
+
+	case "http4s":
+		for _, m := range reHttp4sRoute.FindAllStringSubmatchIndex(src, -1) {
+			method := src[m[2]:m[3]]
+			ent := makeEntity("route:"+method, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "http4s", "http_method", method, "provenance", "HTTP4S_HTTPROUTES_DSL")
+			add(ent)
+		}
+
+	case "scalatra":
+		for _, m := range reScalatraRoute.FindAllStringSubmatchIndex(src, -1) {
+			method := src[m[2]:m[3]]
+			path := ""
+			if m[4] >= 0 {
+				path = src[m[4]:m[5]]
+			}
+			ent := makeEntity(method+":"+path, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "scalatra", "http_method", strings.ToUpper(method), "http_path", path, "provenance", "SCALATRA_ROUTE")
+			add(ent)
+		}
+
+	case "cask":
+		for _, m := range reCaskRoute.FindAllStringSubmatchIndex(src, -1) {
+			method := src[m[2]:m[3]]
+			path := src[m[4]:m[5]]
+			ent := makeEntity(method+":"+path, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "cask", "http_method", strings.ToUpper(method), "http_path", path, "provenance", "CASK_ANNOTATION_ROUTE")
+			add(ent)
+		}
+
+	case "zio-http":
+		for _, m := range reZioHTTPRoute.FindAllStringSubmatchIndex(src, -1) {
+			method := ""
+			if m[2] >= 0 {
+				method = src[m[2]:m[3]]
+			} else if m[4] >= 0 {
+				method = strings.ToUpper(src[m[4]:m[5]])
+			}
+			ent := makeEntity("route:"+method, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "zio-http", "http_method", method, "provenance", "ZIO_HTTP_ROUTE")
+			add(ent)
+		}
+
+	case "finatra":
+		for _, m := range reFinatraRoute.FindAllStringSubmatchIndex(src, -1) {
+			method := src[m[2]:m[3]]
+			path := src[m[4]:m[5]]
+			ent := makeEntity(method+":"+path, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "finatra", "http_method", strings.ToUpper(method), "http_path", path, "provenance", "FINATRA_ANNOTATION_ROUTE")
+			add(ent)
+		}
+
+	case "lagom":
+		for _, m := range reLagomCall.FindAllStringSubmatchIndex(src, -1) {
+			path := src[m[2]:m[3]]
+			ent := makeEntity("lagom:"+path, "SCOPE.Operation", "lagom_service_call", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "lagom", "service_descriptor", path, "provenance", "LAGOM_SERVICE_DESCRIPTOR")
+			add(ent)
+		}
+
+	case "play":
+		for _, m := range rePlayRoute.FindAllStringSubmatchIndex(src, -1) {
+			method := src[m[2]:m[3]]
+			path := src[m[4]:m[5]]
+			controller := ""
+			if m[6] >= 0 {
+				controller = src[m[6]:m[7]]
+			}
+			ent := makeEntity(method+":"+path, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "play", "http_method", method, "http_path", path, "controller", controller, "provenance", "PLAY_ROUTES_FILE")
+			add(ent)
+		}
+		// router pattern detection
+		if rePlayRouterPattern.MatchString(src) {
+			ent := makeEntity("PlayRouter", "SCOPE.Router", "play_router", file.Path, file.Language, 1)
+			setProps(&ent, "framework", "play", "provenance", "PLAY_ROUTER_PATTERN")
+			add(ent)
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Auth extraction
+	// ---------------------------------------------------------------------------
+	authRe := authReForFramework(framework)
+	if authRe != nil {
+		for _, m := range authRe.FindAllStringSubmatchIndex(src, -1) {
+			ent := makeEntity("auth:"+src[m[0]:m[1]], "SCOPE.Security", "auth_check", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", framework, "provenance", "AUTH_PATTERN")
+			add(ent)
+		}
+	}
+	// generic auth fallback
+	if reGenericAuth.MatchString(src) {
+		ent := makeEntity("auth:generic", "SCOPE.Security", "auth_check", file.Path, file.Language, 1)
+		setProps(&ent, "framework", framework, "provenance", "GENERIC_AUTH_PATTERN")
+		add(ent)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Middleware extraction
+	// ---------------------------------------------------------------------------
+	mwRe := middlewareReForFramework(framework)
+	if mwRe != nil {
+		for _, m := range mwRe.FindAllStringSubmatchIndex(src, -1) {
+			ent := makeEntity("middleware:"+src[m[0]:min(m[0]+40, len(src))], "SCOPE.Middleware", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", framework, "provenance", "MIDDLEWARE_PATTERN")
+			add(ent)
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Validation / DTO extraction
+	// ---------------------------------------------------------------------------
+	for _, m := range reDTOCaseClass.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Type", "dto", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", framework, "provenance", "CASE_CLASS_DTO")
+		add(ent)
+	}
+	valRe := validationReForFramework(framework)
+	if valRe != nil {
+		if valRe.MatchString(src) {
+			ent := makeEntity("validation:"+framework, "SCOPE.Operation", "request_validation", file.Path, file.Language, 1)
+			setProps(&ent, "framework", framework, "provenance", "VALIDATION_PATTERN")
+			add(ent)
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Observability extraction (shared, language-level)
+	// ---------------------------------------------------------------------------
+
+	// log_extraction
+	if reScalaSlf4j.MatchString(src) || reScalaLogStatement.MatchString(src) ||
+		rePlayLogger.MatchString(src) || reAkkaLogging.MatchString(src) || reEffectLogging.MatchString(src) {
+		ent := makeEntity("logger:"+strings.TrimSuffix(fileBaseName(file.Path), ".scala"), "SCOPE.Observability", "log_statement", file.Path, file.Language, 1)
+		setProps(&ent, "framework", framework, "provenance", "SCALA_LOGGER")
+		add(ent)
+	}
+
+	// metric_extraction
+	if reScalaMetric.MatchString(src) {
+		ent := makeEntity("metrics:"+fileBaseName(file.Path), "SCOPE.Observability", "metric", file.Path, file.Language, 1)
+		setProps(&ent, "framework", framework, "provenance", "SCALA_METRIC")
+		add(ent)
+	}
+
+	// trace_extraction
+	if reScalaTrace.MatchString(src) {
+		ent := makeEntity("trace:"+fileBaseName(file.Path), "SCOPE.Observability", "trace", file.Path, file.Language, 1)
+		setProps(&ent, "framework", framework, "provenance", "SCALA_TRACE")
+		add(ent)
+	}
+
+	// ---------------------------------------------------------------------------
+	// Testing linkage
+	// ---------------------------------------------------------------------------
+	isTest := reScalaTest.MatchString(src) || reSpecs2.MatchString(src) || reMUnit.MatchString(src) ||
+		reAkkaTestKit.MatchString(src) || reHttp4sTest.MatchString(src) || reCaskTest.MatchString(src) ||
+		reZioTest.MatchString(src) || reFinatraTest.MatchString(src)
+
+	if isTest {
+		ent := makeEntity("test:"+fileBaseName(file.Path), "SCOPE.Test", "test_suite", file.Path, file.Language, 1)
+		setProps(&ent, "framework", framework, "provenance", "SCALA_TEST_SUITE")
+		add(ent)
+	}
+
+	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// detectScalaFramework returns the dominant framework based on imports/code patterns.
+func detectScalaFramework(src string) string {
+	switch {
+	case strings.Contains(src, "akka.http") || strings.Contains(src, "pekko.http"):
+		return "akka-http"
+	case strings.Contains(src, "org.http4s"):
+		return "http4s"
+	case strings.Contains(src, "org.scalatra"):
+		return "scalatra"
+	case strings.Contains(src, "import cask") || strings.Contains(src, "@cask."):
+		return "cask"
+	case strings.Contains(src, "dev.zio") || strings.Contains(src, "zio.http"):
+		return "zio-http"
+	case strings.Contains(src, "com.twitter.finatra"):
+		return "finatra"
+	case strings.Contains(src, "com.lightbend.lagom"):
+		return "lagom"
+	case strings.Contains(src, "play.api") || strings.Contains(src, "import play.") ||
+		// Play conf/routes file: lines like "GET /path controllers.Ctrl.action"
+		rePlayRoute.MatchString(src):
+		return "play"
+	default:
+		return "scala"
+	}
+}
+
+func authReForFramework(fw string) *regexp.Regexp {
+	switch fw {
+	case "akka-http":
+		return reAkkaAuth
+	case "http4s":
+		return reHttp4sAuth
+	case "scalatra":
+		return reScalatraAuth
+	case "cask":
+		return reCaskAuth
+	case "zio-http":
+		return reZioAuth
+	case "finatra":
+		return reFinatraAuth
+	case "lagom":
+		return reLagomAuth
+	}
+	return nil
+}
+
+func middlewareReForFramework(fw string) *regexp.Regexp {
+	switch fw {
+	case "akka-http":
+		return reAkkaMiddleware
+	case "http4s":
+		return reHttp4sMiddleware
+	case "scalatra":
+		return reScalatraMiddleware
+	case "cask":
+		return reCaskMiddleware
+	case "zio-http":
+		return reZioMiddleware
+	case "finatra":
+		return reFinatraMiddleware
+	case "lagom":
+		return reLagomMiddleware
+	}
+	return nil
+}
+
+func validationReForFramework(fw string) *regexp.Regexp {
+	switch fw {
+	case "akka-http":
+		return reAkkaValidation
+	case "http4s":
+		return reHttp4sValidation
+	case "scalatra":
+		return reScalatraValidation
+	case "cask":
+		return reCaskValidation
+	case "zio-http":
+		return reZioValidation
+	case "finatra":
+		return reFinatraValidation
+	case "lagom":
+		return reLagomValidation
+	}
+	return nil
+}
+
+func fileBaseName(path string) string {
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return path
+	}
+	return parts[len(parts)-1]
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/custom/scala/frameworks_test.go
+++ b/internal/custom/scala/frameworks_test.go
@@ -1,0 +1,286 @@
+package scala_test
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Framework extractor tests
+// ---------------------------------------------------------------------------
+
+func TestFrameworksAkkaHttpRoute(t *testing.T) {
+	src := `
+import akka.http.scaladsl.server.Directives._
+val route =
+  pathPrefix("api") {
+    path("users") {
+      get { complete(users) } ~
+      post { entity(as[User]) { u => complete(u) } }
+    }
+  }
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserRoutes.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one http_route entity from akka-http")
+	}
+}
+
+func TestFrameworksHttp4sRoute(t *testing.T) {
+	src := `
+import org.http4s._
+import org.http4s.dsl.io._
+val routes = HttpRoutes.of[IO] {
+  case GET -> Root / "health" => Ok("ok")
+  case POST -> Root / "users" => Ok("created")
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Routes.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one http_route entity from http4s")
+	}
+}
+
+func TestFrameworksScalatraRoute(t *testing.T) {
+	src := `
+import org.scalatra._
+class UserServlet extends ScalatraServlet {
+  get("/users") { "all users" }
+  post("/users") { "create user" }
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserServlet.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one http_route entity from scalatra")
+	}
+}
+
+func TestFrameworksCaskRoute(t *testing.T) {
+	src := `
+import cask._
+object Main extends cask.MainRoutes {
+  @cask.get("/api/users")
+  def getUsers() = "users"
+  @cask.post("/api/users")
+  def createUser(request: cask.Request) = "created"
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Main.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one http_route entity from cask")
+	}
+}
+
+func TestFrameworksFinatraRoute(t *testing.T) {
+	src := `
+import com.twitter.finatra.http._
+class UserController extends HttpController {
+  @Get("/api/users")
+  def getUsers(request: Request): Response = ???
+  @Post("/api/users")
+  def createUser(request: UserRequest): Response = ???
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserController.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one http_route entity from finatra")
+	}
+}
+
+func TestFrameworksLagomServiceCall(t *testing.T) {
+	src := `
+import com.lightbend.lagom.scaladsl.api._
+trait UserService extends Service {
+  def getUser(id: String): ServiceCall[NotUsed, User]
+  override def descriptor = {
+    import Service._
+    named("user-service").withCalls(
+      pathCall("/api/users/:id", getUser _),
+      namedCall("/api/users", createUser _)
+    )
+  }
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserService.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "lagom_service_call" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one lagom_service_call entity")
+	}
+}
+
+func TestFrameworksPlayRoute(t *testing.T) {
+	src := `GET     /users                  controllers.UserController.list
+POST    /users                  controllers.UserController.create
+GET     /users/:id              controllers.UserController.get(id: Long)
+`
+	ents := extract(t, "custom_scala_frameworks", fi("routes", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one http_route entity from play routes file")
+	}
+}
+
+func TestFrameworksObservabilityLogging(t *testing.T) {
+	src := `
+import org.slf4j.LoggerFactory
+class UserService {
+  val logger = LoggerFactory.getLogger(classOf[UserService])
+  def findUser(id: Long) = {
+    logger.info(s"Finding user $id")
+    logger.warn("User not found")
+  }
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserService.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Observability", "UserService.scala") {
+		// Look for any log entity
+		found := false
+		for _, e := range ents {
+			if e.Kind == "SCOPE.Observability" && e.Subtype == "log_statement" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected log_statement entity")
+		}
+	}
+}
+
+func TestFrameworksObservabilityMetrics(t *testing.T) {
+	src := `
+import io.micrometer.core.instrument.{Counter, MeterRegistry}
+class MetricsService(registry: MeterRegistry) {
+  val requestCounter = Counter.builder("http.requests").register(registry)
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Metrics.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Observability" && e.Subtype == "metric" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected metric entity")
+	}
+}
+
+func TestFrameworksTestingLinkage(t *testing.T) {
+	src := `
+import org.scalatest._
+class UserServiceSpec extends AnyFlatSpec {
+  "UserService" should "find a user by id" in {
+    val service = new UserService(mockRepo)
+    service.findById(1L) shouldBe Some(testUser)
+  }
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserServiceSpec.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Test" && e.Subtype == "test_suite" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected test_suite entity for ScalaTest")
+	}
+}
+
+func TestFrameworksZioHttpRoute(t *testing.T) {
+	src := `
+import zio._
+import zio.http._
+val app = Http.collect[Request] {
+  case Method.GET -> Root / "users" => Response.text("users")
+  case Method.POST -> Root / "users" => Response.ok
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("App.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one http_route entity from zio-http")
+	}
+}
+
+func TestFrameworksDTOExtraction(t *testing.T) {
+	src := `
+import akka.http.scaladsl.server.Directives._
+case class CreateUserRequest(name: String, email: String, age: Int)
+case class UserResponse(id: Long, name: String)
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Dto.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Type" && e.Subtype == "dto" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected dto entity from case class")
+	}
+}
+
+func TestFrameworksNoMatchNonScala(t *testing.T) {
+	src := `get("/users") { "all users" }`
+	ents := extract(t, "custom_scala_frameworks", fi("app.rb", "ruby", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for ruby file, got %d", len(ents))
+	}
+}

--- a/internal/custom/scala/type_system.go
+++ b/internal/custom/scala/type_system.go
@@ -1,0 +1,240 @@
+// Package scala — Scala type-system extractor.
+//
+// Covers (missing → partial or full):
+//
+//	Framework records         Cap                          Status
+//	─────────────────────────────────────────────────────────────
+//	all jvm_backend + play    Type System/type_extraction         partial
+//	all jvm_backend + play    Type System/enum_extraction         partial
+//	all jvm_backend + play    Type System/interface_extraction    partial
+//	all jvm_backend + play    Type System/type_alias_extraction   partial
+//
+// Scala's type system:
+//   - case class Foo(...)              → type_extraction (value object/DTO)
+//   - sealed trait / sealed abstract class → enum_extraction (ADT discriminant)
+//   - enum Foo { case A, B }           → enum_extraction (Scala 3 enum)
+//   - trait Foo                        → interface_extraction
+//   - abstract class Foo               → interface_extraction
+//   - type Alias = SomeType            → type_alias_extraction
+//   - opaque type Alias = T            → type_alias_extraction (Scala 3)
+//
+// Honest limit: regex-based, file-local. Cross-file ADT hierarchies
+// (sealed trait in one file, subclasses in another) are only partially
+// detected. Cells are partial.
+package scala
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_scala_type_system", &scalaTypeSystemExtractor{})
+}
+
+type scalaTypeSystemExtractor struct{}
+
+func (e *scalaTypeSystemExtractor) Language() string { return "custom_scala_type_system" }
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// type_extraction: case class (value object / DTO)
+	// Matches: case class Foo(...) or case class Foo[T](...)
+	reCaseClass = regexp.MustCompile(
+		`(?m)^\s*(?:final\s+)?case\s+class\s+(\w+)\s*(?:\[[^\]]*\])?\s*(?:\([^)]*\))?`)
+
+	// type_extraction: plain class
+	rePlainClass = regexp.MustCompile(
+		`(?m)^\s*(?:final\s+|abstract\s+|sealed\s+abstract\s+)?class\s+(\w+)\s*(?:\[[^\]]*\])?`)
+
+	// type_extraction: object (singleton companion)
+	reObject = regexp.MustCompile(
+		`(?m)^\s*(?:case\s+)?object\s+(\w+)\b`)
+
+	// enum_extraction: sealed trait (Scala 2 ADT discriminant)
+	reSealedTrait = regexp.MustCompile(
+		`(?m)^\s*sealed\s+(?:abstract\s+)?trait\s+(\w+)\b`)
+
+	// enum_extraction: sealed abstract class (Scala 2 sealed base)
+	reSealedAbstractClass = regexp.MustCompile(
+		`(?m)^\s*sealed\s+abstract\s+class\s+(\w+)\b`)
+
+	// enum_extraction: Scala 3 enum
+	reScala3Enum = regexp.MustCompile(
+		`(?m)^\s*enum\s+(\w+)\s*(?:\[[^\]]*\])?\s*(?:extends\s+[^\{]+)?\{`)
+
+	// interface_extraction: trait (not sealed — sealed already caught above)
+	reTrait = regexp.MustCompile(
+		`(?m)^\s*(?:private\s+|protected\s+)?(?:sealed\s+)?trait\s+(\w+)\b`)
+
+	// interface_extraction: abstract class
+	reAbstractClass = regexp.MustCompile(
+		`(?m)^\s*(?:private\s+|protected\s+)?abstract\s+class\s+(\w+)\b`)
+
+	// type_alias_extraction: type Alias = SomeType
+	reTypeAlias = regexp.MustCompile(
+		`(?m)^\s*type\s+(\w+)(?:\[[^\]]*\])?\s*=\s*(.+)`)
+
+	// type_alias_extraction: opaque type (Scala 3)
+	reOpaqueType = regexp.MustCompile(
+		`(?m)^\s*opaque\s+type\s+(\w+)(?:\[[^\]]*\])?\s*=\s*(.+)`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *scalaTypeSystemExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/scala")
+	_, span := tracer.Start(ctx, "indexer.scala_type_system.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("extractor", "type_system"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "scala" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// --- type_extraction: case class (value objects / DTOs) ---
+	for _, m := range reCaseClass.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Type", "case_class", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "case_class",
+			"provenance", "SCALA_CASE_CLASS",
+		)
+		add(ent)
+	}
+
+	// --- type_extraction: plain class ---
+	for _, m := range rePlainClass.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		// skip if sealed abstract class (already caught by enum path)
+		ent := makeEntity(name, "SCOPE.Type", "class", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "class",
+			"provenance", "SCALA_CLASS",
+		)
+		add(ent)
+	}
+
+	// --- type_extraction: object (companion/module) ---
+	for _, m := range reObject.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Type", "object", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "object",
+			"provenance", "SCALA_OBJECT",
+		)
+		add(ent)
+	}
+
+	// --- enum_extraction: sealed trait (Scala 2 ADT) ---
+	for _, m := range reSealedTrait.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Type", "sealed_trait", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "sealed_trait",
+			"provenance", "SCALA_SEALED_TRAIT",
+			"is_adt", "true",
+		)
+		add(ent)
+	}
+
+	// --- enum_extraction: sealed abstract class ---
+	for _, m := range reSealedAbstractClass.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Type", "sealed_abstract_class", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "sealed_abstract_class",
+			"provenance", "SCALA_SEALED_ABSTRACT_CLASS",
+			"is_adt", "true",
+		)
+		add(ent)
+	}
+
+	// --- enum_extraction: Scala 3 enum ---
+	for _, m := range reScala3Enum.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Type", "enum", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "enum",
+			"provenance", "SCALA3_ENUM",
+			"is_adt", "true",
+		)
+		add(ent)
+	}
+
+	// --- interface_extraction: trait ---
+	for _, m := range reTrait.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Interface", "trait", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "trait",
+			"provenance", "SCALA_TRAIT",
+		)
+		add(ent)
+	}
+
+	// --- interface_extraction: abstract class ---
+	for _, m := range reAbstractClass.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Interface", "abstract_class", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "abstract_class",
+			"provenance", "SCALA_ABSTRACT_CLASS",
+		)
+		add(ent)
+	}
+
+	// --- type_alias_extraction: type Alias = ... ---
+	for _, m := range reTypeAlias.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Type", "type_alias", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "type_alias",
+			"provenance", "SCALA_TYPE_ALIAS",
+		)
+		add(ent)
+	}
+
+	// --- type_alias_extraction: opaque type (Scala 3) ---
+	for _, m := range reOpaqueType.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Type", "opaque_type", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"type_kind", "opaque_type",
+			"provenance", "SCALA3_OPAQUE_TYPE",
+		)
+		add(ent)
+	}
+
+	return entities, nil
+}

--- a/internal/custom/scala/type_system_test.go
+++ b/internal/custom/scala/type_system_test.go
@@ -1,0 +1,118 @@
+package scala_test
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Type System extractor tests
+// ---------------------------------------------------------------------------
+
+func TestTypeSystemCaseClass(t *testing.T) {
+	src := `
+case class User(id: Long, name: String, email: String)
+case class OrderRequest(userId: Long, items: List[String])
+final case class Address(street: String, city: String)
+`
+	ents := extract(t, "custom_scala_type_system", fi("Models.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Type", "User") {
+		t.Error("expected User case class")
+	}
+	if !containsEntity(ents, "SCOPE.Type", "OrderRequest") {
+		t.Error("expected OrderRequest case class")
+	}
+	if !containsEntity(ents, "SCOPE.Type", "Address") {
+		t.Error("expected Address final case class")
+	}
+}
+
+func TestTypeSystemSealedTrait(t *testing.T) {
+	src := `
+sealed trait PaymentMethod
+sealed abstract class ApiError
+case class CreditCard(number: String) extends PaymentMethod
+case object Cash extends PaymentMethod
+`
+	ents := extract(t, "custom_scala_type_system", fi("Domain.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Type", "PaymentMethod") {
+		t.Error("expected PaymentMethod sealed_trait as ADT enum")
+	}
+	if !containsEntity(ents, "SCOPE.Type", "ApiError") {
+		t.Error("expected ApiError sealed_abstract_class")
+	}
+}
+
+func TestTypeSystemScala3Enum(t *testing.T) {
+	src := `
+enum Color {
+  case Red, Green, Blue
+}
+enum Status extends SomeBase {
+  case Active, Inactive, Pending
+}
+`
+	ents := extract(t, "custom_scala_type_system", fi("Enums.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Type", "Color") {
+		t.Error("expected Color Scala3 enum")
+	}
+	if !containsEntity(ents, "SCOPE.Type", "Status") {
+		t.Error("expected Status Scala3 enum")
+	}
+}
+
+func TestTypeSystemTrait(t *testing.T) {
+	src := `
+trait UserRepository {
+  def findById(id: Long): Option[User]
+  def save(user: User): User
+}
+trait Logging {
+  def log(msg: String): Unit
+}
+`
+	ents := extract(t, "custom_scala_type_system", fi("Repos.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Interface", "UserRepository") {
+		t.Error("expected UserRepository trait")
+	}
+	if !containsEntity(ents, "SCOPE.Interface", "Logging") {
+		t.Error("expected Logging trait")
+	}
+}
+
+func TestTypeSystemAbstractClass(t *testing.T) {
+	src := `
+abstract class BaseService(val db: Database) {
+  def execute(): Unit
+}
+`
+	ents := extract(t, "custom_scala_type_system", fi("Base.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Interface", "BaseService") {
+		t.Error("expected BaseService abstract class as interface")
+	}
+}
+
+func TestTypeSystemTypeAlias(t *testing.T) {
+	src := `
+type UserId = Long
+type UserMap = Map[String, User]
+opaque type Token = String
+`
+	ents := extract(t, "custom_scala_type_system", fi("Types.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Type", "UserId") {
+		t.Error("expected UserId type alias")
+	}
+	if !containsEntity(ents, "SCOPE.Type", "UserMap") {
+		t.Error("expected UserMap type alias")
+	}
+	if !containsEntity(ents, "SCOPE.Type", "Token") {
+		t.Error("expected Token opaque type alias")
+	}
+}
+
+func TestTypeSystemNoMatchNonScala(t *testing.T) {
+	src := `case class Foo(x: Int)`
+	ents := extract(t, "custom_scala_type_system", fi("Foo.java", "java", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for java file, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Summary

- **216 missing cells → 0** across 9 Scala framework records (akka-http, cask, cats-effect, finatra, http4s, lagom, play, scalatra, zio-http) and the 3 build/pkg records (build.sbt, build.mill, pkg.sbt had no missing cells already)
- 3 new extractors in `internal/custom/scala/`: `type_system.go`, `frameworks.go`, `di.go` (6 files including tests)
- All honest: `partial` for what the code actually proves, `not_applicable` for architecturally inapplicable caps

## Cells flipped (216 total)

| Group | Cells | Disposition |
|---|---|---|
| Substrate (def_use/module_cycle/pure_function/template_pattern) | 36 | partial — existing scala substrate files |
| Type System (enum/interface/type_alias/type_extraction) | 35 | partial — new type_system.go |
| Observability (log/metric/trace) | 24 | partial — new frameworks.go |
| DI (binding/injection/scope) | 21 | partial (finatra/lagom/zio-http) or not_applicable (akka-http/cask/http4s/scalatra) |
| Transactions (boundary/propagation/rollback) | 21 | not_applicable — ORM-layer concern, not framework layer |
| AOP (advice/aspect/pointcut) | 21 | not_applicable — no Spring AOP/AspectJ in Scala HTTP frameworks |
| Validation (dto/request_validation) | 14 | partial — new frameworks.go |
| Routing (route_extraction + endpoint_synthesis/handler_attribution/router_pattern) | 11 | partial — frameworks.go + yaml rules |
| Testing (tests_linkage) | 9 | partial — ScalaTest/Specs2/MUnit/ZIO Test/Akka TestKit |
| Auth (auth_coverage) | 7 | partial — framework-specific auth patterns |
| Middleware (middleware_coverage) | 7 | partial — framework-specific middleware patterns |
| Play frontend caps (component_extraction, hook_recognition, data_loaders, etc.) | 7 | not_applicable — Play is server-side MVC, not frontend |
| Play substrate payload (request/response_shape, schema_drift) | 3 | partial — existing payload_shapes_scala.go |

## Validation

```
go build ./internal/... ./tools/coverage/...  ✓
go test ./internal/custom/scala/... ./internal/types/... ./tools/coverage/...  ✓
go run ./tools/coverage validate  ✓ (exit 0)
go run ./tools/coverage fmt --check  ✓ canonical
gofmt -l internal/custom/scala/  ✓ (empty — clean)
```

## Residuals

None — all 216 missing cells resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>