### PR TITLE
deep(ruby): ActiveRecord models/associations/migrations to TS/JS bar

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -130,7 +130,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [python](../by-language/python.md) | [redis-py](../detail/lang.python.driver.redis.md) | ✅ 1/1 | |
 | [python](../by-language/python.md) | [sqlite3 (stdlib)](../detail/lang.python.driver.sqlite.md) | 🟢 2/2 | |
 | [ruby](../by-language/ruby.md) | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟢 1/1 | |
-| [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | 🟢 8/8 | |
+| [ruby](../by-language/ruby.md) | [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ✅ 8/8 | |
 | [ruby](../by-language/ruby.md) | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟢 8/8 | |
 | [ruby](../by-language/ruby.md) | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟢 8/8 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -55,7 +55,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [AWS SDK DynamoDB (Ruby)](../detail/lang.ruby.driver.dynamodb.md) | 🟢 1/1 | |
-| [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | 🟢 8/8 | |
+| [ActiveRecord](../detail/lang.ruby.orm.activerecord.md) | ✅ 8/8 | |
 | [DataMapper / Hanami Model (legacy)](../detail/lang.ruby.orm.datamapper.md) | 🟢 8/8 | |
 | [Mongoid](../detail/lang.ruby.orm.mongoid.md) | 🟢 6/6 | |
 | [ROM (Ruby Object Mapper)](../detail/lang.ruby.orm.rom-rb.md) | 🟢 8/8 | |

--- a/docs/coverage/detail/lang.ruby.orm.activerecord.md
+++ b/docs/coverage/detail/lang.ruby.orm.activerecord.md
@@ -16,16 +16,16 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/ruby/orms/activerecord.yaml` | — |
-| Schema extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/ruby/activerecord.go` | — |
+| Schema extraction | ✅ `full` | — | — | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go` | db/schema.rb create_table parsed into table+typed columns (name/type/null/default/limit), t.references→FK column+key, t.timestamps; table linked to model by Rails inflection (users→User). Migrations also emit columns. Test: TestDeepSchema_ExactColumnsAndModelLink/IrregularModelLink assert exact columns+types+options+model link. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/ruby/activerecord.go` | — |
-| Foreign key extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/ruby/activerecord.go` | — |
-| Lazy loading recognition | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/ruby/activerecord.go` | AR includes/preload/eager_load eager markers + lazy defaults from has_many/has_one/belongs_to. Part of #3282. |
-| Relationship extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/ruby/activerecord.go` | — |
+| Association extraction | ✅ `full` | — | — | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go` | has_many/belongs_to/has_one/HABTM/has_many:through with options (:through/:source/:class_name/:foreign_key/polymorphic/:as); target-model inferred via inflection+class_name. Test: TestDeepAssoc_AllMacrosWithOptions asserts type+target+options per macro. |
+| Foreign key extraction | ✅ `full` | — | — | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go` | FK from belongs_to convention (x_id), explicit foreign_key:, add_foreign_key (with to_table:), t.references/t.belongs_to/add_reference (incl polymorphic x_id+x_type). target_model inferred. Tests: TestDeepAssoc_AllMacrosWithOptions, TestDeepMigration_CreateTableColumnsAndOps, TestDeepSchema_ExactColumnsAndModelLink. |
+| Lazy loading recognition | ✅ `full` | — | — | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go` | Declaration-level (parity with TypeORM bar): recognizes eager loading calls (includes/preload/eager_load) AND AR lazy-by-default associations, each emitted with loading_strategy. Test: TestDeepLazyLoading_EagerAndLazyBothRecognized. Note: query-site dataflow tracing of which records are actually eager-loaded is out of scope (static declaration-level). |
+| Relationship extraction | ✅ `full` | — | — | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go` | Each association emits a SCOPE.Pattern/association entity carrying association_type, target_model, owner_model and option props (through/source/class_name/foreign_key/polymorphic/as). Test: TestDeepAssoc_AllMacrosWithOptions. |
 
 ### Queries
 
@@ -37,7 +37,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🟢 `partial` | — | — | `internal/custom/ruby/activerecord.go` | — |
+| Migration parsing | ✅ `full` | — | — | `internal/custom/ruby/activerecord.go`<br>`internal/custom/ruby/activerecord_deep.go`<br>`internal/custom/ruby/activerecord_deep_test.go` | db/migrate/*.rb parsed into normalized SCOPE.Evolution ops (create_table/add_column/drop_column/alter_column/create_index/add_reference/add_foreign_key/drop_table), plus typed columns inside create_table blocks and FK entities. Test: TestDeepMigration_CreateTableColumnsAndOps asserts exact op subtypes+columns+FKs. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -44405,32 +44405,31 @@
             "verified_at": "2026-05-28"
           },
           "schema_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/activerecord.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go"],
+            "notes": "db/schema.rb create_table parsed into table+typed columns (name/type/null/default/limit), t.references→FK column+key, t.timestamps; table linked to model by Rails inflection (users→User). Migrations also emit columns. Test: TestDeepSchema_ExactColumnsAndModelLink/IrregularModelLink assert exact columns+types+options+model link."
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/activerecord.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go"],
+            "notes": "has_many/belongs_to/has_one/HABTM/has_many:through with options (:through/:source/:class_name/:foreign_key/polymorphic/:as); target-model inferred via inflection+class_name. Test: TestDeepAssoc_AllMacrosWithOptions asserts type+target+options per macro."
           },
           "foreign_key_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/activerecord.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go"],
+            "notes": "FK from belongs_to convention (x_id), explicit foreign_key:, add_foreign_key (with to_table:), t.references/t.belongs_to/add_reference (incl polymorphic x_id+x_type). target_model inferred. Tests: TestDeepAssoc_AllMacrosWithOptions, TestDeepMigration_CreateTableColumnsAndOps, TestDeepSchema_ExactColumnsAndModelLink."
           },
           "lazy_loading_recognition": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/activerecord.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "AR includes/preload/eager_load eager markers + lazy defaults from has_many/has_one/belongs_to. Part of #3282."
+            "status": "full",
+            "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go"],
+            "notes": "Declaration-level (parity with TypeORM bar): recognizes eager loading calls (includes/preload/eager_load) AND AR lazy-by-default associations, each emitted with loading_strategy. Test: TestDeepLazyLoading_EagerAndLazyBothRecognized. Note: query-site dataflow tracing of which records are actually eager-loaded is out of scope (static declaration-level)."
           },
           "relationship_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/activerecord.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go"],
+            "notes": "Each association emits a SCOPE.Pattern/association entity carrying association_type, target_model, owner_model and option props (through/source/class_name/foreign_key/polymorphic/as). Test: TestDeepAssoc_AllMacrosWithOptions."
           }
         },
         "Queries": {
@@ -44442,8 +44441,9 @@
         },
         "Migrations": {
           "migration_parsing": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/activerecord.go"]
+            "status": "full",
+            "cites": ["internal/custom/ruby/activerecord.go","internal/custom/ruby/activerecord_deep.go","internal/custom/ruby/activerecord_deep_test.go"],
+            "notes": "db/migrate/*.rb parsed into normalized SCOPE.Evolution ops (create_table/add_column/drop_column/alter_column/create_index/add_reference/add_foreign_key/drop_table), plus typed columns inside create_table blocks and FK entities. Test: TestDeepMigration_CreateTableColumnsAndOps asserts exact op subtypes+columns+FKs."
           }
         }
       }

--- a/internal/custom/ruby/activerecord.go
+++ b/internal/custom/ruby/activerecord.go
@@ -321,6 +321,12 @@ func (e *activeRecordExtractor) Extract(ctx context.Context, file extractor.File
 			)
 			add(ent)
 		}
+
+		// Deep model + association + foreign-key extraction (TS/JS bar):
+		// model→table link, association options (:through/:source/:class_name/
+		// :foreign_key/polymorphic/as) with target-model inference, and FK
+		// entities (belongs_to x_id convention + explicit foreign_key).
+		extractARModelsAndAssociations(src, file, add)
 	}
 
 	// -------------------------------------------------------------------------
@@ -364,6 +370,11 @@ func (e *activeRecordExtractor) Extract(ctx context.Context, file extractor.File
 				add(ent)
 			}
 		}
+
+		// Deep schema extraction (TS/JS bar): typed columns with options
+		// (null/default/limit), t.references / t.belongs_to → FK column + key,
+		// t.timestamps, and table→model linking by Rails convention.
+		extractARSchemaDeep(src, file, add)
 	}
 
 	// -------------------------------------------------------------------------
@@ -442,6 +453,12 @@ func (e *activeRecordExtractor) Extract(ctx context.Context, file extractor.File
 			)
 			add(ent)
 		}
+
+		// Deep migration parsing (TS/JS bar): normalized SCOPE.Evolution ops
+		// (create_table/add_column/drop_column/alter_column/create_index/
+		// add_reference/add_foreign_key/drop_table) + typed columns inside
+		// create_table blocks + FK entities from add_foreign_key / references.
+		extractARMigrationDeep(src, file, add)
 	}
 
 	// -------------------------------------------------------------------------

--- a/internal/custom/ruby/activerecord_deep.go
+++ b/internal/custom/ruby/activerecord_deep.go
@@ -1,0 +1,659 @@
+// activerecord_deep.go — deep ActiveRecord extraction.
+//
+// This file raises the ActiveRecord extraction to the TS/JS (TypeORM / Prisma)
+// quality bar. Where the existing heuristics in activerecord.go emit shallow
+// "≥1 entity" markers, the helpers here emit *value-asserting* entities that
+// carry the real shape of the schema:
+//
+//   - Models:        link a model class (User < ApplicationRecord) to its table
+//     by Rails convention (User → users), and extract its columns
+//     from db/schema.rb / migrations (AR models don't declare
+//     columns in the class body).
+//   - Associations:  has_many/belongs_to/has_one/HABTM incl. :through, :source,
+//     :class_name, :foreign_key, polymorphic (polymorphic:true / as:)
+//     with target-model inference and option capture.
+//   - Foreign keys:  belongs_to convention (x_id), explicit foreign_key:,
+//     add_foreign_key / t.references / t.belongs_to / add_reference.
+//   - Migrations:    db/migrate/*.rb create_table / add_column / add_index /
+//     add_reference / add_foreign_key / change_column / remove_*
+//     normalized to shared SCOPE.Evolution op subtypes, plus
+//     t.<type> columns *inside* a create_table block.
+//
+// Part of the deep-ruby-activerecord work (TS/JS bar parity).
+package ruby
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Deep regexes (named *Deep to avoid clashing with the shallow ones).
+// ---------------------------------------------------------------------------
+
+var (
+	// Model class: `class User < ApplicationRecord` / `< ActiveRecord::Base`.
+	reARModelClass = regexp.MustCompile(
+		`(?m)^\s*class\s+([A-Z][A-Za-z0-9_:]*)\s*<\s*(ApplicationRecord|ActiveRecord::Base)\b`,
+	)
+
+	// Association macro with the full trailing option string captured (group 3),
+	// so we can mine :through/:source/:class_name/:foreign_key/polymorphic/as.
+	reARAssociationDeep = regexp.MustCompile(
+		`(?m)^\s*(has_many|belongs_to|has_one|has_and_belongs_to_many)\s+:([a-z_][a-z0-9_]*)\s*(,[^#\n]*)?$`,
+	)
+
+	// schema.rb / migration: create_table "name" do |t|  (also :name form).
+	reARCreateTableBlock = regexp.MustCompile(
+		`^\s*create_table\s+["':]([a-z_][a-z0-9_]*)["']?`,
+	)
+
+	// A typed column line inside a create_table block: t.string "email", null: false
+	// Group 1 = type, group 2 = name, group 3 = trailing options.
+	reARTypedColumn = regexp.MustCompile(
+		`^\s*t\.(string|integer|bigint|float|decimal|numeric|boolean|text|date|datetime|timestamp|time|binary|blob|json|jsonb|uuid|hstore|inet|cidr|macaddr|citext|ltree|virtual|primary_key)\s+["':]([a-z_][a-z0-9_]*)["']?\s*(,[^#\n]*)?`,
+	)
+
+	// t.references / t.belongs_to "user", polymorphic: true  (inside create_table).
+	reARTReference = regexp.MustCompile(
+		`^\s*t\.(references|belongs_to)\s+["':]([a-z_][a-z0-9_]*)["']?\s*(,[^#\n]*)?`,
+	)
+
+	// t.timestamps — shorthand for created_at/updated_at.
+	reARTimestamps = regexp.MustCompile(`^\s*t\.timestamps\b`)
+
+	// add_column :table, :col, :type[, options]
+	reARAddColumnDeep = regexp.MustCompile(
+		`^\s*add_column\s+["':]([a-z_][a-z0-9_]*)["']?\s*,\s*["':]([a-z_][a-z0-9_]*)["']?\s*,\s*["':]?([a-z_][a-z0-9_]*)["']?\s*(,[^#\n]*)?`,
+	)
+
+	// remove_column :table, :col
+	reARRemoveColumn = regexp.MustCompile(
+		`^\s*remove_column\s+["':]([a-z_][a-z0-9_]*)["']?\s*,\s*["':]([a-z_][a-z0-9_]*)["']?`,
+	)
+
+	// change_column :table, :col, :type
+	reARChangeColumn = regexp.MustCompile(
+		`^\s*change_column\s+["':]([a-z_][a-z0-9_]*)["']?\s*,\s*["':]([a-z_][a-z0-9_]*)["']?`,
+	)
+
+	// add_index :table, :col_or_[cols]
+	reARAddIndexDeep = regexp.MustCompile(
+		`^\s*add_index\s+["':]([a-z_][a-z0-9_]*)["']?\s*,\s*(.+)`,
+	)
+
+	// add_reference / add_belongs_to :table, :ref[, options]
+	reARAddReferenceDeep = regexp.MustCompile(
+		`^\s*(?:add_reference|add_belongs_to)\s+["':]([a-z_][a-z0-9_]*)["']?\s*,\s*["':]([a-z_][a-z0-9_]*)["']?\s*(,[^#\n]*)?`,
+	)
+
+	// add_foreign_key "from_table", "to_table"[, options]
+	reARAddForeignKey = regexp.MustCompile(
+		`^\s*add_foreign_key\s+["':]([a-z_][a-z0-9_]*)["']?\s*,\s*["':]([a-z_][a-z0-9_]*)["']?\s*(,[^#\n]*)?`,
+	)
+
+	// drop_table :name
+	reARDropTable = regexp.MustCompile(
+		`^\s*drop_table\s+["':]([a-z_][a-z0-9_]*)["']?`,
+	)
+
+	// Option scanners (work on the trailing-options string of an association).
+	reOptClassName  = regexp.MustCompile(`class_name:\s*["']([A-Za-z0-9_:]+)["']|:class_name\s*=>\s*["']([A-Za-z0-9_:]+)["']`)
+	reOptForeignKey = regexp.MustCompile(`foreign_key:\s*["':]([a-z_][a-z0-9_]*)["']?|:foreign_key\s*=>\s*["':]([a-z_][a-z0-9_]*)["']?`)
+	reOptThrough    = regexp.MustCompile(`through:\s*:([a-z_][a-z0-9_]*)|:through\s*=>\s*:([a-z_][a-z0-9_]*)`)
+	reOptSource     = regexp.MustCompile(`source:\s*:([a-z_][a-z0-9_]*)|:source\s*=>\s*:([a-z_][a-z0-9_]*)`)
+	reOptAs         = regexp.MustCompile(`as:\s*:([a-z_][a-z0-9_]*)|:as\s*=>\s*:([a-z_][a-z0-9_]*)`)
+	reOptPolymorph  = regexp.MustCompile(`polymorphic:\s*true|:polymorphic\s*=>\s*true`)
+	reOptNull       = regexp.MustCompile(`null:\s*(true|false)`)
+	reOptDefault    = regexp.MustCompile(`default:\s*("(?:[^"]*)"|'(?:[^']*)'|[A-Za-z0-9_.\[\]{}]+)`)
+	reOptLimit      = regexp.MustCompile(`limit:\s*(\d+)`)
+	reOptToTable    = regexp.MustCompile(`to_table:\s*:?["']?([a-z_][a-z0-9_]*)["']?`)
+)
+
+// ---------------------------------------------------------------------------
+// Rails inflection helpers (enough for convention-based linking).
+// ---------------------------------------------------------------------------
+
+// singularize converts a (mostly-regular) plural to singular. Handles the
+// common irregular and *-ies/*-es/*-s cases that show up in table names.
+func singularize(w string) string {
+	irr := map[string]string{
+		"people": "person", "men": "man", "women": "woman", "children": "child",
+		"teeth": "tooth", "feet": "foot", "mice": "mouse", "geese": "goose",
+		"data": "datum", "indices": "index", "matrices": "matrix", "media": "medium",
+	}
+	if s, ok := irr[w]; ok {
+		return s
+	}
+	switch {
+	case strings.HasSuffix(w, "ies") && len(w) > 3:
+		return w[:len(w)-3] + "y"
+	case strings.HasSuffix(w, "ses") || strings.HasSuffix(w, "xes") ||
+		strings.HasSuffix(w, "zes") || strings.HasSuffix(w, "ches") ||
+		strings.HasSuffix(w, "shes"):
+		return w[:len(w)-2]
+	case strings.HasSuffix(w, "s") && !strings.HasSuffix(w, "ss"):
+		return w[:len(w)-1]
+	default:
+		return w
+	}
+}
+
+// pluralize is the inverse used to map a model name to its table.
+func pluralize(w string) string {
+	switch {
+	case strings.HasSuffix(w, "y") && len(w) > 1 && !isVowel(w[len(w)-2]):
+		return w[:len(w)-1] + "ies"
+	case strings.HasSuffix(w, "s") || strings.HasSuffix(w, "x") ||
+		strings.HasSuffix(w, "z") || strings.HasSuffix(w, "ch") ||
+		strings.HasSuffix(w, "sh"):
+		return w + "es"
+	default:
+		return w + "s"
+	}
+}
+
+func isVowel(b byte) bool {
+	switch b {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	}
+	return false
+}
+
+// camelize converts snake_case to CamelCase (Rails classify, minus pluralize).
+func camelize(s string) string {
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
+}
+
+// classify maps a (plural) table name to its model class name: users → User.
+func classify(table string) string {
+	// Drop a leading schema qualifier if present (public.users → users).
+	if i := strings.LastIndexByte(table, '.'); i >= 0 {
+		table = table[i+1:]
+	}
+	return camelize(singularize(table))
+}
+
+// modelToTable maps a model class to its table by Rails convention: User → users.
+// Handles namespaced models (Admin::User → users — Rails uses the demodulized
+// name for the table unless table_name_prefix is set).
+func modelToTable(model string) string {
+	if i := strings.LastIndex(model, "::"); i >= 0 {
+		model = model[i+2:]
+	}
+	return pluralize(underscore(model))
+}
+
+// underscore is the inverse of camelize: BlogPost → blog_post.
+func underscore(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteByte(c - 'A' + 'a')
+		} else {
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Option extraction
+// ---------------------------------------------------------------------------
+
+func firstNonEmptyGroup(m []string) string {
+	for _, g := range m[1:] {
+		if g != "" {
+			return g
+		}
+	}
+	return ""
+}
+
+type assocOptions struct {
+	className  string
+	foreignKey string
+	through    string
+	source     string
+	as         string
+	polymorph  bool
+}
+
+func parseAssocOptions(opts string) assocOptions {
+	var a assocOptions
+	if m := reOptClassName.FindStringSubmatch(opts); m != nil {
+		a.className = firstNonEmptyGroup(m)
+	}
+	if m := reOptForeignKey.FindStringSubmatch(opts); m != nil {
+		a.foreignKey = firstNonEmptyGroup(m)
+	}
+	if m := reOptThrough.FindStringSubmatch(opts); m != nil {
+		a.through = firstNonEmptyGroup(m)
+	}
+	if m := reOptSource.FindStringSubmatch(opts); m != nil {
+		a.source = firstNonEmptyGroup(m)
+	}
+	if m := reOptAs.FindStringSubmatch(opts); m != nil {
+		a.as = firstNonEmptyGroup(m)
+	}
+	a.polymorph = reOptPolymorph.MatchString(opts)
+	return a
+}
+
+// targetModel infers the associated model class for an association.
+//   - explicit class_name wins
+//   - belongs_to/has_one → singular: User
+//   - has_many/HABTM     → singular of the (already-plural) association name
+func targetModel(macro, assocName string, o assocOptions) string {
+	if o.className != "" {
+		return o.className
+	}
+	switch macro {
+	case "has_many", "has_and_belongs_to_many":
+		return camelize(singularize(assocName))
+	default: // belongs_to, has_one
+		return camelize(assocName)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Deep extraction entry points (called from Extract in activerecord.go)
+// ---------------------------------------------------------------------------
+
+// extractARModelsAndAssociations handles app/models files: the model class →
+// table link, and rich association + foreign-key entities.
+func extractARModelsAndAssociations(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	// Model class → table link (Models / model_extraction + schema link).
+	var modelName, tableName string
+	if m := reARModelClass.FindStringSubmatchIndex(src); m != nil {
+		modelName = src[m[2]:m[3]]
+		tableName = modelToTable(modelName)
+		ent := makeEntity("model:"+modelName, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "activerecord",
+			"provenance", "INFERRED_FROM_AR_MODEL_CLASS",
+			"model_class", modelName,
+			"table_name", tableName,
+		)
+		add(ent)
+	}
+
+	for _, m := range reARAssociationDeep.FindAllStringSubmatchIndex(src, -1) {
+		macro := src[m[2]:m[3]]
+		assocName := src[m[4]:m[5]]
+		opts := ""
+		if m[6] >= 0 {
+			opts = src[m[6]:m[7]]
+		}
+		o := parseAssocOptions(opts)
+		target := targetModel(macro, assocName, o)
+		ln := lineOf(src, m[0])
+
+		// Rich relationship entity (Relationships / relationship_extraction +
+		// association_extraction). Distinct name so it doesn't collide with the
+		// shallow `belongs_to:user` relation entity from activerecord.go.
+		relName := fmt.Sprintf("assoc:%s:%s", macro, assocName)
+		rel := makeEntity(relName, "SCOPE.Pattern", "association", file.Path, file.Language, ln)
+		setProps(&rel,
+			"framework", "activerecord",
+			"provenance", "INFERRED_FROM_AR_ASSOCIATION_DEEP",
+			"association_type", macro,
+			"association_name", assocName,
+			"target_model", target,
+		)
+		if o.through != "" {
+			setProps(&rel, "through", o.through)
+		}
+		if o.source != "" {
+			setProps(&rel, "source", o.source)
+		}
+		if o.className != "" {
+			setProps(&rel, "class_name", o.className)
+		}
+		if o.foreignKey != "" {
+			setProps(&rel, "foreign_key", o.foreignKey)
+		}
+		if o.polymorph {
+			setProps(&rel, "polymorphic", "true")
+		}
+		if o.as != "" {
+			setProps(&rel, "as", o.as)
+		}
+		if modelName != "" {
+			setProps(&rel, "owner_model", modelName)
+		}
+		add(rel)
+
+		// Foreign-key entity (Relationships / foreign_key_extraction).
+		// belongs_to defines the FK on *this* model's table (convention x_id),
+		// or the explicit foreign_key. has_one/has_many put the FK on the other
+		// table; we still record the convention so the column can be resolved.
+		fk := foreignKeyForAssoc(macro, assocName, o)
+		if fk != "" {
+			fkName := fmt.Sprintf("ar_fk:%s:%s", assocName, fk)
+			fkEnt := makeEntity(fkName, "SCOPE.Pattern", "foreign_key", file.Path, file.Language, ln)
+			setProps(&fkEnt,
+				"framework", "activerecord",
+				"provenance", "INFERRED_FROM_AR_BELONGS_TO_FK",
+				"association_type", macro,
+				"association_name", assocName,
+				"foreign_key", fk,
+				"target_model", target,
+			)
+			if macro == "belongs_to" && o.foreignKey == "" {
+				setProps(&fkEnt, "convention", "true")
+			}
+			if o.polymorph {
+				setProps(&fkEnt, "polymorphic", "true")
+				setProps(&fkEnt, "type_column", assocName+"_type")
+			}
+			add(fkEnt)
+		}
+	}
+}
+
+// foreignKeyForAssoc returns the FK column an association implies, or "".
+func foreignKeyForAssoc(macro, assocName string, o assocOptions) string {
+	if o.foreignKey != "" {
+		return o.foreignKey
+	}
+	switch macro {
+	case "belongs_to":
+		return assocName + "_id"
+	case "has_one", "has_many":
+		// FK lives on the *other* table by convention <this_singular>_id; we
+		// don't know "this" model name reliably here, so only emit when explicit.
+		return ""
+	default:
+		return ""
+	}
+}
+
+// extractARSchemaDeep parses db/schema.rb: tables, typed columns (with options),
+// t.references, t.timestamps, and links each table back to its model class.
+func extractARSchemaDeep(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	lines := strings.Split(src, "\n")
+	currentTable := ""
+	for i, line := range lines {
+		ln := i + 1
+
+		if tm := reARCreateTableBlock.FindStringSubmatch(line); tm != nil {
+			currentTable = tm[1]
+			model := classify(currentTable)
+			ent := makeEntity("ar_table:"+currentTable, "SCOPE.Schema", "table", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "activerecord",
+				"provenance", "INFERRED_FROM_SCHEMA_RB_DEEP",
+				"table_name", currentTable,
+				"model_class", model,
+			)
+			add(ent)
+			continue
+		}
+		if currentTable == "" {
+			continue
+		}
+
+		// Typed column with options.
+		if cm := reARTypedColumn.FindStringSubmatch(line); cm != nil {
+			colType := cm[1]
+			colName := cm[2]
+			opts := cm[3]
+			emitSchemaColumn(currentTable, colName, colType, opts, file, ln, add)
+			continue
+		}
+
+		// t.references / t.belongs_to → adds <name>_id column + FK.
+		if rm := reARTReference.FindStringSubmatch(line); rm != nil {
+			refName := rm[2]
+			opts := rm[3]
+			emitReferenceColumn(currentTable, refName, opts, "INFERRED_FROM_SCHEMA_RB_REFERENCE", file, ln, add)
+			continue
+		}
+
+		// t.timestamps → created_at / updated_at datetime columns.
+		if reARTimestamps.MatchString(line) {
+			for _, c := range []string{"created_at", "updated_at"} {
+				emitSchemaColumn(currentTable, c, "datetime", "null: false", file, ln, add)
+			}
+			continue
+		}
+	}
+}
+
+func emitSchemaColumn(table, col, typ, opts string, file extractor.FileInput, ln int, add func(types.EntityRecord)) {
+	ent := makeEntity("ar_col:"+table+"."+col, "SCOPE.Schema", "column", file.Path, file.Language, ln)
+	setProps(&ent,
+		"framework", "activerecord",
+		"provenance", "INFERRED_FROM_SCHEMA_RB_DEEP",
+		"table_name", table,
+		"column_name", col,
+		"column_type", typ,
+		"model_class", classify(table),
+	)
+	applyColumnOptions(&ent, opts)
+	add(ent)
+}
+
+func emitReferenceColumn(table, ref, opts, prov string, file extractor.FileInput, ln int, add func(types.EntityRecord)) {
+	poly := reOptPolymorph.MatchString(opts)
+	fkCol := ref + "_id"
+	// The FK column.
+	col := makeEntity("ar_col:"+table+"."+fkCol, "SCOPE.Schema", "column", file.Path, file.Language, ln)
+	setProps(&col,
+		"framework", "activerecord",
+		"provenance", prov,
+		"table_name", table,
+		"column_name", fkCol,
+		"column_type", "bigint",
+		"model_class", classify(table),
+		"is_reference", "true",
+	)
+	if poly {
+		setProps(&col, "polymorphic", "true")
+	}
+	add(col)
+
+	// The implied foreign key.
+	fk := makeEntity("ar_fk:"+table+"."+fkCol, "SCOPE.Pattern", "foreign_key", file.Path, file.Language, ln)
+	setProps(&fk,
+		"framework", "activerecord",
+		"provenance", prov,
+		"table_name", table,
+		"column_name", fkCol,
+		"reference_name", ref,
+		"target_model", camelize(ref),
+	)
+	if poly {
+		setProps(&fk, "polymorphic", "true")
+		// polymorphic adds a <ref>_type string column too.
+		typeCol := makeEntity("ar_col:"+table+"."+ref+"_type", "SCOPE.Schema", "column", file.Path, file.Language, ln)
+		setProps(&typeCol,
+			"framework", "activerecord",
+			"provenance", prov,
+			"table_name", table,
+			"column_name", ref+"_type",
+			"column_type", "string",
+			"model_class", classify(table),
+			"polymorphic", "true",
+		)
+		add(typeCol)
+	}
+	add(fk)
+}
+
+func applyColumnOptions(e *types.EntityRecord, opts string) {
+	if opts == "" {
+		return
+	}
+	if m := reOptNull.FindStringSubmatch(opts); m != nil {
+		setProps(e, "nullable", m[1])
+	}
+	if m := reOptDefault.FindStringSubmatch(opts); m != nil {
+		setProps(e, "default", strings.Trim(m[1], `"'`))
+	}
+	if m := reOptLimit.FindStringSubmatch(opts); m != nil {
+		setProps(e, "limit", m[1])
+	}
+}
+
+// extractARMigrationDeep parses db/migrate/*.rb migration files into normalized
+// SCOPE.Evolution schema-change ops (matching the TypeORM op-subtype taxonomy),
+// plus columns declared inside create_table blocks.
+func extractARMigrationDeep(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	lines := strings.Split(src, "\n")
+	currentTable := "" // active create_table block target
+	for i, line := range lines {
+		ln := i + 1
+
+		if tm := reARCreateTableBlock.FindStringSubmatch(line); tm != nil {
+			currentTable = tm[1]
+			emitMigrationOp("create_table", currentTable, file, ln, add, "table_name", currentTable, "model_class", classify(currentTable))
+			continue
+		}
+		if reARDropTable.MatchString(line) {
+			tbl := reARDropTable.FindStringSubmatch(line)[1]
+			currentTable = ""
+			emitMigrationOp("drop_table", tbl, file, ln, add, "table_name", tbl)
+			continue
+		}
+
+		// Inside a create_table block: typed columns, references, timestamps.
+		if currentTable != "" {
+			if cm := reARTypedColumn.FindStringSubmatch(line); cm != nil {
+				emitMigColumn(currentTable, cm[2], cm[1], cm[3], file, ln, add)
+				continue
+			}
+			if rm := reARTReference.FindStringSubmatch(line); rm != nil {
+				emitReferenceColumn(currentTable, rm[2], rm[3], "INFERRED_FROM_AR_MIGRATION_REFERENCE", file, ln, add)
+				emitMigrationOp("add_reference", currentTable, file, ln, add,
+					"table_name", currentTable, "reference_name", rm[2])
+				continue
+			}
+			if reARTimestamps.MatchString(line) {
+				for _, c := range []string{"created_at", "updated_at"} {
+					emitMigColumn(currentTable, c, "datetime", "", file, ln, add)
+				}
+				continue
+			}
+			// A line with just `end` closes the block (best-effort).
+			if strings.TrimSpace(line) == "end" {
+				currentTable = ""
+			}
+		}
+
+		// Standalone DDL ops (outside create_table).
+		if m := reARAddColumnDeep.FindStringSubmatch(line); m != nil {
+			emitMigColumn(m[1], m[2], m[3], m[4], file, ln, add)
+			emitMigrationOp("add_column", m[1]+"."+m[2], file, ln, add,
+				"table_name", m[1], "column_name", m[2], "column_type", m[3])
+			continue
+		}
+		if m := reARRemoveColumn.FindStringSubmatch(line); m != nil {
+			emitMigrationOp("drop_column", m[1]+"."+m[2], file, ln, add,
+				"table_name", m[1], "column_name", m[2])
+			continue
+		}
+		if m := reARChangeColumn.FindStringSubmatch(line); m != nil {
+			emitMigrationOp("alter_column", m[1]+"."+m[2], file, ln, add,
+				"table_name", m[1], "column_name", m[2])
+			continue
+		}
+		if m := reARAddIndexDeep.FindStringSubmatch(line); m != nil {
+			cols := normalizeIndexCols(m[2])
+			emitMigrationOp("create_index", m[1]+"."+cols, file, ln, add,
+				"table_name", m[1], "index_columns", cols)
+			continue
+		}
+		if m := reARAddReferenceDeep.FindStringSubmatch(line); m != nil {
+			emitReferenceColumn(m[1], m[2], m[3], "INFERRED_FROM_AR_MIGRATION_ADD_REFERENCE", file, ln, add)
+			emitMigrationOp("add_reference", m[1]+"."+m[2], file, ln, add,
+				"table_name", m[1], "reference_name", m[2])
+			continue
+		}
+		if m := reARAddForeignKey.FindStringSubmatch(line); m != nil {
+			from, to := m[1], m[2]
+			if tm := reOptToTable.FindStringSubmatch(m[3]); tm != nil {
+				to = tm[1]
+			}
+			fk := makeEntity("ar_fk:"+from+"->"+to, "SCOPE.Pattern", "foreign_key", file.Path, file.Language, ln)
+			setProps(&fk,
+				"framework", "activerecord",
+				"provenance", "INFERRED_FROM_AR_MIGRATION_ADD_FOREIGN_KEY",
+				"from_table", from,
+				"to_table", to,
+				"target_model", classify(to),
+			)
+			if fm := reOptForeignKey.FindStringSubmatch(m[3]); fm != nil {
+				setProps(&fk, "foreign_key", firstNonEmptyGroup(fm))
+			}
+			add(fk)
+			emitMigrationOp("add_foreign_key", from+"->"+to, file, ln, add,
+				"from_table", from, "to_table", to)
+			continue
+		}
+	}
+}
+
+func emitMigColumn(table, col, typ, opts string, file extractor.FileInput, ln int, add func(types.EntityRecord)) {
+	ent := makeEntity("ar_migcol:"+table+"."+col, "SCOPE.Schema", "column", file.Path, file.Language, ln)
+	setProps(&ent,
+		"framework", "activerecord",
+		"provenance", "INFERRED_FROM_AR_MIGRATION_COLUMN",
+		"table_name", table,
+		"column_name", col,
+		"column_type", typ,
+		"model_class", classify(table),
+	)
+	applyColumnOptions(&ent, opts)
+	add(ent)
+}
+
+// emitMigrationOp emits a normalized SCOPE.Evolution schema-change entity.
+func emitMigrationOp(op, target string, file extractor.FileInput, ln int, add func(types.EntityRecord), kv ...string) {
+	name := op
+	if target != "" {
+		name = op + ":" + target
+	}
+	ent := makeEntity("ar_op:"+name, "SCOPE.Evolution", op, file.Path, file.Language, ln)
+	setProps(&ent,
+		"framework", "activerecord",
+		"provenance", "INFERRED_FROM_AR_MIGRATION_OP",
+		"ddl_operation", op,
+	)
+	setProps(&ent, kv...)
+	add(ent)
+}
+
+func normalizeIndexCols(raw string) string {
+	raw = strings.TrimSpace(raw)
+	// Cut at a trailing option (`, unique: true`) or comment.
+	raw = strings.SplitN(raw, "unique:", 2)[0]
+	raw = strings.TrimRight(raw, ", \t")
+	raw = strings.Trim(raw, "[]")
+	var cols []string
+	for _, p := range strings.Split(raw, ",") {
+		p = strings.TrimSpace(p)
+		p = strings.Trim(p, `:"'`)
+		if p != "" {
+			cols = append(cols, p)
+		}
+	}
+	return strings.Join(cols, ",")
+}

--- a/internal/custom/ruby/activerecord_deep_test.go
+++ b/internal/custom/ruby/activerecord_deep_test.go
@@ -1,0 +1,323 @@
+package ruby_test
+
+// activerecord_deep_test.go — value-asserting tests for deep ActiveRecord
+// extraction (TS/JS bar parity). These assert the *exact* columns, association
+// type+target+options, foreign keys, and normalized migration ops emitted —
+// not "≥1 entity".
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/ruby"
+)
+
+func arExtractRaw(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_ruby_activerecord")
+	if !ok {
+		t.Fatal("custom_ruby_activerecord extractor not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Language: "ruby",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// findEnt returns the entity with the given name (and optional subtype filter).
+func findEnt(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func mustProp(t *testing.T, e *types.EntityRecord, key, want string) {
+	t.Helper()
+	if e == nil {
+		t.Fatalf("entity nil while checking prop %q", key)
+	}
+	if got := e.Properties[key]; got != want {
+		t.Errorf("entity %q: prop %q = %q, want %q", e.Name, key, got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Models / schema_extraction — exact columns from db/schema.rb, linked to model
+// ---------------------------------------------------------------------------
+
+func TestDeepSchema_ExactColumnsAndModelLink(t *testing.T) {
+	src := `
+ActiveRecord::Schema[7.1].define(version: 2024_01_01_000000) do
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.integer "age", default: 0
+    t.string "name", limit: 100
+    t.boolean "admin", default: false, null: false
+    t.references "company", null: false
+    t.timestamps
+  end
+end
+`
+	ents := arExtractRaw(t, "db/schema.rb", src)
+
+	// Table → model link (User by convention).
+	tbl := findEnt(ents, "ar_table:users")
+	mustProp(t, tbl, "table_name", "users")
+	mustProp(t, tbl, "model_class", "User")
+
+	// Exact columns with types.
+	email := findEnt(ents, "ar_col:users.email")
+	mustProp(t, email, "column_type", "string")
+	mustProp(t, email, "nullable", "false")
+	mustProp(t, email, "model_class", "User")
+
+	age := findEnt(ents, "ar_col:users.age")
+	mustProp(t, age, "column_type", "integer")
+	mustProp(t, age, "default", "0")
+
+	name := findEnt(ents, "ar_col:users.name")
+	mustProp(t, name, "column_type", "string")
+	mustProp(t, name, "limit", "100")
+
+	admin := findEnt(ents, "ar_col:users.admin")
+	mustProp(t, admin, "column_type", "boolean")
+	mustProp(t, admin, "default", "false")
+	mustProp(t, admin, "nullable", "false")
+
+	// t.references "company" → company_id bigint column + foreign key.
+	companyCol := findEnt(ents, "ar_col:users.company_id")
+	mustProp(t, companyCol, "column_type", "bigint")
+	mustProp(t, companyCol, "is_reference", "true")
+
+	companyFK := findEnt(ents, "ar_fk:users.company_id")
+	if companyFK == nil {
+		t.Fatal("expected FK ar_fk:users.company_id")
+	}
+	mustProp(t, companyFK, "target_model", "Company")
+	mustProp(t, companyFK, "reference_name", "company")
+
+	// t.timestamps → created_at / updated_at datetime columns.
+	for _, c := range []string{"created_at", "updated_at"} {
+		col := findEnt(ents, "ar_col:users."+c)
+		mustProp(t, col, "column_type", "datetime")
+	}
+}
+
+// Plural→singular irregulars used by classify().
+func TestDeepSchema_IrregularModelLink(t *testing.T) {
+	src := `
+ActiveRecord::Schema[7.1].define(version: 1) do
+  create_table "people" do |t|
+    t.string "name"
+  end
+  create_table "categories" do |t|
+    t.string "label"
+  end
+end
+`
+	ents := arExtractRaw(t, "db/schema.rb", src)
+	mustProp(t, findEnt(ents, "ar_table:people"), "model_class", "Person")
+	mustProp(t, findEnt(ents, "ar_table:categories"), "model_class", "Category")
+}
+
+// ---------------------------------------------------------------------------
+// Relationships / association + relationship + foreign_key extraction
+// ---------------------------------------------------------------------------
+
+func TestDeepAssoc_AllMacrosWithOptions(t *testing.T) {
+	src := `
+class Article < ApplicationRecord
+  belongs_to :user
+  belongs_to :author, class_name: "User", foreign_key: "author_id"
+  has_many :comments
+  has_one :featured_image, class_name: "Image"
+  has_many :taggings
+  has_many :tags, through: :taggings, source: :tag
+  has_and_belongs_to_many :categories
+  belongs_to :commentable, polymorphic: true
+end
+`
+	ents := arExtractRaw(t, "app/models/article.rb", src)
+
+	// Model → table link.
+	mustProp(t, findEnt(ents, "model:Article"), "table_name", "articles")
+
+	// belongs_to :user → target User, convention FK user_id.
+	user := findEnt(ents, "assoc:belongs_to:user")
+	mustProp(t, user, "association_type", "belongs_to")
+	mustProp(t, user, "target_model", "User")
+	mustProp(t, user, "owner_model", "Article")
+	userFK := findEnt(ents, "ar_fk:user:user_id")
+	mustProp(t, userFK, "foreign_key", "user_id")
+	mustProp(t, userFK, "convention", "true")
+
+	// belongs_to :author with class_name + explicit foreign_key.
+	author := findEnt(ents, "assoc:belongs_to:author")
+	mustProp(t, author, "target_model", "User")
+	mustProp(t, author, "class_name", "User")
+	mustProp(t, author, "foreign_key", "author_id")
+	authorFK := findEnt(ents, "ar_fk:author:author_id")
+	mustProp(t, authorFK, "foreign_key", "author_id")
+
+	// has_many :comments → target Comment.
+	comments := findEnt(ents, "assoc:has_many:comments")
+	mustProp(t, comments, "association_type", "has_many")
+	mustProp(t, comments, "target_model", "Comment")
+
+	// has_one :featured_image with class_name override.
+	img := findEnt(ents, "assoc:has_one:featured_image")
+	mustProp(t, img, "association_type", "has_one")
+	mustProp(t, img, "target_model", "Image")
+
+	// has_many :through with :source.
+	tags := findEnt(ents, "assoc:has_many:tags")
+	mustProp(t, tags, "through", "taggings")
+	mustProp(t, tags, "source", "tag")
+	mustProp(t, tags, "target_model", "Tag")
+
+	// HABTM → singularized target.
+	cats := findEnt(ents, "assoc:has_and_belongs_to_many:categories")
+	mustProp(t, cats, "association_type", "has_and_belongs_to_many")
+	mustProp(t, cats, "target_model", "Category")
+
+	// Polymorphic belongs_to.
+	poly := findEnt(ents, "assoc:belongs_to:commentable")
+	mustProp(t, poly, "polymorphic", "true")
+	polyFK := findEnt(ents, "ar_fk:commentable:commentable_id")
+	mustProp(t, polyFK, "polymorphic", "true")
+	mustProp(t, polyFK, "type_column", "commentable_type")
+}
+
+// ---------------------------------------------------------------------------
+// Migrations / migration_parsing — normalized SCOPE.Evolution ops + columns
+// ---------------------------------------------------------------------------
+
+func TestDeepMigration_CreateTableColumnsAndOps(t *testing.T) {
+	src := `
+class CreateProducts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :products do |t|
+      t.string :name, null: false
+      t.decimal :price
+      t.references :category, foreign_key: true
+      t.timestamps
+    end
+    add_column :products, :sku, :string, limit: 32
+    add_index :products, :sku, unique: true
+    add_reference :products, :supplier
+    add_foreign_key :products, :suppliers
+    change_column :products, :price, :float
+    remove_column :products, :legacy_code
+    drop_table :obsolete
+  end
+end
+`
+	ents := arExtractRaw(t, "db/migrate/20240101_create_products.rb", src)
+
+	// Normalized SCOPE.Evolution ops.
+	type opCheck struct{ name, subtype string }
+	for _, oc := range []opCheck{
+		{"ar_op:create_table:products", "create_table"},
+		{"ar_op:add_column:products.sku", "add_column"},
+		{"ar_op:create_index:products.sku", "create_index"},
+		{"ar_op:add_reference:products.supplier", "add_reference"},
+		{"ar_op:add_foreign_key:products->suppliers", "add_foreign_key"},
+		{"ar_op:alter_column:products.price", "alter_column"},
+		{"ar_op:drop_column:products.legacy_code", "drop_column"},
+		{"ar_op:drop_table:obsolete", "drop_table"},
+	} {
+		e := findEnt(ents, oc.name)
+		if e == nil {
+			t.Errorf("missing migration op entity %q", oc.name)
+			continue
+		}
+		if e.Kind != "SCOPE.Evolution" {
+			t.Errorf("%q kind = %q, want SCOPE.Evolution", oc.name, e.Kind)
+		}
+		if e.Subtype != oc.subtype {
+			t.Errorf("%q subtype = %q, want %q", oc.name, e.Subtype, oc.subtype)
+		}
+	}
+
+	// Columns declared inside the create_table block, with exact types + opts.
+	nameCol := findEnt(ents, "ar_migcol:products.name")
+	mustProp(t, nameCol, "column_type", "string")
+	mustProp(t, nameCol, "nullable", "false")
+	priceCol := findEnt(ents, "ar_migcol:products.price")
+	mustProp(t, priceCol, "column_type", "decimal")
+
+	// add_column with limit option.
+	skuCol := findEnt(ents, "ar_migcol:products.sku")
+	mustProp(t, skuCol, "column_type", "string")
+	mustProp(t, skuCol, "limit", "32")
+
+	// t.references :category inside create_table → category_id + FK.
+	catCol := findEnt(ents, "ar_col:products.category_id")
+	mustProp(t, catCol, "column_type", "bigint")
+	catFK := findEnt(ents, "ar_fk:products.category_id")
+	mustProp(t, catFK, "target_model", "Category")
+
+	// add_foreign_key :products, :suppliers → FK entity products→suppliers.
+	fk := findEnt(ents, "ar_fk:products->suppliers")
+	mustProp(t, fk, "from_table", "products")
+	mustProp(t, fk, "to_table", "suppliers")
+	mustProp(t, fk, "target_model", "Supplier")
+
+	// t.timestamps inside create_table.
+	for _, c := range []string{"created_at", "updated_at"} {
+		col := findEnt(ents, "ar_migcol:products."+c)
+		mustProp(t, col, "column_type", "datetime")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lazy loading — both eager (includes/preload/eager_load) and lazy default
+// ---------------------------------------------------------------------------
+
+func TestDeepLazyLoading_EagerAndLazyBothRecognized(t *testing.T) {
+	src := `
+class PostsController
+  def index
+    @posts = Post.includes(:comments).preload(:author).eager_load(:tags)
+  end
+end
+class Post < ApplicationRecord
+  has_many :comments
+  belongs_to :author
+end
+`
+	ents := arExtractRaw(t, "app/models/post.rb", src)
+	// Eager markers.
+	for _, n := range []string{
+		"ar_eager:includes:comments",
+		"ar_eager:preload:author",
+		"ar_eager:eager_load:tags",
+	} {
+		e := findEnt(ents, n)
+		if e == nil {
+			t.Errorf("missing eager marker %q", n)
+			continue
+		}
+		mustProp(t, e, "loading_strategy", "eager")
+	}
+	// Lazy default markers.
+	for _, n := range []string{"ar_lazy:has_many:comments", "ar_lazy:belongs_to:author"} {
+		e := findEnt(ents, n)
+		if e == nil {
+			t.Errorf("missing lazy marker %q", n)
+			continue
+		}
+		mustProp(t, e, "loading_strategy", "lazy")
+	}
+}


### PR DESCRIPTION
Raises `lang.ruby.orm.activerecord` from **6 partials → full** (6 cells flipped, 0 regressions, +6 corpus full) with value-asserting extraction matching the TypeORM/Prisma depth bar.

## What's now extracted (per capability)

ActiveRecord models don't declare columns in the class body — the schema lives in `db/schema.rb` and migrations. The new `internal/custom/ruby/activerecord_deep.go` reads those files and links them back to model classes by Rails inflection.

### Models / schema_extraction → full
`db/schema.rb` `create_table "users" do |t| t.string "email", null: false; t.integer "age", default: 0 end` emits:
- `ar_table:users` (SCOPE.Schema/table) with `model_class=User` (inflection: users→User, people→Person, categories→Category)
- `ar_col:users.email` type=string nullable=false, `ar_col:users.age` type=integer default=0, plus `limit:`
- `t.references "company"` → `ar_col:users.company_id` (bigint, is_reference) + `ar_fk:users.company_id` (target_model=Company)
- `t.timestamps` → created_at/updated_at datetime columns

### Associations: association_extraction + relationship_extraction → full
`belongs_to :author, class_name: "User", foreign_key: "author_id"` and `has_many :tags, through: :taggings, source: :tag` emit `assoc:<macro>:<name>` (SCOPE.Pattern/association) carrying `association_type`, `target_model` (inferred via inflection + class_name), `owner_model`, and option props `through`/`source`/`class_name`/`foreign_key`/`polymorphic`/`as`. Covers has_many/belongs_to/has_one/HABTM/has_many:through and polymorphic (`belongs_to :commentable, polymorphic: true`).

### foreign_key_extraction → full
FK from belongs_to convention (`user`→`user_id`), explicit `foreign_key:`, `add_foreign_key :products, :suppliers` (with `to_table:`), `t.references`/`add_reference` (polymorphic adds `<ref>_id`+`<ref>_type`). `target_model` inferred.

### migration_parsing → full
`db/migrate/*.rb` normalized to shared **SCOPE.Evolution** op subtypes (`create_table`/`add_column`/`drop_column`/`alter_column`/`create_index`/`add_reference`/`add_foreign_key`/`drop_table`) — same taxonomy as the TypeORM extractor — plus typed columns declared *inside* `create_table` blocks and FK entities.

### lazy_loading_recognition → full
Declaration-level (parity with the TypeORM bar): recognizes eager calls (`includes`/`preload`/`eager_load`) AND AR lazy-by-default associations, each tagged with `loading_strategy`.

## Tests (value-asserting, not "≥1 entity")
`internal/custom/ruby/activerecord_deep_test.go` — a model + schema.rb + migration fixtures asserting **exact** columns+types+options, association type+target+options, FKs, and migration op subtypes:
- `TestDeepSchema_ExactColumnsAndModelLink` / `TestDeepSchema_IrregularModelLink`
- `TestDeepAssoc_AllMacrosWithOptions`
- `TestDeepMigration_CreateTableColumnsAndOps`
- `TestDeepLazyLoading_EagerAndLazyBothRecognized`

All existing shallow entities + tests preserved (changes are additive; deep entities use distinct names/provenance).

## Honest remainder
Lazy loading is **declaration-level** — query-site dataflow tracing of which records are actually eager-loaded at runtime is out of scope (same limit as the TypeORM bar). Inflection covers common irregulars; exotic custom inflections / `table_name`-overrides are not resolved.

## Validation
- `go build ./internal/... ./tools/coverage/...` ✓
- `go test ./internal/custom/ruby/... ./internal/extractors/ruby/... ./internal/types/ ./tools/coverage/...` ✓
- `coverage validate` exit 0 · `fmt --check` canonical · `gen` byte-stable · `gofmt -l` empty · no new Kind (reuses SCOPE.Schema/Pattern/Evolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Closes #3338