### PR TITLE
coverage(python): verify + finish flagship partials to TS/JS bar

### DIFF
--- a/docs/coverage/detail/lang.python.framework.celery.md
+++ b/docs/coverage/detail/lang.python.framework.celery.md
@@ -41,7 +41,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/pytest.go` | pytest.go extracts test functions and fixtures; coverage is partial because Celery-task test helpers are not directly linked |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/python/pytest.go` | pytest.go extracts test functions (test_*), test classes (Test*), pytest fixtures (@pytest.fixture with scope/autouse), parametrize marks, and conftest.py fixtures. These cover all generic Python tests including Celery task tests written with pytest. Partial because: Celery-specific test helpers (pytest-celery, celery.contrib.pytest app fixture, task.apply() / task.delay() calls within test bodies) are not specifically linked back to the Celery task entity via TESTS edges — test functions and Celery task entities are both emitted but the TESTS edge between them is not synthesised. Tests: TestPytest_TestFunction, TestPytest_Fixture. |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.python.framework.django-drf.md
+++ b/docs/coverage/detail/lang.python.framework.django-drf.md
@@ -29,14 +29,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/python/drf_serializer_fields.go`<br>`internal/extractors/python/drf_serializer_fields_test.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/extractors/python/django_drf_permissions.go`<br>`internal/extractors/python/django_drf_permissions_test.go` | — |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/python/django.go`<br>`internal/extractors/python/drf_serializer_fields.go` | django.go emits DRF ModelSerializer/Serializer/HyperlinkedModelSerializer class entities. drf_serializer_fields.go emits REFERENCES edges from PrimaryKeyRelatedField/NestedSerializer/source= fields. Partial because: SerializerMethodField return-type inference is not done; writable vs read-only field distinction not captured; custom Field subclasses not tracked. Tests: TestDjango_DRFSerializer, drf_serializer_fields_test.go. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/python/http_reqresp_generic.go`<br>`internal/extractors/python/drf_serializer_fields.go` | http_reqresp_generic.go detects DRF request.data, .validated_data, serializer.is_valid() in CBV/APIView post/put/patch handler bodies. drf_serializer_fields.go emits REFERENCES edges from serializer fields to model entities. Tests: TestGHR_DRF_RequestData, TestGHR_DRF_ValidatedData cover the validation evidence chain. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/engine/django_imports_rewrite.go` | Django middleware import rewriting provides partial coverage; DRF-specific middleware detection not yet implemented |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/engine/django_imports_rewrite.go` | Django import rewriting provides coverage for stock Django middleware (SecurityMiddleware, SessionMiddleware etc.) via class-name rewriting. Partial because: DRF DEFAULT_AUTHENTICATION_CLASSES / DEFAULT_THROTTLE_CLASSES in settings.py are not parsed; custom DRF middleware (BaseAuthentication subclasses used as middleware) is not detected; no MIDDLEWARE_CLASSES list parsing. DRF has no dedicated middleware extractor. |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
-| Metric extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
-| Trace extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of stdlib logging (logging.getLogger + call sites), loguru (from loguru import logger + bind/opt/contextualize), and structlog (structlog.get_logger + structlog.configure). Emits SCOPE.Pattern/logger + SCOPE.Pattern/log_statement entities per file. Partial by design: no cross-file dataflow — a logger declared in utils.py and used in views.py produces entities only in the file where the call site lives. Tests: TestObservability_StdlibLogging, TestObservability_Loguru, TestObservability_Structlog, TestObservability_FixtureLogging. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of prometheus_client (Counter/Gauge/Histogram/Summary construction + push_to_gateway), statsd (incr/decr/gauge/timing/histogram calls), and datadog DogStatsd (increment/gauge/histogram/timing). Emits SCOPE.Pattern/metric entities with metric_type and metric_name properties. Partial by design: no cross-file dataflow; prometheus_client REGISTRY custom collector classes not detected; StatsD pipelines not followed. Tests: TestObservability_PrometheusClient, TestObservability_Statsd, TestObservability_Datadog, TestObservability_FixtureMetrics. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of OpenTelemetry (tracer.start_as_current_span decorator + context-manager + start_span), ddtrace (@tracer.wrap decorator + tracer.trace context-manager), and jaeger_client (Config(service_name=) + tracer.start_span). Emits SCOPE.Pattern/trace_span entities with span_name, span_kind, and library properties. Partial by design: no cross-file dataflow; OTel Resource/TracerProvider setup not tracked; auto-instrumentation via opentelemetry-instrument not detected. Tests: TestObservability_OpenTelemetry, TestObservability_DDTrace, TestObservability_JaegerClient, TestObservability_FixtureTracing. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.django.md
+++ b/docs/coverage/detail/lang.python.framework.django.md
@@ -29,14 +29,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/django.go` | Django admin registrations (admin.site.register, @admin.register) and form patterns; full form field introspection not yet implemented |
-| Request validation | 🟢 `partial` | `2026-05-29` | 3185 | `internal/custom/python/django.go`<br>`internal/custom/python/http_reqresp_generic.go` | Django Form.is_valid() + cleaned_data patterns in FBV/CBV handlers; DRF request.data/.validated_data/.is_valid() patterns detected via generic HTTP extractor. |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/python/django.go`<br>`internal/custom/python/http_reqresp_generic.go` | django.go emits DRF Serializer/ModelSerializer class entities and Form/ModelForm admin class entities. http_reqresp_generic.go emits djangoFormClassRe-matched Form/ModelForm classes as request_dto entities. Partial because: individual form field types (CharField, IntegerField) are not introspected per-field; FormSet is not detected; inline forms not handled. Tests: TestDjango_DRFSerializer, TestGHR_Django_FormIsValid, TestGHR_Django_ModelForm. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/python/http_reqresp_generic.go` | http_reqresp_generic.go: djangoIsValidRe detects form.is_valid() calls, djangoCleanedDataRe detects .cleaned_data access, drfRequestDataRe detects request.data/.query_params/.FILES, drfValidatedDataRe detects serializer.validated_data, drfIsValidRe detects serializer.is_valid() — all in Django FBV/CBV handler bodies. Tests: TestGHR_Django_FormIsValid, TestGHR_Django_CleanedData, TestGHR_DRF_RequestData, TestGHR_DRF_ValidatedData. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/python/django.go` | Middleware class and process_request/process_response/process_view hooks extracted; MIDDLEWARE setting list analysis not yet implemented |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/python/django.go` | django.go extracts *Middleware class definitions (djangoMiddlewareClassRe) + process_request/process_response/process_view/process_exception hook methods. Partial because: Django MIDDLEWARE settings list (settings.py list of dotted paths) is not parsed; new-style __call__-based middleware is detected via class name but __call__ method is not specifically emitted; mixin-based middleware (MiddlewareMixin subclass) is covered. Test: TestDjango_Middleware. |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
-| Metric extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
-| Trace extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of stdlib logging (logging.getLogger + call sites), loguru (from loguru import logger + bind/opt/contextualize), and structlog (structlog.get_logger + structlog.configure). Emits SCOPE.Pattern/logger + SCOPE.Pattern/log_statement entities per file. Partial by design: no cross-file dataflow — a logger declared in utils.py and used in views.py produces entities only in the file where the call site lives. Tests: TestObservability_StdlibLogging, TestObservability_Loguru, TestObservability_Structlog, TestObservability_FixtureLogging. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of prometheus_client (Counter/Gauge/Histogram/Summary construction + push_to_gateway), statsd (incr/decr/gauge/timing/histogram calls), and datadog DogStatsd (increment/gauge/histogram/timing). Emits SCOPE.Pattern/metric entities with metric_type and metric_name properties. Partial by design: no cross-file dataflow; prometheus_client REGISTRY custom collector classes not detected; StatsD pipelines not followed. Tests: TestObservability_PrometheusClient, TestObservability_Statsd, TestObservability_Datadog, TestObservability_FixtureMetrics. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of OpenTelemetry (tracer.start_as_current_span decorator + context-manager + start_span), ddtrace (@tracer.wrap decorator + tracer.trace context-manager), and jaeger_client (Config(service_name=) + tracer.start_span). Emits SCOPE.Pattern/trace_span entities with span_name, span_kind, and library properties. Partial by design: no cross-file dataflow; OTel Resource/TracerProvider setup not tracked; auto-instrumentation via opentelemetry-instrument not detected. Tests: TestObservability_OpenTelemetry, TestObservability_DDTrace, TestObservability_JaegerClient, TestObservability_FixtureTracing. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.fastapi.md
+++ b/docs/coverage/detail/lang.python.framework.fastapi.md
@@ -29,14 +29,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/fastapi_reqresp.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/fastapi.go`<br>`internal/custom/python/fastapi_reqresp.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/python/fastapi.go`<br>`internal/custom/python/fastapi_reqresp.go` | fastapi_reqresp.go extracts Pydantic BaseModel body params (ACCEPTS_INPUT), response_model= kwarg (RETURNS), and return type annotations for all FastAPI route decorators; fastapi.go extracts APIRouter, Depends(), and per-route metadata. Fixture test TestFastAPIReqResp_FullFixture proves CreateOrderRequest/UpdateOrderRequest body params + OrderResponse response_model and annotation returns. Pydantic v1/v2 unwrapping via unwrapType. Depends/Query/Path injection tokens skipped. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/python/fastapi.go`<br>`internal/custom/python/fastapi_reqresp.go`<br>`internal/custom/python/http_reqresp_generic.go` | fastapi.go extracts Depends() injection tokens (dependency-injection as validation). fastapi_reqresp.go extracts Pydantic body-parameter type annotations (ACCEPTS_INPUT) proving request validation at the type level. http_reqresp_generic.go handles pydantic model_validate/parse_obj/from_orm calls in handler bodies. Tests: TestFastAPI_Depends, TestFastAPIReqResp_AcceptsInput, TestFastAPIReqResp_FullFixture. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/python/fastapi.go` | — |
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/python/fastapi.go`<br>`internal/custom/python/http_middleware.go` | @app.middleware('http') decorator extracted by fastapi.go (faMiddlewareRe); app.add_middleware(Cls, ...) extracted via starletteAddMiddlewareRe in http_middleware.go for Starlette/FastAPI. Tests: TestFastAPI_Middleware (decorator form), TestFastAPI_FullFixture_Middleware (fixture). Covers both ASGI middleware registration patterns used in FastAPI. |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
-| Metric extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
-| Trace extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of stdlib logging (logging.getLogger + call sites), loguru (from loguru import logger + bind/opt/contextualize), and structlog (structlog.get_logger + structlog.configure). Emits SCOPE.Pattern/logger + SCOPE.Pattern/log_statement entities per file. Partial by design: no cross-file dataflow — a logger declared in utils.py and used in views.py produces entities only in the file where the call site lives. Tests: TestObservability_StdlibLogging, TestObservability_Loguru, TestObservability_Structlog, TestObservability_FixtureLogging. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of prometheus_client (Counter/Gauge/Histogram/Summary construction + push_to_gateway), statsd (incr/decr/gauge/timing/histogram calls), and datadog DogStatsd (increment/gauge/histogram/timing). Emits SCOPE.Pattern/metric entities with metric_type and metric_name properties. Partial by design: no cross-file dataflow; prometheus_client REGISTRY custom collector classes not detected; StatsD pipelines not followed. Tests: TestObservability_PrometheusClient, TestObservability_Statsd, TestObservability_Datadog, TestObservability_FixtureMetrics. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of OpenTelemetry (tracer.start_as_current_span decorator + context-manager + start_span), ddtrace (@tracer.wrap decorator + tracer.trace context-manager), and jaeger_client (Config(service_name=) + tracer.start_span). Emits SCOPE.Pattern/trace_span entities with span_name, span_kind, and library properties. Partial by design: no cross-file dataflow; OTel Resource/TracerProvider setup not tracked; auto-instrumentation via opentelemetry-instrument not detected. Tests: TestObservability_OpenTelemetry, TestObservability_DDTrace, TestObservability_JaegerClient, TestObservability_FixtureTracing. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.python.framework.flask.md
+++ b/docs/coverage/detail/lang.python.framework.flask.md
@@ -29,14 +29,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/flask_reqresp.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-29` | backfill:dictionary-completeness | `internal/custom/python/flask.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/python/flask.go`<br>`internal/custom/python/flask_reqresp.go` | flask_reqresp.go extracts marshmallow Schema.load() call sites in route handler bodies (ACCEPTS_INPUT), and return type annotations (RETURNS). flask.go emits FlaskForm/class entities as schema-level DTOs. canonicalSchemaName converts snake_case schema vars to PascalCase. Tests: TestFlaskReqResp_SchemaLoad, TestFlaskReqResp_Returns, TestFlaskReqResp_PascalCaseSchema, TestFlask_FlaskForm. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/python/flask.go`<br>`internal/custom/python/flask_reqresp.go`<br>`internal/custom/python/http_reqresp_generic.go` | flask_reqresp.go detects marshmallow schema.load() in handler bodies as ACCEPTS_INPUT evidence. flask.go emits before_request hooks (lifecycle gates). http_reqresp_generic.go detects Pydantic model_validate/parse_obj calls and marshmallow load in Flask handlers. Partial because: Flask-WTF form.validate_on_submit() is not explicitly detected; request.json/request.form.get() raw access patterns are not tracked; no Flask-RESTX/flask-smorest RequestParser body validation. Tests: TestFlaskReqResp_SchemaLoad, TestGHR_Marshmallow_SchemaLoad. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-29` | — | `internal/custom/python/flask.go` | — |
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/python/flask.go` | flask.go extracts @app.before_request / @app.after_request / @app.teardown_request / @bp.before_app_request decorators as request_hook pattern entities — these ARE Flask's middleware mechanism (no traditional middleware class in Flask; hooks are the canonical approach). Test: TestFlask_RequestHook proves before_request hook extraction with hook_type property. |
 
 ### Type System
 
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
-| Metric extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
-| Trace extraction | 🟢 `partial` | — | 3063 | `internal/custom/python/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of stdlib logging (logging.getLogger + call sites), loguru (from loguru import logger + bind/opt/contextualize), and structlog (structlog.get_logger + structlog.configure). Emits SCOPE.Pattern/logger + SCOPE.Pattern/log_statement entities per file. Partial by design: no cross-file dataflow — a logger declared in utils.py and used in views.py produces entities only in the file where the call site lives. Tests: TestObservability_StdlibLogging, TestObservability_Loguru, TestObservability_Structlog, TestObservability_FixtureLogging. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of prometheus_client (Counter/Gauge/Histogram/Summary construction + push_to_gateway), statsd (incr/decr/gauge/timing/histogram calls), and datadog DogStatsd (increment/gauge/histogram/timing). Emits SCOPE.Pattern/metric entities with metric_type and metric_name properties. Partial by design: no cross-file dataflow; prometheus_client REGISTRY custom collector classes not detected; StatsD pipelines not followed. Tests: TestObservability_PrometheusClient, TestObservability_Statsd, TestObservability_Datadog, TestObservability_FixtureMetrics. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | 3063 | `internal/custom/python/observability.go` | observability.go: import-heuristic detection of OpenTelemetry (tracer.start_as_current_span decorator + context-manager + start_span), ddtrace (@tracer.wrap decorator + tracer.trace context-manager), and jaeger_client (Config(service_name=) + tracer.start_span). Emits SCOPE.Pattern/trace_span entities with span_name, span_kind, and library properties. Partial by design: no cross-file dataflow; OTel Resource/TracerProvider setup not tracked; auto-instrumentation via opentelemetry-instrument not detected. Tests: TestObservability_OpenTelemetry, TestObservability_DDTrace, TestObservability_JaegerClient, TestObservability_FixtureTracing. |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -37441,8 +37441,8 @@
             "status": "partial",
             "cites": ["internal/custom/python/pytest.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "pytest.go extracts test functions and fixtures; coverage is partial because Celery-task test helpers are not directly linked",
-            "verified_at": "2026-05-29"
+            "notes": "pytest.go extracts test functions (test_*), test classes (Test*), pytest fixtures (@pytest.fixture with scope/autouse), parametrize marks, and conftest.py fixtures. These cover all generic Python tests including Celery task tests written with pytest. Partial because: Celery-specific test helpers (pytest-celery, celery.contrib.pytest app fixture, task.apply() / task.delay() calls within test bodies) are not specifically linked back to the Celery task entity via TESTS edges — test functions and Celery task entities are both emitted but the TESTS edge between them is not synthesised. Tests: TestPytest_TestFunction, TestPytest_Fixture.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -37858,25 +37858,24 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/python/django.go"],
+            "cites": ["internal/custom/python/django.go","internal/custom/python/http_reqresp_generic.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Django admin registrations (admin.site.register, @admin.register) and form patterns; full form field introspection not yet implemented",
-            "verified_at": "2026-05-29"
+            "notes": "django.go emits DRF Serializer/ModelSerializer class entities and Form/ModelForm admin class entities. http_reqresp_generic.go emits djangoFormClassRe-matched Form/ModelForm classes as request_dto entities. Partial because: individual form field types (CharField, IntegerField) are not introspected per-field; FormSet is not detected; inline forms not handled. Tests: TestDjango_DRFSerializer, TestGHR_Django_FormIsValid, TestGHR_Django_ModelForm.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/python/django.go","internal/custom/python/http_reqresp_generic.go"],
-            "issue": "3185",
-            "notes": "Django Form.is_valid() + cleaned_data patterns in FBV/CBV handlers; DRF request.data/.validated_data/.is_valid() patterns detected via generic HTTP extractor.",
-            "verified_at": "2026-05-29"
+            "status": "full",
+            "cites": ["internal/custom/python/http_reqresp_generic.go"],
+            "notes": "http_reqresp_generic.go: djangoIsValidRe detects form.is_valid() calls, djangoCleanedDataRe detects .cleaned_data access, drfRequestDataRe detects request.data/.query_params/.FILES, drfValidatedDataRe detects serializer.validated_data, drfIsValidRe detects serializer.is_valid() — all in Django FBV/CBV handler bodies. Tests: TestGHR_Django_FormIsValid, TestGHR_Django_CleanedData, TestGHR_DRF_RequestData, TestGHR_DRF_ValidatedData.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
             "cites": ["internal/custom/python/django.go"],
-            "notes": "Middleware class and process_request/process_response/process_view hooks extracted; MIDDLEWARE setting list analysis not yet implemented",
-            "verified_at": "2026-05-29"
+            "notes": "django.go extracts *Middleware class definitions (djangoMiddlewareClassRe) + process_request/process_response/process_view/process_exception hook methods. Partial because: Django MIDDLEWARE settings list (settings.py list of dotted paths) is not parsed; new-style __call__-based middleware is detected via class name but __call__ method is not specifically emitted; mixin-based middleware (MiddlewareMixin subclass) is covered. Test: TestDjango_Middleware.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -37918,17 +37917,23 @@
           "log_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of stdlib logging (logging.getLogger + call sites), loguru (from loguru import logger + bind/opt/contextualize), and structlog (structlog.get_logger + structlog.configure). Emits SCOPE.Pattern/logger + SCOPE.Pattern/log_statement entities per file. Partial by design: no cross-file dataflow — a logger declared in utils.py and used in views.py produces entities only in the file where the call site lives. Tests: TestObservability_StdlibLogging, TestObservability_Loguru, TestObservability_Structlog, TestObservability_FixtureLogging.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of prometheus_client (Counter/Gauge/Histogram/Summary construction + push_to_gateway), statsd (incr/decr/gauge/timing/histogram calls), and datadog DogStatsd (increment/gauge/histogram/timing). Emits SCOPE.Pattern/metric entities with metric_type and metric_name properties. Partial by design: no cross-file dataflow; prometheus_client REGISTRY custom collector classes not detected; StatsD pipelines not followed. Tests: TestObservability_PrometheusClient, TestObservability_Statsd, TestObservability_Datadog, TestObservability_FixtureMetrics.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of OpenTelemetry (tracer.start_as_current_span decorator + context-manager + start_span), ddtrace (@tracer.wrap decorator + tracer.trace context-manager), and jaeger_client (Config(service_name=) + tracer.start_span). Emits SCOPE.Pattern/trace_span entities with span_name, span_kind, and library properties. Partial by design: no cross-file dataflow; OTel Resource/TracerProvider setup not tracked; auto-instrumentation via opentelemetry-instrument not detected. Tests: TestObservability_OpenTelemetry, TestObservability_DDTrace, TestObservability_JaegerClient, TestObservability_FixtureTracing.",
+            "verified_at": "2026-05-30"
           }
         },
         "Data": {
@@ -38093,23 +38098,24 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/extractors/python/drf_serializer_fields.go","internal/extractors/python/drf_serializer_fields_test.go"],
+            "cites": ["internal/custom/python/django.go","internal/extractors/python/drf_serializer_fields.go"],
             "issue": "backfill:dictionary-completeness",
-            "verified_at": "2026-05-29"
+            "notes": "django.go emits DRF ModelSerializer/Serializer/HyperlinkedModelSerializer class entities. drf_serializer_fields.go emits REFERENCES edges from PrimaryKeyRelatedField/NestedSerializer/source= fields. Partial because: SerializerMethodField return-type inference is not done; writable vs read-only field distinction not captured; custom Field subclasses not tracked. Tests: TestDjango_DRFSerializer, drf_serializer_fields_test.go.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/extractors/python/django_drf_permissions.go","internal/extractors/python/django_drf_permissions_test.go"],
-            "issue": "backfill:dictionary-completeness",
-            "verified_at": "2026-05-29"
+            "status": "full",
+            "cites": ["internal/custom/python/http_reqresp_generic.go","internal/extractors/python/drf_serializer_fields.go"],
+            "notes": "http_reqresp_generic.go detects DRF request.data, .validated_data, serializer.is_valid() in CBV/APIView post/put/patch handler bodies. drf_serializer_fields.go emits REFERENCES edges from serializer fields to model entities. Tests: TestGHR_DRF_RequestData, TestGHR_DRF_ValidatedData cover the validation evidence chain.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
             "cites": ["internal/engine/django_imports_rewrite.go"],
-            "notes": "Django middleware import rewriting provides partial coverage; DRF-specific middleware detection not yet implemented",
-            "verified_at": "2026-05-29"
+            "notes": "Django import rewriting provides coverage for stock Django middleware (SecurityMiddleware, SessionMiddleware etc.) via class-name rewriting. Partial because: DRF DEFAULT_AUTHENTICATION_CLASSES / DEFAULT_THROTTLE_CLASSES in settings.py are not parsed; custom DRF middleware (BaseAuthentication subclasses used as middleware) is not detected; no MIDDLEWARE_CLASSES list parsing. DRF has no dedicated middleware extractor.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -38151,17 +38157,23 @@
           "log_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of stdlib logging (logging.getLogger + call sites), loguru (from loguru import logger + bind/opt/contextualize), and structlog (structlog.get_logger + structlog.configure). Emits SCOPE.Pattern/logger + SCOPE.Pattern/log_statement entities per file. Partial by design: no cross-file dataflow — a logger declared in utils.py and used in views.py produces entities only in the file where the call site lives. Tests: TestObservability_StdlibLogging, TestObservability_Loguru, TestObservability_Structlog, TestObservability_FixtureLogging.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of prometheus_client (Counter/Gauge/Histogram/Summary construction + push_to_gateway), statsd (incr/decr/gauge/timing/histogram calls), and datadog DogStatsd (increment/gauge/histogram/timing). Emits SCOPE.Pattern/metric entities with metric_type and metric_name properties. Partial by design: no cross-file dataflow; prometheus_client REGISTRY custom collector classes not detected; StatsD pipelines not followed. Tests: TestObservability_PrometheusClient, TestObservability_Statsd, TestObservability_Datadog, TestObservability_FixtureMetrics.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of OpenTelemetry (tracer.start_as_current_span decorator + context-manager + start_span), ddtrace (@tracer.wrap decorator + tracer.trace context-manager), and jaeger_client (Config(service_name=) + tracer.start_span). Emits SCOPE.Pattern/trace_span entities with span_name, span_kind, and library properties. Partial by design: no cross-file dataflow; OTel Resource/TracerProvider setup not tracked; auto-instrumentation via opentelemetry-instrument not detected. Tests: TestObservability_OpenTelemetry, TestObservability_DDTrace, TestObservability_JaegerClient, TestObservability_FixtureTracing.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -38764,23 +38776,24 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/python/fastapi_reqresp.go"],
-            "issue": "backfill:dictionary-completeness",
-            "verified_at": "2026-05-29"
+            "status": "full",
+            "cites": ["internal/custom/python/fastapi.go","internal/custom/python/fastapi_reqresp.go"],
+            "notes": "fastapi_reqresp.go extracts Pydantic BaseModel body params (ACCEPTS_INPUT), response_model= kwarg (RETURNS), and return type annotations for all FastAPI route decorators; fastapi.go extracts APIRouter, Depends(), and per-route metadata. Fixture test TestFastAPIReqResp_FullFixture proves CreateOrderRequest/UpdateOrderRequest body params + OrderResponse response_model and annotation returns. Pydantic v1/v2 unwrapping via unwrapType. Depends/Query/Path injection tokens skipped.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/python/fastapi.go","internal/custom/python/fastapi_reqresp.go"],
-            "issue": "backfill:dictionary-completeness",
-            "verified_at": "2026-05-29"
+            "status": "full",
+            "cites": ["internal/custom/python/fastapi.go","internal/custom/python/fastapi_reqresp.go","internal/custom/python/http_reqresp_generic.go"],
+            "notes": "fastapi.go extracts Depends() injection tokens (dependency-injection as validation). fastapi_reqresp.go extracts Pydantic body-parameter type annotations (ACCEPTS_INPUT) proving request validation at the type level. http_reqresp_generic.go handles pydantic model_validate/parse_obj/from_orm calls in handler bodies. Tests: TestFastAPI_Depends, TestFastAPIReqResp_AcceptsInput, TestFastAPIReqResp_FullFixture.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/python/fastapi.go"],
-            "verified_at": "2026-05-29"
+            "status": "full",
+            "cites": ["internal/custom/python/fastapi.go","internal/custom/python/http_middleware.go"],
+            "notes": "@app.middleware('http') decorator extracted by fastapi.go (faMiddlewareRe); app.add_middleware(Cls, ...) extracted via starletteAddMiddlewareRe in http_middleware.go for Starlette/FastAPI. Tests: TestFastAPI_Middleware (decorator form), TestFastAPI_FullFixture_Middleware (fixture). Covers both ASGI middleware registration patterns used in FastAPI.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -38822,17 +38835,23 @@
           "log_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of stdlib logging (logging.getLogger + call sites), loguru (from loguru import logger + bind/opt/contextualize), and structlog (structlog.get_logger + structlog.configure). Emits SCOPE.Pattern/logger + SCOPE.Pattern/log_statement entities per file. Partial by design: no cross-file dataflow — a logger declared in utils.py and used in views.py produces entities only in the file where the call site lives. Tests: TestObservability_StdlibLogging, TestObservability_Loguru, TestObservability_Structlog, TestObservability_FixtureLogging.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of prometheus_client (Counter/Gauge/Histogram/Summary construction + push_to_gateway), statsd (incr/decr/gauge/timing/histogram calls), and datadog DogStatsd (increment/gauge/histogram/timing). Emits SCOPE.Pattern/metric entities with metric_type and metric_name properties. Partial by design: no cross-file dataflow; prometheus_client REGISTRY custom collector classes not detected; StatsD pipelines not followed. Tests: TestObservability_PrometheusClient, TestObservability_Statsd, TestObservability_Datadog, TestObservability_FixtureMetrics.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of OpenTelemetry (tracer.start_as_current_span decorator + context-manager + start_span), ddtrace (@tracer.wrap decorator + tracer.trace context-manager), and jaeger_client (Config(service_name=) + tracer.start_span). Emits SCOPE.Pattern/trace_span entities with span_name, span_kind, and library properties. Partial by design: no cross-file dataflow; OTel Resource/TracerProvider setup not tracked; auto-instrumentation via opentelemetry-instrument not detected. Tests: TestObservability_OpenTelemetry, TestObservability_DDTrace, TestObservability_JaegerClient, TestObservability_FixtureTracing.",
+            "verified_at": "2026-05-30"
           }
         },
         "Data": {
@@ -38997,23 +39016,25 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/python/flask_reqresp.go"],
-            "issue": "backfill:dictionary-completeness",
-            "verified_at": "2026-05-29"
+            "status": "full",
+            "cites": ["internal/custom/python/flask.go","internal/custom/python/flask_reqresp.go"],
+            "notes": "flask_reqresp.go extracts marshmallow Schema.load() call sites in route handler bodies (ACCEPTS_INPUT), and return type annotations (RETURNS). flask.go emits FlaskForm/class entities as schema-level DTOs. canonicalSchemaName converts snake_case schema vars to PascalCase. Tests: TestFlaskReqResp_SchemaLoad, TestFlaskReqResp_Returns, TestFlaskReqResp_PascalCaseSchema, TestFlask_FlaskForm.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/python/flask.go"],
+            "cites": ["internal/custom/python/flask.go","internal/custom/python/flask_reqresp.go","internal/custom/python/http_reqresp_generic.go"],
             "issue": "backfill:dictionary-completeness",
-            "verified_at": "2026-05-29"
+            "notes": "flask_reqresp.go detects marshmallow schema.load() in handler bodies as ACCEPTS_INPUT evidence. flask.go emits before_request hooks (lifecycle gates). http_reqresp_generic.go detects Pydantic model_validate/parse_obj calls and marshmallow load in Flask handlers. Partial because: Flask-WTF form.validate_on_submit() is not explicitly detected; request.json/request.form.get() raw access patterns are not tracked; no Flask-RESTX/flask-smorest RequestParser body validation. Tests: TestFlaskReqResp_SchemaLoad, TestGHR_Marshmallow_SchemaLoad.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/python/flask.go"],
-            "verified_at": "2026-05-29"
+            "notes": "flask.go extracts @app.before_request / @app.after_request / @app.teardown_request / @bp.before_app_request decorators as request_hook pattern entities — these ARE Flask's middleware mechanism (no traditional middleware class in Flask; hooks are the canonical approach). Test: TestFlask_RequestHook proves before_request hook extraction with hook_type property.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -39055,17 +39076,23 @@
           "log_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of stdlib logging (logging.getLogger + call sites), loguru (from loguru import logger + bind/opt/contextualize), and structlog (structlog.get_logger + structlog.configure). Emits SCOPE.Pattern/logger + SCOPE.Pattern/log_statement entities per file. Partial by design: no cross-file dataflow — a logger declared in utils.py and used in views.py produces entities only in the file where the call site lives. Tests: TestObservability_StdlibLogging, TestObservability_Loguru, TestObservability_Structlog, TestObservability_FixtureLogging.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of prometheus_client (Counter/Gauge/Histogram/Summary construction + push_to_gateway), statsd (incr/decr/gauge/timing/histogram calls), and datadog DogStatsd (increment/gauge/histogram/timing). Emits SCOPE.Pattern/metric entities with metric_type and metric_name properties. Partial by design: no cross-file dataflow; prometheus_client REGISTRY custom collector classes not detected; StatsD pipelines not followed. Tests: TestObservability_PrometheusClient, TestObservability_Statsd, TestObservability_Datadog, TestObservability_FixtureMetrics.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
             "status": "partial",
             "cites": ["internal/custom/python/observability.go"],
-            "issue": "3063"
+            "issue": "3063",
+            "notes": "observability.go: import-heuristic detection of OpenTelemetry (tracer.start_as_current_span decorator + context-manager + start_span), ddtrace (@tracer.wrap decorator + tracer.trace context-manager), and jaeger_client (Config(service_name=) + tracer.start_span). Emits SCOPE.Pattern/trace_span entities with span_name, span_kind, and library properties. Partial by design: no cross-file dataflow; OTel Resource/TracerProvider setup not tracked; auto-instrumentation via opentelemetry-instrument not detected. Tests: TestObservability_OpenTelemetry, TestObservability_DDTrace, TestObservability_JaegerClient, TestObservability_FixtureTracing.",
+            "verified_at": "2026-05-30"
           }
         },
         "Data": {


### PR DESCRIPTION
## Summary

Honest verification pass for 21 partial cells across `django`, `django-drf`, `fastapi`, `flask`, and `celery`. Each cell was read-and-judged against the TS/JS quality bar (AST/engine-level extraction + value-asserting tests). No Go files changed — registry-only.

### Upgraded to `full` (7 cells)

| Cell | Extractor | Proving test |
|---|---|---|
| fastapi / Validation/dto_extraction | `fastapi_reqresp.go` — Pydantic body params + `response_model=` + return annotations | `TestFastAPIReqResp_FullFixture` |
| fastapi / Validation/request_validation | `fastapi.go` Depends() + `fastapi_reqresp.go` body DTO params + `http_reqresp_generic.go` model_validate | `TestFastAPI_Depends`, `TestFastAPIReqResp_AcceptsInput` |
| fastapi / Middleware/middleware_coverage | `fastapi.go` `@app.middleware('http')` + `http_middleware.go` `app.add_middleware` | `TestFastAPI_Middleware`, `TestFastAPI_FullFixture_Middleware` |
| flask / Validation/dto_extraction | `flask_reqresp.go` marshmallow schema.load() + return annotations; `flask.go` FlaskForm entities | `TestFlaskReqResp_SchemaLoad`, `TestFlask_FlaskForm` |
| flask / Middleware/middleware_coverage | `flask.go` before_request/after_request hooks (Flask's canonical middleware mechanism) | `TestFlask_RequestHook` |
| django / Validation/request_validation | `http_reqresp_generic.go` form.is_valid() + cleaned_data + DRF request.data + validated_data + serializer.is_valid() | `TestGHR_Django_FormIsValid`, `TestGHR_DRF_RequestData`, `TestGHR_DRF_ValidatedData` |
| django-drf / Validation/request_validation | Same extractor, DRF-specific patterns; drf_serializer_fields.go REFERENCES edges | `TestGHR_DRF_RequestData`, `TestGHR_DRF_ValidatedData` |

### Honest partials with improved notes (14 cells)

- **django / Validation/dto_extraction** — Form class detected but no per-field type introspection; FormSet/inline forms missing
- **django / Middleware/middleware_coverage** — Middleware class + process_* hooks extracted; MIDDLEWARE settings list not parsed
- **django-drf / Validation/dto_extraction** — Serializer class + REFERENCES edges; SerializerMethodField return-type inference and custom Field subclasses not tracked
- **django-drf / Middleware/middleware_coverage** — Import rewriting only; DEFAULT_THROTTLE_CLASSES/DEFAULT_AUTHENTICATION_CLASSES in settings.py not parsed
- **flask / Validation/request_validation** — schema.load() + model_validate calls detected; form.validate_on_submit() / request.form.get() not tracked
- **All 4 frameworks / Observability (12 cells)** — Import-heuristic extraction correct by design; no cross-file dataflow. Notes filled in for all 12 previously-empty-notes cells.
- **celery / Testing/tests_linkage** — pytest.go extracts all test functions/fixtures; TESTS edges from test body to Celery task entity not synthesised

## Test plan

- [x] `go build ./internal/... ./tools/coverage/...` — exit 0
- [x] `go test ./internal/custom/python/... ./internal/engine/... ./internal/types/ ./tools/coverage/...` — all pass
- [x] `go run ./tools/coverage validate` — exit 0
- [x] `go run ./tools/coverage fmt --check` — canonical
- [x] `go run ./tools/coverage gen` — 5 detail pages regenerated, byte-stable

## Backlog

| Cell | Specific gap |
|---|---|
| django / Validation/dto_extraction | Per-field type introspection for Form fields; FormSet; inline forms |
| django / Middleware/middleware_coverage | Parse `MIDDLEWARE = [...]` settings list |
| django-drf / Validation/dto_extraction | SerializerMethodField return-type inference; writable vs read-only field distinction |
| django-drf / Middleware/middleware_coverage | Parse `DEFAULT_AUTHENTICATION_CLASSES`, `DEFAULT_THROTTLE_CLASSES` from DRF settings |
| flask / Validation/request_validation | Flask-WTF `form.validate_on_submit()`; `request.form.get()` raw access |
| All frameworks / Observability | Cross-file dataflow (logger declared in utils.py, called in views.py) |
| celery / Testing/tests_linkage | TESTS edges: test body to Celery task entity via `task.apply()` / `task.delay()` detection |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>