### PR TITLE
fix(coverage/scala): replace vacuous routing tests with specific path/method assertions

### DIFF
--- a/internal/custom/scala/frameworks.go
+++ b/internal/custom/scala/frameworks.go
@@ -83,16 +83,27 @@ func (e *scalaFrameworksExtractor) Language() string { return "custom_scala_fram
 // ---------------------------------------------------------------------------
 
 var (
-	// Akka-HTTP / Pekko: path("segment") { get { ... } }
-	reAkkaRoute = regexp.MustCompile(
-		`(?m)\b(get|post|put|delete|patch|head|options)\s*\{`)
-
 	reAkkaPathDirective = regexp.MustCompile(
 		`\b(?:pathPrefix|path|pathEnd)\s*\(\s*"([^"]+)"`)
 
-	// http4s: case GET -> Root / "seg" => ...
+	// Akka-HTTP positional context: find positions of pathPrefix/path directives and
+	// HTTP method directives, then associate each method with nearest enclosing path context.
+	reAkkaFwPathPrefix = regexp.MustCompile(
+		`\bpathPrefix\s*\(\s*"([^"]+)"`)
+
+	reAkkaFwPathSeg = regexp.MustCompile(
+		`\bpath\s*\(\s*"([^"]+)"`)
+
+	reAkkaMethodDir = regexp.MustCompile(
+		`\b(get|post|put|delete|patch|head|options)\s*\{`)
+
+	// http4s: case GET -> Root / "seg1" / "seg2" => ...
+	// Captures: group1=method, then remainder is Root-path segments
 	reHttp4sRoute = regexp.MustCompile(
-		`\bcase\s+(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*->\s*Root\s*(?:/\s*"[^"]*"\s*)*`)
+		`\bcase\s+(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*->\s*Root((?:\s*/\s*"[^"]*")*)\s*=>`)
+
+	// http4s: extract each "segment" from a Root / "seg1" / "seg2" chain
+	reHttp4sPathSeg = regexp.MustCompile(`"([^"]+)"`)
 
 	// Scalatra: get("/path") { ... }
 	reScalatraRoute = regexp.MustCompile(
@@ -102,9 +113,13 @@ var (
 	reCaskRoute = regexp.MustCompile(
 		`@cask\.(get|post|put|delete|patch)\s*\(\s*"([^"]*)"`)
 
-	// ZIO-HTTP: Http.collect { case Method.GET -> Root / "seg" => ... }
+	// ZIO-HTTP: case Method.GET -> Root / "seg" => ...
+	// Captures: group1=method, group2=Root-path segments chain
 	reZioHTTPRoute = regexp.MustCompile(
-		`(?:Method\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)|Request\.(get|post))\s*->`)
+		`\bcase\s+Method\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*->\s*Root((?:\s*/\s*"[^"]*")*)\s*=>`)
+
+	// ZIO-HTTP: extract each "segment" from Root / "seg1" / "seg2"
+	reZioHTTPPathSeg = regexp.MustCompile(`"([^"]+)"`)
 
 	// Finatra: @Get("/path") or @Post("/path") annotations
 	reFinatraRoute = regexp.MustCompile(
@@ -338,14 +353,64 @@ func (e *scalaFrameworksExtractor) Extract(ctx context.Context, file extractor.F
 	// ---------------------------------------------------------------------------
 	switch framework {
 	case "akka-http", "pekko-http":
-		for _, m := range reAkkaRoute.FindAllStringSubmatchIndex(src, -1) {
-			method := src[m[2]:m[3]]
-			ent := makeEntity("route:"+method, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
-			setProps(&ent, "framework", framework, "http_method", strings.ToUpper(method), "provenance", "AKKA_HTTP_ROUTE_DSL")
-			add(ent)
+		// Positional combination: associate each HTTP method directive with the nearest
+		// preceding pathPrefix and path segment directives (within a 512-char window).
+		// This handles any number of method siblings inside the same path block.
+		type akkaPathPos struct {
+			pos int
+			val string
 		}
+		var prefixPositions []akkaPathPos
+		for _, m := range reAkkaFwPathPrefix.FindAllStringSubmatchIndex(src, -1) {
+			prefixPositions = append(prefixPositions, akkaPathPos{m[0], src[m[2]:m[3]]})
+		}
+		var segPositions []akkaPathPos
+		for _, m := range reAkkaFwPathSeg.FindAllStringSubmatchIndex(src, -1) {
+			segPositions = append(segPositions, akkaPathPos{m[0], src[m[2]:m[3]]})
+		}
+		nearestBefore := func(positions []akkaPathPos, pos int, window int) string {
+			best := ""
+			for _, p := range positions {
+				if p.pos < pos && pos-p.pos <= window {
+					best = p.val
+				}
+			}
+			return best
+		}
+
+		combinedPathSeen := make(map[string]bool)
+		combinedMethodSeen := make(map[string]bool)
+		const window = 512
+		for _, m := range reAkkaMethodDir.FindAllStringSubmatchIndex(src, -1) {
+			method := src[m[2]:m[3]]
+			upperMethod := strings.ToUpper(method)
+			seg := nearestBefore(segPositions, m[0], window)
+			prefix := nearestBefore(prefixPositions, m[0], window)
+			if seg != "" {
+				// Build combined path
+				var fullPath string
+				if prefix != "" {
+					fullPath = "/" + strings.Trim(prefix, "/") + "/" + strings.Trim(seg, "/")
+				} else {
+					fullPath = "/" + strings.Trim(seg, "/")
+				}
+				name := upperMethod + ":" + fullPath
+				combinedMethodSeen[upperMethod] = true
+				if prefix != "" {
+					combinedPathSeen[prefix] = true
+				}
+				combinedPathSeen[seg] = true
+				ent := makeEntity(name, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+				setProps(&ent, "framework", framework, "http_method", upperMethod, "http_path", fullPath, "provenance", "AKKA_HTTP_COMBINED_ROUTE")
+				add(ent)
+			}
+		}
+		// Emit individual path-directive entities not covered by combined (no associated methods)
 		for _, m := range reAkkaPathDirective.FindAllStringSubmatchIndex(src, -1) {
 			path := src[m[2]:m[3]]
+			if combinedPathSeen[path] {
+				continue
+			}
 			ent := makeEntity(path, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent, "framework", framework, "http_path", path, "provenance", "AKKA_HTTP_PATH_DIRECTIVE")
 			add(ent)
@@ -354,8 +419,22 @@ func (e *scalaFrameworksExtractor) Extract(ctx context.Context, file extractor.F
 	case "http4s":
 		for _, m := range reHttp4sRoute.FindAllStringSubmatchIndex(src, -1) {
 			method := src[m[2]:m[3]]
-			ent := makeEntity("route:"+method, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
-			setProps(&ent, "framework", "http4s", "http_method", method, "provenance", "HTTP4S_HTTPROUTES_DSL")
+			segChain := ""
+			if m[4] >= 0 {
+				segChain = src[m[4]:m[5]]
+			}
+			// Build path from Root / "seg1" / "seg2" ... chain
+			fullPath := "/"
+			for _, sm := range reHttp4sPathSeg.FindAllStringSubmatch(segChain, -1) {
+				fullPath += sm[1] + "/"
+			}
+			fullPath = strings.TrimRight(fullPath, "/")
+			if fullPath == "" {
+				fullPath = "/"
+			}
+			name := "route:" + method + ":" + fullPath
+			ent := makeEntity(name, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "http4s", "http_method", method, "http_path", fullPath, "provenance", "HTTP4S_HTTPROUTES_DSL")
 			add(ent)
 		}
 
@@ -382,14 +461,23 @@ func (e *scalaFrameworksExtractor) Extract(ctx context.Context, file extractor.F
 
 	case "zio-http":
 		for _, m := range reZioHTTPRoute.FindAllStringSubmatchIndex(src, -1) {
-			method := ""
-			if m[2] >= 0 {
-				method = src[m[2]:m[3]]
-			} else if m[4] >= 0 {
-				method = strings.ToUpper(src[m[4]:m[5]])
+			method := src[m[2]:m[3]]
+			segChain := ""
+			if m[4] >= 0 {
+				segChain = src[m[4]:m[5]]
 			}
-			ent := makeEntity("route:"+method, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
-			setProps(&ent, "framework", "zio-http", "http_method", method, "provenance", "ZIO_HTTP_ROUTE")
+			// Build path from Root / "seg1" / "seg2" ... chain
+			fullPath := "/"
+			for _, sm := range reZioHTTPPathSeg.FindAllStringSubmatch(segChain, -1) {
+				fullPath += sm[1] + "/"
+			}
+			fullPath = strings.TrimRight(fullPath, "/")
+			if fullPath == "" {
+				fullPath = "/"
+			}
+			name := "route:" + method + ":" + fullPath
+			ent := makeEntity(name, "SCOPE.Operation", "http_route", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "zio-http", "http_method", method, "http_path", fullPath, "provenance", "ZIO_HTTP_ROUTE")
 			add(ent)
 		}
 

--- a/internal/custom/scala/frameworks_test.go
+++ b/internal/custom/scala/frameworks_test.go
@@ -5,7 +5,42 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Framework extractor tests
+// Framework routing tests — specific path+method assertions.
+//
+// Each test asserts exact entity names the extractor actually produces for the
+// given fixture.  A vacuous "≥1 http_route exists" check is NOT sufficient to
+// prove the extractor correctly parses the DSL.
+// ---------------------------------------------------------------------------
+
+// containsRouteEntity checks that entities contain an http_route (or lagom_service_call)
+// with the given exact Name.
+func containsRouteEntity(ents []entitySummary, subtype, name string) bool {
+	for _, e := range ents {
+		if e.Subtype == subtype && e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// dumpEntities formats entities for diagnostic failure messages.
+func dumpEntities(ents []entitySummary) string {
+	out := ""
+	for _, e := range ents {
+		out += "\n  {Kind:" + e.Kind + " Subtype:" + e.Subtype + " Name:" + e.Name + "}"
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Akka-HTTP
+//
+// Fixture: pathPrefix("api") { path("users") { get { ... } ~ post { ... } } }
+//
+// The extractor uses positional context (nearest preceding pathPrefix + path)
+// to combine nested directives.  Both methods produce fully combined entities:
+//   GET:/api/users
+//   POST:/api/users
 // ---------------------------------------------------------------------------
 
 func TestFrameworksAkkaHttpRoute(t *testing.T) {
@@ -20,17 +55,27 @@ val route =
   }
 `
 	ents := extract(t, "custom_scala_frameworks", fi("UserRoutes.scala", "scala", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
-			found = true
-			break
-		}
+	got := dumpEntities(ents)
+	if !containsRouteEntity(ents, "http_route", "GET:/api/users") {
+		t.Errorf("expected http_route GET:/api/users from akka-http; got:%s", got)
 	}
-	if !found {
-		t.Error("expected at least one http_route entity from akka-http")
+	if !containsRouteEntity(ents, "http_route", "POST:/api/users") {
+		t.Errorf("expected http_route POST:/api/users from akka-http; got:%s", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// http4s
+//
+// Fixture: HttpRoutes.of[IO] {
+//   case GET  -> Root / "health" => Ok("ok")
+//   case POST -> Root / "users"  => Ok("created")
+// }
+//
+// The extractor parses method + Root path-segment chain, producing:
+//   route:GET:/health
+//   route:POST:/users
+// ---------------------------------------------------------------------------
 
 func TestFrameworksHttp4sRoute(t *testing.T) {
 	src := `
@@ -42,17 +87,24 @@ val routes = HttpRoutes.of[IO] {
 }
 `
 	ents := extract(t, "custom_scala_frameworks", fi("Routes.scala", "scala", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
-			found = true
-			break
-		}
+	got := dumpEntities(ents)
+	if !containsRouteEntity(ents, "http_route", "route:GET:/health") {
+		t.Errorf("expected http_route route:GET:/health from http4s; got:%s", got)
 	}
-	if !found {
-		t.Error("expected at least one http_route entity from http4s")
+	if !containsRouteEntity(ents, "http_route", "route:POST:/users") {
+		t.Errorf("expected http_route route:POST:/users from http4s; got:%s", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Scalatra
+//
+// Fixture: get("/users") { ... }  /  post("/users") { ... }
+//
+// The extractor produces method:path combined names:
+//   get:/users
+//   post:/users
+// ---------------------------------------------------------------------------
 
 func TestFrameworksScalatraRoute(t *testing.T) {
 	src := `
@@ -63,17 +115,24 @@ class UserServlet extends ScalatraServlet {
 }
 `
 	ents := extract(t, "custom_scala_frameworks", fi("UserServlet.scala", "scala", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
-			found = true
-			break
-		}
+	got := dumpEntities(ents)
+	if !containsRouteEntity(ents, "http_route", "get:/users") {
+		t.Errorf("expected http_route get:/users from scalatra; got:%s", got)
 	}
-	if !found {
-		t.Error("expected at least one http_route entity from scalatra")
+	if !containsRouteEntity(ents, "http_route", "post:/users") {
+		t.Errorf("expected http_route post:/users from scalatra; got:%s", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Cask
+//
+// Fixture: @cask.get("/api/users") / @cask.post("/api/users") annotations
+//
+// The extractor reads method + path from annotations:
+//   get:/api/users
+//   post:/api/users
+// ---------------------------------------------------------------------------
 
 func TestFrameworksCaskRoute(t *testing.T) {
 	src := `
@@ -86,17 +145,24 @@ object Main extends cask.MainRoutes {
 }
 `
 	ents := extract(t, "custom_scala_frameworks", fi("Main.scala", "scala", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
-			found = true
-			break
-		}
+	got := dumpEntities(ents)
+	if !containsRouteEntity(ents, "http_route", "get:/api/users") {
+		t.Errorf("expected http_route get:/api/users from cask; got:%s", got)
 	}
-	if !found {
-		t.Error("expected at least one http_route entity from cask")
+	if !containsRouteEntity(ents, "http_route", "post:/api/users") {
+		t.Errorf("expected http_route post:/api/users from cask; got:%s", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Finatra
+//
+// Fixture: @Get("/api/users") / @Post("/api/users") Java-style annotations
+//
+// The extractor reads the annotation method + path (preserving original case):
+//   Get:/api/users
+//   Post:/api/users
+// ---------------------------------------------------------------------------
 
 func TestFrameworksFinatraRoute(t *testing.T) {
 	src := `
@@ -109,17 +175,24 @@ class UserController extends HttpController {
 }
 `
 	ents := extract(t, "custom_scala_frameworks", fi("UserController.scala", "scala", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
-			found = true
-			break
-		}
+	got := dumpEntities(ents)
+	if !containsRouteEntity(ents, "http_route", "Get:/api/users") {
+		t.Errorf("expected http_route Get:/api/users from finatra; got:%s", got)
 	}
-	if !found {
-		t.Error("expected at least one http_route entity from finatra")
+	if !containsRouteEntity(ents, "http_route", "Post:/api/users") {
+		t.Errorf("expected http_route Post:/api/users from finatra; got:%s", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Lagom
+//
+// Fixture: pathCall("/api/users/:id", getUser _) / namedCall("/api/users", createUser _)
+//
+// The extractor produces lagom_service_call entities (subtype differs from http_route):
+//   lagom:/api/users/:id
+//   lagom:/api/users
+// ---------------------------------------------------------------------------
 
 func TestFrameworksLagomServiceCall(t *testing.T) {
 	src := `
@@ -136,17 +209,28 @@ trait UserService extends Service {
 }
 `
 	ents := extract(t, "custom_scala_frameworks", fi("UserService.scala", "scala", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "lagom_service_call" {
-			found = true
-			break
-		}
+	got := dumpEntities(ents)
+	if !containsRouteEntity(ents, "lagom_service_call", "lagom:/api/users/:id") {
+		t.Errorf("expected lagom_service_call lagom:/api/users/:id from lagom; got:%s", got)
 	}
-	if !found {
-		t.Error("expected at least one lagom_service_call entity")
+	if !containsRouteEntity(ents, "lagom_service_call", "lagom:/api/users") {
+		t.Errorf("expected lagom_service_call lagom:/api/users from lagom; got:%s", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Play
+//
+// Fixture: standard conf/routes file
+//   GET  /users       controllers.UserController.list
+//   POST /users       controllers.UserController.create
+//   GET  /users/:id   controllers.UserController.get(id: Long)
+//
+// The extractor reads method:path pairs:
+//   GET:/users
+//   POST:/users
+//   GET:/users/:id
+// ---------------------------------------------------------------------------
 
 func TestFrameworksPlayRoute(t *testing.T) {
 	src := `GET     /users                  controllers.UserController.list
@@ -154,17 +238,21 @@ POST    /users                  controllers.UserController.create
 GET     /users/:id              controllers.UserController.get(id: Long)
 `
 	ents := extract(t, "custom_scala_frameworks", fi("routes", "scala", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
-			found = true
-			break
-		}
+	got := dumpEntities(ents)
+	if !containsRouteEntity(ents, "http_route", "GET:/users") {
+		t.Errorf("expected http_route GET:/users from play; got:%s", got)
 	}
-	if !found {
-		t.Error("expected at least one http_route entity from play routes file")
+	if !containsRouteEntity(ents, "http_route", "POST:/users") {
+		t.Errorf("expected http_route POST:/users from play; got:%s", got)
+	}
+	if !containsRouteEntity(ents, "http_route", "GET:/users/:id") {
+		t.Errorf("expected http_route GET:/users/:id from play; got:%s", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Observability tests (unchanged — not routing)
+// ---------------------------------------------------------------------------
 
 func TestFrameworksObservabilityLogging(t *testing.T) {
 	src := `
@@ -236,6 +324,19 @@ class UserServiceSpec extends AnyFlatSpec {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// ZIO-HTTP
+//
+// Fixture: Http.collect[Request] {
+//   case Method.GET  -> Root / "users" => Response.text("users")
+//   case Method.POST -> Root / "users" => Response.ok
+// }
+//
+// The extractor parses method + Root path-segment chain, producing:
+//   route:GET:/users
+//   route:POST:/users
+// ---------------------------------------------------------------------------
+
 func TestFrameworksZioHttpRoute(t *testing.T) {
 	src := `
 import zio._
@@ -246,15 +347,12 @@ val app = Http.collect[Request] {
 }
 `
 	ents := extract(t, "custom_scala_frameworks", fi("App.scala", "scala", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "http_route" {
-			found = true
-			break
-		}
+	got := dumpEntities(ents)
+	if !containsRouteEntity(ents, "http_route", "route:GET:/users") {
+		t.Errorf("expected http_route route:GET:/users from zio-http; got:%s", got)
 	}
-	if !found {
-		t.Error("expected at least one http_route entity from zio-http")
+	if !containsRouteEntity(ents, "http_route", "route:POST:/users") {
+		t.Errorf("expected http_route route:POST:/users from zio-http; got:%s", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

All 8 Scala framework routing tests were vacuous: they only checked that **at least one `http_route` entity existed**. A completely wrong extractor could emit a garbage entity and still pass.

Audit also found **akka-http** emitted separate `route:get` / `api` / `users` entities — never combining `pathPrefix("api") { path("users") { get } }` into `/api/users`. Similarly, **http4s** and **zio-http** only extracted the HTTP method, not the path segments from `Root / "health"`.

## Extractor changes (`frameworks.go`)

| Framework | Before | After |
|---|---|---|
| akka-http | `route:get` + separate `api`, `users` path entities | `GET:/api/users`, `POST:/api/users` via positional-context combiner (nearest preceding `pathPrefix`+`path` within 512-char window) |
| http4s | `route:GET` (method only) | `route:GET:/health`, `route:POST:/users` (Root/seg chain parsed) |
| zio-http | `route:GET` (method only) | `route:GET:/users`, `route:POST:/users` (Root/seg chain parsed) |
| scalatra / cask / finatra / play / lagom | Already correct | No change needed |

## Test changes (`frameworks_test.go`)

Each of the 8 routing tests now asserts **specific entity names** that prove the extractor correctly parsed the DSL:

- **akka-http**: `GET:/api/users`, `POST:/api/users`
- **http4s**: `route:GET:/health`, `route:POST:/users`
- **scalatra**: `get:/users`, `post:/users`
- **cask**: `get:/api/users`, `post:/api/users`
- **finatra**: `Get:/api/users`, `Post:/api/users`
- **lagom**: `lagom:/api/users/:id`, `lagom:/api/users` (subtype `lagom_service_call`)
- **play**: `GET:/users`, `POST:/users`, `GET:/users/:id`
- **zio-http**: `route:GET:/users`, `route:POST:/users`

## Honesty / coverage status

No cells were downgraded. All 8 frameworks now produce correct full path+method output that honestly justifies `partial` `route_extraction` status. The extractor is still regex-based and file-local (no cross-file wiring), so `partial` remains accurate.

## Validation

```
go build ./internal/... ./tools/coverage/...          ✓
go test ./internal/custom/scala/... ./internal/types/ ./tools/coverage/...  ✓ (all pass)
go run ./tools/coverage validate                      exit 0
go run ./tools/coverage fmt --check                   ok: canonical
gofmt -l <touched files>                              (empty)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>