### PR TITLE
fix(mcp): whoami reports index counts + honors explicit group=

### DIFF
--- a/internal/mcp/docstate_test.go
+++ b/internal/mcp/docstate_test.go
@@ -446,6 +446,280 @@ func checkField(t *testing.T, m map[string]any, key, want string) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Fix #1 — whoami docgen-trap: entity/relationship/tests_edges counts
+// ---------------------------------------------------------------------------
+
+// TestHandleWhoami_indexCounts asserts that archigraph_whoami always returns
+// entity_count, relationship_count, and an index{} block even when no docgen
+// has ever been run — so a fully-indexed group is never mistaken for empty.
+func TestHandleWhoami_indexCounts(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "") // normal mode
+
+	// Build a graph with 4 entities, 3 edges (2 CALLS + 1 TESTS).
+	repoDir := filepath.Join(tmp, "repo-a")
+	doc := &graph.Document{
+		Repo: "repo-a",
+		Entities: []graph.Entity{
+			{ID: "a1", Name: "Foo", Kind: "function", SourceFile: "foo.go", StartLine: 1, EndLine: 5},
+			{ID: "a2", Name: "Bar", Kind: "function", SourceFile: "bar.go", StartLine: 1, EndLine: 5},
+			{ID: "a3", Name: "Baz", Kind: "function", SourceFile: "baz.go", StartLine: 1, EndLine: 5},
+			{ID: "t1", Name: "TestFoo", Kind: "function", SourceFile: "foo_test.go", StartLine: 1, EndLine: 5},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "a1", ToID: "a2", Kind: "CALLS"},
+			{ID: "r2", FromID: "a2", ToID: "a3", Kind: "CALLS"},
+			{ID: "r3", FromID: "t1", ToID: "a1", Kind: "TESTS"},
+		},
+	}
+	writeGraph(t, repoDir, doc)
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-a": repoDir},
+	})
+
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := srv.handleWhoami(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleWhoami: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+
+	out := extractResultJSON(t, res)
+
+	// Top-level counts must be present.
+	ec, ok := out["entity_count"].(float64)
+	if !ok {
+		t.Fatalf("entity_count: missing or wrong type (got %T: %v)", out["entity_count"], out["entity_count"])
+	}
+	if ec != 4 {
+		t.Errorf("entity_count: got %v want 4", ec)
+	}
+	rc, ok := out["relationship_count"].(float64)
+	if !ok {
+		t.Fatalf("relationship_count: missing or wrong type (got %T: %v)", out["relationship_count"], out["relationship_count"])
+	}
+	if rc != 3 {
+		t.Errorf("relationship_count: got %v want 3", rc)
+	}
+
+	// index{} sub-object must mirror the top-level counts and include tests_edges.
+	idx, ok := out["index"].(map[string]any)
+	if !ok {
+		t.Fatalf("index: missing or wrong type (got %T: %v)", out["index"], out["index"])
+	}
+	if v, _ := idx["entity_count"].(float64); v != 4 {
+		t.Errorf("index.entity_count: got %v want 4", idx["entity_count"])
+	}
+	if v, _ := idx["relationship_count"].(float64); v != 3 {
+		t.Errorf("index.relationship_count: got %v want 3", idx["relationship_count"])
+	}
+	if v, _ := idx["tests_edges"].(float64); v != 1 {
+		t.Errorf("index.tests_edges: got %v want 1", idx["tests_edges"])
+	}
+	// indexed_sha and indexed_ref must be present (may be empty string in test env).
+	if _, present := idx["indexed_sha"]; !present {
+		t.Error("index.indexed_sha: field must be present")
+	}
+	if _, present := idx["indexed_ref"]; !present {
+		t.Error("index.indexed_ref: field must be present")
+	}
+}
+
+// TestHandleWhoami_indexCounts_multiRepo asserts that entity/relationship counts
+// aggregate across all repos in the group, matching archigraph_stats behaviour.
+func TestHandleWhoami_indexCounts_multiRepo(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "")
+
+	repoADir := filepath.Join(tmp, "repo-a")
+	repoBDir := filepath.Join(tmp, "repo-b")
+
+	docA := &graph.Document{
+		Repo: "repo-a",
+		Entities: []graph.Entity{
+			{ID: "a1", Name: "FuncA1", Kind: "function", SourceFile: "a.go", StartLine: 1, EndLine: 5},
+			{ID: "a2", Name: "FuncA2", Kind: "function", SourceFile: "a.go", StartLine: 6, EndLine: 10},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "a1", ToID: "a2", Kind: "CALLS"},
+		},
+	}
+	docB := &graph.Document{
+		Repo: "repo-b",
+		Entities: []graph.Entity{
+			{ID: "b1", Name: "FuncB1", Kind: "function", SourceFile: "b.go", StartLine: 1, EndLine: 5},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r2", FromID: "b1", ToID: "a1", Kind: "TESTS"},
+		},
+	}
+	writeGraph(t, repoADir, docA)
+	writeGraph(t, repoBDir, docB)
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-a": repoADir, "repo-b": repoBDir},
+	})
+
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := srv.handleWhoami(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleWhoami: %v", err)
+	}
+	out := extractResultJSON(t, res)
+
+	// repo-a has 2 entities + 1 rel; repo-b has 1 entity + 1 TESTS rel → totals: 3 + 2.
+	if v, _ := out["entity_count"].(float64); v != 3 {
+		t.Errorf("entity_count: got %v want 3", out["entity_count"])
+	}
+	if v, _ := out["relationship_count"].(float64); v != 2 {
+		t.Errorf("relationship_count: got %v want 2", out["relationship_count"])
+	}
+	idx, _ := out["index"].(map[string]any)
+	if idx == nil {
+		t.Fatal("index: missing")
+	}
+	if v, _ := idx["tests_edges"].(float64); v != 1 {
+		t.Errorf("index.tests_edges: got %v want 1", idx["tests_edges"])
+	}
+}
+
+// TestHandleWhoami_indexCounts_quietMode asserts that index counts are NOT
+// present when ARCHIGRAPH_WHOAMI_NUDGE=quiet (early return path).
+func TestHandleWhoami_indexCounts_quietMode(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "quiet")
+
+	repoDir := filepath.Join(tmp, "repo-a")
+	doc := fixtureDoc("repo-a")
+	writeGraph(t, repoDir, doc)
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-a": repoDir},
+	})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := srv.handleWhoami(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleWhoami: %v", err)
+	}
+	out := extractResultJSON(t, res)
+
+	// In quiet mode the enrichment block (including index counts) is suppressed.
+	if _, found := out["entity_count"]; found {
+		t.Error("entity_count should be absent in quiet mode")
+	}
+	if _, found := out["index"]; found {
+		t.Error("index should be absent in quiet mode")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fix #2 — whoami must honor explicit group= for index-state fields
+// ---------------------------------------------------------------------------
+
+// TestHandleWhoami_explicitGroup_indexState asserts that when group= is
+// provided explicitly, the indexed_sha/indexed_ref in the response key off the
+// queried group's repos (not the cwd). The test sets up two groups in the same
+// registry and queries each via explicit group= to verify the index block
+// reflects the correct group.
+func TestHandleWhoami_explicitGroup_indexState(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "")
+
+	// Two groups, each with a different repo and entity count.
+	repoAlphaDir := filepath.Join(tmp, "repo-alpha")
+	repoBetaDir := filepath.Join(tmp, "repo-beta")
+
+	docAlpha := &graph.Document{
+		Repo: "repo-alpha",
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "AlphaFunc", Kind: "function", SourceFile: "alpha.go", StartLine: 1, EndLine: 5},
+			{ID: "e2", Name: "AlphaStruct", Kind: "struct", SourceFile: "alpha.go", StartLine: 6, EndLine: 10},
+			{ID: "e3", Name: "AlphaHelper", Kind: "function", SourceFile: "alpha.go", StartLine: 11, EndLine: 15},
+		},
+	}
+	docBeta := &graph.Document{
+		Repo: "repo-beta",
+		Entities: []graph.Entity{
+			{ID: "f1", Name: "BetaFunc", Kind: "function", SourceFile: "beta.go", StartLine: 1, EndLine: 5},
+		},
+	}
+	writeGraph(t, repoAlphaDir, docAlpha)
+	writeGraph(t, repoBetaDir, docBeta)
+
+	// Both groups in the same registry.
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"alpha-group": {"repo-alpha": repoAlphaDir},
+		"beta-group":  {"repo-beta": repoBetaDir},
+	})
+
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// Query alpha-group explicitly.
+	reqAlpha := mcpapi.CallToolRequest{}
+	reqAlpha.Params.Arguments = map[string]any{"group": "alpha-group"}
+	resAlpha, err := srv.handleWhoami(context.Background(), reqAlpha)
+	if err != nil {
+		t.Fatalf("handleWhoami(alpha-group): %v", err)
+	}
+	outAlpha := extractResultJSON(t, resAlpha)
+	if v, _ := outAlpha["entity_count"].(float64); v != 3 {
+		t.Errorf("alpha-group entity_count: got %v want 3", outAlpha["entity_count"])
+	}
+	if v, _ := outAlpha["group"].(string); v != "alpha-group" {
+		t.Errorf("alpha-group group field: got %q want %q", v, "alpha-group")
+	}
+
+	// Query beta-group explicitly.
+	reqBeta := mcpapi.CallToolRequest{}
+	reqBeta.Params.Arguments = map[string]any{"group": "beta-group"}
+	resBeta, err := srv.handleWhoami(context.Background(), reqBeta)
+	if err != nil {
+		t.Fatalf("handleWhoami(beta-group): %v", err)
+	}
+	outBeta := extractResultJSON(t, resBeta)
+	if v, _ := outBeta["entity_count"].(float64); v != 1 {
+		t.Errorf("beta-group entity_count: got %v want 1", outBeta["entity_count"])
+	}
+	if v, _ := outBeta["group"].(string); v != "beta-group" {
+		t.Errorf("beta-group group field: got %q want %q", v, "beta-group")
+	}
+
+	// The two results must have different entity counts, proving each query
+	// resolved against its own group's index (not the cwd's).
+	alphaEC, _ := outAlpha["entity_count"].(float64)
+	betaEC, _ := outBeta["entity_count"].(float64)
+	if alphaEC == betaEC {
+		t.Errorf("entity_count must differ between groups: alpha=%v beta=%v", alphaEC, betaEC)
+	}
+}
+
 // makeLoadedGroupWithFile builds a minimal LoadedGroup with one repo whose
 // entity graph has the given source file path relative to repoDir.
 func makeLoadedGroupWithFile(t *testing.T, groupName, repoName, repoDir, relFile string) *LoadedGroup {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/enrichment"
+	"github.com/cajasmota/archigraph/internal/gitmeta"
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/links"
 	"github.com/cajasmota/archigraph/internal/types"
@@ -304,6 +305,22 @@ func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (
 		}
 	}
 
+	// Fix #2: when an explicit group= was provided, indexed_ref/indexed_sha must
+	// reflect the queried group's canonical repo, not the cwd's repo. We derive
+	// them from the group's loaded repos (first alphabetically) so the index
+	// fields correspond to the group being queried.
+	//
+	// If no explicit group was given, fall back to the cwd-derived values as
+	// before — that preserves all existing behaviour.
+	var indexedRef, indexedSHA string
+	if explicit != "" {
+		// Resolve ref/sha from the queried group's repos (not cwd).
+		indexedRef, indexedSHA = groupIndexedRefSHA(s.State, group)
+	} else {
+		indexedRef = cwdRes.Ref
+		indexedSHA = cwdRes.SHA
+	}
+
 	// Base response. PH1c ref fields come from sessionMeta (#2337).
 	sm := sessionMeta(nil, &cwdRes)
 	resp := map[string]any{
@@ -315,9 +332,11 @@ func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (
 		// PH1c ref fields (via sessionMeta — exclusive to whoami per #2337).
 		"cwd_resolved_to": cwdResolvedTo,
 		"is_worktree":     sm["is_worktree"],
-		"indexed_ref":     sm["indexed_ref"],
-		"indexed_sha":     sm["indexed_sha"],
-		"parent_repo":     sm["parent_repo"],
+		// Fix #2: indexed_ref/indexed_sha now key off the queried group when
+		// an explicit group= is supplied (not the cwd's repo).
+		"indexed_ref": indexedRef,
+		"indexed_sha": indexedSHA,
+		"parent_repo": sm["parent_repo"],
 	}
 	if cwdRes.Source == "worktree" {
 		resp["tier"] = "cold" // worktree refs may not be hot-loaded yet
@@ -334,6 +353,25 @@ func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (
 	lg := s.State.Group(group)
 	if lg == nil {
 		return jsonResult(resp), nil
+	}
+
+	// Fix #1: add an index-state block so agents always see that entities are
+	// present. Without this, a fully-indexed group read as "empty / never
+	// indexed" because the response only contained docgen fields — causing
+	// agents to fall back to grep (the "docgen-trap").
+	//
+	// entity_count and relationship_count mirror the totals reported by
+	// archigraph_stats so the two tools always agree. tests_edges is the count
+	// of TESTS-kind relationships aggregated across all loaded repos.
+	totalE, totalR, totalTests := groupIndexCounts(lg)
+	resp["entity_count"] = totalE       // top-level for immediate visibility
+	resp["relationship_count"] = totalR // top-level for immediate visibility
+	resp["index"] = map[string]any{
+		"entity_count":       totalE,
+		"relationship_count": totalR,
+		"tests_edges":        totalTests,
+		"indexed_sha":        indexedSHA,
+		"indexed_ref":        indexedRef,
 	}
 
 	docState := ComputeDocState(group, lg)
@@ -356,6 +394,58 @@ func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (
 	}
 
 	return jsonResult(resp), nil
+}
+
+// groupIndexCounts returns the total entity count, relationship count, and
+// TESTS-edge count aggregated across all loaded repos in the group. These
+// values are computed the same way archigraph_stats does so the two tools
+// always agree (Fix #1, the "docgen-trap" in archigraph_whoami).
+func groupIndexCounts(lg *LoadedGroup) (entities, relationships, testsEdges int) {
+	for _, r := range lg.Repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		entities += len(r.Doc.Entities)
+		relationships += len(r.Doc.Relationships)
+		for i := range r.Doc.Relationships {
+			if r.Doc.Relationships[i].Kind == "TESTS" {
+				testsEdges++
+			}
+		}
+	}
+	return
+}
+
+// groupIndexedRefSHA returns the git ref and abbreviated SHA for the canonical
+// repo of a group. When the group has multiple repos the first one in
+// alphabetical slug order is used (deterministic). This is used by Fix #2 so
+// that an explicit group= query returns the queried group's ref/sha rather than
+// the cwd's ref/sha.
+//
+// Returns ("", "") when the group is unknown or has no loaded repos.
+func groupIndexedRefSHA(s *State, groupName string) (ref, sha string) {
+	if s == nil {
+		return "", ""
+	}
+	gentry, ok := s.registry.Groups[groupName]
+	if !ok {
+		return "", ""
+	}
+	// Pick the first repo alphabetically for deterministic output.
+	slugs := make([]string, 0, len(gentry.Repos))
+	for slug := range gentry.Repos {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	for _, slug := range slugs {
+		repo := gentry.Repos[slug]
+		if repo.Path == "" {
+			continue
+		}
+		meta := gitmeta.Capture(repo.Path)
+		return meta.Ref, meta.SHA
+	}
+	return "", ""
 }
 
 // countPatterns returns the total number of patterns (candidate + approved) for a group.


### PR DESCRIPTION
## Summary

Fixes two `archigraph_whoami` bugs surfaced during the upvate-v2 stress-test diagnosis.

### Fix #1 (HIGH) — docgen-trap

`whoami` previously returned only docgen fields (`documentation_state`, `candidate_count`, `patterns_count`, `residual_count`, `stale_count`, `last_docgen_at`, `suggested_action`) with **no entity or relationship counts**. A fully-indexed group therefore read as "empty / never indexed", causing agents to fall back to grep instead of querying the graph — the root cause of several false grep-fallback incidents.

**Added fields (present whenever the group is loaded; suppressed in `ARCHIGRAPH_WHOAMI_NUDGE=quiet` mode):**

| Field | Description |
|---|---|
| `entity_count` | Total entities across all repos (top-level, for immediate visibility) |
| `relationship_count` | Total relationships across all repos (top-level) |
| `index.entity_count` | Same value, grouped under `index{}` sub-object |
| `index.relationship_count` | Same value |
| `index.tests_edges` | Count of TESTS-kind relationships (same as `test_coverage` uses) |
| `index.indexed_sha` | The group's canonical indexed commit SHA |
| `index.indexed_ref` | The group's canonical indexed branch/ref |

Counts are computed by the new `groupIndexCounts` helper using the same source (`r.Doc.Entities` / `r.Doc.Relationships`) as `archigraph_stats`, so the two tools always agree.

### Fix #2 (MED) — explicit `group=` ignored for index state

When `group=` was passed explicitly, `indexed_sha` and `indexed_ref` reflected the **cwd's** repo rather than the queried group's repo. E.g. `whoami group=upvate` from the `core-backend-v2` cwd returned `repo: core-backend-v2` metadata.

**Fix:** a new `groupIndexedRefSHA` helper resolves ref/sha from the queried group's registry entry (first slug alphabetically via `gitmeta.Capture`) when an explicit `group=` is provided. `cwd_resolved_to` is intentionally preserved as the cwd-derived label (that is its stated purpose).

## Before / after sample payload

**Before** (group fully indexed, no docgen run):
```json
{
  "group": "upvate",
  "repo": "core-backend-v2",
  "indexed_sha": "a1b2c3d4e5f6",
  "documentation_state": "never_generated",
  "suggested_action": "run /archigraph-tech-docs"
}
```
*(entity_count absent → agent concludes graph is empty)*

**After:**
```json
{
  "group": "upvate",
  "repo": "core-backend-v2",
  "entity_count": 14823,
  "relationship_count": 61204,
  "indexed_sha": "a1b2c3d4e5f6",
  "indexed_ref": "main",
  "index": {
    "entity_count": 14823,
    "relationship_count": 61204,
    "tests_edges": 3812,
    "indexed_sha": "a1b2c3d4e5f6",
    "indexed_ref": "main"
  },
  "documentation_state": "never_generated",
  "suggested_action": "run /archigraph-tech-docs"
}
```

## Tests added (`internal/mcp/docstate_test.go`)

- `TestHandleWhoami_indexCounts` — verifies `entity_count`, `relationship_count`, `index{}` sub-object, `tests_edges` count
- `TestHandleWhoami_indexCounts_multiRepo` — verifies aggregation across multiple repos matches `archigraph_stats`
- `TestHandleWhoami_indexCounts_quietMode` — verifies counts are absent in `ARCHIGRAPH_WHOAMI_NUDGE=quiet`
- `TestHandleWhoami_explicitGroup_indexState` — two groups in same registry; explicit `group=` query returns each group's own counts

## Build / test results

```
go build ./internal/... ./cmd/...    # clean
gofmt -l ...                          # empty (no formatting issues)
go test ./internal/mcp/...            # ok  (23s)
go test ./internal/graph/...          # ok  (4s)
go test ./internal/types/...          # ok  (2s)
```

All 12 whoami/docstate tests pass (8 pre-existing + 4 new).

> **Deploy note:** deploying requires a daemon rebuild+restart. The coordinator will handle this.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>