### PR TITLE
fix(extractors): don't treat test-file endpoint declarations as production routes

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -122,6 +122,82 @@ func synthesisSupportsLanguage(lang string) bool {
 	}
 }
 
+// isTestSourceFile reports whether filePath is a test/spec/fixture file that
+// should be excluded from production endpoint synthesis.
+//
+// Test files often contain framework setup code (NestJS @Controller inside an
+// e2e spec, Express app.get() inside a Supertest fixture, Django views in a
+// conftest, etc.) that looks identical to a production route declaration. We
+// must NOT emit http_endpoint_definition entities for routes that only exist
+// to support the test harness — they would appear in the production endpoint
+// catalogue and generate spurious cross-repo links.
+//
+// The patterns below mirror the per-language conventions tracked by
+// internal/graph/coverage.go's isTestFile and the testmap extractor's
+// frameworkEntry filename/path hints. They are intentionally conservative:
+// a file that does NOT match these patterns is treated as production code even
+// if it imports a test library (import-based detection is deferred to the
+// testmap extractor which emits SCOPE.Pattern/test_coverage, not endpoints).
+func isTestSourceFile(filePath string) bool {
+	// Normalise to forward slashes for cross-platform consistency.
+	slashed := "/" + filepath.ToSlash(strings.ToLower(filePath))
+
+	// Directory-segment fast-path: canonical test directories.
+	for _, seg := range []string{"/__tests__/", "/test/", "/tests/", "/spec/", "/e2e/", "/fixtures/"} {
+		if strings.Contains(slashed, seg) {
+			return true
+		}
+	}
+
+	base := filepath.Base(filePath)
+	lower := strings.ToLower(base)
+	ext := filepath.Ext(lower)
+	stem := strings.TrimSuffix(lower, ext)
+
+	switch ext {
+	case ".go":
+		// Go: foo_test.go
+		return strings.HasSuffix(stem, "_test")
+	case ".py":
+		// Python: test_foo.py  or  foo_test.py
+		return strings.HasPrefix(stem, "test_") || strings.HasSuffix(stem, "_test")
+	case ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs":
+		// JS/TS: foo.test.ts, foo.spec.ts, foo.e2e-spec.ts, foo.e2e.spec.ts, …
+		//
+		// Patterns covered:
+		//   foo.spec.ts      → stem="foo.spec"      HasSuffix ".spec"
+		//   foo.test.ts      → stem="foo.test"      HasSuffix ".test"
+		//   foo.e2e-spec.ts  → stem="foo.e2e-spec"  HasSuffix "-spec"
+		//   foo.e2e-test.ts  → stem="foo.e2e-test"  HasSuffix "-test"
+		//   foo.e2e.spec.ts  → lower contains ".spec."
+		//   foo.e2e.test.ts  → lower contains ".test."
+		return strings.Contains(lower, ".test.") ||
+			strings.Contains(lower, ".spec.") ||
+			strings.HasSuffix(stem, ".test") ||
+			strings.HasSuffix(stem, ".spec") ||
+			strings.HasSuffix(stem, "-spec") ||
+			strings.HasSuffix(stem, "-test")
+	case ".rb":
+		// Ruby: foo_spec.rb
+		return strings.HasSuffix(stem, "_spec")
+	case ".java", ".kt", ".cs", ".scala", ".swift":
+		// Java/Kotlin/C#/Scala/Swift: FooTest.java, FooTests.java, FooIT.java, FooSpec.java
+		return strings.HasSuffix(stem, "test") ||
+			strings.HasSuffix(stem, "tests") ||
+			strings.HasSuffix(stem, "it") ||
+			strings.HasSuffix(stem, "spec")
+	case ".php":
+		// PHP: FooTest.php
+		return strings.HasSuffix(stem, "test")
+	case ".rs":
+		// Rust tests live in modules within production files; file-level
+		// exclusion is not meaningful. Return false and rely on the testmap
+		// extractor for Rust coverage.
+		return false
+	}
+	return false
+}
+
 // applyHTTPEndpointSynthesis runs after the existing route-composition
 // passes and APPENDS synthetic http_endpoint entities + edges to the
 // detector's output. It never modifies or removes existing entities or
@@ -136,6 +212,15 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	entities := args.Entities
 	relationships := args.Relationships
 	if len(content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	// Guard: test/spec/fixture files contain framework setup code that looks
+	// identical to production route declarations (e.g. NestJS @Controller in an
+	// *.e2e-spec.ts, Express app.get() in a Supertest fixture). Do NOT emit
+	// http_endpoint_definition entities from test files — they are not real
+	// production routes. See isTestSourceFile for the pattern catalogue.
+	if isTestSourceFile(path) {
 		return DetectorPassResult{Entities: entities, Relationships: relationships}
 	}
 

--- a/internal/engine/http_endpoint_test_file_exclusion_test.go
+++ b/internal/engine/http_endpoint_test_file_exclusion_test.go
@@ -1,0 +1,250 @@
+package engine
+
+// Tests for finding #4 (upvate-v2 stress-test): endpoint declarations inside
+// test/spec/e2e-spec files must NOT be extracted as production routes.
+//
+// Root cause: applyHTTPEndpointSynthesis had no guard against test files.
+// NestJS e2e spec files (*.e2e-spec.ts) routinely import @nestjs/common,
+// stand up a full TestingModule with real @Controller classes, and even call
+// app.get('/buildings', ...) through Supertest — all of which match the
+// synthesizeNestJS / synthesizeExpress patterns.
+//
+// Fix: isTestSourceFile() is consulted at the top of
+// applyHTTPEndpointSynthesis; any file whose path matches a test/spec
+// convention returns early without emitting http_endpoint_definition entities.
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// isTestSourceFile unit tests
+// ---------------------------------------------------------------------------
+
+func TestIsTestSourceFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+		desc string
+	}{
+		// JS/TS — spec files
+		{"src/app.e2e-spec.ts", true, "NestJS e2e spec"},
+		{"test/app.e2e-spec.ts", true, "NestJS e2e spec in test/"},
+		{"src/buildings/buildings.e2e-spec.ts", true, "nested NestJS e2e spec"},
+		{"src/foo.spec.ts", true, "plain .spec.ts"},
+		{"src/foo.test.ts", true, "plain .test.ts"},
+		{"src/foo.spec.js", true, "plain .spec.js"},
+		{"src/foo.test.js", true, "plain .test.js"},
+		{"src/foo.spec.tsx", true, "React spec tsx"},
+		{"src/foo.test.tsx", true, "React test tsx"},
+		{"src/foo.spec.mjs", true, "ESM spec"},
+		{"src/foo.test.cjs", true, "CJS test"},
+		// JS/TS — __tests__ directory
+		{"src/__tests__/bar.ts", true, "__tests__ directory"},
+		{"__tests__/bar.js", true, "__tests__ at root"},
+		// JS/TS — e2e directory
+		{"e2e/app.ts", true, "e2e directory"},
+		{"src/e2e/flows.ts", true, "nested e2e directory"},
+		// JS/TS — production files (must NOT be excluded)
+		{"src/app.controller.ts", false, "NestJS controller (production)"},
+		{"src/users/users.controller.ts", false, "production controller"},
+		{"src/main.ts", false, "entry point"},
+		{"src/routes/index.ts", false, "routes (but not spec)"},
+
+		// Python
+		{"tests/test_buildings.py", true, "Python test in /tests/"},
+		{"test_buildings.py", true, "Python test_ prefix"},
+		{"buildings_test.py", true, "Python _test suffix"},
+		{"conftest.py", false, "conftest is not a test file by name"},
+		{"buildings/views.py", false, "Django view (production)"},
+
+		// Go
+		{"internal/handler_test.go", true, "Go _test.go"},
+		{"internal/handler.go", false, "Go production file"},
+
+		// Ruby
+		{"spec/models/user_spec.rb", true, "Ruby spec"},
+		{"app/models/user.rb", false, "Ruby production model"},
+
+		// Java
+		{"src/test/java/UserTest.java", true, "Java Test suffix"},
+		{"src/test/java/UserTests.java", true, "Java Tests suffix"},
+		{"src/main/java/UserService.java", false, "Java production service"},
+
+		// test/ directory catch-all
+		{"test/utils.ts", true, "test/ directory"},
+		{"tests/utils.ts", true, "tests/ directory"},
+		{"spec/helpers.ts", true, "spec/ directory"},
+	}
+
+	for _, tc := range cases {
+		got := isTestSourceFile(tc.path)
+		if got != tc.want {
+			t.Errorf("isTestSourceFile(%q) = %v, want %v (%s)", tc.path, got, tc.want, tc.desc)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: synthesis pass must not emit endpoints from test files
+// ---------------------------------------------------------------------------
+
+// NestJS e2e-spec: the canonical upvate-v2 finding #4 case.
+// A *.e2e-spec.ts file contains a full NestJS module setup with @Controller
+// and @Get/@Post decorators — synthesis must produce NO http_endpoint entities.
+func TestSynthesis_NestJSE2ESpec_NoEndpoints(t *testing.T) {
+	// This mirrors the shape of a real NestJS e2e spec file (e.g.
+	// src/buildings/buildings.e2e-spec.ts in upvate-v2).
+	src := `import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+// Inline test controller that imitates the real controller for integration testing.
+import { Controller, Get, Post, Body } from '@nestjs/common';
+
+@Controller('buildings')
+class TestBuildingsController {
+  @Get()
+  list() { return []; }
+
+  @Post()
+  create(@Body() body: any) { return body; }
+}
+
+describe('Buildings (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+      controllers: [TestBuildingsController],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  it('/buildings (GET)', () => {
+    return request(app.getHttpServer()).get('/buildings').expect(200);
+  });
+
+  it('/buildings (POST)', () => {
+    return request(app.getHttpServer()).post('/buildings').send({}).expect(201);
+  });
+});
+`
+	got, _ := runDetect(t, "typescript", "src/buildings/buildings.e2e-spec.ts", src)
+	if len(got) != 0 {
+		t.Errorf("e2e-spec file should emit 0 http_endpoint entities, got %d: %v", len(got), got)
+	}
+}
+
+// Counterpart: the same @Controller in a production file DOES produce endpoints.
+func TestSynthesis_NestJSController_Production_HasEndpoints(t *testing.T) {
+	src := `import { Controller, Get, Post, Body } from '@nestjs/common';
+
+@Controller('buildings')
+export class BuildingsController {
+  @Get()
+  list() { return []; }
+
+  @Post()
+  create(@Body() body: any) { return body; }
+}
+`
+	got, _ := runDetect(t, "typescript", "src/buildings/buildings.controller.ts", src)
+	want := []string{"http:GET:/buildings", "http:POST:/buildings"}
+	requireContains(t, got, want, "NestJS production controller")
+}
+
+// Plain .spec.ts file (unit test, not e2e) — must also be excluded.
+func TestSynthesis_NestJSSpecTs_NoEndpoints(t *testing.T) {
+	src := `import { Test, TestingModule } from '@nestjs/testing';
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+class HealthController {
+  @Get()
+  check() { return { status: 'ok' }; }
+}
+
+describe('HealthController', () => {
+  it('should be defined', () => {});
+});
+`
+	got, _ := runDetect(t, "typescript", "src/health/health.controller.spec.ts", src)
+	if len(got) != 0 {
+		t.Errorf("spec.ts file should emit 0 http_endpoint entities, got %d: %v", len(got), got)
+	}
+}
+
+// Express app.get() inside a test file must also be excluded.
+func TestSynthesis_ExpressInTestFile_NoEndpoints(t *testing.T) {
+	src := `const express = require('express');
+const app = express();
+
+app.get('/health', (req, res) => res.json({ ok: true }));
+app.post('/users', (req, res) => res.json({}));
+
+module.exports = app;
+`
+	// A Supertest fixture file in __tests__/
+	got, _ := runDetect(t, "javascript", "__tests__/app.fixture.js", src)
+	if len(got) != 0 {
+		t.Errorf("__tests__ fixture should emit 0 http_endpoint entities, got %d: %v", len(got), got)
+	}
+}
+
+// Python test file: FastAPI test client setup with route declarations
+// inside conftest/test file must not produce endpoint entities.
+func TestSynthesis_FastAPIInPyTestFile_NoEndpoints(t *testing.T) {
+	src := `from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.post("/items")
+def create_item(item: dict):
+    return item
+
+client = TestClient(app)
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+`
+	got, _ := runDetect(t, "python", "tests/test_api.py", src)
+	if len(got) != 0 {
+		t.Errorf("Python test file should emit 0 http_endpoint entities, got %d: %v", len(got), got)
+	}
+}
+
+// Go _test.go file with net/http handler setup: must not produce endpoint entities.
+func TestSynthesis_GoTestFile_NoEndpoints(t *testing.T) {
+	src := `package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealth(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+	req := httptest.NewRequest("GET", "/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+}
+`
+	got, _ := runDetect(t, "go", "internal/handler_test.go", src)
+	if len(got) != 0 {
+		t.Errorf("Go _test.go file should emit 0 http_endpoint entities, got %d: %v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Problem

Finding #4 from the upvate-v2 stress-test: `test_coverage group=upvate-v2` reported spurious production endpoints whose source files were test fixtures — e.g.:

- `http:GET:/health → scripts/docs-check.mjs:28`
- `http:POST:/buildings → src/shared/mongo/builder/aggregation.builder.ts:67`

The `/buildings` endpoint is declared inside a NestJS e2e spec file (`buildings.e2e-spec.ts`) that sets up a `TestingModule` with a real `@Controller('buildings')` + `@Get()` / `@Post()` for integration testing. It is not a real production route.

## Root Cause

`applyHTTPEndpointSynthesis` in `internal/engine/http_endpoint_synthesis.go` had no guard against test file paths. Every synthesizer (`synthesizeNestJS`, `synthesizeExpress`, `synthesizeFastAPI`, `synthesizeFlask`, `synthesizeSpringFromComposed`, etc.) ran on every source file, including:

- `*.e2e-spec.ts` — NestJS integration test files with full `@Controller` setup
- `*.spec.ts` / `*.test.ts` — Unit test files with mock controllers
- `tests/test_*.py` — Python test files with FastAPI/Flask test apps
- `*_test.go` — Go test files with `http.HandleFunc` harnesses

## Fix

Added `isTestSourceFile(path string) bool` to `http_endpoint_synthesis.go` with comprehensive coverage of test file naming conventions across all supported languages:

- **JS/TS**: `*.spec.ts`, `*.test.ts`, `*.e2e-spec.ts`, `*.e2e-test.ts`, `*.spec.js`, `*.test.js`, etc.
- **Python**: `test_*.py`, `*_test.py`, `/tests/` directory
- **Go**: `*_test.go`
- **Ruby**: `*_spec.rb`, `/spec/` directory
- **Java/Kotlin/C#/Scala/Swift**: `*Test.java`, `*Tests.java`, `*IT.java`
- **PHP**: `*Test.php`
- **Directories**: `/__tests__/`, `/test/`, `/tests/`, `/spec/`, `/e2e/`, `/fixtures/`

An early-return guard at the top of `applyHTTPEndpointSynthesis` skips synthesis for test files entirely. No graph data is lost — test-origin routes were never valid production endpoints.

## Note on the /health mis-location

The `http:GET:/health → docs-check.mjs:28` case appears to be a separate SourceFile attribution bug (the entity's SourceFile is stamped with the wrong file, not just a test-file-leakage issue). This is out of scope for this PR and should be tracked separately.

## Tests

7 new tests in `internal/engine/http_endpoint_test_file_exclusion_test.go`:

- `TestIsTestSourceFile` — 30 path cases proving the detection function
- `TestSynthesis_NestJSE2ESpec_NoEndpoints` — canonical finding #4 case
- `TestSynthesis_NestJSController_Production_HasEndpoints` — production controller still works
- `TestSynthesis_NestJSSpecTs_NoEndpoints` — `.spec.ts` excluded
- `TestSynthesis_ExpressInTestFile_NoEndpoints` — `__tests__/` Express excluded
- `TestSynthesis_FastAPIInPyTestFile_NoEndpoints` — Python test file excluded
- `TestSynthesis_GoTestFile_NoEndpoints` — Go `_test.go` excluded

Full engine test suite passes (`go test ./internal/engine/` — 18.6s, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>