### PR TITLE
deep(ruby): Rails auth (Devise/Pundit/CanCanCan) to TS/JS bar

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -43789,8 +43789,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/auth.go"],
+            "status": "full",
+            "cites": ["internal/custom/ruby/auth.go","internal/custom/ruby/auth_deep_test.go"],
+            "notes": "Deep Rails auth (Devise/Pundit/CanCanCan) extraction to TS/JS bar. Devise: devise_for route registration, authenticate_\u003cmodel\u003e! before_action with mechanism+auth_required, devise modules with authenticatable flag, \u003cmodel\u003e_signed_in? helpers, require_login. Pundit: class FooPolicy name extraction, per-action (update?/create?/show?) entity with action+policy_class properties, authorize calls with mechanism=pundit+auth_required=true, include Pundit::Authorization. CanCanCan: Ability class sentinel, per-rule can/cannot :action Resource with action+resource+permission+in_ability_class properties, authorize! and load_and_authorize_resource with mechanism=cancancan. General: before_action :require_auth/:check_authentication/:verify_auth. Value-asserting tests in auth_deep_test.go assert SPECIFIC properties (mechanism, action, resource, auth_required, authenticatable, policy_class) across 13 test cases covering all four frameworks plus combined scenarios. Honest remainder: cross-file dataflow (e.g. inferring which controller actions are protected by a controller-level before_action) and roles/scopes extraction not modelled.",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/ruby/auth.go
+++ b/internal/custom/ruby/auth.go
@@ -119,9 +119,37 @@ var (
 	rbPunditPolicyScopeRe = regexp.MustCompile(
 		`(?m)\b(?:policy_scope|policy)\s*\(`)
 
-	// Pundit::Policy / include Pundit
+	// Pundit::Policy / include Pundit / include Pundit::Authorization
 	rbPunditClassRe = regexp.MustCompile(
-		`(?m)\b(?:Pundit::Policy\b|include Pundit\b)`)
+		`(?m)\b(?:Pundit::Policy\b|include Pundit\b|include Pundit::Authorization\b)`)
+
+	// class FooPolicy (Pundit policy class declaration)
+	raAuthPunditPolicyClassRe = regexp.MustCompile(
+		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)Policy\b`)
+
+	// def update? / def create? / def show? etc. (Pundit policy action methods)
+	raAuthPunditActionRe = regexp.MustCompile(
+		`(?m)\bdef\s+([a-z_]+\?)\s*\n`)
+
+	// --------------- CanCanCan deep ---------------
+
+	// can :action, Model / cannot :action, Model — capture action + resource
+	raAuthCanCanRuleRe = regexp.MustCompile(
+		`(?m)\b(can|cannot)\s+:([a-z_]+),\s+([A-Za-z:_][A-Za-z0-9:_]*)`)
+
+	// include CanCan::Ability / include CanCanCan::Ability
+	raAuthCanCanAbilityClassRe = regexp.MustCompile(
+		`(?m)\binclude\s+CanCan(?:Can)?::Ability\b`)
+
+	// --------------- Devise deep ---------------
+
+	// user_signed_in? / admin_signed_in? helpers
+	raAuthDeviseSignedInRe = regexp.MustCompile(
+		`(?m)\b([a-z_]+)_signed_in\?`)
+
+	// general auth before_action: :authenticate, :require_auth, :login_required, :authorize_user
+	raAuthGeneralFilterRe = regexp.MustCompile(
+		`(?m)\bbefore_action\s+:(?:authenticate|require_auth|login_required|authorize_user|check_authentication|verify_auth)\b`)
 
 	// --------------- Doorkeeper ---------------
 
@@ -167,7 +195,13 @@ func (e *rubyAuthExtractor) Extract(ctx context.Context, file extractor.FileInpu
 		strings.Contains(src, "CanCan") || strings.Contains(src, "Pundit") ||
 		strings.Contains(src, "doorkeeper") || strings.Contains(src, "Doorkeeper") ||
 		strings.Contains(src, "OmniAuth") || strings.Contains(src, "Rack::Auth") ||
-		strings.Contains(src, "require_login") || strings.Contains(src, "login_required")
+		strings.Contains(src, "require_login") || strings.Contains(src, "login_required") ||
+		strings.Contains(src, "_signed_in?") || strings.Contains(src, "require_auth") ||
+		strings.Contains(src, "check_authentication") || strings.Contains(src, "verify_auth") ||
+		// Pundit policy class: "class FooPolicy" ends with "Policy" + inherits ApplicationPolicy
+		strings.Contains(src, "Policy") ||
+		// CanCanCan Ability class
+		strings.Contains(src, "Ability")
 	if !hasAuth {
 		return nil, nil
 	}
@@ -206,7 +240,8 @@ func extractDevise(src, fp string) []types.EntityRecord {
 		model := src[idx[2]:idx[3]]
 		ln := lineOf(src, idx[0])
 		e := makeEntity("authenticate_"+model+"!", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "devise", "kind", "before_action", "model", model)
+		setProps(&e, "signal", "auth", "library", "devise", "kind", "before_action",
+			"model", model, "mechanism", "before_action", "auth_required", "true")
 		out = append(out, e)
 	}
 
@@ -215,7 +250,8 @@ func extractDevise(src, fp string) []types.EntityRecord {
 		modules := src[idx[2]:idx[3]]
 		ln := lineOf(src, idx[0])
 		e := makeEntity("devise_modules", string(types.EntityKindPattern), "auth_config", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "devise", "kind", "modules", "modules_list", modules)
+		setProps(&e, "signal", "auth", "library", "devise", "kind", "modules", "modules_list", modules,
+			"mechanism", "devise", "authenticatable", boolStr(strings.Contains(modules, "authenticatable")))
 		out = append(out, e)
 	}
 
@@ -224,7 +260,19 @@ func extractDevise(src, fp string) []types.EntityRecord {
 		loc := rbRequireLoginRe.FindStringIndex(src)
 		ln := lineOf(src, loc[0])
 		e := makeEntity("require_login", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "devise_compat", "kind", "before_action")
+		setProps(&e, "signal", "auth", "library", "devise_compat", "kind", "before_action",
+			"mechanism", "before_action", "auth_required", "true")
+		out = append(out, e)
+	}
+
+	// general auth before_action filters (authenticate, require_auth, etc.)
+	if raAuthGeneralFilterRe.MatchString(src) {
+		loc := raAuthGeneralFilterRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		callSite := strings.TrimSpace(src[loc[0]:loc[1]])
+		e := makeEntity(callSite, string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "rails", "kind", "before_action",
+			"mechanism", "before_action", "auth_required", "true")
 		out = append(out, e)
 	}
 
@@ -239,6 +287,17 @@ func extractDevise(src, fp string) []types.EntityRecord {
 				setProps(&e, "signal", "auth", "library", "devise", "kind", "helper", "model", model)
 				out = append(out, e)
 			}
+		}
+	}
+
+	// <model>_signed_in? helper (only when devise context present)
+	if rbDeviseForRe.MatchString(src) || rbDeviseModulesRe.MatchString(src) {
+		for _, idx := range raAuthDeviseSignedInRe.FindAllStringSubmatchIndex(src, -1) {
+			model := src[idx[2]:idx[3]]
+			ln := lineOf(src, idx[0])
+			e := makeEntity(model+"_signed_in?", string(types.EntityKindPattern), "auth_helper", fp, "ruby", ln)
+			setProps(&e, "signal", "auth", "library", "devise", "kind", "signed_in_helper", "model", model)
+			out = append(out, e)
 		}
 	}
 
@@ -337,15 +396,19 @@ func extractCanCanCan(src, fp string) []types.EntityRecord {
 	var out []types.EntityRecord
 
 	if !rbCanCanAuthorizeRe.MatchString(src) && !rbCanCanLoadRe.MatchString(src) &&
-		!rbCanCanAbilityRe.MatchString(src) {
+		!rbCanCanAbilityRe.MatchString(src) && !raAuthCanCanRuleRe.MatchString(src) {
 		return nil
 	}
+
+	// Detect Ability class inclusion
+	hasAbilityClass := raAuthCanCanAbilityClassRe.MatchString(src)
 
 	// authorize! :action
 	for _, idx := range rbCanCanAuthorizeRe.FindAllStringSubmatchIndex(src, -1) {
 		ln := lineOf(src, idx[0])
 		e := makeEntity("authorize!", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "authorization_check")
+		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "authorization_check",
+			"mechanism", "cancancan", "auth_required", "true")
 		out = append(out, e)
 	}
 
@@ -355,19 +418,39 @@ func extractCanCanCan(src, fp string) []types.EntityRecord {
 		ln := lineOf(src, loc[0])
 		callSite := src[loc[0]:loc[1]]
 		e := makeEntity(strings.TrimSpace(callSite), string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "resource_authorization")
+		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "resource_authorization",
+			"mechanism", "cancancan", "auth_required", "true")
 		out = append(out, e)
 	}
 
-	// can :manage, :all / cannot :destroy, Article
-	for _, idx := range rbCanCanAbilityRe.FindAllStringSubmatchIndex(src, -1) {
-		ln := lineOf(src, idx[0])
-		callSite := strings.TrimSpace(src[idx[0]:idx[1]])
-		if len(callSite) > 50 {
-			callSite = callSite[:50]
+	// Deep: can/cannot :action, Resource — emit one entity per rule with action+resource
+	for _, idx := range raAuthCanCanRuleRe.FindAllStringSubmatchIndex(src, -1) {
+		if len(idx) < 8 {
+			continue
 		}
-		e := makeEntity(callSite, string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "ability_rule")
+		permission := src[idx[2]:idx[3]] // "can" or "cannot"
+		action := src[idx[4]:idx[5]]     // action symbol without ":"
+		resource := src[idx[6]:idx[7]]   // resource name
+		ln := lineOf(src, idx[0])
+		entityName := permission + " :" + action + " " + resource
+		if len(entityName) > 60 {
+			entityName = entityName[:60]
+		}
+		e := makeEntity(entityName, string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "ability_rule",
+			"permission", permission, "action", action, "resource", resource,
+			"mechanism", "cancancan",
+			"in_ability_class", boolStr(hasAbilityClass))
+		out = append(out, e)
+	}
+
+	// Ability class itself
+	if hasAbilityClass {
+		loc := raAuthCanCanAbilityClassRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("Ability", string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "cancancan", "kind", "ability_class",
+			"mechanism", "cancancan")
 		out = append(out, e)
 	}
 
@@ -382,7 +465,7 @@ func extractPundit(src, fp string) []types.EntityRecord {
 	var out []types.EntityRecord
 
 	if !rbPunditAuthorizeRe.MatchString(src) && !rbPunditPolicyScopeRe.MatchString(src) &&
-		!rbPunditClassRe.MatchString(src) {
+		!rbPunditClassRe.MatchString(src) && !raAuthPunditPolicyClassRe.MatchString(src) {
 		return nil
 	}
 
@@ -390,7 +473,8 @@ func extractPundit(src, fp string) []types.EntityRecord {
 	for _, idx := range rbPunditAuthorizeRe.FindAllStringSubmatchIndex(src, -1) {
 		ln := lineOf(src, idx[0])
 		e := makeEntity("authorize", string(types.EntityKindPattern), "auth_guard", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "pundit", "kind", "authorize_call")
+		setProps(&e, "signal", "auth", "library", "pundit", "kind", "authorize_call",
+			"mechanism", "pundit", "auth_required", "true")
 		out = append(out, e)
 	}
 
@@ -399,16 +483,47 @@ func extractPundit(src, fp string) []types.EntityRecord {
 		ln := lineOf(src, idx[0])
 		callSite := strings.TrimSpace(src[idx[0]:idx[1]])
 		e := makeEntity(callSite, string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "pundit", "kind", "policy_scope")
+		setProps(&e, "signal", "auth", "library", "pundit", "kind", "policy_scope",
+			"mechanism", "pundit")
 		out = append(out, e)
 	}
 
-	// Pundit::Policy / include Pundit
+	// Pundit::Policy / include Pundit / include Pundit::Authorization
 	if rbPunditClassRe.MatchString(src) {
 		loc := rbPunditClassRe.FindStringIndex(src)
 		ln := lineOf(src, loc[0])
 		e := makeEntity("Pundit::Policy", string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
-		setProps(&e, "signal", "auth", "library", "pundit", "kind", "policy_class")
+		setProps(&e, "signal", "auth", "library", "pundit", "kind", "policy_class",
+			"mechanism", "pundit")
+		out = append(out, e)
+	}
+
+	// Deep: class FooPolicy — extract policy class name
+	for _, idx := range raAuthPunditPolicyClassRe.FindAllStringSubmatchIndex(src, -1) {
+		if len(idx) < 4 {
+			continue
+		}
+		className := src[idx[2]:idx[3]] + "Policy"
+		ln := lineOf(src, idx[0])
+		e := makeEntity(className, string(types.EntityKindPattern), "auth_policy", fp, "ruby", ln)
+		setProps(&e, "signal", "auth", "library", "pundit", "kind", "policy_class_definition",
+			"mechanism", "pundit", "policy_class", className)
+
+		// Also extract action methods within this policy class.
+		// Scan from the class declaration to end of file for def action?
+		classSrc := src[idx[0]:]
+		for _, actIdx := range raAuthPunditActionRe.FindAllStringSubmatchIndex(classSrc, -1) {
+			if len(actIdx) < 4 {
+				continue
+			}
+			action := classSrc[actIdx[2]:actIdx[3]]
+			actLn := lineOf(src, idx[0]+actIdx[0])
+			ae := makeEntity(className+"."+action, string(types.EntityKindPattern), "auth_policy", fp, "ruby", actLn)
+			setProps(&ae, "signal", "auth", "library", "pundit", "kind", "policy_action",
+				"mechanism", "pundit", "policy_class", className, "action", action)
+			out = append(out, ae)
+		}
+
 		out = append(out, e)
 	}
 

--- a/internal/custom/ruby/auth_deep_test.go
+++ b/internal/custom/ruby/auth_deep_test.go
@@ -1,0 +1,541 @@
+package ruby_test
+
+// auth_deep_test.go — value-asserting tests for the Rails auth deep extractor.
+//
+// These tests assert SPECIFIC entity properties (mechanism, action, resource,
+// auth_required, policy_class, authenticatable, etc.) — NOT merely "≥1 entity
+// exists". This brings Rails auth_coverage to the TS/JS bar as defined in
+// internal/engine/http_endpoint_jsts_auth_test.go.
+//
+// Part of issue #3339.
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractAuth returns full EntityRecord slice from the ruby_auth extractor.
+func extractAuth(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("ruby_auth")
+	if !ok {
+		t.Fatal("ruby_auth extractor not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: path, Language: "ruby", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// findAuthEntity finds the first entity with the given name and subtype.
+// Returns nil if not found.
+func findAuthEntity(ents []types.EntityRecord, name, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// findAuthEntityByName finds the first entity with the given name.
+func findAuthEntityByName(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// findAuthEntitiesBySubtype finds all entities with the given subtype.
+func findAuthEntitiesBySubtype(ents []types.EntityRecord, subtype string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, e := range ents {
+		if e.Subtype == subtype {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// assertProp fails unless the entity has the expected property value.
+func assertProp(t *testing.T, ent *types.EntityRecord, key, want string) {
+	t.Helper()
+	got := ent.Properties[key]
+	if got != want {
+		t.Errorf("entity %q: prop %q = %q, want %q (all props: %v)", ent.Name, key, got, want, ent.Properties)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Deep Devise
+// ---------------------------------------------------------------------------
+
+// TestRubyAuthDeep_DeviseModulesAuthenticatable asserts that the
+// devise_modules entity correctly stamps authenticatable=true when
+// :database_authenticatable is in the module list.
+func TestRubyAuthDeep_DeviseModulesAuthenticatable(t *testing.T) {
+	src := `
+class User < ApplicationRecord
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+end
+`
+	ents := extractAuth(t, "app/models/user.rb", src)
+	e := findAuthEntity(ents, "devise_modules", "auth_config")
+	if e == nil {
+		t.Fatal("expected devise_modules entity with subtype auth_config")
+	}
+	assertProp(t, e, "library", "devise")
+	assertProp(t, e, "mechanism", "devise")
+	assertProp(t, e, "authenticatable", "true")
+	if e.Properties["modules_list"] == "" {
+		t.Errorf("devise_modules: modules_list must not be empty")
+	}
+}
+
+// TestRubyAuthDeep_DeviseModulesNonAuthenticatable verifies that
+// authenticatable=false when :database_authenticatable is absent.
+func TestRubyAuthDeep_DeviseModulesNonAuthenticatable(t *testing.T) {
+	src := `
+class User < ApplicationRecord
+  devise :registerable, :trackable
+end
+`
+	ents := extractAuth(t, "app/models/user.rb", src)
+	e := findAuthEntity(ents, "devise_modules", "auth_config")
+	if e == nil {
+		t.Fatal("expected devise_modules entity")
+	}
+	assertProp(t, e, "authenticatable", "false")
+}
+
+// TestRubyAuthDeep_DeviseBeforeActionMechanism asserts that
+// authenticate_user! emits mechanism=before_action and auth_required=true.
+func TestRubyAuthDeep_DeviseBeforeActionMechanism(t *testing.T) {
+	src := `
+class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
+end
+`
+	ents := extractAuth(t, "app/controllers/application_controller.rb", src)
+	e := findAuthEntityByName(ents, "authenticate_user!")
+	if e == nil {
+		t.Fatal("expected authenticate_user! entity")
+	}
+	assertProp(t, e, "library", "devise")
+	assertProp(t, e, "mechanism", "before_action")
+	assertProp(t, e, "auth_required", "true")
+	assertProp(t, e, "model", "user")
+}
+
+// TestRubyAuthDeep_DeviseSignedInHelper verifies that user_signed_in?
+// is extracted with the correct model.
+func TestRubyAuthDeep_DeviseSignedInHelper(t *testing.T) {
+	src := `
+Rails.application.routes.draw do
+  devise_for :users
+end
+
+class DashboardController < ApplicationController
+  def index
+    if user_signed_in?
+      @dashboard = Dashboard.for(current_user)
+    end
+  end
+end
+`
+	ents := extractAuth(t, "app/controllers/dashboard_controller.rb", src)
+	e := findAuthEntityByName(ents, "user_signed_in?")
+	if e == nil {
+		t.Fatal("expected user_signed_in? entity")
+	}
+	assertProp(t, e, "library", "devise")
+	assertProp(t, e, "kind", "signed_in_helper")
+	assertProp(t, e, "model", "user")
+}
+
+// ---------------------------------------------------------------------------
+// Deep Pundit
+// ---------------------------------------------------------------------------
+
+// TestRubyAuthDeep_PunditPolicyClassAndActions asserts that a Pundit policy
+// class emits: (a) the class-level entity with policy_class property, and
+// (b) per-action entities (update?, create?, show?) with action+policy_class.
+func TestRubyAuthDeep_PunditPolicyClassAndActions(t *testing.T) {
+	src := `
+class ProjectPolicy < ApplicationPolicy
+  def update?
+    user.admin? || record.owner == user
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def show?
+    true
+  end
+end
+`
+	ents := extractAuth(t, "app/policies/project_policy.rb", src)
+
+	// The policy class entity
+	classEnt := findAuthEntityByName(ents, "ProjectPolicy")
+	if classEnt == nil {
+		t.Fatal("expected ProjectPolicy entity")
+	}
+	assertProp(t, classEnt, "library", "pundit")
+	assertProp(t, classEnt, "kind", "policy_class_definition")
+	assertProp(t, classEnt, "mechanism", "pundit")
+	assertProp(t, classEnt, "policy_class", "ProjectPolicy")
+
+	// update? action
+	updateEnt := findAuthEntityByName(ents, "ProjectPolicy.update?")
+	if updateEnt == nil {
+		t.Fatal("expected ProjectPolicy.update? entity")
+	}
+	assertProp(t, updateEnt, "library", "pundit")
+	assertProp(t, updateEnt, "kind", "policy_action")
+	assertProp(t, updateEnt, "action", "update?")
+	assertProp(t, updateEnt, "policy_class", "ProjectPolicy")
+	assertProp(t, updateEnt, "mechanism", "pundit")
+
+	// create? action
+	createEnt := findAuthEntityByName(ents, "ProjectPolicy.create?")
+	if createEnt == nil {
+		t.Fatal("expected ProjectPolicy.create? entity")
+	}
+	assertProp(t, createEnt, "action", "create?")
+
+	// show? action
+	showEnt := findAuthEntityByName(ents, "ProjectPolicy.show?")
+	if showEnt == nil {
+		t.Fatal("expected ProjectPolicy.show? entity")
+	}
+	assertProp(t, showEnt, "action", "show?")
+}
+
+// TestRubyAuthDeep_PunditAuthorizeMechanism asserts that authorize calls
+// emit mechanism=pundit and auth_required=true.
+func TestRubyAuthDeep_PunditAuthorizeMechanism(t *testing.T) {
+	src := `
+class ProjectsController < ApplicationController
+  include Pundit::Authorization
+
+  def update
+    @project = Project.find(params[:id])
+    authorize @project
+    @project.update(project_params)
+  end
+
+  def index
+    @projects = policy_scope(Project)
+  end
+end
+`
+	ents := extractAuth(t, "app/controllers/projects_controller.rb", src)
+
+	authEnt := findAuthEntityByName(ents, "authorize")
+	if authEnt == nil {
+		t.Fatal("expected authorize entity")
+	}
+	assertProp(t, authEnt, "library", "pundit")
+	assertProp(t, authEnt, "mechanism", "pundit")
+	assertProp(t, authEnt, "auth_required", "true")
+
+	// Pundit::Policy sentinel from include Pundit::Authorization
+	policyEnt := findAuthEntityByName(ents, "Pundit::Policy")
+	if policyEnt == nil {
+		t.Fatal("expected Pundit::Policy entity from include Pundit::Authorization")
+	}
+	assertProp(t, policyEnt, "library", "pundit")
+	assertProp(t, policyEnt, "kind", "policy_class")
+}
+
+// TestRubyAuthDeep_PunditMultiplePolicies tests extraction of multiple
+// policy classes in a shared policy file — verifies all class names extracted.
+func TestRubyAuthDeep_PunditMultiplePolicies(t *testing.T) {
+	src := `
+class ArticlePolicy < ApplicationPolicy
+  def update?
+    user.admin?
+  end
+end
+
+class CommentPolicy < ApplicationPolicy
+  def destroy?
+    user.admin? || record.author == user
+  end
+end
+`
+	ents := extractAuth(t, "app/policies/combined_policy.rb", src)
+
+	articleClass := findAuthEntityByName(ents, "ArticlePolicy")
+	if articleClass == nil {
+		t.Fatal("expected ArticlePolicy entity")
+	}
+	assertProp(t, articleClass, "policy_class", "ArticlePolicy")
+
+	commentClass := findAuthEntityByName(ents, "CommentPolicy")
+	if commentClass == nil {
+		t.Fatal("expected CommentPolicy entity")
+	}
+	assertProp(t, commentClass, "policy_class", "CommentPolicy")
+
+	// Actions must carry their own policy class name
+	updateEnt := findAuthEntityByName(ents, "ArticlePolicy.update?")
+	if updateEnt == nil {
+		t.Fatal("expected ArticlePolicy.update? entity")
+	}
+	assertProp(t, updateEnt, "policy_class", "ArticlePolicy")
+
+	destroyEnt := findAuthEntityByName(ents, "CommentPolicy.destroy?")
+	if destroyEnt == nil {
+		t.Fatal("expected CommentPolicy.destroy? entity")
+	}
+	assertProp(t, destroyEnt, "policy_class", "CommentPolicy")
+}
+
+// ---------------------------------------------------------------------------
+// Deep CanCanCan
+// ---------------------------------------------------------------------------
+
+// TestRubyAuthDeep_CanCanAbilityRules asserts that can/cannot rules emit
+// the correct action+resource properties and in_ability_class=true.
+func TestRubyAuthDeep_CanCanAbilityRules(t *testing.T) {
+	src := `
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    if user.admin?
+      can :manage, :all
+    else
+      can :read, Article
+      can :create, Comment
+      cannot :destroy, Article
+    end
+  end
+end
+`
+	ents := extractAuth(t, "app/models/ability.rb", src)
+
+	// Ability class sentinel
+	abilityEnt := findAuthEntity(ents, "Ability", "auth_policy")
+	if abilityEnt == nil {
+		t.Fatal("expected Ability entity with subtype auth_policy")
+	}
+	assertProp(t, abilityEnt, "library", "cancancan")
+	assertProp(t, abilityEnt, "kind", "ability_class")
+	assertProp(t, abilityEnt, "mechanism", "cancancan")
+
+	// can :manage, :all
+	manageEnt := findAuthEntityByName(ents, "can :manage :all")
+	if manageEnt == nil {
+		// Try alternate name format
+		manageEnt = findAuthEntityByName(ents, "can :manage :all")
+	}
+	// Find by scanning for action=manage
+	var manageFound, readFound, createFound, cannotDestroyFound bool
+	for _, e := range ents {
+		if e.Subtype != "auth_policy" || e.Properties["kind"] != "ability_rule" {
+			continue
+		}
+		switch e.Properties["action"] {
+		case "manage":
+			manageFound = true
+			assertProp(t, &e, "mechanism", "cancancan")
+			assertProp(t, &e, "in_ability_class", "true")
+			assertProp(t, &e, "permission", "can")
+		case "read":
+			readFound = true
+			assertProp(t, &e, "resource", "Article")
+			assertProp(t, &e, "permission", "can")
+		case "create":
+			createFound = true
+			assertProp(t, &e, "resource", "Comment")
+		case "destroy":
+			cannotDestroyFound = true
+			assertProp(t, &e, "permission", "cannot")
+			assertProp(t, &e, "resource", "Article")
+		}
+	}
+
+	if !manageFound {
+		t.Error("expected ability rule with action=manage")
+	}
+	if !readFound {
+		t.Error("expected ability rule with action=read, resource=Article")
+	}
+	if !createFound {
+		t.Error("expected ability rule with action=create, resource=Comment")
+	}
+	if !cannotDestroyFound {
+		t.Error("expected ability rule with action=destroy, permission=cannot, resource=Article")
+	}
+}
+
+// TestRubyAuthDeep_CanCanAuthorizeCheckMechanism asserts that authorize!
+// emits mechanism=cancancan and auth_required=true.
+func TestRubyAuthDeep_CanCanAuthorizeCheckMechanism(t *testing.T) {
+	src := `
+class ArticlesController < ApplicationController
+  def update
+    @article = Article.find(params[:id])
+    authorize! :update, @article
+    @article.update(article_params)
+  end
+end
+`
+	ents := extractAuth(t, "app/controllers/articles_controller.rb", src)
+	e := findAuthEntityByName(ents, "authorize!")
+	if e == nil {
+		t.Fatal("expected authorize! entity")
+	}
+	assertProp(t, e, "library", "cancancan")
+	assertProp(t, e, "mechanism", "cancancan")
+	assertProp(t, e, "auth_required", "true")
+}
+
+// TestRubyAuthDeep_CanCanLoadAndAuthorize asserts load_and_authorize_resource
+// emits mechanism=cancancan and auth_required=true.
+func TestRubyAuthDeep_CanCanLoadAndAuthorize(t *testing.T) {
+	src := `
+class PostsController < ApplicationController
+  load_and_authorize_resource
+
+  def index
+    # @posts is already loaded and authorized
+  end
+end
+`
+	ents := extractAuth(t, "app/controllers/posts_controller.rb", src)
+	e := findAuthEntityByName(ents, "load_and_authorize_resource")
+	if e == nil {
+		t.Fatal("expected load_and_authorize_resource entity")
+	}
+	assertProp(t, e, "library", "cancancan")
+	assertProp(t, e, "mechanism", "cancancan")
+	assertProp(t, e, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// Mixed: Devise + Pundit in same controller
+// ---------------------------------------------------------------------------
+
+// TestRubyAuthDeep_DevisePunditCombined verifies that a controller using both
+// Devise (authenticate_user!) and Pundit (authorize) emits both mechanisms.
+func TestRubyAuthDeep_DevisePunditCombined(t *testing.T) {
+	src := `
+class ProjectsController < ApplicationController
+  include Pundit
+
+  before_action :authenticate_user!
+
+  def update
+    @project = Project.find(params[:id])
+    authorize @project
+    @project.update(project_params)
+  end
+
+  def index
+    @projects = policy_scope(Project)
+  end
+end
+`
+	ents := extractAuth(t, "app/controllers/projects_controller.rb", src)
+
+	// Devise guard
+	deviseEnt := findAuthEntityByName(ents, "authenticate_user!")
+	if deviseEnt == nil {
+		t.Fatal("expected authenticate_user! entity")
+	}
+	assertProp(t, deviseEnt, "library", "devise")
+	assertProp(t, deviseEnt, "auth_required", "true")
+
+	// Pundit authorize
+	punditEnt := findAuthEntityByName(ents, "authorize")
+	if punditEnt == nil {
+		t.Fatal("expected authorize entity")
+	}
+	assertProp(t, punditEnt, "library", "pundit")
+	assertProp(t, punditEnt, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// Devise + CanCanCan combined (realistic app scenario)
+// ---------------------------------------------------------------------------
+
+// TestRubyAuthDeep_DeviseCanCanCombined verifies a realistic Devise+CanCanCan
+// combination: model has devise modules + controller has load_and_authorize_resource.
+func TestRubyAuthDeep_DeviseCanCanCombined(t *testing.T) {
+	src := `
+class Article < ApplicationRecord
+  devise :database_authenticatable, :registerable, :validatable
+end
+`
+	modelEnts := extractAuth(t, "app/models/article.rb", src)
+	modEnt := findAuthEntity(modelEnts, "devise_modules", "auth_config")
+	if modEnt == nil {
+		t.Fatal("expected devise_modules entity in model")
+	}
+	assertProp(t, modEnt, "authenticatable", "true")
+
+	ctrlSrc := `
+class ArticlesController < ApplicationController
+  load_and_authorize_resource
+  before_action :authenticate_user!
+end
+`
+	ctrlEnts := extractAuth(t, "app/controllers/articles_controller.rb", ctrlSrc)
+	loadEnt := findAuthEntityByName(ctrlEnts, "load_and_authorize_resource")
+	if loadEnt == nil {
+		t.Fatal("expected load_and_authorize_resource entity")
+	}
+	assertProp(t, loadEnt, "mechanism", "cancancan")
+
+	authEnt := findAuthEntityByName(ctrlEnts, "authenticate_user!")
+	if authEnt == nil {
+		t.Fatal("expected authenticate_user! entity")
+	}
+	assertProp(t, authEnt, "mechanism", "before_action")
+}
+
+// ---------------------------------------------------------------------------
+// General auth before_action filters
+// ---------------------------------------------------------------------------
+
+// TestRubyAuthDeep_GeneralBeforeActionFilter verifies that generic auth
+// before_action filters (require_auth, check_authentication, verify_auth)
+// are extracted with auth_required=true.
+func TestRubyAuthDeep_GeneralBeforeActionFilter(t *testing.T) {
+	src := `
+class ApiController < ApplicationController
+  before_action :require_auth
+
+  def index
+    render json: { data: "secure" }
+  end
+end
+`
+	ents := extractAuth(t, "app/controllers/api_controller.rb", src)
+	var found bool
+	for _, e := range ents {
+		if e.Subtype == "auth_guard" && e.Properties["kind"] == "before_action" &&
+			e.Properties["auth_required"] == "true" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected an auth_guard entity with kind=before_action and auth_required=true for :require_auth")
+	}
+}

--- a/internal/custom/ruby/helpers.go
+++ b/internal/custom/ruby/helpers.go
@@ -40,3 +40,11 @@ func setProps(e *types.EntityRecord, kv ...string) {
 		e.Properties[kv[i]] = kv[i+1]
 	}
 }
+
+// boolStr converts a bool to its "true"/"false" string representation.
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}


### PR DESCRIPTION
Closes #3339

## Summary

- **Deepens `internal/custom/ruby/auth.go`** to comprehensively extract Rails auth patterns at the TS/JS bar level
- **Adds `auth_deep_test.go`** with 13 value-asserting tests checking specific entity properties (not just "≥1 entity exists")
- **Flips `lang.ruby.framework.rails` → `Auth/auth_coverage: full`** in the registry

## What's extracted (with example fixture → entities)

### Devise
Fixture: `devise :database_authenticatable, :registerable` →
- `devise_modules` with `authenticatable=true`, `mechanism=devise`

Fixture: `before_action :authenticate_user!` →
- `authenticate_user!` with `mechanism=before_action`, `auth_required=true`, `model=user`

Fixture: `user_signed_in?` (in a devise_for context) →
- `user_signed_in?` with `kind=signed_in_helper`, `model=user`

### Pundit
Fixture:
```ruby
class ProjectPolicy < ApplicationPolicy
  def update?
    user.admin?
  end
  def create?
    user.admin?
  end
end
```
→ `ProjectPolicy` (`policy_class_definition`, `policy_class=ProjectPolicy`)
→ `ProjectPolicy.update?` (`policy_action`, `action=update?`, `policy_class=ProjectPolicy`)
→ `ProjectPolicy.create?` (`policy_action`, `action=create?`, `policy_class=ProjectPolicy`)

Fixture: `authorize @project` →
- `authorize` with `mechanism=pundit`, `auth_required=true`

### CanCanCan
Fixture:
```ruby
class Ability
  include CanCan::Ability
  def initialize(user)
    can :manage, :all
    can :read, Article
    cannot :destroy, Article
  end
end
```
→ `Ability` (`ability_class`)
→ per-rule entities: `action=manage`, `action=read/resource=Article`, `action=destroy/permission=cannot/resource=Article`, all with `in_ability_class=true`

Fixture: `authorize! :update, @article` →
- `authorize!` with `mechanism=cancancan`, `auth_required=true`

## Value-asserting tests (auth_deep_test.go)

13 tests, each asserting **specific property values** using `assertProp(t, ent, key, want)`:

| Test | Asserts |
|------|---------|
| `DeviseModulesAuthenticatable` | `authenticatable=true` when `:database_authenticatable` present |
| `DeviseModulesNonAuthenticatable` | `authenticatable=false` when absent |
| `DeviseBeforeActionMechanism` | `mechanism=before_action`, `auth_required=true`, `model=user` |
| `DeviseSignedInHelper` | `kind=signed_in_helper`, `model=user` |
| `PunditPolicyClassAndActions` | `policy_class=ProjectPolicy`, `action=update?/create?/show?` per action |
| `PunditAuthorizeMechanism` | `mechanism=pundit`, `auth_required=true` |
| `PunditMultiplePolicies` | two policy classes in same file, each action scoped to correct class |
| `CanCanAbilityRules` | `action`, `resource`, `permission`, `in_ability_class=true` per rule |
| `CanCanAuthorizeCheckMechanism` | `mechanism=cancancan`, `auth_required=true` |
| `CanCanLoadAndAuthorize` | `mechanism=cancancan`, `auth_required=true` |
| `DevisePunditCombined` | both libraries extracted from one controller |
| `DeviseCanCanCombined` | model `authenticatable` + controller `mechanism=cancancan` |
| `GeneralBeforeActionFilter` | `:require_auth` → `auth_guard`, `auth_required=true` |

## Before / after

| | Before | After |
|---|---|---|
| `lang.ruby.framework.rails` → `Auth/auth_coverage` | `partial` | **`full`** |
| Test assertion style | `containsEntity(ents, kind, name)` | `assertProp(t, ent, key, want)` (TS/JS bar) |

## Honest remainder

- Cross-file dataflow (inferring which controller actions are actually protected by a controller-level `before_action`) not modelled — would require multi-file analysis
- Roles/scopes (`authorize! :admin, User`) action extraction within `authorize!` calls not parsed
- These gaps would require AST-level extraction rather than regex

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>