### PR TITLE
coverage(php): ORM+driver+test records → green

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -70,11 +70,11 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [multi](../by-language/multi.md) | [Dockerfile](../detail/build.dockerfile.md) | ✅ | — | — | ✅ | |
 | [multi](../by-language/multi.md) | [Justfile](../detail/build.justfile.md) | ✅ | — | — | ✅ | |
 | [multi](../by-language/multi.md) | [Makefile](../detail/build.makefile.md) | 🔴 | — | — | 🟢 | |
-| [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🔴 | — | — | 🔴 | |
-| [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🔴 | — | — | 🔴 | |
+| [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🟢 | — | — | 🟢 | |
+| [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🟢 | — | — | 🟢 | |
 | [php](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | — | — | ✅ | |
 | [php](../by-language/php.md) | [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | ✅ | |
-| [php](../by-language/php.md) | [Pest](../detail/test.pest.md) | 🔴 | — | — | 🔴 | |
+| [php](../by-language/php.md) | [Pest](../detail/test.pest.md) | 🟢 | — | — | 🟢 | |
 | [python](../by-language/python.md) | [Flit](../detail/build.flit.md) | 🟢 | — | — | 🟢 | |
 | [python](../by-language/python.md) | [Hatch](../detail/build.hatch.md) | 🟢 | — | — | 🟢 | |
 | [python](../by-language/python.md) | [Hypothesis (property tests)](../detail/test.hypothesis.md) | — | — | — | 🟢 | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -98,20 +98,20 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟢 8/8 | |
-| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/6 | |
-| [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🔴 0/8 | |
-| [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 2/8 | |
-| [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟡 2/8 | |
-| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟡 1/6 | |
-| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟡 1/6 | |
-| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟡 1/6 | |
-| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | 🟡 2/8 | |
-| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟡 2/8 | |
-| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟡 1/6 | |
-| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟡 1/6 | |
-| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 1/6 | |
-| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 1/6 | |
-| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/6 | |
+| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟢 1/1 | |
+| [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟢 8/8 | |
+| [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟢 8/8 | |
+| [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟢 8/8 | |
+| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟢 2/2 | |
+| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟢 2/2 | |
+| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟢 2/2 | |
+| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | 🟢 8/8 | |
+| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟢 5/5 | |
+| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟢 1/1 | |
+| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟢 1/1 | |
+| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟢 1/1 | |
+| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟢 1/1 | |
+| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟢 1/1 | |
 | [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟢 2/2 | |
 | [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟢 6/6 | |
 | [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 8/8 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -44,11 +44,11 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
 |---|---|---|---|---|---|
-| [Behat](../detail/test.behat.md) | 🔴 | — | — | 🔴 | |
-| [Codeception](../detail/test.codeception.md) | 🔴 | — | — | 🔴 | |
+| [Behat](../detail/test.behat.md) | 🟢 | — | — | 🟢 | |
+| [Codeception](../detail/test.codeception.md) | 🟢 | — | — | 🟢 | |
 | [Composer](../detail/build.composer.md) | ✅ | — | — | ✅ | |
 | [PHPUnit](../detail/test.phpunit.md) | ✅ | — | — | ✅ | |
-| [Pest](../detail/test.pest.md) | 🔴 | — | — | 🔴 | |
+| [Pest](../detail/test.pest.md) | 🟢 | — | — | 🟢 | |
 | [composer.json](../detail/pkg.composer.md) | — | ✅ | ✅ | — | |
 
 ## ORMs
@@ -58,17 +58,17 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/6 | |
-| [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🔴 0/8 | |
-| [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 2/8 | |
-| [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟡 2/8 | |
-| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟡 1/6 | |
-| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟡 1/6 | |
-| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟡 1/6 | |
-| [Propel](../detail/lang.php.orm.propel.md) | 🟡 2/8 | |
-| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟡 2/8 | |
-| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟡 1/6 | |
-| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟡 1/6 | |
-| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 1/6 | |
-| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 1/6 | |
-| [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/6 | |
+| [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟢 1/1 | |
+| [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟢 8/8 | |
+| [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟢 8/8 | |
+| [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟢 8/8 | |
+| [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟢 2/2 | |
+| [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟢 2/2 | |
+| [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟢 2/2 | |
+| [Propel](../detail/lang.php.orm.propel.md) | 🟢 8/8 | |
+| [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟢 5/5 | |
+| [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟢 1/1 | |
+| [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟢 1/1 | |
+| [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟢 1/1 | |
+| [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟢 1/1 | |
+| [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟢 1/1 | |

--- a/docs/coverage/detail/lang.php.driver.cassandra.md
+++ b/docs/coverage/detail/lang.php.driver.cassandra.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | — `not_applicable` | — | — | — | Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.php.driver.dynamodb.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | — `not_applicable` | — | — | — | Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.driver.elastic.md
+++ b/docs/coverage/detail/lang.php.driver.elastic.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | — `not_applicable` | — | — | — | Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.driver.mongodb.md
+++ b/docs/coverage/detail/lang.php.driver.mongodb.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | — `not_applicable` | — | — | — | Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.driver.mysql.md
+++ b/docs/coverage/detail/lang.php.driver.mysql.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/driver_sql.go` | CREATE TABLE statements in PDO/mysqli execute calls scanned for table + column names (heuristic). |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.driver.neo4j.md
+++ b/docs/coverage/detail/lang.php.driver.neo4j.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | — `not_applicable` | — | — | — | Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.driver.postgres.md
+++ b/docs/coverage/detail/lang.php.driver.postgres.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/driver_sql.go` | CREATE TABLE statements in PDO::pgsql/pg_query execute calls scanned for table + column names (heuristic). |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.driver.redis.md
+++ b/docs/coverage/detail/lang.php.driver.redis.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | — `not_applicable` | — | — | — | Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.driver.sqlite.md
+++ b/docs/coverage/detail/lang.php.driver.sqlite.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/driver_sql.go` | CREATE TABLE statements in PDO::sqlite/SQLite3 execute calls scanned for table + column names (heuristic). |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Foreign key extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
+| Relationship extraction | — `not_applicable` | — | — | — | Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients. |
 
 ### Queries
 

--- a/docs/coverage/detail/lang.php.orm.cycleorm.md
+++ b/docs/coverage/detail/lang.php.orm.cycleorm.md
@@ -15,29 +15,29 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🔴 `missing` | — | — | — | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model extraction | 🟢 `partial` | — | — | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
+| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
+| Foreign key extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
+| Lazy loading recognition | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
+| Relationship extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | — | — | — |
+| Query attribution | 🟢 `partial` | — | — | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
 
 ### Migrations
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | — | — | `internal/custom/php/orm_data.go` | CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.doctrine.md
+++ b/docs/coverage/detail/lang.php.orm.doctrine.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/php/orms/doctrine_orm.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Doctrine #[ORM\Column] attributes scanned forward to property names; association/FK/lazy/migration also extracted. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | ORM relation type attributes scanned (OneToMany/ManyToMany). |
+| Foreign key extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | #[ORM\JoinColumn] attributes scanned. |
+| Lazy loading recognition | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | fetch=LAZY / fetch='LAZY' annotation patterns scanned. |
+| Relationship extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | OneToMany/ManyToOne/ManyToMany/OneToOne Doctrine attributes scanned. |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | — | — | `internal/custom/php/orm_data.go` | AbstractMigration subclasses + up/down methods scanned. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.eloquent.md
+++ b/docs/coverage/detail/lang.php.orm.eloquent.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/php/orms/eloquent_laravel_orm.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL. |
+| Foreign key extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL. |
+| Lazy loading recognition | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL. |
+| Relationship extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL. |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | — | — | `internal/custom/php/orm_data.go` | Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.propel.md
+++ b/docs/coverage/detail/lang.php.orm.propel.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/propel.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls. |
+| Foreign key extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls. |
+| Lazy loading recognition | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls. |
+| Relationship extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls. |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | 🟢 `partial` | — | — | `internal/custom/php/orm_data.go` | Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls. |
 
 ## Provenance
 

--- a/docs/coverage/detail/lang.php.orm.redbeanphp.md
+++ b/docs/coverage/detail/lang.php.orm.redbeanphp.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/php/orms/redbeanphp.yaml` | — |
-| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | RedBeanPHP R::dispense/'table' implicit schema; R::related/associate relations. Zero-config ORM — no explicit FK/lazy/migration concepts. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
-| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | RedBeanPHP R::dispense/'table' implicit schema; R::related/associate relations. Zero-config ORM — no explicit FK/lazy/migration concepts. |
+| Foreign key extraction | — `not_applicable` | — | — | — | RedBeanPHP zero-config ORM: foreign keys are auto-managed server-side via convention (ownXList/sharedXList), not extractable from PHP source. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | RedBeanPHP loads eagerly by default; no lazy-loading configuration surface in PHP code. |
+| Relationship extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/orm_data.go` | RedBeanPHP R::dispense/'table' implicit schema; R::related/associate relations. Zero-config ORM — no explicit FK/lazy/migration concepts. |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | — | — | — |
+| Migration parsing | — `not_applicable` | — | — | — | RedBeanPHP is zero-config — schema is created/altered automatically at runtime; no migration files to parse. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.behat.md
+++ b/docs/coverage/detail/test.behat.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🟢 `partial` | — | — | `internal/custom/php/test_data.go` | Behat Context class deps (implements Context/extends RawMinkContext) + step annotation targets scanned. |
+| Target extraction | 🟢 `partial` | — | — | `internal/custom/php/test_data.go`<br>`internal/engine/rules/php/test_patterns.yaml` | Feature/Scenario declarations in .feature files + step annotation patterns in PHP context classes extracted. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.codeception.md
+++ b/docs/coverage/detail/test.codeception.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🟢 `partial` | — | — | `internal/custom/php/test_data.go` | Codeception module imports + Actor type dependencies (AcceptanceTester/FunctionalTester/UnitTester) scanned. |
+| Target extraction | 🟢 `partial` | — | — | `internal/custom/php/test_data.go`<br>`internal/engine/rules/php/test_patterns.yaml` | Cest class declarations + public test methods with Actor params extracted. |
 
 ## Provenance
 

--- a/docs/coverage/detail/test.pest.md
+++ b/docs/coverage/detail/test.pest.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency graph | 🔴 `missing` | — | — | — | — |
-| Target extraction | 🔴 `missing` | — | — | — | — |
+| Dependency graph | 🟢 `partial` | — | — | `internal/custom/php/test_data.go` | uses(ClassName::class) declarations + beforeEach/afterEach hooks + arch() architectural constraints scanned. |
+| Target extraction | 🟢 `partial` | — | — | `internal/custom/php/test_data.go`<br>`internal/engine/rules/php/test_patterns.yaml` | it()/test() declarations + describe() blocks + dataset() declarations extracted. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -33004,26 +33004,26 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -33052,26 +33052,26 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -33100,26 +33100,26 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -33148,26 +33148,26 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -33196,26 +33196,28 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/driver_sql.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CREATE TABLE statements in PDO/mysqli execute calls scanned for table + column names (heuristic)."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -33244,26 +33246,26 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -33292,26 +33294,28 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/driver_sql.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CREATE TABLE statements in PDO::pgsql/pg_query execute calls scanned for table + column names (heuristic)."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -33340,26 +33344,26 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Schema-less or server-side schema only; raw PHP driver has no PHP-level schema model to extract."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -33388,26 +33392,28 @@
             "status": "not_applicable"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/driver_sql.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CREATE TABLE statements in PDO::sqlite/SQLite3 execute calls scanned for table + column names (heuristic)."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "Raw PHP driver — no ORM relation layer; association/relationship/lazy-loading do not apply to raw connection clients."
           }
         },
         "Queries": {
@@ -36109,39 +36115,55 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
           }
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "notes": "CycleORM #[Entity]/#[Column] attributes; HasMany/BelongsTo/ManyToMany relations; lazy Promise proxy; findByPK/findOne/select queries; MigrationInterface class and schema sync."
           }
         }
       }
@@ -36160,26 +36182,36 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Doctrine #[ORM\\Column] attributes scanned forward to property names; association/FK/lazy/migration also extracted."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "ORM relation type attributes scanned (OneToMany/ManyToMany)."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "#[ORM\\JoinColumn] attributes scanned."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "fetch=LAZY / fetch='LAZY' annotation patterns scanned."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "OneToMany/ManyToOne/ManyToMany/OneToOne Doctrine attributes scanned."
           }
         },
         "Queries": {
@@ -36191,7 +36223,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "notes": "AbstractMigration subclasses + up/down methods scanned."
           }
         }
       }
@@ -36210,26 +36244,36 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL."
           }
         },
         "Queries": {
@@ -36241,7 +36285,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "notes": "Eloquent $fillable/$casts/Schema::create/Blueprint columns; belongsTo/belongsToMany FK relations; $with eager hints; migration DDL."
           }
         }
       }
@@ -36260,26 +36306,36 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls."
           }
         },
         "Queries": {
@@ -36291,7 +36347,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "notes": "Propel TableMap COL_* constants (schema); addRelation/addForeignKey (relations/FK); LAZY_LOAD constant; PropelMigration classes; XxxQuery::create() calls."
           }
         }
       }
@@ -36310,26 +36368,32 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "RedBeanPHP R::dispense/'table' implicit schema; R::related/associate relations. Zero-config ORM — no explicit FK/lazy/migration concepts."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "RedBeanPHP R::dispense/'table' implicit schema; R::related/associate relations. Zero-config ORM — no explicit FK/lazy/migration concepts."
           },
           "foreign_key_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "RedBeanPHP zero-config ORM: foreign keys are auto-managed server-side via convention (ownXList/sharedXList), not extractable from PHP source."
           },
           "lazy_loading_recognition": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "not_applicable",
+            "notes": "RedBeanPHP loads eagerly by default; no lazy-loading configuration surface in PHP code."
           },
           "relationship_extraction": {
-            "status": "missing",
-            "issue": "backfill:dictionary-completeness"
+            "status": "partial",
+            "cites": ["internal/custom/php/orm_data.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "RedBeanPHP R::dispense/'table' implicit schema; R::related/associate relations. Zero-config ORM — no explicit FK/lazy/migration concepts."
           }
         },
         "Queries": {
@@ -36341,7 +36405,8 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "missing"
+            "status": "not_applicable",
+            "notes": "RedBeanPHP is zero-config — schema is created/altered automatically at runtime; no migration files to parse."
           }
         }
       }
@@ -51656,10 +51721,14 @@
       "label": "Behat",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/custom/php/test_data.go"],
+          "notes": "Behat Context class deps (implements Context/extends RawMinkContext) + step annotation targets scanned."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/custom/php/test_data.go","internal/engine/rules/php/test_patterns.yaml"],
+          "notes": "Feature/Scenario declarations in .feature files + step annotation patterns in PHP context classes extracted."
         }
       }
     },
@@ -51716,10 +51785,14 @@
       "label": "Codeception",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/custom/php/test_data.go"],
+          "notes": "Codeception module imports + Actor type dependencies (AcceptanceTester/FunctionalTester/UnitTester) scanned."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/custom/php/test_data.go","internal/engine/rules/php/test_patterns.yaml"],
+          "notes": "Cest class declarations + public test methods with Actor params extracted."
         }
       }
     },
@@ -52156,10 +52229,14 @@
       "label": "Pest",
       "capabilities": {
         "dependency_graph": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/custom/php/test_data.go"],
+          "notes": "uses(ClassName::class) declarations + beforeEach/afterEach hooks + arch() architectural constraints scanned."
         },
         "target_extraction": {
-          "status": "missing"
+          "status": "partial",
+          "cites": ["internal/custom/php/test_data.go","internal/engine/rules/php/test_patterns.yaml"],
+          "notes": "it()/test() declarations + describe() blocks + dataset() declarations extracted."
         }
       }
     },

--- a/internal/custom/php/data_extractors_test.go
+++ b/internal/custom/php/data_extractors_test.go
@@ -1,0 +1,665 @@
+package php_test
+
+// data_extractors_test.go — tests for orm_data.go, driver_sql.go, test_data.go
+// Coverage: Doctrine, Eloquent, CycleORM, Propel, RedBeanPHP schema/rel/migration;
+// MySQL/Postgres/SQLite driver schema; Behat/Codeception/Pest test extractors.
+
+import "testing"
+
+// ============================================================================
+// Doctrine ORM
+// ============================================================================
+
+func TestDoctrineColumn(t *testing.T) {
+	src := `<?php
+namespace App\Entity;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+class User
+{
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $username;
+
+    #[ORM\Column(type: 'string', unique: true)]
+    private string $email;
+}
+`
+	ents := extract(t, "php_doctrine_orm_data", fi("User.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "username") {
+		t.Error("expected username column schema")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "email") {
+		t.Error("expected email column schema")
+	}
+}
+
+func TestDoctrineRelationship(t *testing.T) {
+	src := `<?php
+#[ORM\Entity]
+class Order
+{
+    #[ORM\ManyToOne(targetEntity: Customer::class, inversedBy: 'orders')]
+    private Customer $customer;
+
+    #[ORM\OneToMany(targetEntity: OrderItem::class, mappedBy: 'order')]
+    private Collection $items;
+}
+`
+	ents := extract(t, "php_doctrine_orm_data", fi("Order.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "relation:ManyToOne") {
+		t.Error("expected ManyToOne relation component")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "relation:OneToMany") {
+		t.Error("expected OneToMany relation component")
+	}
+}
+
+func TestDoctrineFK(t *testing.T) {
+	src := `<?php
+#[ORM\Entity]
+class OrderItem
+{
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false)]
+    private Order $order;
+}
+`
+	ents := extract(t, "php_doctrine_orm_data", fi("OrderItem.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "join_column") {
+		t.Error("expected join_column FK entity")
+	}
+}
+
+func TestDoctrineLazyLoading(t *testing.T) {
+	src := `<?php
+#[ORM\Entity]
+class Product
+{
+    #[ORM\OneToMany(fetch: 'LAZY', targetEntity: Review::class)]
+    private Collection $reviews;
+}
+`
+	ents := extract(t, "php_doctrine_orm_data", fi("Product.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "lazy:LAZY") {
+		t.Error("expected lazy:LAZY pattern entity")
+	}
+}
+
+func TestDoctrineMigration(t *testing.T) {
+	src := `<?php
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20230101120000 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE user (id INT NOT NULL)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE user');
+    }
+}
+`
+	ents := extract(t, "php_doctrine_orm_data", fi("Version20230101120000.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Operation", "Version20230101120000") {
+		t.Error("expected migration class entity")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "migration:up") {
+		t.Error("expected migration:up entity")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "migration:down") {
+		t.Error("expected migration:down entity")
+	}
+}
+
+func TestDoctrineNoMatch(t *testing.T) {
+	src := `<?php echo "hello doctrine";`
+	ents := extract(t, "php_doctrine_orm_data", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// Eloquent ORM
+// ============================================================================
+
+func TestEloquentFillableSchema(t *testing.T) {
+	src := `<?php
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    protected $fillable = ['title', 'content', 'published_at'];
+    protected $casts = [
+        'published_at' => 'datetime',
+        'is_active' => 'boolean',
+    ];
+}
+`
+	ents := extract(t, "php_eloquent_orm_data", fi("Post.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "title") {
+		t.Error("expected title column schema from fillable")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "published_at") {
+		t.Error("expected published_at column from fillable OR casts")
+	}
+}
+
+func TestEloquentBelongsToFK(t *testing.T) {
+	src := `<?php
+class Comment extends Model
+{
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class);
+    }
+}
+`
+	ents := extract(t, "php_eloquent_orm_data", fi("Comment.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "post") {
+		t.Error("expected post belongsTo relation")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "tags") {
+		t.Error("expected tags belongsToMany relation")
+	}
+}
+
+func TestEloquentMigration(t *testing.T) {
+	src := `<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('content');
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->timestamps();
+        });
+    }
+}
+`
+	ents := extract(t, "php_eloquent_orm_data", fi("2023_01_01_create_posts_table.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Operation", "create:posts") {
+		t.Error("expected create:posts migration entity")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "title") {
+		t.Error("expected title column schema from blueprint")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "fk:user_id") {
+		t.Error("expected fk:user_id foreign key entity")
+	}
+}
+
+func TestEloquentEagerLoading(t *testing.T) {
+	src := `<?php
+class User extends Model
+{
+    protected $with = ['profile', 'roles'];
+}
+`
+	ents := extract(t, "php_eloquent_orm_data", fi("User.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "eager_with") {
+		t.Error("expected eager_with lazy/eager loading pattern")
+	}
+}
+
+// ============================================================================
+// CycleORM
+// ============================================================================
+
+func TestCycleORMEntity(t *testing.T) {
+	src := `<?php
+namespace App\Entity;
+
+use Cycle\Annotated\Annotation\Entity;
+use Cycle\Annotated\Annotation\Column;
+
+#[Entity(table: 'users')]
+class User
+{
+    #[Column(type: 'primary')]
+    private int $id;
+
+    #[Column(type: 'string')]
+    private string $name;
+}
+`
+	ents := extract(t, "php_cycleorm_data", fi("User.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "User") {
+		t.Error("expected User entity model")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "id") {
+		t.Error("expected id column entity")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "name") {
+		t.Error("expected name column entity")
+	}
+}
+
+func TestCycleORMRelation(t *testing.T) {
+	src := `<?php
+use Cycle\Annotated\Annotation\Relation\HasMany;
+use Cycle\Annotated\Annotation\Relation\BelongsTo;
+
+#[Entity]
+class Post
+{
+    #[HasMany(target: Comment::class)]
+    private array $comments;
+
+    #[BelongsTo(target: User::class)]
+    private User $author;
+}
+`
+	ents := extract(t, "php_cycleorm_data", fi("Post.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "relation:HasMany") {
+		t.Error("expected HasMany relation")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "relation:BelongsTo") {
+		t.Error("expected BelongsTo relation")
+	}
+}
+
+func TestCycleORMQuery(t *testing.T) {
+	src := `<?php
+class UserRepository
+{
+    public function findByEmail(string $email): ?User
+    {
+        return $this->orm->findOne(User::class, ['email' => $email]);
+    }
+}
+`
+	ents := extract(t, "php_cycleorm_data", fi("UserRepository.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Operation", "query:findOne") {
+		t.Error("expected query:findOne entity")
+	}
+}
+
+// ============================================================================
+// Propel ORM
+// ============================================================================
+
+func TestPropelTableMap(t *testing.T) {
+	src := `<?php
+use Propel\Runtime\Map\TableMap;
+
+class UserTableMap extends TableMap
+{
+    const COL_ID = 'user.id';
+    const COL_USERNAME = 'user.username';
+    const COL_EMAIL = 'user.email';
+}
+`
+	ents := extract(t, "php_propel_orm_data", fi("UserTableMap.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "UserTableMap") {
+		t.Error("expected UserTableMap schema entity")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "COL_USERNAME") {
+		t.Error("expected COL_USERNAME column entity")
+	}
+}
+
+func TestPropelRelation(t *testing.T) {
+	src := `<?php
+class BookTableMap extends TableMap
+{
+    public function initialize()
+    {
+        $this->addRelation('Author', AuthorTableMap::CLASS_DEFAULT, RelationMap::MANY_TO_ONE);
+        $this->addForeignKey('author_id', 'id', 'INTEGER', 'author', 'id');
+    }
+}
+`
+	ents := extract(t, "php_propel_orm_data", fi("BookTableMap.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "relation:Author") {
+		t.Error("expected relation:Author component")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "foreign_key") {
+		t.Error("expected foreign_key entity")
+	}
+}
+
+func TestPropelQuery(t *testing.T) {
+	src := `<?php
+$users = UserQuery::create()
+    ->filterByIsActive(true)
+    ->find();
+
+$book = BookQuery::create()->findOne();
+`
+	ents := extract(t, "php_propel_orm_data", fi("list.php", "php", src))
+	if len(ents) == 0 {
+		t.Error("expected Propel query entities from UserQuery::create()")
+	}
+}
+
+// ============================================================================
+// RedBeanPHP
+// ============================================================================
+
+func TestRedBeanDispense(t *testing.T) {
+	src := `<?php
+R::setup('mysql:host=localhost;dbname=shop', 'root', 'password');
+$product = R::dispense('product');
+$product->name = 'Widget';
+$product->price = 9.99;
+R::store($product);
+`
+	ents := extract(t, "php_redbeanphp_data", fi("store.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "product") {
+		t.Error("expected product table schema from R::dispense")
+	}
+}
+
+func TestRedBeanRelation(t *testing.T) {
+	src := `<?php
+R::associate($product, $category);
+$related = R::related($product, 'category');
+`
+	ents := extract(t, "php_redbeanphp_data", fi("relate.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "relation:associate") {
+		t.Error("expected relation:associate component")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "relation:related") {
+		t.Error("expected relation:related component")
+	}
+}
+
+func TestRedBeanFind(t *testing.T) {
+	src := `<?php
+$products = R::find('product', ' price > ? ', [10]);
+$user = R::findOne('user', ' email = ? ', [$email]);
+`
+	ents := extract(t, "php_redbeanphp_data", fi("query.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "product") {
+		t.Error("expected product schema from R::find")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "user") {
+		t.Error("expected user schema from R::findOne")
+	}
+}
+
+func TestRedBeanNoMatch(t *testing.T) {
+	src := `<?php class Plain { public function run() {} }`
+	ents := extract(t, "php_redbeanphp_data", fi("Plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// PHP SQL Driver Schema (mysql/postgres/sqlite)
+// ============================================================================
+
+func TestPHPSQLDriverMySQLCreateTable(t *testing.T) {
+	src := `<?php
+$pdo = new PDO("mysql:host=localhost;dbname=app", "root", "");
+$pdo->exec("
+    CREATE TABLE IF NOT EXISTS users (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        username VARCHAR(255) NOT NULL,
+        email VARCHAR(255) UNIQUE
+    )
+");
+`
+	ents := extract(t, "php_sql_driver_schema", fi("setup.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "users") {
+		t.Error("expected users table schema")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "users.username") {
+		t.Error("expected users.username column schema")
+	}
+}
+
+func TestPHPSQLDriverSQLiteCreateTable(t *testing.T) {
+	src := `<?php
+$db = new SQLite3('/tmp/test.db');
+$db->exec('CREATE TABLE orders (
+    id INTEGER PRIMARY KEY,
+    total REAL NOT NULL,
+    status TEXT DEFAULT "pending"
+)');
+`
+	ents := extract(t, "php_sql_driver_schema", fi("init.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "orders") {
+		t.Error("expected orders table schema")
+	}
+}
+
+func TestPHPSQLDriverNoMatch(t *testing.T) {
+	src := `<?php echo "no driver here";`
+	ents := extract(t, "php_sql_driver_schema", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// Behat
+// ============================================================================
+
+func TestBehatFeature(t *testing.T) {
+	src := `Feature: User login
+  In order to access the application
+  As a user
+  I need to be able to log in
+
+  Scenario: Successful login
+    Given I am on the login page
+    When I fill in "email" with "user@example.com"
+    Then I should see "Dashboard"
+
+  Scenario: Failed login
+    Given I am on the login page
+    When I fill in "email" with "bad@example.com"
+    Then I should see "Invalid credentials"
+`
+	ents := extract(t, "php_behat_test", fi("login.feature", "gherkin", src))
+	if !containsEntity(ents, "SCOPE.Operation", "feature:User login") {
+		t.Error("expected feature entity")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "scenario:Successful login") {
+		t.Error("expected Successful login scenario")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "scenario:Failed login") {
+		t.Error("expected Failed login scenario")
+	}
+}
+
+func TestBehatContextClass(t *testing.T) {
+	src := `<?php
+use Behat\Behat\Context\Context;
+
+class FeatureContext implements Context
+{
+    /**
+     * @Given I am on the login page
+     */
+    #[Given('/^I am on the login page$/')]
+    public function iAmOnTheLoginPage()
+    {
+        // ...
+    }
+
+    /**
+     * @When I fill in :field with :value
+     */
+    public function iFillIn($field, $value) {}
+}
+`
+	ents := extract(t, "php_behat_test", fi("FeatureContext.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "FeatureContext") {
+		t.Error("expected FeatureContext context class entity")
+	}
+}
+
+func TestBehatNoMatch(t *testing.T) {
+	src := `<?php class NoBehatHere {}`
+	ents := extract(t, "php_behat_test", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// Codeception
+// ============================================================================
+
+func TestCodeceptionCest(t *testing.T) {
+	src := `<?php
+use Codeception\Module\WebDriver;
+
+class UserLoginCest
+{
+    public function loginSuccessfully(AcceptanceTester $I)
+    {
+        $I->amOnPage('/login');
+        $I->fillField('email', 'user@example.com');
+        $I->seeCurrentUrlEquals('/dashboard');
+    }
+
+    public function loginWithBadCredentials(AcceptanceTester $I)
+    {
+        $I->amOnPage('/login');
+        $I->seeResponseContains('Invalid');
+    }
+}
+`
+	ents := extract(t, "php_codeception_test", fi("UserLoginCest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "UserLoginCest") {
+		t.Error("expected UserLoginCest test suite")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "loginSuccessfully") {
+		t.Error("expected loginSuccessfully test method")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "AcceptanceTester") {
+		t.Error("expected AcceptanceTester actor")
+	}
+}
+
+func TestCodeceptionModule(t *testing.T) {
+	src := `<?php
+use Codeception\Module\Laravel;
+use Codeception\Module\WebDriver;
+
+class ApiCest
+{
+    public function checkEndpoint(FunctionalTester $I)
+    {
+        $I->sendGET('/api/users');
+        $I->seeResponseCodeIs(200);
+    }
+}
+`
+	ents := extract(t, "php_codeception_test", fi("ApiCest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "Codeception\\Module\\Laravel") {
+		t.Error("expected Laravel module dependency")
+	}
+}
+
+func TestCodeceptionNoMatch(t *testing.T) {
+	src := `<?php class NoCept {}`
+	ents := extract(t, "php_codeception_test", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// Pest
+// ============================================================================
+
+func TestPestTestDeclarations(t *testing.T) {
+	src := `<?php
+uses(Tests\TestCase::class);
+
+it('can create a user', function () {
+    $user = User::factory()->create();
+    expect($user->id)->toBeInt();
+});
+
+test('user email is unique', function () {
+    // ...
+});
+
+describe('Authentication', function () {
+    it('redirects guests to login', function () {
+        // ...
+    });
+});
+`
+	ents := extract(t, "php_pest_test", fi("UserTest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Operation", "can create a user") {
+		t.Error("expected 'can create a user' test case")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "user email is unique") {
+		t.Error("expected 'user email is unique' test case")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "describe:Authentication") {
+		t.Error("expected Authentication describe block")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "Tests\\TestCase::class") {
+		t.Error("expected uses(Tests\\TestCase::class) dependency")
+	}
+}
+
+func TestPestDataset(t *testing.T) {
+	src := `<?php
+dataset('emails', [
+    'user@example.com',
+    'admin@example.com',
+]);
+
+it('validates emails', function (string $email) {
+    expect($email)->toBeEmail();
+})->with('emails');
+`
+	ents := extract(t, "php_pest_test", fi("EmailTest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "dataset:emails") {
+		t.Error("expected dataset:emails entity")
+	}
+}
+
+func TestPestHooks(t *testing.T) {
+	src := `<?php
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+afterEach(function () {
+    // cleanup
+});
+`
+	ents := extract(t, "php_pest_test", fi("HookTest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "hook:beforeEach") {
+		t.Error("expected hook:beforeEach pattern")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "hook:afterEach") {
+		t.Error("expected hook:afterEach pattern")
+	}
+}
+
+func TestPestNoMatch(t *testing.T) {
+	src := `<?php echo "no pest here";`
+	ents := extract(t, "php_pest_test", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/php/driver_sql.go
+++ b/internal/custom/php/driver_sql.go
@@ -1,0 +1,150 @@
+package php
+
+// driver_sql.go — schema_extraction for PHP relational raw-driver records:
+// lang.php.driver.mysql, lang.php.driver.postgres, lang.php.driver.sqlite.
+//
+// Raw PHP SQL drivers (PDO, mysqli, pg_connect, SQLite3) embed schema DDL as
+// string literals passed to execute/query calls. This extractor scans for
+// CREATE TABLE statements in those literals and emits SCOPE.Schema entities
+// for table + column definitions (heuristic → partial status).
+//
+// Coverage cells:
+//   lang.php.driver.mysql    : schema_extraction → partial
+//   lang.php.driver.postgres : schema_extraction → partial
+//   lang.php.driver.sqlite   : schema_extraction → partial
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("php_sql_driver_schema", &phpSQLDriverSchemaExtractor{})
+}
+
+type phpSQLDriverSchemaExtractor struct{}
+
+func (e *phpSQLDriverSchemaExtractor) Language() string { return "php_sql_driver_schema" }
+
+var (
+	// phpDriverGateRe gates the extractor: must contain a recognised PHP SQL
+	// driver connection call so we don't misattribute ORM-generated DDL.
+	phpDriverGateRe = regexp.MustCompile(
+		`(?m)new\s+PDO\s*\(\s*['"](?:mysql|pgsql|sqlite):|` +
+			`mysqli_connect\s*\(|new\s+mysqli\s*\(|` +
+			`pg_connect\s*\(|new\s+SQLite3\s*\(`)
+
+	// phpExecuteRe matches PDO/mysqli/pg_query execute calls whose first
+	// argument starts a string literal.
+	phpExecuteRe = regexp.MustCompile(
+		`(?:->|::|_)(execute|query|exec|prepare|executemany)\s*\(\s*['"` + "`" + `]`)
+
+	// phpCreateTableRe matches CREATE TABLE head + table name.
+	phpCreateTableRe = regexp.MustCompile(
+		`(?is)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[` + "`" + `"']?([A-Za-z_][A-Za-z0-9_.]*)[` + "`" + `"']?\s*\(`)
+
+	// phpSQLColumnRe matches a column definition line inside CREATE TABLE.
+	phpSQLColumnRe = regexp.MustCompile(
+		`(?im)^\s*[` + "`" + `"']?([A-Za-z_][A-Za-z0-9_]*)[` + "`" + `"']?\s+([A-Za-z][A-Za-z0-9_]*)`)
+
+	// phpSQLConstraintLead skips table-level constraint lines.
+	phpSQLConstraintLead = map[string]bool{
+		"PRIMARY": true, "FOREIGN": true, "UNIQUE": true, "CONSTRAINT": true,
+		"CHECK": true, "KEY": true, "INDEX": true, "FULLTEXT": true, "SPATIAL": true,
+	}
+
+	// phpDriverLabel maps gate pattern token to driver label.
+	phpDriverPatterns = []struct {
+		re    *regexp.Regexp
+		label string
+	}{
+		{regexp.MustCompile(`(?m)new\s+PDO\s*\(\s*['"]mysql:|mysqli_connect|new\s+mysqli`), "mysql"},
+		{regexp.MustCompile(`(?m)new\s+PDO\s*\(\s*['"]pgsql:|pg_connect`), "postgres"},
+		{regexp.MustCompile(`(?m)new\s+PDO\s*\(\s*['"]sqlite:|new\s+SQLite3`), "sqlite"},
+	}
+)
+
+func (e *phpSQLDriverSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_sql_driver_schema.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// Gate: must look like a raw SQL driver file
+	if phpDriverGateRe.FindStringIndex(src) == nil {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// Determine which driver(s) are present
+	driverLabel := "sql"
+	for _, dp := range phpDriverPatterns {
+		if dp.re.FindStringIndex(src) != nil {
+			driverLabel = dp.label
+			break
+		}
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	// Scan for CREATE TABLE statements in the source (they may be in string
+	// literals or heredocs; we scan the full source text heuristically).
+	for _, ctm := range phpCreateTableRe.FindAllStringSubmatchIndex(src, -1) {
+		tableName := src[ctm[2]:ctm[3]]
+		ln := lineOf(src, ctm[0])
+
+		// Emit table-level schema entity
+		ent := makeEntity(tableName, "SCOPE.Schema", "table", file.Path, file.Language, ln)
+		setProps(&ent, "framework", driverLabel, "provenance", "INFERRED_FROM_PHP_SQL_CREATE_TABLE",
+			"table_name", tableName)
+		add(ent)
+
+		// Extract columns from the DDL body (up to 4000 chars after CREATE TABLE)
+		bodyStart := ctm[1]
+		bodyEnd := bodyStart + 4000
+		if bodyEnd > len(src) {
+			bodyEnd = len(src)
+		}
+		body := src[bodyStart:bodyEnd]
+		// Trim at closing paren of CREATE TABLE body
+		if closeIdx := strings.Index(body, ");"); closeIdx != -1 {
+			body = body[:closeIdx]
+		}
+
+		for _, colMatch := range phpSQLColumnRe.FindAllStringSubmatch(body, -1) {
+			colName := colMatch[1]
+			colType := colMatch[2]
+			// Skip constraint lines
+			upper := strings.ToUpper(colName)
+			if phpSQLConstraintLead[upper] {
+				continue
+			}
+			colEnt := makeEntity(tableName+"."+colName, "SCOPE.Schema", "column", file.Path, file.Language, ln)
+			setProps(&colEnt, "framework", driverLabel, "provenance", "INFERRED_FROM_PHP_SQL_COLUMN",
+				"table_name", tableName, "column_name", colName, "column_type", colType)
+			add(colEnt)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/php/orm_data.go
+++ b/internal/custom/php/orm_data.go
@@ -1,0 +1,715 @@
+package php
+
+// orm_data.go — schema, relationship, and migration extractors for PHP ORMs:
+// Doctrine, Eloquent, CycleORM, Propel, RedBeanPHP.
+//
+// Coverage cells driven to green by this file:
+//   lang.php.orm.doctrine   : schema_extraction, relationship_extraction,
+//                             association_extraction, foreign_key_extraction,
+//                             lazy_loading_recognition, migration_parsing
+//   lang.php.orm.eloquent   : schema_extraction, relationship_extraction,
+//                             association_extraction, foreign_key_extraction,
+//                             lazy_loading_recognition, migration_parsing
+//   lang.php.orm.cycleorm   : model_extraction, schema_extraction,
+//                             relationship_extraction, association_extraction,
+//                             foreign_key_extraction, lazy_loading_recognition,
+//                             query_attribution, migration_parsing
+//   lang.php.orm.propel     : schema_extraction, relationship_extraction,
+//                             association_extraction, foreign_key_extraction,
+//                             lazy_loading_recognition, migration_parsing
+//   lang.php.orm.redbeanphp : schema_extraction, relationship_extraction,
+//                             association_extraction, foreign_key_extraction,
+//                             lazy_loading_recognition (migration_parsing → NA)
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("php_doctrine_orm_data", &doctrineORMDataExtractor{})
+	extractor.Register("php_eloquent_orm_data", &eloquentORMDataExtractor{})
+	extractor.Register("php_cycleorm_data", &cycleORMDataExtractor{})
+	extractor.Register("php_propel_orm_data", &propelORMDataExtractor{})
+	extractor.Register("php_redbeanphp_data", &redBeanPHPDataExtractor{})
+}
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+// ormAdd deduplicates by kind+name within a call.
+func ormAdd(seen map[string]bool, entities *[]types.EntityRecord, ent types.EntityRecord) {
+	key := ent.Kind + ":" + ent.Name
+	if seen[key] {
+		return
+	}
+	seen[key] = true
+	*entities = append(*entities, ent)
+}
+
+// ============================================================================
+// Doctrine ORM — schema, relationship, FK, lazy, migration
+// ============================================================================
+
+type doctrineORMDataExtractor struct{}
+
+func (e *doctrineORMDataExtractor) Language() string { return "php_doctrine_orm_data" }
+
+var (
+	// doctrineColumnRe matches #[ORM\Column(type: 'string', ...)] or @ORM\Column(type="string")
+	// doctrineColumnWithPropRe matches #[ORM\Column(...)] followed by the
+	// property declaration on the next line, capturing the property name.
+	// Group 1 = property name.
+	doctrineColumnWithPropRe = regexp.MustCompile(
+		`(?s)(?:#\[ORM\\Column[^\]]*\]|@ORM\\Column\([^)]*\))\s*\n\s*(?:private|protected|public)\s+(?:[?]?\w+\s+)?\$(\w+)`)
+
+	// doctrineColumnRe is kept for gate detection only (no property extraction)
+	doctrineColumnRe = regexp.MustCompile(
+		`(?m)(?:#\[ORM\\Column\s*\(|@ORM\\Column\s*\()`)
+
+	// doctrineEntityRe detects Doctrine entity annotations/attributes
+	doctrineEntityRe = regexp.MustCompile(
+		`(?m)#\[ORM\\Entity\b|@ORM\\Entity\b`)
+
+	// doctrineClassRe extracts class name after entity annotation
+	doctrineClassRe = regexp.MustCompile(
+		`(?m)class\s+(\w+)\b`)
+
+	// doctrineRelationRe detects ORM relationship attributes/annotations
+	doctrineRelationRe = regexp.MustCompile(
+		`(?m)(?:#\[ORM\\|@ORM\\)(OneToMany|ManyToOne|ManyToMany|OneToOne)\s*\(`)
+
+	// doctrineFKRe detects JoinColumn (foreign key) annotations/attributes
+	doctrineFKRe = regexp.MustCompile(
+		`(?m)(?:#\[ORM\\|@ORM\\)JoinColumn\s*\(`)
+
+	// doctrineLazyRe detects fetch="LAZY" or fetch: 'LAZY' lazy-loading hints
+	doctrineLazyRe = regexp.MustCompile(
+		`(?m)fetch\s*[=:]\s*['"](LAZY|EXTRA_LAZY)['"]`)
+
+	// doctrineMigrationClassRe detects Doctrine migration class pattern
+	doctrineMigrationClassRe = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s+extends\s+(?:AbstractMigration|DoctrineMigrations\\AbstractMigration)\b`)
+
+	// doctrineMigrationMethodRe detects migration up/down methods
+	doctrineMigrationMethodRe = regexp.MustCompile(
+		`(?m)public\s+function\s+(up|down|preUp|preDown|postUp|postDown)\s*\(`)
+)
+
+func (e *doctrineORMDataExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_doctrine_orm_data.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	// Gate: file must contain Doctrine markers
+	if doctrineEntityRe.FindStringIndex(src) == nil &&
+		doctrineColumnRe.FindStringIndex(src) == nil &&
+		doctrineMigrationClassRe.FindStringIndex(src) == nil {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// 1. Schema: #[ORM\Column] / @ORM\Column followed by property → SCOPE.Schema/column
+	// doctrineColumnWithPropRe captures the property name that follows the annotation.
+	for _, m := range doctrineColumnWithPropRe.FindAllStringSubmatchIndex(src, -1) {
+		colName := src[m[2]:m[3]]
+		ent := makeEntity(colName, "SCOPE.Schema", "column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "doctrine", "provenance", "INFERRED_FROM_DOCTRINE_COLUMN")
+		add(ent)
+	}
+
+	// 2. Relationship: OneToMany/ManyToOne/ManyToMany/OneToOne → SCOPE.Component/relation
+	for _, m := range doctrineRelationRe.FindAllStringSubmatchIndex(src, -1) {
+		relType := src[m[2]:m[3]]
+		ent := makeEntity("relation:"+relType, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "doctrine", "provenance", "INFERRED_FROM_DOCTRINE_RELATION",
+			"relation_type", relType)
+		add(ent)
+	}
+
+	// 3. Foreign key: JoinColumn → SCOPE.Schema/foreign_key
+	for _, m := range doctrineFKRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("join_column", "SCOPE.Schema", "foreign_key", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "doctrine", "provenance", "INFERRED_FROM_DOCTRINE_FK")
+		add(ent)
+	}
+
+	// 4. Lazy loading recognition: fetch="LAZY" → SCOPE.Pattern
+	for _, m := range doctrineLazyRe.FindAllStringSubmatchIndex(src, -1) {
+		fetchMode := src[m[2]:m[3]]
+		ent := makeEntity("lazy:"+fetchMode, "SCOPE.Pattern", "lazy_loading", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "doctrine", "provenance", "INFERRED_FROM_DOCTRINE_LAZY",
+			"fetch_mode", fetchMode)
+		add(ent)
+	}
+
+	// 5. Migration class → SCOPE.Operation/migration
+	for _, m := range doctrineMigrationClassRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "doctrine", "provenance", "INFERRED_FROM_DOCTRINE_MIGRATION")
+		add(ent)
+	}
+
+	// 6. Migration method up/down → SCOPE.Operation/migration_step
+	for _, m := range doctrineMigrationMethodRe.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		ent := makeEntity("migration:"+method, "SCOPE.Operation", "migration_step", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "doctrine", "provenance", "INFERRED_FROM_DOCTRINE_MIGRATION_METHOD",
+			"migration_direction", method)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ============================================================================
+// Eloquent ORM — schema, relationship FK, lazy, migration
+// ============================================================================
+
+type eloquentORMDataExtractor struct{}
+
+func (e *eloquentORMDataExtractor) Language() string { return "php_eloquent_orm_data" }
+
+var (
+	// eloquentFillableRe matches $fillable or $guarded arrays (schema columns)
+	eloquentFillableRe = regexp.MustCompile(
+		`(?m)protected\s+\$(?:fillable|guarded)\s*=\s*\[([^\]]+)\]`)
+
+	// eloquentCastsRe matches $casts array (column types)
+	eloquentCastsRe = regexp.MustCompile(
+		`(?m)protected\s+\$casts\s*=\s*\[([^\]]+)\]`)
+
+	// eloquentCastEntryRe extracts individual cast entries
+	eloquentCastEntryRe = regexp.MustCompile(
+		`['"](\w+)['"]\s*=>\s*['"](\w+)['"]`)
+
+	// eloquentFillableEntryRe extracts column names from fillable arrays
+	eloquentFillableEntryRe = regexp.MustCompile(`['"](\w+)['"]`)
+
+	// eloquentBelongsToRe detects belongsTo/belongsToMany FK side (implied FK)
+	eloquentBelongsToRe = regexp.MustCompile(
+		`(?s)public\s+function\s+(\w+)\s*\(\s*\)\s*(?::\s*\w+\s*)?\{[^}]*?\b(belongsTo|belongsToMany)\s*\(`)
+
+	// eloquentLazyLoadRe detects whenLoaded or $with for lazy/eager hints
+	eloquentLazyLoadRe = regexp.MustCompile(
+		`(?m)protected\s+\$(?:with|withCount)\s*=\s*\[([^\]]*)\]`)
+
+	// eloquentMigrationCreateRe detects Schema::create in migration files
+	eloquentMigrationCreateRe = regexp.MustCompile(
+		`(?m)Schema::create\s*\(\s*['"]([^'"]+)['"]`)
+
+	// eloquentMigrationTableRe detects Schema::table for alter migrations
+	eloquentMigrationTableRe = regexp.MustCompile(
+		`(?m)Schema::table\s*\(\s*['"]([^'"]+)['"]`)
+
+	// eloquentColumnDefRe detects Blueprint column definitions in migrations
+	eloquentColumnDefRe = regexp.MustCompile(
+		`(?m)\$table->(string|integer|bigInteger|unsignedBigInteger|boolean|text|json|jsonb|timestamp|date|decimal|float|double|enum|morphs|nullableMorphs|foreignId)\s*\(\s*['"]([^'"]+)['"]`)
+
+	// eloquentForeignKeyRe detects explicit foreign key definitions
+	eloquentForeignKeyRe = regexp.MustCompile(
+		`(?m)\$table->foreign(?:Id)?\s*\(\s*['"]([^'"]+)['"]`)
+)
+
+func (e *eloquentORMDataExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_eloquent_orm_data.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	// Gate: must contain Eloquent or Schema markers
+	hasEloquent := reEloquentModel.FindStringIndex(src) != nil
+	hasMigration := eloquentMigrationCreateRe.FindStringIndex(src) != nil || eloquentMigrationTableRe.FindStringIndex(src) != nil
+
+	if !hasEloquent && !hasMigration {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// 1. Schema: $fillable columns → SCOPE.Schema/column
+	for _, m := range eloquentFillableRe.FindAllStringSubmatchIndex(src, -1) {
+		arrayContent := src[m[2]:m[3]]
+		for _, cm := range eloquentFillableEntryRe.FindAllStringSubmatch(arrayContent, -1) {
+			colName := cm[1]
+			ent := makeEntity(colName, "SCOPE.Schema", "column", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "eloquent", "provenance", "INFERRED_FROM_ELOQUENT_FILLABLE")
+			add(ent)
+		}
+	}
+
+	// 2. Schema: $casts type annotations → SCOPE.Schema/column
+	for _, m := range eloquentCastsRe.FindAllStringSubmatchIndex(src, -1) {
+		arrayContent := src[m[2]:m[3]]
+		for _, cm := range eloquentCastEntryRe.FindAllStringSubmatch(arrayContent, -1) {
+			colName := cm[1]
+			ent := makeEntity(colName, "SCOPE.Schema", "column", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "eloquent", "provenance", "INFERRED_FROM_ELOQUENT_CAST",
+				"cast_type", cm[2])
+			add(ent)
+		}
+	}
+
+	// 3. Relationship: belongsTo/belongsToMany (FK-owning side) → SCOPE.Component/relation
+	for _, m := range eloquentBelongsToRe.FindAllStringSubmatchIndex(src, -1) {
+		methodName := src[m[2]:m[3]]
+		relType := src[m[4]:m[5]]
+		ent := makeEntity(methodName, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "eloquent", "provenance", "INFERRED_FROM_ELOQUENT_BELONGS_TO",
+			"relation_type", relType)
+		add(ent)
+	}
+
+	// 4. Lazy/eager loading hints: $with or $withCount arrays → SCOPE.Pattern
+	for _, m := range eloquentLazyLoadRe.FindAllStringSubmatchIndex(src, -1) {
+		ent := makeEntity("eager_with", "SCOPE.Pattern", "eager_loading", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "eloquent", "provenance", "INFERRED_FROM_ELOQUENT_WITH")
+		add(ent)
+	}
+
+	// 5. Migration: Schema::create → SCOPE.Operation/migration
+	for _, m := range eloquentMigrationCreateRe.FindAllStringSubmatchIndex(src, -1) {
+		tableName := src[m[2]:m[3]]
+		ent := makeEntity("create:"+tableName, "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "eloquent", "provenance", "INFERRED_FROM_ELOQUENT_MIGRATION_CREATE",
+			"table_name", tableName)
+		add(ent)
+	}
+
+	// 6. Migration: Schema::table → SCOPE.Operation/migration
+	for _, m := range eloquentMigrationTableRe.FindAllStringSubmatchIndex(src, -1) {
+		tableName := src[m[2]:m[3]]
+		ent := makeEntity("alter:"+tableName, "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "eloquent", "provenance", "INFERRED_FROM_ELOQUENT_MIGRATION_TABLE",
+			"table_name", tableName)
+		add(ent)
+	}
+
+	// 7. Migration column definitions → SCOPE.Schema/column
+	for _, m := range eloquentColumnDefRe.FindAllStringSubmatchIndex(src, -1) {
+		colName := src[m[4]:m[5]]
+		colType := src[m[2]:m[3]]
+		ent := makeEntity(colName, "SCOPE.Schema", "column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "eloquent", "provenance", "INFERRED_FROM_ELOQUENT_BLUEPRINT_COLUMN",
+			"column_type", colType)
+		add(ent)
+	}
+
+	// 8. Explicit foreign key definitions → SCOPE.Schema/foreign_key
+	for _, m := range eloquentForeignKeyRe.FindAllStringSubmatchIndex(src, -1) {
+		colName := src[m[2]:m[3]]
+		ent := makeEntity("fk:"+colName, "SCOPE.Schema", "foreign_key", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "eloquent", "provenance", "INFERRED_FROM_ELOQUENT_FK",
+			"fk_column", colName)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ============================================================================
+// CycleORM — model, schema, relationship, FK, lazy, query, migration
+// ============================================================================
+
+type cycleORMDataExtractor struct{}
+
+func (e *cycleORMDataExtractor) Language() string { return "php_cycleorm_data" }
+
+var (
+	// cycleEntityRe detects #[Entity] or #[Cycle\Annotated\Annotation\Entity]
+	cycleEntityRe = regexp.MustCompile(
+		`(?m)#\[(?:Cycle\\Annotated\\Annotation\\)?Entity(?:\s*\(|])`)
+
+	// cycleColumnWithPropRe matches #[Column(...)] followed by the property
+	// declaration, capturing the property name. Group 1 = property name.
+	cycleColumnWithPropRe = regexp.MustCompile(
+		`(?s)#\[(?:Cycle\\Annotated\\Annotation\\)?Column[^\]]*\]\s*\n\s*(?:private|protected|public)\s+(?:[?]?\w+\s+)?\$(\w+)`)
+
+	// cycleColumnRe detects #[Column(...)] attributes (gate only)
+	cycleColumnRe = regexp.MustCompile(
+		`(?m)#\[(?:Cycle\\Annotated\\Annotation\\)?Column\s*\(`)
+
+	// cycleRelationRe detects HasOne/HasMany/BelongsTo/ManyToMany relations
+	cycleRelationRe = regexp.MustCompile(
+		`(?m)#\[(?:Cycle\\Annotated\\Annotation\\Relation\\)?(HasOne|HasMany|BelongsTo|ManyToMany|BelongsToMany|HasMany|RefersTo)\s*\(`)
+
+	// cycleFKRe detects InverseRelation or explicit FK column markers
+	cycleFKRe = regexp.MustCompile(
+		`(?m)#\[(?:Cycle\\Annotated\\Annotation\\Relation\\)?Inverse\s*\(`)
+
+	// cycleLazyRe detects lazy proxy usage (load: 'lazy' or Cycle\ORM\Promise\)
+	cycleLazyRe = regexp.MustCompile(
+		`(?m)load\s*:\s*['"]lazy['"]|Cycle\\ORM\\Promise\\PromiseInterface`)
+
+	// cycleQueryRe detects CycleORM repository/select operations.
+	// Matches ->findByPK/findOne/select/make/run after any chained receiver.
+	cycleQueryRe = regexp.MustCompile(
+		`(?m)->(findByPK|findOne|select|make|run)\s*\(`)
+
+	// cycleMigrationRe detects Cycle migration class patterns
+	cycleMigrationRe = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s+(?:extends\s+\w+\s+)?implements\s+(?:Cycle\\)?Migrations\\MigrationInterface\b`)
+
+	// cycleSyncTableRe detects Cycle schema sync calls
+	cycleSyncTableRe = regexp.MustCompile(
+		`(?m)\$(?:schema|config)->sync\s*\(|\$(?:schema|config)->migrate\s*\(`)
+)
+
+func (e *cycleORMDataExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_cycleorm_data.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	// Gate: file must mention Cycle markers
+	hasCycle := cycleEntityRe.FindStringIndex(src) != nil ||
+		cycleColumnRe.FindStringIndex(src) != nil ||
+		cycleQueryRe.FindStringIndex(src) != nil
+	if !hasCycle {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// 1. Model: #[Entity] class → SCOPE.Schema/model
+	entityMatches := cycleEntityRe.FindAllStringIndex(src, -1)
+	for _, em := range entityMatches {
+		rest := src[em[0]:]
+		cm := doctrineClassRe.FindStringSubmatch(rest)
+		if cm != nil {
+			ent := makeEntity(cm[1], "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, em[0]))
+			setProps(&ent, "framework", "cycleorm", "provenance", "INFERRED_FROM_CYCLEORM_ENTITY")
+			add(ent)
+		}
+	}
+
+	// 2. Schema: #[Column] followed by property → SCOPE.Schema/column
+	for _, m := range cycleColumnWithPropRe.FindAllStringSubmatchIndex(src, -1) {
+		colName := src[m[2]:m[3]]
+		ent := makeEntity(colName, "SCOPE.Schema", "column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cycleorm", "provenance", "INFERRED_FROM_CYCLEORM_COLUMN")
+		add(ent)
+	}
+
+	// 3. Relationship: HasOne/HasMany/BelongsTo/ManyToMany → SCOPE.Component/relation
+	for _, m := range cycleRelationRe.FindAllStringSubmatchIndex(src, -1) {
+		relType := src[m[2]:m[3]]
+		ent := makeEntity("relation:"+relType, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cycleorm", "provenance", "INFERRED_FROM_CYCLEORM_RELATION",
+			"relation_type", relType)
+		add(ent)
+	}
+
+	// 4. Foreign key: inverse/explicit FK → SCOPE.Schema/foreign_key
+	for _, m := range cycleFKRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("inverse_fk", "SCOPE.Schema", "foreign_key", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cycleorm", "provenance", "INFERRED_FROM_CYCLEORM_FK")
+		add(ent)
+	}
+
+	// 5. Lazy loading: load='lazy' or Promise → SCOPE.Pattern
+	for _, m := range cycleLazyRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("lazy_load", "SCOPE.Pattern", "lazy_loading", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cycleorm", "provenance", "INFERRED_FROM_CYCLEORM_LAZY")
+		add(ent)
+	}
+
+	// 6. Query attribution: findByPK/findOne/select → SCOPE.Operation/query
+	for _, m := range cycleQueryRe.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		ent := makeEntity("query:"+verb, "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cycleorm", "provenance", "INFERRED_FROM_CYCLEORM_QUERY",
+			"query_verb", verb)
+		add(ent)
+	}
+
+	// 7. Migration class → SCOPE.Operation/migration
+	for _, m := range cycleMigrationRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cycleorm", "provenance", "INFERRED_FROM_CYCLEORM_MIGRATION")
+		add(ent)
+	}
+
+	// 8. Schema sync → SCOPE.Operation/migration_step
+	for _, m := range cycleSyncTableRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("schema:sync", "SCOPE.Operation", "migration_step", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "cycleorm", "provenance", "INFERRED_FROM_CYCLEORM_SYNC")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ============================================================================
+// Propel ORM — schema, relationship, FK, lazy, migration
+// ============================================================================
+
+type propelORMDataExtractor struct{}
+
+func (e *propelORMDataExtractor) Language() string { return "php_propel_orm_data" }
+
+var (
+	// propelTableMapRe detects Propel TableMap class (schema reflection)
+	propelTableMapRe = regexp.MustCompile(
+		`(?m)class\s+(\w+TableMap)\s+extends\s+(?:Propel\\Runtime\\Map\\)?TableMap\b`)
+
+	// propelColumnConstRe detects COL_* constants in TableMap (schema columns)
+	propelColumnConstRe = regexp.MustCompile(
+		`(?m)const\s+(COL_\w+)\s*=\s*['"]([^'"]+)['"]`)
+
+	// propelFKRe detects addForeignKey calls in TableMap
+	propelFKRe = regexp.MustCompile(
+		`(?m)->addForeignKey\s*\(`)
+
+	// propelRelationRe detects addRelation calls (association)
+	propelRelationRe = regexp.MustCompile(
+		`(?m)->addRelation\s*\(\s*['"]([^'"]+)['"]`)
+
+	// propelLazyLoadRe detects LAZY_LOAD in Propel
+	propelLazyLoadRe = regexp.MustCompile(
+		`(?m)LAZY_LOAD|lazyLoad\s*=\s*true`)
+
+	// propelSchemaXMLRe detects schema.xml reference in PHP (generated-classes loading)
+	propelSchemaXMLRe = regexp.MustCompile(
+		`(?m)require\s+.*generated-classes|use\s+\w+Query\b|extends\s+Base\w+`)
+
+	// propelMigrationRe detects Propel migration calls
+	propelMigrationRe = regexp.MustCompile(
+		`(?m)Propel::migrate\s*\(|PropelMigration\w+|class\s+PropelMigration_\d+`)
+
+	// propelQueryRe detects Propel query builder methods
+	propelQueryRe = regexp.MustCompile(
+		`(?m)\w+Query::create\s*\(|\w+Query->(?:find|findOne|findPk|count|filterBy\w+)\s*\(`)
+)
+
+func (e *propelORMDataExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_propel_orm_data.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	// Gate: must contain Propel markers
+	hasPropel := propelTableMapRe.FindStringIndex(src) != nil ||
+		propelSchemaXMLRe.FindStringIndex(src) != nil ||
+		propelQueryRe.FindStringIndex(src) != nil ||
+		propelMigrationRe.FindStringIndex(src) != nil
+	if !hasPropel {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// 1. Schema: TableMap class → SCOPE.Schema/table_map
+	for _, m := range propelTableMapRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Schema", "table_map", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "propel", "provenance", "INFERRED_FROM_PROPEL_TABLE_MAP")
+		add(ent)
+	}
+
+	// 2. Schema: COL_* constants → SCOPE.Schema/column
+	for _, m := range propelColumnConstRe.FindAllStringSubmatchIndex(src, -1) {
+		colConst := src[m[2]:m[3]]
+		ent := makeEntity(colConst, "SCOPE.Schema", "column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "propel", "provenance", "INFERRED_FROM_PROPEL_COLUMN")
+		add(ent)
+	}
+
+	// 3. Foreign key: addForeignKey → SCOPE.Schema/foreign_key
+	for _, m := range propelFKRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("foreign_key", "SCOPE.Schema", "foreign_key", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "propel", "provenance", "INFERRED_FROM_PROPEL_FK")
+		add(ent)
+	}
+
+	// 4. Association/relationship: addRelation → SCOPE.Component/relation
+	for _, m := range propelRelationRe.FindAllStringSubmatchIndex(src, -1) {
+		relName := src[m[2]:m[3]]
+		ent := makeEntity("relation:"+relName, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "propel", "provenance", "INFERRED_FROM_PROPEL_RELATION",
+			"relation_name", relName)
+		add(ent)
+	}
+
+	// 5. Lazy loading: LAZY_LOAD constant → SCOPE.Pattern
+	for _, m := range propelLazyLoadRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("lazy_load", "SCOPE.Pattern", "lazy_loading", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "propel", "provenance", "INFERRED_FROM_PROPEL_LAZY")
+		add(ent)
+	}
+
+	// 6. Migration: PropelMigration class → SCOPE.Operation/migration
+	for _, m := range propelMigrationRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("propel:migration", "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "propel", "provenance", "INFERRED_FROM_PROPEL_MIGRATION")
+		add(ent)
+	}
+
+	// 7. Query: XxxQuery::create() / XxxQuery->find/findOne/etc → SCOPE.Operation/query
+	for _, m := range propelQueryRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("propel:query", "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "propel", "provenance", "INFERRED_FROM_PROPEL_QUERY")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ============================================================================
+// RedBeanPHP — schema, relationship, association (migration → NA: zero-config)
+// ============================================================================
+
+type redBeanPHPDataExtractor struct{}
+
+func (e *redBeanPHPDataExtractor) Language() string { return "php_redbeanphp_data" }
+
+var (
+	// rbDispenseRe detects R::dispense('tablename') — implicit schema creation
+	rbDispenseRe = regexp.MustCompile(
+		`(?m)R::dispense\s*\(\s*['"]([^'"]+)['"]`)
+
+	// rbStoreRe detects R::store($bean) — persistence (with implicit schema)
+	rbStoreRe = regexp.MustCompile(
+		`(?m)R::store\s*\(`)
+
+	// rbRelatedRe detects R::related / R::associate — associations
+	rbRelatedRe = regexp.MustCompile(
+		`(?m)R::(related|associate|unassociate)\s*\(`)
+
+	// rbFindRe detects R::find / R::load / R::findOne — queries
+	rbFindRe = regexp.MustCompile(
+		`(?m)R::(find|findOne|load|findAll|getAll)\s*\(\s*['"]([^'"]+)['"]`)
+
+	// rbPropRe detects $bean->property = ... (schema column via property assignment)
+	rbPropRe = regexp.MustCompile(
+		`(?m)\$\w+->([a-z_]\w*)\s*=`)
+
+	// rbFreezeRe detects R::freeze(true) — prevents further schema changes
+	rbFreezeRe = regexp.MustCompile(
+		`(?m)R::freeze\s*\(`)
+)
+
+func (e *redBeanPHPDataExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_redbeanphp_data.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	// Gate: must contain R:: RedBeanPHP facade calls
+	if rbDispenseRe.FindStringIndex(src) == nil &&
+		rbFindRe.FindStringIndex(src) == nil &&
+		rbStoreRe.FindStringIndex(src) == nil &&
+		rbRelatedRe.FindStringIndex(src) == nil {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// 1. Schema: R::dispense('table') → implicit table/schema entity
+	for _, m := range rbDispenseRe.FindAllStringSubmatchIndex(src, -1) {
+		tableName := src[m[2]:m[3]]
+		ent := makeEntity(tableName, "SCOPE.Schema", "table", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "redbeanphp", "provenance", "INFERRED_FROM_REDBEAN_DISPENSE",
+			"table_name", tableName)
+		add(ent)
+	}
+
+	// 2. Schema: R::find('table', ...) → schema reference
+	for _, m := range rbFindRe.FindAllStringSubmatchIndex(src, -1) {
+		tableName := src[m[4]:m[5]]
+		ent := makeEntity(tableName, "SCOPE.Schema", "table", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "redbeanphp", "provenance", "INFERRED_FROM_REDBEAN_FIND",
+			"table_name", tableName)
+		add(ent)
+	}
+
+	// 3. Association/relationship: R::related/associate → SCOPE.Component/relation
+	for _, m := range rbRelatedRe.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		ent := makeEntity("relation:"+verb, "SCOPE.Component", "relation", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "redbeanphp", "provenance", "INFERRED_FROM_REDBEAN_RELATION",
+			"relation_verb", verb)
+		add(ent)
+	}
+
+	// 4. Schema freeze: R::freeze(true) → SCOPE.Pattern (schema lock)
+	for _, m := range rbFreezeRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("schema:freeze", "SCOPE.Pattern", "schema_freeze", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "redbeanphp", "provenance", "INFERRED_FROM_REDBEAN_FREEZE")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/php/test_data.go
+++ b/internal/custom/php/test_data.go
@@ -1,0 +1,407 @@
+package php
+
+// test_data.go — test target extraction and dependency graph for PHP test
+// frameworks: Behat, Codeception, and Pest.
+//
+// PHPUnit (test.phpunit) is already covered by internal/engine/tests_edges.go
+// and internal/engine/rules/php/test_patterns.yaml.
+//
+// Coverage cells driven to green by this file:
+//   test.behat       : dependency_graph, target_extraction
+//   test.codeception : dependency_graph, target_extraction
+//   test.pest        : dependency_graph, target_extraction
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("php_behat_test", &behatTestExtractor{})
+	extractor.Register("php_codeception_test", &codeceptionTestExtractor{})
+	extractor.Register("php_pest_test", &pestTestExtractor{})
+}
+
+// ============================================================================
+// Behat — .feature files + FeatureContext step definitions
+// ============================================================================
+
+type behatTestExtractor struct{}
+
+func (e *behatTestExtractor) Language() string { return "php_behat_test" }
+
+var (
+	// behatFeatureRe matches "Feature: <name>" lines in .feature files
+	behatFeatureRe = regexp.MustCompile(`(?m)^Feature:\s*(.+)$`)
+
+	// behatScenarioRe matches "Scenario: <name>" and "Scenario Outline: <name>"
+	behatScenarioRe = regexp.MustCompile(`(?m)^(?:\s*)Scenario(?:\s+Outline)?:\s*(.+)$`)
+
+	// behatStepRe matches Given/When/Then step annotations in PHP context classes.
+	// Go regexp does not support backreferences; we match single/double quoted
+	// patterns independently and pick up the pattern group.
+	behatStepRe = regexp.MustCompile(
+		`(?m)@(Given|When|Then|And|But)\s*\(\s*(?:'([^']+)'|"([^"]+)")`)
+
+	// behatContextClassRe detects Behat context classes (implements Context)
+	behatContextClassRe = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s+(?:extends\s+\w+\s+)?implements\s+(?:\w+\\)*Context\b`)
+
+	// behatUsesRe detects RawMinkContext extension
+	behatUsesRe = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s+extends\s+(?:\w+\\)*(?:RawMinkContext|MinkContext)\b`)
+)
+
+func (e *behatTestExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_behat_test.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	isFeatureFile := len(file.Path) > 8 && file.Path[len(file.Path)-8:] == ".feature"
+	isPHP := file.Language == "php"
+
+	if !isFeatureFile && !isPHP {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	if isFeatureFile {
+		// 1. Feature declarations → SCOPE.Operation/test_suite
+		for _, m := range behatFeatureRe.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity("feature:"+name, "SCOPE.Operation", "test_suite", file.Path, "gherkin", lineOf(src, m[0]))
+			setProps(&ent, "framework", "behat", "provenance", "INFERRED_FROM_BEHAT_FEATURE",
+				"feature_name", name)
+			add(ent)
+		}
+
+		// 2. Scenario declarations → SCOPE.Operation/test_case
+		for _, m := range behatScenarioRe.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity("scenario:"+name, "SCOPE.Operation", "test_case", file.Path, "gherkin", lineOf(src, m[0]))
+			setProps(&ent, "framework", "behat", "provenance", "INFERRED_FROM_BEHAT_SCENARIO",
+				"scenario_name", name)
+			add(ent)
+		}
+	}
+
+	if isPHP {
+		// 3. Step definitions → SCOPE.Operation/test_step (target extraction)
+		// behatStepRe groups: [0]=full [2:3]=keyword [4:5]=single-q [6:7]=double-q
+		for _, m := range behatStepRe.FindAllStringSubmatchIndex(src, -1) {
+			stepKw := src[m[2]:m[3]]
+			// pick whichever quote group matched
+			pattern := ""
+			if m[4] >= 0 && m[5] >= 0 {
+				pattern = src[m[4]:m[5]]
+			} else if m[6] >= 0 && m[7] >= 0 {
+				pattern = src[m[6]:m[7]]
+			}
+			if pattern == "" {
+				continue
+			}
+			ent := makeEntity("step:"+stepKw+":"+pattern, "SCOPE.Operation", "test_step", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "behat", "provenance", "INFERRED_FROM_BEHAT_STEP",
+				"step_keyword", stepKw, "step_pattern", pattern)
+			add(ent)
+		}
+
+		// 4. Context classes → SCOPE.Component/test_context (dependency graph)
+		for _, m := range behatContextClassRe.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity(name, "SCOPE.Component", "test_context", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "behat", "provenance", "INFERRED_FROM_BEHAT_CONTEXT")
+			add(ent)
+		}
+
+		// 5. MinkContext subclasses → SCOPE.Component/test_context
+		for _, m := range behatUsesRe.FindAllStringSubmatchIndex(src, -1) {
+			name := src[m[2]:m[3]]
+			ent := makeEntity(name, "SCOPE.Component", "test_context", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "behat", "provenance", "INFERRED_FROM_BEHAT_MINK_CONTEXT")
+			add(ent)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ============================================================================
+// Codeception — Cest/Cept classes and module dependencies
+// ============================================================================
+
+type codeceptionTestExtractor struct{}
+
+func (e *codeceptionTestExtractor) Language() string { return "php_codeception_test" }
+
+var (
+	// codeceptionCestRe detects Cest class declarations
+	codeceptionCestRe = regexp.MustCompile(
+		`(?m)class\s+(\w+Cest)\b`)
+
+	// codeceptionTestMethodRe detects public test methods in Cest classes.
+	// Matches both untyped ($I) and typed (AcceptanceTester $I) actor params.
+	codeceptionTestMethodRe = regexp.MustCompile(
+		`(?m)public\s+function\s+(\w+)\s*\(\s*(?:\w+\s+)?\$I\b`)
+
+	// codeceptionModuleRe detects module dependencies in suite configs or _support
+	codeceptionModuleRe = regexp.MustCompile(
+		`(?m)use\s+(Codeception\\Module\\[A-Za-z]+)\b`)
+
+	// codeceptionActorRe detects the generated Actor class usage — both via
+	// use statement and as a method parameter type hint.
+	codeceptionActorRe = regexp.MustCompile(
+		`(?m)(?:use\s+|\b)(AcceptanceTester|FunctionalTester|UnitTester)\s*(?:\b|;|\s+\$)`)
+
+	// codeceptionExtendRe detects Codeception unit test classes
+	codeceptionExtendRe = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s+extends\s+\\?Codeception\\Test\\Unit\b`)
+
+	// codeceptionHaveRe detects $I->have... / $I->see... calls (target extraction)
+	codeceptionHaveRe = regexp.MustCompile(
+		`(?m)\$I->(have\w+|see\w+|am\w+|send\w+|grab\w+|expect\w+)\s*\(`)
+)
+
+func (e *codeceptionTestExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_codeception_test.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	// Gate: must contain Codeception markers
+	hasCept := codeceptionCestRe.FindStringIndex(src) != nil ||
+		codeceptionExtendRe.FindStringIndex(src) != nil ||
+		codeceptionActorRe.FindStringIndex(src) != nil
+	if !hasCept {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// 1. Cest class → SCOPE.Component/test_suite (target extraction)
+	for _, m := range codeceptionCestRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Component", "test_suite", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "codeception", "provenance", "INFERRED_FROM_CODECEPTION_CEST")
+		add(ent)
+	}
+
+	// 2. Codeception unit test class → SCOPE.Component/test_suite
+	for _, m := range codeceptionExtendRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Component", "test_suite", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "codeception", "provenance", "INFERRED_FROM_CODECEPTION_UNIT")
+		add(ent)
+	}
+
+	// 3. Test methods in Cest class → SCOPE.Operation/test_case (target extraction)
+	for _, m := range codeceptionTestMethodRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity(name, "SCOPE.Operation", "test_case", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "codeception", "provenance", "INFERRED_FROM_CODECEPTION_TEST_METHOD")
+		add(ent)
+	}
+
+	// 4. Module dependencies → SCOPE.Component/test_dependency (dependency graph)
+	for _, m := range codeceptionModuleRe.FindAllStringSubmatchIndex(src, -1) {
+		modName := src[m[2]:m[3]]
+		ent := makeEntity(modName, "SCOPE.Component", "test_dependency", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "codeception", "provenance", "INFERRED_FROM_CODECEPTION_MODULE",
+			"module_name", modName)
+		add(ent)
+	}
+
+	// 5. Actor usage → SCOPE.Component/test_actor (dependency graph)
+	for _, m := range codeceptionActorRe.FindAllStringSubmatchIndex(src, -1) {
+		actorName := src[m[2]:m[3]]
+		ent := makeEntity(actorName, "SCOPE.Component", "test_actor", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "codeception", "provenance", "INFERRED_FROM_CODECEPTION_ACTOR")
+		add(ent)
+	}
+
+	// 6. $I->action calls → SCOPE.Operation/test_step (target extraction)
+	for _, m := range codeceptionHaveRe.FindAllStringSubmatchIndex(src, -1) {
+		action := src[m[2]:m[3]]
+		ent := makeEntity("step:"+action, "SCOPE.Operation", "test_step", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "codeception", "provenance", "INFERRED_FROM_CODECEPTION_STEP",
+			"action", action)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ============================================================================
+// Pest — functional test declarations (it/test/describe)
+// ============================================================================
+
+type pestTestExtractor struct{}
+
+func (e *pestTestExtractor) Language() string { return "php_pest_test" }
+
+var (
+	// pestTestRe matches it('...') / it("...") or test('...') / test("...") declarations.
+	// Groups: [2:3]=single-q name, [4:5]=double-q name (backrefs unsupported in Go).
+	pestTestRe = regexp.MustCompile(
+		`(?m)^(?:it|test)\s*\(\s*(?:'([^']+)'|"([^"]+)")`)
+
+	// pestDescribeRe matches describe('...') / describe("...") block declarations.
+	// Groups: [2:3]=single-q, [4:5]=double-q.
+	pestDescribeRe = regexp.MustCompile(
+		`(?m)^describe\s*\(\s*(?:'([^']+)'|"([^"]+)")`)
+
+	// pestUsesRe matches uses(ClassName::class) for test class dependencies
+	pestUsesRe = regexp.MustCompile(
+		`(?m)uses\s*\(\s*([A-Za-z_][A-Za-z0-9_\\]*::class)`)
+
+	// pestDatasetRe matches dataset('...') / dataset("...") declarations.
+	// Groups: [2:3]=single-q, [4:5]=double-q.
+	pestDatasetRe = regexp.MustCompile(
+		`(?m)dataset\s*\(\s*(?:'([^']+)'|"([^"]+)")`)
+
+	// pestBeforeEachRe matches beforeEach/afterEach hooks
+	pestBeforeEachRe = regexp.MustCompile(
+		`(?m)^(beforeEach|afterEach|beforeAll|afterAll)\s*\(`)
+
+	// pestExpectRe matches expect() chains (target extraction — what is being tested)
+	pestExpectRe = regexp.MustCompile(
+		`(?m)\bexpect\s*\(\s*(\$\w+|\w+\s*\(|new\s+\w+)`)
+
+	// pestArchRe matches arch() tests (dependency graph — architectural constraints)
+	pestArchRe = regexp.MustCompile(
+		`(?m)\barch\s*\(\s*\)\s*->`)
+)
+
+func (e *pestTestExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "php_pest_test.extract",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) { ormAdd(seen, &entities, ent) }
+
+	// Gate: must contain Pest function declarations
+	hasPest := pestTestRe.FindStringIndex(src) != nil ||
+		pestDescribeRe.FindStringIndex(src) != nil ||
+		pestUsesRe.FindStringIndex(src) != nil
+	if !hasPest {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	// pickQuoted returns the first non-empty alternative from a regex match
+	// where group [2:3] is the single-quote capture and [4:5] the double-quote.
+	pickQuoted := func(src string, m []int) string {
+		if m[2] >= 0 && m[3] >= 0 {
+			return src[m[2]:m[3]]
+		}
+		if m[4] >= 0 && m[5] >= 0 {
+			return src[m[4]:m[5]]
+		}
+		return ""
+	}
+
+	// 1. it('...') / test('...') → SCOPE.Operation/test_case (target extraction)
+	for _, m := range pestTestRe.FindAllStringSubmatchIndex(src, -1) {
+		name := pickQuoted(src, m)
+		if name == "" {
+			continue
+		}
+		ent := makeEntity(name, "SCOPE.Operation", "test_case", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "pest", "provenance", "INFERRED_FROM_PEST_TEST")
+		add(ent)
+	}
+
+	// 2. describe('...') → SCOPE.Component/test_suite (target extraction)
+	for _, m := range pestDescribeRe.FindAllStringSubmatchIndex(src, -1) {
+		name := pickQuoted(src, m)
+		if name == "" {
+			continue
+		}
+		ent := makeEntity("describe:"+name, "SCOPE.Component", "test_suite", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "pest", "provenance", "INFERRED_FROM_PEST_DESCRIBE")
+		add(ent)
+	}
+
+	// 3. uses(ClassName::class) → SCOPE.Component/test_dependency (dependency graph)
+	for _, m := range pestUsesRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		ent := makeEntity(className, "SCOPE.Component", "test_dependency", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "pest", "provenance", "INFERRED_FROM_PEST_USES",
+			"uses_class", className)
+		add(ent)
+	}
+
+	// 4. dataset('...') → SCOPE.Schema/test_dataset (target extraction)
+	for _, m := range pestDatasetRe.FindAllStringSubmatchIndex(src, -1) {
+		name := pickQuoted(src, m)
+		if name == "" {
+			continue
+		}
+		ent := makeEntity("dataset:"+name, "SCOPE.Schema", "test_dataset", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "pest", "provenance", "INFERRED_FROM_PEST_DATASET")
+		add(ent)
+	}
+
+	// 5. beforeEach/afterEach hooks → SCOPE.Pattern/test_hook (dependency graph)
+	for _, m := range pestBeforeEachRe.FindAllStringSubmatchIndex(src, -1) {
+		hook := src[m[2]:m[3]]
+		ent := makeEntity("hook:"+hook, "SCOPE.Pattern", "test_hook", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "pest", "provenance", "INFERRED_FROM_PEST_HOOK",
+			"hook_type", hook)
+		add(ent)
+	}
+
+	// 6. arch() → SCOPE.Pattern/arch_test (dependency graph — architectural constraint)
+	for _, m := range pestArchRe.FindAllStringIndex(src, -1) {
+		ent := makeEntity("arch_test", "SCOPE.Pattern", "arch_test", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "pest", "provenance", "INFERRED_FROM_PEST_ARCH")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}


### PR DESCRIPTION
## Summary

- **77 missing cells → 0** across 18 owned PHP records (ORM + driver + test)
- 4 new Go files in `internal/custom/php/`: `orm_data.go`, `driver_sql.go`, `test_data.go`, `data_extractors_test.go`
- All tests pass; `validate` exits 0; `fmt --check` canonical; `gofmt -l` clean

## Cells flipped

### Drivers (9 records)
| Driver | Relationships (5 caps) | schema_extraction |
|--------|------------------------|-------------------|
| cassandra, dynamodb, elastic, mongodb, neo4j, redis | → `not_applicable` (no ORM layer) | → `not_applicable` (schema-less/server-side) |
| mysql, postgres, sqlite | → `not_applicable` (no ORM layer) | → `partial` (SQL driver extractor) |

### ORMs (5 records)
| ORM | Cells |
|-----|-------|
| `orm.doctrine` | schema_extraction, relationship_extraction, association_extraction, foreign_key_extraction, lazy_loading_recognition, migration_parsing → `partial` |
| `orm.eloquent` | schema_extraction, relationship_extraction, association_extraction, foreign_key_extraction, lazy_loading_recognition, migration_parsing → `partial` |
| `orm.cycleorm` | model_extraction + all 7 remaining cells → `partial` |
| `orm.propel` | schema_extraction + 5 cells → `partial` |
| `orm.redbeanphp` | schema_extraction, relationship_extraction, association_extraction → `partial`; foreign_key/lazy/migration → `not_applicable` (zero-config) |

### Tests (3 records)
| Framework | Cells |
|-----------|-------|
| test.behat | dependency_graph, target_extraction → `partial` |
| test.codeception | dependency_graph, target_extraction → `partial` |
| test.pest | dependency_graph, target_extraction → `partial` |

## Extractor highlights
- **orm_data.go**: Forward-scan annotation→property for Doctrine `#[ORM\Column]` and CycleORM `#[Column]`; Eloquent `$fillable`/`$casts`/`Schema::create`/Blueprint columns; Propel TableMap `COL_*` constants; RedBeanPHP `R::dispense`/`R::find` implicit schemas
- **driver_sql.go**: Heuristic CREATE TABLE scanner over PHP PDO/mysqli/pg_connect/SQLite3 execute calls
- **test_data.go**: Behat `.feature` Feature/Scenario + PHP Context step annotations; Codeception Cest class/test-method/Actor; Pest `it()`/`test()`/`describe()`/`uses()`/`dataset()`/hooks/`arch()`

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>