### PR TITLE
fix(hooks): index the worktree the hook fired in, not the hardcoded registered path

### DIFF
--- a/internal/install/hooks/hooks.go
+++ b/internal/install/hooks/hooks.go
@@ -83,6 +83,11 @@ func Uninstall(repo string) error {
 // BlockFor returns the managed hook body for a single hook name.
 // When group is non-empty the block also refreshes the cross-repo
 // links table by invoking `archigraph links pass <group>`.
+//
+// The generated script resolves the repo path at runtime via
+// `git rev-parse --show-toplevel` so that hooks shared through
+// .git/hooks across worktrees index the worktree that fired the
+// hook, not the hardcoded registered main-repo path.
 func BlockFor(hookName, binPath, repo string, group ...string) string {
 	g := ""
 	if len(group) > 0 {
@@ -90,17 +95,19 @@ func BlockFor(hookName, binPath, repo string, group ...string) string {
 	}
 	if g == "" {
 		return fmt.Sprintf(`%s
-# archigraph %s — re-index the repo after %s.
-%q index %q >/dev/null 2>&1 || true
+# archigraph %s — re-index the repo (or worktree) after %s.
+_ag_repo="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -n "$_ag_repo" ] && %q index "$_ag_repo" >/dev/null 2>&1 || true
 %s
-`, MarkerBegin, hookName, hookName, binPath, repo, MarkerEnd)
+`, MarkerBegin, hookName, hookName, binPath, MarkerEnd)
 	}
 	return fmt.Sprintf(`%s
-# archigraph %s — re-index the repo and refresh cross-repo links for group %s.
-%q index %q >/dev/null 2>&1 || true
+# archigraph %s — re-index the repo (or worktree) and refresh cross-repo links for group %s.
+_ag_repo="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -n "$_ag_repo" ] && %q index "$_ag_repo" >/dev/null 2>&1 || true
 %q links pass %q >/dev/null 2>&1 || true
 %s
-`, MarkerBegin, hookName, g, binPath, repo, binPath, g, MarkerEnd)
+`, MarkerBegin, hookName, g, binPath, binPath, g, MarkerEnd)
 }
 
 func hooksDir(repo string) (string, error) {

--- a/internal/install/hooks/hooks_test.go
+++ b/internal/install/hooks/hooks_test.go
@@ -44,6 +44,75 @@ func TestInstallIdempotent(t *testing.T) {
 	}
 }
 
+// TestBlockForWorktreeResolution asserts that every generated hook script
+// uses `git rev-parse --show-toplevel` at runtime to discover the repo/worktree
+// path, and does NOT hardcode the registered repo path. This ensures that when
+// the hook fires inside a worktree it indexes that worktree's branch, not main.
+func TestBlockForWorktreeResolution(t *testing.T) {
+	const binPath = "/usr/local/bin/archigraph"
+	const registeredRepo = "/home/user/myrepo"
+	const group = "mygroup"
+
+	for _, hookName := range HookNames {
+		t.Run(hookName+"/no-group", func(t *testing.T) {
+			block := BlockFor(hookName, binPath, registeredRepo)
+			if !strings.Contains(block, `git rev-parse --show-toplevel`) {
+				t.Errorf("hook %s: missing git rev-parse --show-toplevel:\n%s", hookName, block)
+			}
+			if !strings.Contains(block, `index "$_ag_repo"`) {
+				t.Errorf("hook %s: missing `index \"$_ag_repo\"`:\n%s", hookName, block)
+			}
+			// Must NOT hardcode the registered repo path as an index argument.
+			if strings.Contains(block, `index "`+registeredRepo+`"`) {
+				t.Errorf("hook %s: hardcoded repo path found — worktrees would be mis-indexed:\n%s", hookName, block)
+			}
+		})
+
+		t.Run(hookName+"/with-group", func(t *testing.T) {
+			block := BlockFor(hookName, binPath, registeredRepo, group)
+			if !strings.Contains(block, `git rev-parse --show-toplevel`) {
+				t.Errorf("hook %s+group: missing git rev-parse --show-toplevel:\n%s", hookName, block)
+			}
+			if !strings.Contains(block, `index "$_ag_repo"`) {
+				t.Errorf("hook %s+group: missing `index \"$_ag_repo\"`:\n%s", hookName, block)
+			}
+			if strings.Contains(block, `index "`+registeredRepo+`"`) {
+				t.Errorf("hook %s+group: hardcoded repo path found — worktrees would be mis-indexed:\n%s", hookName, block)
+			}
+			// Group links pass must still be present.
+			if !strings.Contains(block, `links pass "`+group+`"`) {
+				t.Errorf("hook %s+group: links pass line missing:\n%s", hookName, block)
+			}
+		})
+	}
+}
+
+// TestInstallWorktreeResolution verifies the generated hook file (after a real
+// Install call) uses runtime worktree resolution and preserves the managed markers.
+func TestInstallWorktreeResolution(t *testing.T) {
+	repo := gitRepo(t)
+	const binPath = "/usr/local/bin/archigraph"
+	if err := Install(repo, binPath, "mygroup"); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range HookNames {
+		b, err := os.ReadFile(filepath.Join(repo, ".git/hooks", name))
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		script := string(b)
+		if !strings.Contains(script, `git rev-parse --show-toplevel`) {
+			t.Errorf("%s: runtime worktree resolution missing:\n%s", name, script)
+		}
+		if !strings.Contains(script, `index "$_ag_repo"`) {
+			t.Errorf("%s: index with runtime var missing:\n%s", name, script)
+		}
+		if !strings.Contains(script, MarkerBegin) || !strings.Contains(script, MarkerEnd) {
+			t.Errorf("%s: managed markers missing:\n%s", name, script)
+		}
+	}
+}
+
 func TestInstallPreservesUserContent(t *testing.T) {
 	repo := gitRepo(t)
 	user := "#!/bin/sh\necho user-script\n"


### PR DESCRIPTION
## Summary

Closes #3352.

Git worktrees share the common `.git/hooks` directory. The old hook script hardcoded the registered main-repo path, so a commit or checkout **inside a worktree** re-indexed main — not the worktree's branch. Worktree work was silently never indexed by the hook.

### Root cause

`BlockFor` generated:
```sh
"/usr/local/bin/archigraph" index "/path/to/main-repo" >/dev/null 2>&1 || true
```

The path `/path/to/main-repo` was baked in at install time and never changed regardless of which worktree fired the hook.

### Fix

The generated script now resolves the actual worktree at **runtime**:

```sh
_ag_repo="$(git rev-parse --show-toplevel 2>/dev/null)"
[ -n "$_ag_repo" ] && "/usr/local/bin/archigraph" index "$_ag_repo" >/dev/null 2>&1 || true
```

`git rev-parse --show-toplevel` runs with `cwd` set by git to the worktree root, so it correctly yields:
- the **worktree path** when the hook fires in a worktree
- the **main-repo path** when the hook fires in a normal main checkout

Both cases are correct. The `repo` parameter to `BlockFor` is retained for API/caller compatibility but is no longer embedded in the script.

### Bonus: `git worktree add` onboards instantly

`git worktree add` triggers **post-checkout** in the new worktree. With this fix, that immediately indexes the new worktree's branch — no manual `archigraph index` step needed after adding a worktree.

### Preserved unchanged
- `# >>> archigraph managed >>>` / `<<<` markers
- Shebang-preservation logic in `installOne`
- post-commit / post-merge / post-checkout hook set
- Optional `links pass <group>` line

### Tests added
- `TestBlockForWorktreeResolution` — for every hook name x with/without group: asserts `git rev-parse --show-toplevel` present, `index "$_ag_repo"` present, hardcoded registered path absent
- `TestInstallWorktreeResolution` — end-to-end `Install` call with same assertions plus marker checks

## Test plan
- [ ] `go build ./internal/... ./cmd/...` — clean
- [ ] `go test ./internal/install/... ./internal/types/` — all pass (verified locally)
- [ ] `gofmt -l` — empty on touched files (verified locally)
- [ ] Manual: install hooks in a repo, add a worktree, commit in the worktree, confirm the worktree branch is indexed

## Deploy note
A daemon rebuild + reinstall of hooks (`archigraph install`) is required on each repo to pick up the new template. Existing hooks written by old versions continue to work (they just index main as before until reinstalled). Daemon rebuild is deferred.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>