### PR TITLE
fix(daemon): run worktree discovery + watch worktree working trees; event-driven onboarding

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/daemon/sched"
 	"github.com/cajasmota/archigraph/internal/daemon/watch"
+	"github.com/cajasmota/archigraph/internal/daemon/worktree"
 	"github.com/cajasmota/archigraph/internal/dashboard"
 	"github.com/cajasmota/archigraph/internal/docgen"
 	"github.com/cajasmota/archigraph/internal/extractor"
@@ -282,11 +283,16 @@ func runDaemon(argv []string) error {
 		// reindex skips Pass 4 (graph algorithms) so a freshly-saved
 		// file becomes queryable as soon as the basic graph lands;
 		// the algorithm pass is run separately on a 30s debounce.
-		ReposToWatch:   daemonReposToWatch,
-		GroupsForRepo:  daemonGroupsForRepo,
-		SchedulerIndex: daemonSchedulerIndex,
-		SchedulerLinks: daemonSchedulerLinks,
-		SchedulerAlgo:  daemonSchedulerAlgo,
+		ReposToWatch:  daemonReposToWatch,
+		GroupsForRepo: daemonGroupsForRepo,
+
+		// #3353/#3354: linked-worktree discovery + working-tree watching.
+		// Only groups with track_worktrees or watchers enabled are returned;
+		// nil → discovery not started.
+		WorktreeParents: daemonWorktreeParents,
+		SchedulerIndex:  daemonSchedulerIndex,
+		SchedulerLinks:  daemonSchedulerLinks,
+		SchedulerAlgo:   daemonSchedulerAlgo,
 		// Issue #2406: capture extractorCfg at construction time so the closure
 		// owns an immutable pointer — no package-level singleton needed.
 		SchedulerIncremental: func(ctx context.Context, repoPath string, ref string) sched.IncrementalResult {
@@ -477,6 +483,53 @@ func daemonGroupsForRepo(repoPath string) []string {
 				out = append(out, g.Name)
 				break
 			}
+		}
+	}
+	return out
+}
+
+// daemonWorktreeParents returns the registered repos whose group opts into
+// linked-worktree tracking (#3353/#3354). A group opts in when either
+// features.track_worktrees OR features.watchers is true — worktree
+// working-tree watching is a strict extension of the file watcher, so any
+// group that already has watchers enabled gets it. Returns nil when no
+// group opts in (the daemon then does not start worktree discovery).
+//
+// Each returned ParentRepo carries the group name, repo slug, and the
+// resolved absolute path to the main checkout. Bare worktrees and the main
+// checkout itself are filtered downstream by runWorktreeList.
+func daemonWorktreeParents() []worktree.ParentRepo {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []worktree.ParentRepo
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		if !cfg.Features.TrackWorktrees && !cfg.Features.Watchers {
+			continue
+		}
+		for _, r := range cfg.Repos {
+			abs, aerr := filepath.Abs(r.Path)
+			if aerr != nil {
+				abs = r.Path
+			}
+			// Dedup on (group, path): a repo may legitimately appear in
+			// multiple groups, but within a group the path is unique.
+			key := g.Name + "\x00" + abs
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, worktree.ParentRepo{
+				GroupName: g.Name,
+				Slug:      r.Slug,
+				Path:      abs,
+			})
 		}
 	}
 	return out

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -11,6 +11,7 @@ import (
 	"net/rpc/jsonrpc"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -21,6 +22,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon/sched"
 	"github.com/cajasmota/archigraph/internal/daemon/transport"
 	"github.com/cajasmota/archigraph/internal/daemon/watch"
+	"github.com/cajasmota/archigraph/internal/daemon/worktree"
 	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/gitmeta"
 )
@@ -40,11 +42,25 @@ type Config struct {
 	// repo returned by ReposToWatch. The Index field above remains
 	// the synchronous RPC entrypoint; the scheduler uses
 	// SchedulerIndex for fast (algo-skipped) reactive reindexes.
-	ReposToWatch   func() []string                                          // repos to subscribe at startup
-	GroupsForRepo  func(repoPath string) []string                           // for cross-repo link debounce
-	SchedulerIndex func(ctx context.Context, repo string, ref string) error // fast reindex (skip algo pass); ref is the git branch captured at enqueue time
-	SchedulerLinks func(ctx context.Context, group string) error
-	SchedulerAlgo  func(ctx context.Context, repo string) error
+	ReposToWatch  func() []string                // repos to subscribe at startup
+	GroupsForRepo func(repoPath string) []string // for cross-repo link debounce
+
+	// WorktreeParents, when non-nil, enables linked-worktree discovery
+	// (#3353/#3354). It returns the set of registered repos whose group has
+	// worktree tracking enabled (features.track_worktrees / watchers). The
+	// daemon starts a worktree.Watcher that:
+	//   - discovers each parent's linked worktrees and persists them to
+	//     ~/.archigraph/worktrees.json,
+	//   - subscribes each worktree's WORKING TREE to the fsnotify watcher so
+	//     uncommitted edits trigger a reindex of that worktree's ref tier,
+	//   - watches each parent's .git/worktrees/ dir (event-driven onboarding)
+	//     and runs a periodic reconciliation poll for removals/missed events.
+	// Only started when the fsnotify watcher itself is up. Returns nil when
+	// no group opts in (the Watcher is then not started).
+	WorktreeParents func() []worktree.ParentRepo
+	SchedulerIndex  func(ctx context.Context, repo string, ref string) error // fast reindex (skip algo pass); ref is the git branch captured at enqueue time
+	SchedulerLinks  func(ctx context.Context, group string) error
+	SchedulerAlgo   func(ctx context.Context, repo string) error
 
 	// SchedulerIncremental, when non-nil, is wired as the S3 incremental
 	// file-level reindex hook (issue #2153). It is attempted before
@@ -375,6 +391,45 @@ func Run(ctx context.Context, cfg Config) error {
 			}
 			if cfg.OnWatcherReady != nil {
 				cfg.OnWatcherReady(watcher)
+			}
+
+			// #3353/#3354: linked-worktree discovery + working-tree watching.
+			// Gated on the fsnotify watcher being up (we reuse it to watch each
+			// worktree's working tree) and on a caller-supplied parents provider
+			// (non-nil only when some group opts into worktree tracking).
+			if cfg.WorktreeParents != nil {
+				wtStorePath := filepath.Join(cfg.Layout.Root, "worktrees.json")
+				wtStore := worktree.NewStore(wtStorePath)
+				if err := wtStore.Load(); err != nil {
+					logger.Warn("worktree: failed to load store; starting empty", "path", wtStorePath, "err", err)
+				}
+				wtWatcher := worktree.NewWatcher(wtStore, cfg.WorktreeParents, logger)
+
+				// On activation, subscribe the worktree's WORKING TREE to the
+				// fsnotify watcher so uncommitted edits trigger a reactive
+				// reindex, and enqueue one immediate reindex of its ref tier.
+				// scheduler.Enqueue captures the worktree's checked-out ref via
+				// RefCapture(worktreePath), so the graph lands in the correct
+				// per-ref dir keyed by the worktree path (multi-ref model).
+				wtWatcher.OnActivate = func(child *worktree.WorktreeChild) {
+					if _, aerr := watcher.AddRepo(child.Path); aerr != nil {
+						logger.Warn("worktree: failed to watch working tree", "path", child.Path, "err", aerr)
+					}
+					scheduler.Enqueue(child.Path)
+					logger.Info("worktree: watching working tree + enqueued initial reindex",
+						"path", child.Path, "branch", child.Branch, "group", child.GroupName, "slug", child.ParentSlug, "locked", child.Locked)
+				}
+				// On expiry, unsubscribe the working tree from the watcher.
+				wtWatcher.OnExpire = func(child *worktree.WorktreeChild) {
+					watcher.RemoveRepo(child.Path)
+					logger.Info("worktree: unwatched expired working tree", "path", child.Path)
+				}
+
+				wtCtx, wtCancel := context.WithCancel(ctx)
+				go wtWatcher.Start(wtCtx)
+				defer wtCancel()
+				logger.Info("worktree: discovery started",
+					"store", wtStorePath, "reconcile_env", "ARCHIGRAPH_WORKTREE_POLL_SECONDS")
 			}
 		}
 	}

--- a/internal/daemon/worktree/export_test.go
+++ b/internal/daemon/worktree/export_test.go
@@ -1,7 +1,14 @@
 package worktree
 
+import "time"
+
 // ParseWorktreeListForTest exposes the package-internal parseWorktreeList
 // function for white-box unit tests in the _test package.
 func ParseWorktreeListForTest(s string) []RawWorktree {
 	return parseWorktreeList(s)
+}
+
+// IntervalForTest exposes the resolved reconciliation interval for tests.
+func (w *Watcher) IntervalForTest() time.Duration {
+	return w.interval
 }

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -16,12 +16,18 @@
 //
 // # Discovery loop
 //
-// The Watcher polls `git worktree list --porcelain` for every registered
-// repo every 5 minutes (ARCHIGRAPH_WORKTREE_POLL_MINUTES override).
+// Discovery is event-driven: the post-checkout git hook (#3352) and an
+// fsnotify watch on each parent's .git/worktrees/ directory call Sync()
+// promptly when a worktree is added or removed.  The Watcher ALSO runs a
+// periodic RECONCILIATION poll of `git worktree list --porcelain` for
+// every registered repo (default 60s, ARCHIGRAPH_WORKTREE_POLL_SECONDS
+// override; ARCHIGRAPH_WORKTREE_POLL_MINUTES still honoured) to catch any
+// events missed while the daemon was down or dropped.
 //
-//   - New worktrees → added to the Store.
+//   - New worktrees → added to the Store; OnActivate fires.
 //   - Still-present worktrees → LastSeenAt refreshed.
-//   - Removed worktrees → Status set to StatusExpired and StaleAt recorded.
+//   - Removed worktrees → Status set to StatusExpired, StaleAt recorded;
+//     OnExpire fires.
 //
 // # Per-parent cap
 //
@@ -53,6 +59,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 // ---------------------------------------------------------------------------
@@ -445,18 +453,49 @@ type ParentRepo struct {
 
 // Watcher is a background goroutine that polls registered repos for linked
 // worktrees and syncs them into the Store.
+//
+// The poll is now a RECONCILIATION pass (#3354): event-driven onboarding
+// happens via the post-checkout git hook (#3352) and/or the daemon's
+// fsnotify watch on each parent's .git/worktrees/ directory, which call
+// Sync() directly.  The periodic poll exists only to (a) catch worktrees
+// that were added/removed while the daemon was down or while events were
+// dropped, and (b) detect REMOVED worktrees (no inotify event fires on the
+// parent for a `git worktree remove` of an external dir).
+//
+// OnActivate / OnExpire let the daemon react to liveness transitions
+// (e.g. subscribe/unsubscribe the worktree working tree from the file
+// watcher and enqueue an initial reindex).  Both may be nil.
 type Watcher struct {
 	store    *Store
 	parents  func() []ParentRepo // called on every tick to get the current set
 	interval time.Duration
 	logger   *slog.Logger
+
+	// OnActivate fires once per child when it becomes (or re-becomes)
+	// active — i.e. on first discovery and on re-activation after expiry.
+	// Used by the daemon to watch the worktree working tree and trigger an
+	// initial reindex of the worktree's ref tier.  May be nil.
+	OnActivate func(child *WorktreeChild)
+	// OnExpire fires once per child when it transitions to expired (the
+	// worktree was removed).  Used by the daemon to unsubscribe the
+	// worktree working tree from the file watcher.  May be nil.
+	OnExpire func(child *WorktreeChild)
 }
 
-// defaultPollInterval is the default discovery interval.
-const defaultPollInterval = 5 * time.Minute
+// defaultPollInterval is the default reconciliation interval.
+const defaultPollInterval = 60 * time.Second
 
-// pollInterval reads ARCHIGRAPH_WORKTREE_POLL_MINUTES or returns the default.
+// pollInterval returns the reconciliation interval.
+//
+// ARCHIGRAPH_WORKTREE_POLL_SECONDS takes precedence (the poll is now a
+// fast reconciliation pass, #3354).  ARCHIGRAPH_WORKTREE_POLL_MINUTES is
+// still honoured for backward compatibility when SECONDS is unset.
 func pollInterval() time.Duration {
+	if v := os.Getenv("ARCHIGRAPH_WORKTREE_POLL_SECONDS"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
 	if v := os.Getenv("ARCHIGRAPH_WORKTREE_POLL_MINUTES"); v != "" {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
 			return time.Duration(n) * time.Minute
@@ -480,9 +519,25 @@ func NewWatcher(store *Store, parents func() []ParentRepo, logger *slog.Logger) 
 }
 
 // Start runs the discovery loop until ctx is cancelled.  It performs one
-// immediate poll before waiting for the first tick.
+// immediate discovery pass, then drives both:
+//
+//   - an event-driven fsnotify watch on each parent's .git/worktrees/
+//     directory, so `git worktree add`/`remove` is picked up promptly, and
+//   - a periodic RECONCILIATION poll (default 60s) that catches removals
+//     and any events missed while the daemon was down or dropped.
+//
+// Both call Sync(), which de-dups via a single `git worktree list` per
+// parent per pass.
 func (w *Watcher) Start(ctx context.Context) {
 	w.poll()
+
+	// Event-driven onboarding: fsnotify-watch each parent's common
+	// .git/worktrees/ dir.  git creates/removes a child dir there on every
+	// `git worktree add`/`remove`, so a Create/Remove event is a reliable,
+	// prompt signal to reconcile.  Best-effort — failures fall back to poll.
+	gitWatch := w.startGitDirsWatch(ctx)
+	defer gitWatch()
+
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
 	for {
@@ -495,8 +550,118 @@ func (w *Watcher) Start(ctx context.Context) {
 	}
 }
 
-// Poll runs one discovery cycle synchronously.  Exported for test control.
+// startGitDirsWatch sets up an fsnotify watch on every parent's
+// .git/worktrees/ directory.  On any event it debounces briefly and calls
+// Sync().  It also re-resolves the parent set lazily (cheap) so newly
+// registered repos get watched on the next reconciliation tick (which calls
+// this is not re-run; the periodic poll still covers them).  Returns a stop
+// func.  Best-effort: if fsnotify is unavailable it returns a no-op.
+func (w *Watcher) startGitDirsWatch(ctx context.Context) func() {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		w.logger.Warn("worktree: fsnotify unavailable, relying on reconciliation poll", "err", err)
+		return func() {}
+	}
+
+	added := 0
+	for _, p := range w.parents() {
+		dir := gitWorktreesDir(p.Path)
+		if dir == "" {
+			continue
+		}
+		// Ensure the dir exists so the watch survives the first
+		// `git worktree add` (git creates .git/worktrees/ on demand).
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			continue
+		}
+		if err := fw.Add(dir); err != nil {
+			w.logger.Warn("worktree: failed to watch .git/worktrees", "dir", dir, "err", err)
+			continue
+		}
+		added++
+	}
+	if added == 0 {
+		_ = fw.Close()
+		return func() {}
+	}
+	w.logger.Info("worktree: event-driven onboarding active", "git_worktrees_dirs", added)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var timer *time.Timer
+		const debounce = 750 * time.Millisecond
+		fire := func() { w.poll() }
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-fw.Events:
+				if !ok {
+					return
+				}
+				if timer != nil {
+					timer.Stop()
+				}
+				timer = time.AfterFunc(debounce, fire)
+			case _, ok := <-fw.Errors:
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+
+	return func() {
+		_ = fw.Close()
+		<-done
+	}
+}
+
+// gitWorktreesDir returns the absolute path to the common
+// .git/worktrees/ directory for repoPath, or "" if it cannot be resolved.
+// It handles both a normal repo (.git is a directory) — the common case —
+// returning <repo>/.git/worktrees.  When .git is a file (i.e. repoPath is
+// itself a linked worktree) we resolve the gitdir's parent; callers should
+// only pass main checkouts, so this is a defensive fallback.
+func gitWorktreesDir(repoPath string) string {
+	gitPath := filepath.Join(repoPath, ".git")
+	fi, err := os.Stat(gitPath)
+	if err != nil {
+		return ""
+	}
+	if fi.IsDir() {
+		return filepath.Join(gitPath, "worktrees")
+	}
+	// .git is a file ("gitdir: <path>"). Resolve and take its parent dir's
+	// worktrees subdir.
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(data))
+	line = strings.TrimPrefix(line, "gitdir:")
+	gitdir := strings.TrimSpace(line)
+	if gitdir == "" {
+		return ""
+	}
+	// gitdir is typically <common>/worktrees/<name>; its parent is the
+	// worktrees dir we want.
+	return filepath.Dir(gitdir)
+}
+
+// Poll runs one reconciliation cycle synchronously.  Exported for test
+// control.  See Sync for the event-driven entry point with identical
+// semantics.
 func (w *Watcher) Poll() { w.poll() }
+
+// Sync runs one reconciliation/discovery cycle synchronously.  It is the
+// event-driven entry point: the daemon calls Sync when an fsnotify event
+// fires on a parent's .git/worktrees/ directory (a worktree was added or
+// removed) or when the post-checkout git hook reports a new worktree.
+// Semantics are identical to a poll tick — it is safe and cheap to call
+// frequently because the per-parent `git worktree list` runs at most once.
+func (w *Watcher) Sync() { w.poll() }
 
 func (w *Watcher) poll() {
 	parents := w.parents()
@@ -505,6 +670,11 @@ func (w *Watcher) poll() {
 
 	// Track every path seen in this tick across all parents.
 	seenPaths := make(map[string]bool)
+
+	// Transitions to fire callbacks for, collected while holding the lock
+	// and dispatched after release so callbacks never run under s.mu
+	// (they call back into the daemon's file watcher / scheduler).
+	var activated, expired []*WorktreeChild
 
 	for _, p := range parents {
 		linked, err := runWorktreeList(p.Path)
@@ -534,6 +704,7 @@ func (w *Watcher) poll() {
 					Status:       StatusActive,
 				}
 				w.store.upsert(child)
+				activated = append(activated, child)
 				w.logger.Info("worktree: registered", "group", p.GroupName, "slug", p.Slug, "path", raw.Path, "branch", raw.Branch)
 			} else {
 				// Refresh.
@@ -543,6 +714,7 @@ func (w *Watcher) poll() {
 				if existing.Status == StatusExpired {
 					existing.Status = StatusActive
 					existing.StaleAt = nil
+					activated = append(activated, existing)
 					w.logger.Info("worktree: re-activated", "group", p.GroupName, "slug", p.Slug, "path", raw.Path)
 				}
 			}
@@ -550,11 +722,14 @@ func (w *Watcher) poll() {
 		w.store.mu.Unlock()
 	}
 
-	// Mark removed worktrees as expired.
+	// Mark removed worktrees as expired.  Reconciliation: this is the
+	// primary mechanism for detecting `git worktree remove` since no
+	// fsnotify event fires on the parent for an external worktree dir.
 	w.store.mu.Lock()
 	for _, c := range w.store.children {
 		if c.Status == StatusActive && !seenPaths[normPath(c.Path)] {
 			w.store.markExpired(c.Path)
+			expired = append(expired, c)
 			w.logger.Info("worktree: expired", "group", c.GroupName, "slug", c.ParentSlug, "path", c.Path, "reason", "no longer listed by git")
 		}
 	}
@@ -562,4 +737,16 @@ func (w *Watcher) poll() {
 		w.logger.Error("worktree: failed to persist store", "err", err)
 	}
 	w.store.mu.Unlock()
+
+	// Fire transition callbacks outside the lock.
+	if w.OnActivate != nil {
+		for _, c := range activated {
+			w.OnActivate(c)
+		}
+	}
+	if w.OnExpire != nil {
+		for _, c := range expired {
+			w.OnExpire(c)
+		}
+	}
 }

--- a/internal/daemon/worktree/worktree_test.go
+++ b/internal/daemon/worktree/worktree_test.go
@@ -415,6 +415,173 @@ func TestLookupByParent(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// #3353/#3354: activation/expiry callbacks + event-driven Sync
+// ---------------------------------------------------------------------------
+
+// TestWatcher_OnActivate_fires_on_discovery verifies that OnActivate fires
+// exactly once per newly discovered worktree, carrying the correct path and
+// branch — this is the hook the daemon uses to subscribe the worktree's
+// working tree to the file watcher and enqueue an initial reindex.
+func TestWatcher_OnActivate_fires_on_discovery(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repoDir)
+	wt1 := filepath.Join(tmp, "wt1")
+	addWorktree(t, repoDir, wt1, "feat/activate")
+
+	store := worktree.NewStore(filepath.Join(tmp, "wt.json"))
+	parents := func() []worktree.ParentRepo {
+		return []worktree.ParentRepo{{GroupName: "g", Slug: "r", Path: repoDir}}
+	}
+	w := worktree.NewWatcher(store, parents, nil)
+
+	var activated []*worktree.WorktreeChild
+	w.OnActivate = func(c *worktree.WorktreeChild) { activated = append(activated, c) }
+
+	w.Poll()
+	if len(activated) != 1 {
+		t.Fatalf("OnActivate fired %d times, want 1", len(activated))
+	}
+	if activated[0].Branch != "feat/activate" {
+		t.Errorf("activated branch = %q, want feat/activate", activated[0].Branch)
+	}
+	realWt1 := realPath(t, wt1)
+	if activated[0].Path != realWt1 && activated[0].Path != wt1 {
+		t.Errorf("activated path = %q, want %q", activated[0].Path, realWt1)
+	}
+
+	// Re-poll with the same worktree: must NOT fire again (idempotent).
+	activated = nil
+	w.Poll()
+	if len(activated) != 0 {
+		t.Fatalf("OnActivate fired %d times on second poll, want 0", len(activated))
+	}
+}
+
+// TestWatcher_OnExpire_fires_on_removal verifies OnExpire fires when a
+// worktree is removed — the daemon uses it to unsubscribe the working tree.
+func TestWatcher_OnExpire_fires_on_removal(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repoDir)
+	wt1 := filepath.Join(tmp, "wt1")
+	addWorktree(t, repoDir, wt1, "feat/expire")
+
+	store := worktree.NewStore(filepath.Join(tmp, "wt.json"))
+	parents := func() []worktree.ParentRepo {
+		return []worktree.ParentRepo{{GroupName: "g", Slug: "r", Path: repoDir}}
+	}
+	w := worktree.NewWatcher(store, parents, nil)
+
+	var expired []*worktree.WorktreeChild
+	w.OnExpire = func(c *worktree.WorktreeChild) { expired = append(expired, c) }
+
+	w.Poll()
+	if len(expired) != 0 {
+		t.Fatalf("OnExpire fired before removal: %d", len(expired))
+	}
+
+	realWt1 := realPath(t, wt1)
+	cmd := exec.Command("git", "-C", repoDir, "worktree", "remove", "--force", wt1)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree remove: %v\n%s", err, out)
+	}
+
+	w.Poll()
+	if len(expired) != 1 {
+		t.Fatalf("OnExpire fired %d times after removal, want 1", len(expired))
+	}
+	if expired[0].Path != realWt1 && expired[0].Path != wt1 {
+		t.Errorf("expired path = %q, want %q", expired[0].Path, realWt1)
+	}
+}
+
+// TestWatcher_Sync_discovers verifies the event-driven entry point Sync()
+// has identical semantics to Poll() — a working-tree edit followed by a
+// Sync registers and persists the WorktreeChild.
+func TestWatcher_Sync_discovers_and_persists(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repoDir)
+	wt1 := filepath.Join(tmp, "wt1")
+	addWorktree(t, repoDir, wt1, "feat/sync")
+
+	// Simulate in-progress (uncommitted) work in the worktree.
+	if err := os.WriteFile(filepath.Join(wt1, "new.txt"), []byte("wip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath := filepath.Join(tmp, "wt.json")
+	store := worktree.NewStore(storePath)
+	parents := func() []worktree.ParentRepo {
+		return []worktree.ParentRepo{{GroupName: "g", Slug: "r", Path: repoDir}}
+	}
+	w := worktree.NewWatcher(store, parents, nil)
+	w.Sync()
+
+	if len(store.Active()) != 1 {
+		t.Fatalf("Sync: want 1 active child, got %d", len(store.Active()))
+	}
+	// Persistence: a fresh Store loads the same child from disk.
+	store2 := worktree.NewStore(storePath)
+	if err := store2.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(store2.Active()) != 1 {
+		t.Fatalf("persisted store: want 1 active, got %d", len(store2.Active()))
+	}
+}
+
+// TestPollInterval_seconds_env verifies the new SECONDS override takes
+// precedence and that the default is the demoted 60s reconciliation cadence.
+func TestPollInterval_seconds_env(t *testing.T) {
+	// Default (no env) → 60s.
+	t.Setenv("ARCHIGRAPH_WORKTREE_POLL_SECONDS", "")
+	t.Setenv("ARCHIGRAPH_WORKTREE_POLL_MINUTES", "")
+	store := worktree.NewStore(filepath.Join(t.TempDir(), "wt.json"))
+	parents := func() []worktree.ParentRepo { return nil }
+	if got := worktree.NewWatcher(store, parents, nil).IntervalForTest(); got != 60*time.Second {
+		t.Errorf("default interval = %v, want 60s", got)
+	}
+
+	// SECONDS override wins.
+	t.Setenv("ARCHIGRAPH_WORKTREE_POLL_SECONDS", "5")
+	if got := worktree.NewWatcher(store, parents, nil).IntervalForTest(); got != 5*time.Second {
+		t.Errorf("SECONDS interval = %v, want 5s", got)
+	}
+
+	// SECONDS takes precedence over MINUTES.
+	t.Setenv("ARCHIGRAPH_WORKTREE_POLL_MINUTES", "10")
+	if got := worktree.NewWatcher(store, parents, nil).IntervalForTest(); got != 5*time.Second {
+		t.Errorf("SECONDS should win over MINUTES, got %v", got)
+	}
+
+	// MINUTES still honoured for back-compat when SECONDS unset.
+	t.Setenv("ARCHIGRAPH_WORKTREE_POLL_SECONDS", "")
+	if got := worktree.NewWatcher(store, parents, nil).IntervalForTest(); got != 10*time.Minute {
+		t.Errorf("MINUTES back-compat = %v, want 10m", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Worktree TTL policy constants (integration with tier.TTLConfig)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3353, #3354.

## Root cause

The `worktree.Watcher` (`internal/daemon/worktree/worktree.go`) was fully implemented — discovery, `Store`, `worktrees.json` persistence, per-parent cap, TTL slot kinds — but it was **never instantiated or started anywhere in the daemon boot path**. The only references to `worktree.NewStore` / `worktree.NewWatcher` in non-test code lived in `internal/cli/status.go`, which only *reads* the store for `archigraph status` display.

Consequences (exactly the live-diagnosed symptoms):
- `~/.archigraph/worktrees.json` was never written.
- No fsnotify watch was ever registered for any worktree working tree, so uncommitted worktree edits were never live-indexed.
- The feature was additionally gated on `features.track_worktrees`, which *nothing in the daemon* consulted — only `status.go`.

(The daemon's committed branch-ref tiering works via the HEAD poller, which is why per-ref indexing functioned while worktree working-tree watching did not.)

## What changed

**`internal/daemon/server.go`** — under the live fsnotify watcher block (only when the watcher is up), start a `worktree.Watcher` when `Config.WorktreeParents` is non-nil:
- `OnActivate(child)` → `watcher.AddRepo(child.Path)` (subscribe the worktree **working tree**, debounced like the main repo) **+** `scheduler.Enqueue(child.Path)` (initial reindex). `scheduler.Enqueue` captures the worktree's checked-out ref via `RefCapture(worktreePath)`, so the graph lands in the correct per-ref dir **keyed by the worktree path** (existing multi-ref model).
- `OnExpire(child)` → `watcher.RemoveRepo(child.Path)`.
- Store persists to `Layout.Root/worktrees.json` (sandbox-aware via `ARCHIGRAPH_DAEMON_ROOT`).

**`cmd/archigraph/daemon.go`** — `daemonWorktreeParents()` returns `ParentRepo{group, slug, abs-path}` for every repo in a group with `features.track_worktrees` **OR** `features.watchers` enabled (worktree working-tree watching is a strict extension of the file watcher, so any watchers-enabled group gets it — matching the live group's `watchers:true`). Returns nil when no group opts in → discovery not started.

**`internal/daemon/worktree/worktree.go`**:
- `OnActivate` / `OnExpire` transition callbacks, collected under the store lock and fired **after** release (they call back into the watcher/scheduler).
- `Sync()` — event-driven entry point (identical semantics to a poll tick; one `git worktree list` per parent).
- fsnotify watch on each parent's common `.git/worktrees/` dir → debounced `Sync()` for **prompt onboarding** of `git worktree add`/`remove`.
- **Demoted the 5-min poll to a 60s RECONCILIATION pass** that catches removals and missed events. New `ARCHIGRAPH_WORKTREE_POLL_SECONDS` (default **60s**) takes precedence; `ARCHIGRAPH_WORKTREE_POLL_MINUTES` still honoured for back-compat.
- Existing per-parent cap, locked-flag propagation, and bare/main-checkout filtering are preserved (`runWorktreeList` unchanged).

## Before / after

- **Before:** `watchers:true` group with linked worktrees → `worktrees.json` absent, zero worktree watches, uncommitted worktree work never indexed.
- **After:** each linked worktree is discovered + persisted as an ephemeral `WorktreeChild`, its working tree is fsnotify-watched, and an uncommitted edit reindexes that worktree's own ref tier. New worktrees are onboarded promptly via the `.git/worktrees/` watch (and the companion #3352 hook); removals are reconciled within ~60s.

## Tests (real linked-worktree fixtures, sandboxed)

`internal/daemon/worktree/worktree_test.go`:
- `OnActivate` fires exactly once per discovered worktree, carries correct path+branch, and is idempotent on re-poll.
- `OnExpire` fires on `git worktree remove`.
- `Sync()` discovers + persists a worktree with an uncommitted edit (fresh `Store.Load()` sees it).
- Poll interval resolves SECONDS > MINUTES > 60s default.

Validation (sandboxed, scoped — never `./...`): `go build ./internal/... ./cmd/...`; `go test ./internal/daemon/worktree/... ./internal/daemon/watch/... ./internal/types/...` all pass; `gofmt -l` empty on touched files.

## Backlogged remainder

None of the core scope is deferred. Event-driven onboarding via the git hook itself is the companion #3352 PR; this PR provides the daemon-side `.git/worktrees/` fsnotify fallback + the `Sync()` entry point the hook will call.

**Deploy needs a daemon rebuild + restart (deferred — not done here to avoid disrupting the live daemon).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)