### PR TITLE
deep(ruby): Rails Rack middleware + filters to TS/JS full bar

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -43810,8 +43810,8 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/middleware.go"]
+            "status": "full",
+            "cites": ["internal/custom/ruby/middleware.go","internal/custom/ruby/middleware_test.go"]
           }
         },
         "Type System": {

--- a/internal/custom/ruby/middleware.go
+++ b/internal/custom/ruby/middleware.go
@@ -2,8 +2,14 @@
 //
 // Detects:
 //   - Rack `use SomeMiddleware` calls (all frameworks that mount Rack stacks)
+//   - Rails config.middleware stack: use/insert_before/insert_after/swap/delete
+//     in config/application.rb + per-environment files — emits each middleware
+//     with operation name and order_position (sequential index within file).
+//   - Custom Rack middleware classes: class with `def initialize(app)` +
+//     `def call(env)` — emitted as rack_middleware_class entities.
 //   - Rails / Padrino / Sinatra `before_action` / `after_action` / `around_action`
-//     controller filters (middleware-equivalent pattern)
+//     controller filters with full `:only`/`:except` scope capture
+//     (middleware-equivalent pattern).
 //   - Grape `before` / `after` / `rescue_from` hooks
 //   - Hanami middleware in config/application.rb (config.middleware.use ...)
 //   - Roda plugin + before/after
@@ -16,16 +22,17 @@
 //	lang.ruby.framework.grape    Middleware/middleware_coverage → partial
 //	lang.ruby.framework.hanami   Middleware/middleware_coverage → partial
 //	lang.ruby.framework.padrino  Middleware/middleware_coverage → partial
-//	lang.ruby.framework.rails    Middleware/middleware_coverage → partial
+//	lang.ruby.framework.rails    Middleware/middleware_coverage → full   (#3341)
 //	lang.ruby.framework.roda     Middleware/middleware_coverage → partial
 //	lang.ruby.framework.sinatra  Middleware/middleware_coverage → partial
 //
-// Part of #3282.
+// Part of #3282 / #3341.
 package ruby
 
 import (
 	"context"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -35,6 +42,9 @@ import (
 	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// itoa converts an integer to its decimal string representation.
+func itoa(n int) string { return strconv.Itoa(n) }
 
 func init() {
 	extractor.Register("ruby_middleware", &rubyMiddlewareExtractor{})
@@ -54,14 +64,59 @@ var (
 		`(?m)^\s*use\s+([A-Z][A-Za-z0-9_:]+)`,
 	)
 
-	// Rails/Padrino config middleware: config.middleware.use Middleware
-	reMWConfigUse = regexp.MustCompile(
-		`(?m)\bconfig\.middleware\.(?:use|insert_before|insert_after)\s+([A-Z][A-Za-z0-9_:]+)`,
+	// Rails/Padrino config middleware — captures the operation name and the
+	// middleware class name.  Handles:
+	//   config.middleware.use          MiddlewareClass
+	//   config.middleware.insert_before OtherClass, MiddlewareClass
+	//   config.middleware.insert_after  OtherClass, MiddlewareClass
+	//   config.middleware.swap          OtherClass, MiddlewareClass
+	//   config.middleware.delete        MiddlewareClass
+	//
+	// Group 1 = operation (use|insert_before|insert_after|swap|delete)
+	// Group 2 = first class-name token (the anchor class for insert/swap ops or
+	//            the target class for use/delete)
+	// Group 3 = optional second class-name token (the new middleware for
+	//            insert_before/insert_after/swap)
+	reMWConfigOp = regexp.MustCompile(
+		`(?m)\bconfig\.middleware\.(use|insert_before|insert_after|swap|delete)\s+([A-Z][A-Za-z0-9_:]+)(?:\s*,\s*([A-Z][A-Za-z0-9_:]+))?`,
 	)
 
-	// Rails before_action / after_action / around_action (already in rails.go
-	// for CALLS edges; here we also emit a middleware_coverage entity so the
-	// middleware_coverage cell is satisfied independently).
+	// Rails before_action / after_action / around_action with optional
+	// :only / :except scoping.
+	//
+	// Examples matched:
+	//   before_action :authenticate_user!
+	//   before_action :set_resource, only: [:show, :edit, :update, :destroy]
+	//   after_action  :log_request, except: [:index]
+	//
+	// Group 1 = filter type  (before_action|after_action|around_action)
+	// Group 2 = method name  (:symbol)
+	// Group 3 = scope kind   (only|except) — may be empty
+	// Group 4 = scope value  (raw text after "only:" or "except:") — may be empty
+	reMWRailsFilterScoped = regexp.MustCompile(
+		`(?m)^\s*(before_action|after_action|around_action)\s+:([a-z_]+[!?]?)` +
+			`(?:[^#\n]*?\b(only|except)\s*:\s*(\[[^\]]*\]|\:[a-z_]+[!?]?))?`,
+	)
+
+	// Custom Rack middleware class: any Ruby class that defines both
+	// `def initialize(app)` and `def call(env)`.  We detect them in two phases:
+	//   Phase 1 — class-name line: `class SomeName`
+	//   Phase 2 — presence of both initialize(app) and call(env) in the same
+	//             source (file-level check; good enough for single-class files
+	//             which is the idiomatic Rack pattern).
+	raMwClassDef = regexp.MustCompile(
+		`(?m)^\s*class\s+([A-Z][A-Za-z0-9_:]*)`,
+	)
+	raMwInitApp = regexp.MustCompile(
+		`(?m)\bdef\s+initialize\s*\(\s*app\b`,
+	)
+	raMwCallEnv = regexp.MustCompile(
+		`(?m)\bdef\s+call\s*\(\s*@?env\b`,
+	)
+
+	// Rails before_action / after_action / around_action (legacy — kept for
+	// backwards compat with non-scoped fast-path; replaced by reMWRailsFilterScoped
+	// in the extraction loop but retained so existing callers compile).
 	reMWRailsFilter = regexp.MustCompile(
 		`(?m)^\s*(before_action|after_action|around_action)\s+:([a-z_]+[!?]?)`,
 	)
@@ -137,7 +192,10 @@ func (e *rubyMiddlewareExtractor) Extract(ctx context.Context, file extractor.Fi
 		strings.Contains(src, `after "`) ||
 		strings.Contains(src, "rescue_from") ||
 		strings.Contains(src, "plugin :") ||
-		strings.Contains(src, "config.middleware")
+		strings.Contains(src, "config.middleware") ||
+		(strings.Contains(src, "def initialize(app)") && strings.Contains(src, "def call(env)")) ||
+		(strings.Contains(src, "def initialize(app)") && strings.Contains(src, "def call(@env)")) ||
+		(strings.Contains(src, "def initialize( app") && strings.Contains(src, "def call( env"))
 	if !hasMW {
 		return nil, nil
 	}
@@ -180,37 +238,98 @@ func (e *rubyMiddlewareExtractor) Extract(ctx context.Context, file extractor.Fi
 		add(ent)
 	}
 
-	// ---- config.middleware.use ----
-	for _, idx := range reMWConfigUse.FindAllStringSubmatchIndex(src, -1) {
-		mwName := src[idx[2]:idx[3]]
-		ln := lineOf(src, idx[0])
-		fw := "rails"
-		if isPadrino {
-			fw = "padrino"
+	// ---- config.middleware stack (use/insert_before/insert_after/swap/delete) ----
+	// Emit one entity per operation, tagged with the operation name and an
+	// order_position (1-based sequential index within the file) so consumers can
+	// reconstruct the declaration order of the middleware stack.
+	{
+		allOps := reMWConfigOp.FindAllStringSubmatchIndex(src, -1)
+		for pos, idx := range allOps {
+			op := src[idx[2]:idx[3]]   // use|insert_before|insert_after|swap|delete
+			cls1 := src[idx[4]:idx[5]] // first class token
+
+			// For insert_before/insert_after/swap the second token (if present)
+			// is the middleware being added; for use/delete the first token is.
+			mwName := cls1
+			anchorClass := ""
+			if idx[6] >= 0 {
+				// second token present — cls1 is the anchor, cls2 is the new MW
+				anchorClass = cls1
+				mwName = src[idx[6]:idx[7]]
+			}
+
+			ln := lineOf(src, idx[0])
+			fw := "rails"
+			if isPadrino {
+				fw = "padrino"
+			}
+
+			name := "config_mw:" + mwName
+			// For delete/swap with anchor, qualify name to allow multiple ops on same class.
+			if op == "delete" {
+				name = "config_mw_delete:" + mwName
+			} else if (op == "insert_before" || op == "insert_after" || op == "swap") && anchorClass != "" {
+				name = "config_mw_" + op + ":" + anchorClass + ":" + mwName
+			}
+
+			ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", fw,
+				"provenance", "INFERRED_FROM_CONFIG_MIDDLEWARE_OP",
+				"middleware_class", mwName,
+				"middleware_op", op,
+				"order_position", itoa(pos+1),
+			)
+			if anchorClass != "" {
+				setProps(&ent, "anchor_class", anchorClass)
+			}
+			add(ent)
 		}
-		ent := makeEntity("config_mw:"+mwName, "SCOPE.Pattern", "middleware", file.Path, file.Language, ln)
-		setProps(&ent,
-			"framework", fw,
-			"provenance", "INFERRED_FROM_CONFIG_MIDDLEWARE_USE",
-			"middleware_class", mwName,
-		)
-		add(ent)
 	}
 
-	// ---- Rails filters ----
+	// ---- Custom Rack middleware classes ----
+	// A class is a Rack middleware if it defines both initialize(app) and call(env).
+	if raMwInitApp.MatchString(src) && raMwCallEnv.MatchString(src) {
+		for _, cidx := range raMwClassDef.FindAllStringSubmatchIndex(src, -1) {
+			className := src[cidx[2]:cidx[3]]
+			ln := lineOf(src, cidx[0])
+			fw := detectFramework(isRails, isGrape, isSinatra, isPadrino, isHanami, isRoda, isCuba)
+			name := "rack_middleware_class:" + className
+			ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", fw,
+				"provenance", "INFERRED_FROM_RACK_MIDDLEWARE_CLASS",
+				"middleware_class", className,
+				"rack_interface", "initialize(app)+call(env)",
+			)
+			add(ent)
+		}
+	}
+
+	// ---- Rails filters (scoped: only/except) ----
 	if isRails {
-		for _, idx := range reMWRailsFilter.FindAllStringSubmatchIndex(src, -1) {
+		for _, idx := range reMWRailsFilterScoped.FindAllStringSubmatchIndex(src, -1) {
 			filterType := src[idx[2]:idx[3]]
 			filterMethod := src[idx[4]:idx[5]]
 			name := "rails_filter:" + filterType + ":" + filterMethod
 			ln := lineOf(src, idx[0])
 			ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, ln)
-			setProps(&ent,
+			props := []string{
 				"framework", "rails",
 				"provenance", "INFERRED_FROM_RAILS_FILTER_MW",
 				"filter_type", filterType,
 				"filter_method", filterMethod,
-			)
+			}
+			// Capture :only/:except scope when present (groups 3 and 4).
+			if idx[6] >= 0 {
+				scopeKind := src[idx[6]:idx[7]]
+				scopeVal := ""
+				if idx[8] >= 0 {
+					scopeVal = src[idx[8]:idx[9]]
+				}
+				props = append(props, "filter_scope_kind", scopeKind, "filter_scope", scopeVal)
+			}
+			setProps(&ent, props...)
 			add(ent)
 		}
 	}

--- a/internal/custom/ruby/middleware_test.go
+++ b/internal/custom/ruby/middleware_test.go
@@ -1,11 +1,68 @@
 package ruby_test
 
 // middleware_test.go — tests for the ruby_middleware extractor.
-// Part of #3282.
+// Part of #3282 / #3341.
 
 import (
+	"context"
 	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
 )
+
+// mwExtractRaw returns raw EntityRecord values so tests can inspect Properties.
+func mwExtractRaw(t *testing.T, path, src string) []interface{ GetName() string } {
+	t.Helper()
+	e, ok := extreg.Get("ruby_middleware")
+	if !ok {
+		t.Fatal("ruby_middleware extractor not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: path, Language: "ruby", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	// Return as-is; callers use the raw slice directly.
+	_ = ents
+	return nil
+}
+
+// mwExtractProps returns raw entities so callers can access Properties.
+func mwExtractProps(t *testing.T, path, src string) []map[string]string {
+	t.Helper()
+	e, ok := extreg.Get("ruby_middleware")
+	if !ok {
+		t.Fatal("ruby_middleware extractor not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: path, Language: "ruby", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	out := make([]map[string]string, len(ents))
+	for i, ent := range ents {
+		m := make(map[string]string, len(ent.Properties)+2)
+		m["__name"] = ent.Name
+		m["__kind"] = ent.Kind
+		for k, v := range ent.Properties {
+			m[k] = v
+		}
+		out[i] = m
+	}
+	return out
+}
+
+// findByName returns the property map for the first entity with matching name.
+func findByName(props []map[string]string, name string) map[string]string {
+	for _, p := range props {
+		if p["__name"] == name {
+			return p
+		}
+	}
+	return nil
+}
 
 func mwExtract(t *testing.T, path, src string) []entitySummary {
 	t.Helper()
@@ -210,5 +267,172 @@ func TestMWNoMatch_EmptyFile(t *testing.T) {
 	ents := mwExtract(t, "empty.rb", "")
 	if len(ents) != 0 {
 		t.Errorf("expected no entities for empty file, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VALUE-ASSERTING TESTS — Rails Rack middleware stack (#3341)
+// ---------------------------------------------------------------------------
+
+// TestMWRails_ConfigMiddlewareStack_OrderAndOps verifies that a config/application.rb
+// containing use + insert_before + insert_after + swap + delete emits:
+//   - Exact entity names for each operation
+//   - Correct middleware_op property per entity
+//   - order_position values reflecting declaration order (1-based)
+//   - anchor_class on insert_before/insert_after/swap ops
+//
+// This is the canonical value-asserting test for Rails Rack middleware stack
+// extraction introduced in #3341.
+func TestMWRails_ConfigMiddlewareStack_OrderAndOps(t *testing.T) {
+	src := `
+class Application < Rails::Application
+  config.middleware.use Rack::Attack
+  config.middleware.insert_before ActionDispatch::Static, Rack::Cors
+  config.middleware.insert_after ActionDispatch::Executor, Rack::Logger
+  config.middleware.swap ActionDispatch::ShowExceptions, CustomErrorMiddleware
+  config.middleware.delete ActionDispatch::Static
+end
+`
+	props := mwExtractProps(t, "config/application.rb", src)
+
+	tests := []struct {
+		name         string
+		wantOp       string
+		wantMWClass  string
+		wantPosition string
+		wantAnchor   string
+	}{
+		{
+			name: "config_mw:Rack::Attack", wantOp: "use",
+			wantMWClass: "Rack::Attack", wantPosition: "1", wantAnchor: "",
+		},
+		{
+			name: "config_mw_insert_before:ActionDispatch::Static:Rack::Cors", wantOp: "insert_before",
+			wantMWClass: "Rack::Cors", wantPosition: "2", wantAnchor: "ActionDispatch::Static",
+		},
+		{
+			name: "config_mw_insert_after:ActionDispatch::Executor:Rack::Logger", wantOp: "insert_after",
+			wantMWClass: "Rack::Logger", wantPosition: "3", wantAnchor: "ActionDispatch::Executor",
+		},
+		{
+			name: "config_mw_swap:ActionDispatch::ShowExceptions:CustomErrorMiddleware", wantOp: "swap",
+			wantMWClass: "CustomErrorMiddleware", wantPosition: "4", wantAnchor: "ActionDispatch::ShowExceptions",
+		},
+		{
+			name: "config_mw_delete:ActionDispatch::Static", wantOp: "delete",
+			wantMWClass: "ActionDispatch::Static", wantPosition: "5", wantAnchor: "",
+		},
+	}
+
+	for _, tc := range tests {
+		p := findByName(props, tc.name)
+		if p == nil {
+			t.Errorf("entity %q: not found (got %d entities)", tc.name, len(props))
+			continue
+		}
+		if got := p["middleware_op"]; got != tc.wantOp {
+			t.Errorf("entity %q: middleware_op = %q, want %q", tc.name, got, tc.wantOp)
+		}
+		if got := p["middleware_class"]; got != tc.wantMWClass {
+			t.Errorf("entity %q: middleware_class = %q, want %q", tc.name, got, tc.wantMWClass)
+		}
+		if got := p["order_position"]; got != tc.wantPosition {
+			t.Errorf("entity %q: order_position = %q, want %q", tc.name, got, tc.wantPosition)
+		}
+		if tc.wantAnchor != "" {
+			if got := p["anchor_class"]; got != tc.wantAnchor {
+				t.Errorf("entity %q: anchor_class = %q, want %q", tc.name, got, tc.wantAnchor)
+			}
+		}
+	}
+}
+
+// TestMWRails_CustomRackMiddlewareClass verifies that a Ruby class implementing
+// the Rack middleware interface (initialize(app) + call(env)) is emitted as a
+// rack_middleware_class entity.
+func TestMWRails_CustomRackMiddlewareClass(t *testing.T) {
+	src := `
+class RequestTimingMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    start = Time.now
+    status, headers, body = @app.call(env)
+    duration = Time.now - start
+    headers['X-Runtime'] = duration.to_s
+    [status, headers, body]
+  end
+end
+`
+	ents := mwExtract(t, "lib/request_timing_middleware.rb", src)
+	if !containsEntity(ents, "SCOPE.Pattern", "rack_middleware_class:RequestTimingMiddleware") {
+		t.Error("expected rack_middleware_class:RequestTimingMiddleware entity")
+	}
+
+	props := mwExtractProps(t, "lib/request_timing_middleware.rb", src)
+	p := findByName(props, "rack_middleware_class:RequestTimingMiddleware")
+	if p == nil {
+		t.Fatal("rack_middleware_class:RequestTimingMiddleware not found in props")
+	}
+	if got := p["rack_interface"]; got != "initialize(app)+call(env)" {
+		t.Errorf("rack_interface = %q, want initialize(app)+call(env)", got)
+	}
+	if got := p["provenance"]; got != "INFERRED_FROM_RACK_MIDDLEWARE_CLASS" {
+		t.Errorf("provenance = %q, want INFERRED_FROM_RACK_MIDDLEWARE_CLASS", got)
+	}
+}
+
+// TestMWRails_FilterScoping verifies that before_action/after_action/around_action
+// with :only/:except scoping emits filter_scope_kind and filter_scope properties
+// with the exact scope values.
+func TestMWRails_FilterScoping(t *testing.T) {
+	src := `
+class PostsController < ActionController::Base
+  before_action :authenticate!, only: [:show, :edit, :update, :destroy]
+  after_action  :log_request, except: [:index]
+  around_action :wrap_transaction
+end
+`
+	props := mwExtractProps(t, "app/controllers/posts_controller.rb", src)
+
+	tests := []struct {
+		entityName    string
+		wantScopeKind string
+		wantScopeVal  string // empty string means no scope expected
+	}{
+		{
+			entityName:    "rails_filter:before_action:authenticate!",
+			wantScopeKind: "only", wantScopeVal: "[:show, :edit, :update, :destroy]",
+		},
+		{
+			entityName:    "rails_filter:after_action:log_request",
+			wantScopeKind: "except", wantScopeVal: "[:index]",
+		},
+		{
+			entityName:    "rails_filter:around_action:wrap_transaction",
+			wantScopeKind: "", wantScopeVal: "",
+		},
+	}
+
+	for _, tc := range tests {
+		p := findByName(props, tc.entityName)
+		if p == nil {
+			t.Errorf("entity %q: not found", tc.entityName)
+			continue
+		}
+		if tc.wantScopeKind == "" {
+			if got := p["filter_scope_kind"]; got != "" {
+				t.Errorf("entity %q: expected no scope, got filter_scope_kind=%q", tc.entityName, got)
+			}
+		} else {
+			if got := p["filter_scope_kind"]; got != tc.wantScopeKind {
+				t.Errorf("entity %q: filter_scope_kind = %q, want %q", tc.entityName, got, tc.wantScopeKind)
+			}
+			if got := p["filter_scope"]; got != tc.wantScopeVal {
+				t.Errorf("entity %q: filter_scope = %q, want %q", tc.entityName, got, tc.wantScopeVal)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Deepens `internal/custom/ruby/middleware.go` for `lang.ruby.framework.rails` `Middleware/middleware_coverage`: **partial → full** — matching the TS/JS (Express/Koa/Fastify) bar.
- Adds three extraction categories: (1) full Rack middleware stack operations with declaration order, (2) custom Rack middleware class detection, (3) controller filter scoping.
- 3 new value-asserting tests; all 13 middleware tests pass; registry flip verified.

## What was added

### 1. Config middleware stack — `use/insert_before/insert_after/swap/delete`
Replaced the old `reMWConfigUse` (only handled `use/insert_before/insert_after`) with `reMWConfigOp` which:
- Captures all 5 operations (adds `swap` and `delete`)
- Captures the **anchor class** for `insert_before/insert_after/swap` (second token)
- Emits `order_position` (1-based sequential index within the file) so consumers can reconstruct declaration order
- Entity names: `config_mw:<Class>` (use), `config_mw_insert_before:<Anchor>:<Class>`, `config_mw_insert_after:<Anchor>:<Class>`, `config_mw_swap:<Anchor>:<Class>`, `config_mw_delete:<Class>`
- Properties: `middleware_op`, `middleware_class`, `order_position`, `anchor_class` (when applicable)

### 2. Custom Rack middleware classes
Detects any Ruby class implementing the Rack interface (`def initialize(app)` + `def call(env)`) — the idiomatic pattern for Rack middleware — and emits `rack_middleware_class:<ClassName>` with `rack_interface=initialize(app)+call(env)`.

### 3. Controller filters with `:only`/`:except` scoping
Replaced `reMWRailsFilter` with `reMWRailsFilterScoped` which captures the optional `only:/except:` scope token and value into `filter_scope_kind` / `filter_scope` properties. Unscoped filters continue to emit without scope keys (backward-compatible).

## Value-asserting tests (NOT "≥1")

| Test | Fixture | What is asserted |
|---|---|---|
| `TestMWRails_ConfigMiddlewareStack_OrderAndOps` | `config/application.rb` with `Rack::Attack` (use), `Rack::Cors` (insert_before), `Rack::Logger` (insert_after), `CustomErrorMiddleware` (swap), `ActionDispatch::Static` (delete) | Exact entity names, `middleware_op`, `order_position` 1–5, `anchor_class` |
| `TestMWRails_CustomRackMiddlewareClass` | `RequestTimingMiddleware` class with `initialize(app)` + `call(env)` | Entity name, `rack_interface`, `provenance` |
| `TestMWRails_FilterScoping` | `PostsController` with `before_action :authenticate!, only: [...]`, `after_action :log_request, except: [...]`, `around_action :wrap_transaction` | `filter_scope_kind` + `filter_scope` exact values; unscoped action emits no scope keys |

## Before / After

| | Before | After |
|---|---|---|
| `lang.ruby.framework.rails` `middleware_coverage` | `partial` | **`full`** |
| Operations extracted | `use`, `insert_before`, `insert_after` | `use`, `insert_before`, `insert_after`, `swap`, `delete` |
| Order tracking | none | `order_position` (1-based) |
| Anchor class | none | `anchor_class` on insert/swap ops |
| Custom Rack classes | not extracted | `rack_middleware_class:<Name>` entities |
| Filter scoping | not extracted | `filter_scope_kind` + `filter_scope` properties |

## Validation

```
go build ./internal/... ./tools/coverage/...  ✓
go test ./internal/custom/ruby/... ./internal/types/... ./tools/coverage/...  ✓ (all pass)
go run ./tools/coverage validate  ✓ (exit 0)
go run ./tools/coverage fmt --check  ✓ (canonical)
gofmt -l internal/custom/ruby/middleware{,_test}.go  ✓ (empty)
```

## Remaining partial cells (not in scope for this PR)

`lang.ruby.framework.{cuba,grape,hanami,padrino,roda,sinatra}` remain at `partial` — deeper extraction for those frameworks is tracked separately under #3282.

Closes #3341

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>