### PR TITLE
fix(coverage/php): dead CakePHP auth regex + normalize dead_code_detection status

### DIFF
--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -73,7 +73,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
 | Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | DB effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |
-| Dead code detection | ✅ `full` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_php.go` | Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks |
 | Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_php.go` | PHP def-use sniffer registered in substrate; flows through language-agnostic def_use_pass |
 | Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/php.go`<br>`internal/substrate/substrate.go` | — |
 | Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_php.go` | — |

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -33554,8 +33554,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -33777,8 +33778,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -34000,8 +34002,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -34223,8 +34226,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -34447,7 +34451,8 @@
           },
           "dead_code_detection": {
             "status": "partial",
-            "cites": ["internal/links/reachability.go","internal/substrate/entry_points_php.go"],
+            "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -34669,8 +34674,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -34892,8 +34898,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -35115,8 +35122,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -35338,8 +35346,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -35561,8 +35570,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -35784,8 +35794,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {
@@ -36007,8 +36018,9 @@
             "verified_at": "2026-05-28"
           },
           "dead_code_detection": {
-            "status": "full",
+            "status": "partial",
             "cites": ["internal/links/reachability.go","internal/mcp/dead_code.go","internal/substrate/entry_points.go","internal/substrate/entry_points_php.go"],
+            "notes": "Framework-agnostic reachability pass via php open-tag and public-function entry points; lifecycle hooks matched by name heuristic only — unified status across all PHP frameworks",
             "verified_at": "2026-05-28"
           },
           "def_use_chain_extraction": {

--- a/internal/custom/php/extractors_test.go
+++ b/internal/custom/php/extractors_test.go
@@ -323,6 +323,31 @@ $middlewareQueue->add(new CsrfProtectionMiddleware());
 	}
 }
 
+// TestCakePHPAuthDollarThis verifies that the CakePHP auth regex correctly
+// matches $this->Authentication and $this->Authorization — the two alternations
+// that were previously dead due to an unescaped $ acting as end-of-text anchor
+// in Go's regexp engine instead of a literal dollar sign.
+func TestCakePHPAuthDollarThis(t *testing.T) {
+	src := `<?php
+$this->Authentication->check();
+$this->Authorization->can($user, 'edit');
+`
+	ents := extract(t, "custom_php_cakephp", fi("AppController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "cakephp:auth") {
+		t.Error("expected cakephp:auth entity for $this->Authentication usage (was dead before regex fix)")
+	}
+}
+
+func TestCakePHPAuthDollarThisAuthorization(t *testing.T) {
+	src := `<?php
+$this->Authorization->can($user, 'delete');
+`
+	ents := extract(t, "custom_php_cakephp", fi("PostsController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "cakephp:auth") {
+		t.Error("expected cakephp:auth entity for $this->Authorization usage (was dead before regex fix)")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // CodeIgniter
 // ---------------------------------------------------------------------------
@@ -476,6 +501,21 @@ $app->post('/api/robots/add', RobotsController::class);
 	}
 }
 
+// TestPhalconAuthDollarThis verifies that the Phalcon auth regex correctly
+// matches $this->auth — previously dead due to an unescaped $ in an alternation
+// inside a \b-bounded group ($ is not a word character so the boundary never matched).
+func TestPhalconAuthDollarThis(t *testing.T) {
+	src := `<?php
+if (!$this->auth->isLoggedIn()) {
+    return $this->response->redirect('/login');
+}
+`
+	ents := extract(t, "custom_php_phalcon", fi("ControllerBase.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "phalcon:auth") {
+		t.Error("expected phalcon:auth entity for $this->auth usage (was dead before regex fix)")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Laminas
 // ---------------------------------------------------------------------------
@@ -508,5 +548,25 @@ class AuthMiddleware implements MiddlewareInterface {
 	ents := extract(t, "custom_php_laminas", fi("AuthMiddleware.php", "php", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "middleware:AuthMiddleware") {
 		t.Error("expected middleware:AuthMiddleware pattern")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Yii auth dollar-this regression
+// ---------------------------------------------------------------------------
+
+// TestYiiAuthDollarApp verifies that the Yii auth regex correctly matches
+// Yii::$app->user — previously dead due to unescaped $ inside an alternation
+// group with a leading \b word-boundary ($ is not a word character).
+func TestYiiAuthDollarApp(t *testing.T) {
+	src := `<?php
+$identity = Yii::$app->user->identity;
+if (Yii::$app->user->isGuest) {
+    return $this->redirect(['site/login']);
+}
+`
+	ents := extract(t, "custom_php_yii", fi("SiteController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "yii:auth") {
+		t.Error("expected yii:auth entity for Yii::$app->user usage (was dead before regex fix)")
 	}
 }

--- a/internal/custom/php/frameworks.go
+++ b/internal/custom/php/frameworks.go
@@ -229,7 +229,7 @@ var (
 		`(?m)\$middlewareQueue->add\s*\(\s*new\s+(\w+)`,
 	)
 	reCakePHPAuth = regexp.MustCompile(
-		`(?m)\b(?:AuthenticationService|AuthorizationService|$this->Authentication|$this->Authorization|isAuthenticated|isAuthorized)\b`,
+		`(?m)(?:\b(?:AuthenticationService|AuthorizationService|isAuthenticated|isAuthorized)\b|\$this->Authentication|\$this->Authorization)`,
 	)
 	reCakePHPValidation = regexp.MustCompile(
 		`(?m)\$validator->(?:notEmptyString|requirePresence|add|allowEmpty|notEmpty)\s*\(\s*['"]([^'"]+)['"]`,
@@ -773,7 +773,7 @@ var (
 		`(?m)class\s+(\w+)\s+implements\s+(?:MiddlewareInterface|BeforeMiddleware|AfterMiddleware)\b`,
 	)
 	rePhalconAuth = regexp.MustCompile(
-		`(?m)\b(?:Auth|Acl|Phalcon\\Acl|Phalcon\\Security|$this->auth)\b`,
+		`(?m)(?:\b(?:Auth|Acl|Phalcon\\Acl|Phalcon\\Security)\b|\$this->auth)`,
 	)
 	rePhalconValidation = regexp.MustCompile(
 		`(?m)class\s+(\w+)\s+extends\s+Validation\b`,
@@ -1081,7 +1081,7 @@ var (
 		`(?m)class\s+(\w+)\s+extends\s+ActionFilter\b`,
 	)
 	reYiiAuth = regexp.MustCompile(
-		`(?m)\b(?:Yii::app\(\)->user|Yii::$app->user|checkAccess|can\s*\(|AccessControl|HttpBearerAuth|QueryParamAuth)\b`,
+		`(?m)\b(?:Yii::app\(\)->user|Yii::\$app->user|checkAccess|can\s*\(|AccessControl|HttpBearerAuth|QueryParamAuth)\b`,
 	)
 	reYiiValidator = regexp.MustCompile(
 		`(?m)class\s+(\w+)\s+extends\s+Validator\b`,


### PR DESCRIPTION
## Audit findings

### BUG 1 — Three PHP framework auth regexes permanently dead (silent miss)

In Go raw string literals (backticks), `\$` does produce a literal dollar in the regexp engine — **but** these patterns were also wrapped inside a `\b(…)\b` word-boundary group. Since `$` is not a word character, `\b` immediately before `\$this` is **always false**, making those entire alternation branches dead.

| Regex | Dead branch | Symptom |
|---|---|---|
| `reCakePHPAuth` | `$this->Authentication` | CakePHP 4.x auth plugin calls silently skipped |
| `reCakePHPAuth` | `$this->Authorization` | Authorization checks silently skipped |
| `rePhalconAuth` | `$this->auth` | Phalcon controller auth guards silently skipped |
| `reYiiAuth` | `Yii::$app->user` | Most common Yii2 user-access pattern silently skipped |

**Fix:** Pull dollar-prefixed alternatives out of the word-boundary group into a separate non-boundary branch:
```go
// Before (broken):
`(?m)\b(?:WordTerm|$this->Authentication|…)\b`

// After (fixed):
`(?m)(?:\b(?:WordTerm|…)\b|\$this->Authentication|\$this->Authorization)`
```

**Regression tests added** (assert specific auth entity is emitted):
- `TestCakePHPAuthDollarThis` — `$this->Authentication->check()`
- `TestCakePHPAuthDollarThisAuthorization` — `$this->Authorization->can($user)`
- `TestPhalconAuthDollarThis` — `$this->auth->isLoggedIn()`
- `TestYiiAuthDollarApp` — `Yii::$app->user->isGuest`

### BUG 2 — `dead_code_detection` Substrate status inconsistent across PHP frameworks

Laravel had `partial` (2 cites) while all other 11 PHP frameworks had `full` (4 cites). The underlying pass is identical and framework-agnostic: `entry_points_php.go` uses `<?php` open-tag + public-function heuristics + lifecycle method name-matching — no per-framework semantic understanding. **Normalized all 12 PHP frameworks to `partial`** with the complete 4-cite set and a clarifying notes field.

Before/after:
```
lang.php.framework.cakephp:    full  → partial
lang.php.framework.codeigniter: full → partial
lang.php.framework.drupal:      full → partial
lang.php.framework.laminas:     full → partial
lang.php.framework.laravel:   partial (already correct, cites expanded)
lang.php.framework.lumen:       full → partial
lang.php.framework.magento:     full → partial
lang.php.framework.phalcon:     full → partial
lang.php.framework.slim:        full → partial
lang.php.framework.symfony:     full → partial
lang.php.framework.wordpress:   full → partial
lang.php.framework.yii:         full → partial
```

## Validation

```
go build ./internal/... ./tools/coverage/... ✓
go test ./internal/custom/php/... ./internal/types/ ./tools/coverage/... ✓ (4 new tests pass)
go run ./tools/coverage validate  exit 0 ✓
go run ./tools/coverage fmt --check ✓
go run ./tools/coverage gen (byte-stable) ✓
gofmt -l (empty on touched files) ✓
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>