### PR TITLE
deep(ruby): Sinatra routing/filters/middleware to TS/JS bar

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -102,8 +102,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [Roda](../detail/lang.ruby.framework.roda.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟢 2/2 | — | 🟢 1/1 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
 | [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-language/ruby.md
+++ b/docs/coverage/by-language/ruby.md
@@ -31,8 +31,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Hanami](../detail/lang.ruby.framework.hanami.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Padrino](../detail/lang.ruby.framework.padrino.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Roda](../detail/lang.ruby.framework.roda.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟢 2/2 | — | 🟢 1/1 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
 
 

--- a/docs/coverage/detail/lang.ruby.framework.rails.md
+++ b/docs/coverage/detail/lang.ruby.framework.rails.md
@@ -23,20 +23,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
+| Auth coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/auth.go`<br>`internal/custom/ruby/auth_deep_test.go` | Deep Rails auth (Devise/Pundit/CanCanCan) extraction to TS/JS bar. Devise: devise_for route registration, authenticate_<model>! before_action with mechanism+auth_required, devise modules with authenticatable flag, <model>_signed_in? helpers, require_login. Pundit: class FooPolicy name extraction, per-action (update?/create?/show?) entity with action+policy_class properties, authorize calls with mechanism=pundit+auth_required=true, include Pundit::Authorization. CanCanCan: Ability class sentinel, per-rule can/cannot :action Resource with action+resource+permission+in_ability_class properties, authorize! and load_and_authorize_resource with mechanism=cancancan. General: before_action :require_auth/:check_authentication/:verify_auth. Value-asserting tests in auth_deep_test.go assert SPECIFIC properties (mechanism, action, resource, auth_required, authenticatable, policy_class) across 13 test cases covering all four frameworks plus combined scenarios. Honest remainder: cross-file dataflow (e.g. inferring which controller actions are protected by a controller-level before_action) and roles/scopes extraction not modelled. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/validation.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/validation.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/validation.go`<br>`internal/custom/ruby/validation_deep.go`<br>`internal/custom/ruby/validation_deep_test.go` | Deep Rails dto_extraction: params.require(:model).permit(...) now emits per-field sp_field:<param>:<field> entities (scalar/array/nested) with permit_type prop. with_options blocks supported. Value-asserting tests in validation_deep_test.go assert exact param+field+permit_type. Closes #3340. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/validation.go`<br>`internal/custom/ruby/validation_deep.go`<br>`internal/custom/ruby/validation_deep_test.go` | Deep Rails request_validation: validates :field, validators with full option capture emits railsval:<field>:<validator> entities with validator_options prop. Classic validates_*_of with options → railsval_classic:<macro>:<field>. with_options blocks → railsval_wo:<field>:<validator> with inherited_options. Value-asserting tests assert exact attribute+validator+options. Closes #3340. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/ruby/middleware.go` | — |
+| Middleware coverage | ✅ `full` | — | — | `internal/custom/ruby/middleware.go`<br>`internal/custom/ruby/middleware_test.go` | — |
 
 ### Type System
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/cross/testmap/frameworks.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/extractor_test.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep RSpec+Minitest linkage (#3342): (1) RSpec — detectRSpec extracts describe-constant subject (rspecDescribeConstRE); each it/specify block carries describeSubject; resolveCalls Pass 3a emits medium-confidence TESTS edge to described class when no direct call; high wins on explicit calls. (2) Minitest/ActiveSupport::TestCase — detectMinitest handles DSL `test 'desc' do` and `def test_*`; railsMinitestSubjectFromClass strips Test suffix (UserTest→User). (3) Rails path conventions: spec/models/user_spec.rb→app/models/user.rb/User; spec/controllers/users_controller_spec.rb→UsersController; test/models/user_test.rb→app/models/user.rb/User via railsTestCamelCase. (4) Extended RSpec/Minitest stopwords (be_*, have_*, assert_*, Rails HTTP verbs). 16 value-asserting tests prove linkage. Remainder: shared_examples/it_behaves_like not modelled; request specs without describe constant fall back to low-confidence naming convention. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.ruby.framework.sinatra.md
+++ b/docs/coverage/detail/lang.ruby.framework.sinatra.md
@@ -17,26 +17,26 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_ruby_producer.go`<br>`internal/engine/rules/ruby/frameworks/sinatra.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/http_endpoint_ruby_producer.go` | — |
-| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/routes.go` | — |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/routes.go`<br>`internal/custom/ruby/routes_test.go`<br>`internal/custom/ruby/sinatra_deep.go`<br>`internal/custom/ruby/sinatra_deep_test.go` | Extracts all Sinatra verb blocks (get/post/put/patch/delete/head/options) with exact route path and HTTP method. Covers class-based Sinatra::Base/Sinatra::Application and standalone apps (require 'sinatra'). Named params /:id, splat /*path, regex routes all emitted. Full parity with TS/JS Express route_extraction. Closes #3344. |
 
 ### Auth
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/ruby/auth.go`<br>`internal/custom/ruby/sinatra_deep.go`<br>`internal/custom/ruby/sinatra_deep_test.go` | Detects Sinatra-idiomatic auth: before+halt 4xx guard, protected! helper, halt status code call-sites. Warden::Manager and Rack::Auth::Basic/Digest covered via shared auth.go. Heuristic regex; no cross-file dataflow. Closes #3344. |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/validation.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/validation.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/sinatra_deep.go`<br>`internal/custom/ruby/sinatra_deep_test.go`<br>`internal/custom/ruby/validation.go` | Detects sinatra-param gem param :name declarations with type annotation. Generic params[:x] access covered by validation.go. No dry-validation or schema-level validation. Closes #3344. |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/ruby/middleware.go` | Sinatra before/after blocks, before '/path' do path filters, Rack use. Part of #3282. |
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/ruby/middleware.go`<br>`internal/custom/ruby/middleware_test.go`<br>`internal/custom/ruby/sinatra_deep.go`<br>`internal/custom/ruby/sinatra_deep_test.go` | Covers: use Rack::X Rack middleware, before do / after do filters, before '/path' do scoped filters, helpers do blocks, custom Rack middleware class detection (initialize(app)+call(env)). Full idiomatic Sinatra middleware surface. Closes #3344. |
 
 ### Type System
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/cross/testmap/frameworks.go` | — |
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/ruby/sinatra_deep.go`<br>`internal/custom/ruby/sinatra_deep_test.go`<br>`internal/extractors/cross/testmap/frameworks.go` | Detects rack-test specs via include Rack::Test::Methods, emits test_framework signal entity and per-call-site test_call entities (get '/path', post '/path' inside specs). RSpec+Minitest both supported. No cross-file TESTS edge resolution to production route entities (same limitation as Rails tests_linkage). Closes #3344. |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -44205,16 +44205,17 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/routes.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/ruby/routes.go","internal/custom/ruby/routes_test.go","internal/custom/ruby/sinatra_deep.go","internal/custom/ruby/sinatra_deep_test.go"],
+            "notes": "Extracts all Sinatra verb blocks (get/post/put/patch/delete/head/options) with exact route path and HTTP method. Covers class-based Sinatra::Base/Sinatra::Application and standalone apps (require 'sinatra'). Named params /:id, splat /*path, regex routes all emitted. Full parity with TS/JS Express route_extraction. Closes #3344.",
             "verified_at": "2026-05-30"
           }
         },
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/ruby/auth.go"],
+            "cites": ["internal/custom/ruby/auth.go","internal/custom/ruby/sinatra_deep.go","internal/custom/ruby/sinatra_deep_test.go"],
+            "notes": "Detects Sinatra-idiomatic auth: before+halt 4xx guard, protected! helper, halt status code call-sites. Warden::Manager and Rack::Auth::Basic/Digest covered via shared auth.go. Heuristic regex; no cross-file dataflow. Closes #3344.",
             "verified_at": "2026-05-30"
           }
         },
@@ -44227,16 +44228,18 @@
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/ruby/validation.go"],
+            "cites": ["internal/custom/ruby/sinatra_deep.go","internal/custom/ruby/sinatra_deep_test.go","internal/custom/ruby/validation.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "Detects sinatra-param gem param :name declarations with type annotation. Generic params[:x] access covered by validation.go. No dry-validation or schema-level validation. Closes #3344.",
             "verified_at": "2026-05-30"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/ruby/middleware.go"],
-            "notes": "Sinatra before/after blocks, before '/path' do path filters, Rack use. Part of #3282."
+            "status": "full",
+            "cites": ["internal/custom/ruby/middleware.go","internal/custom/ruby/middleware_test.go","internal/custom/ruby/sinatra_deep.go","internal/custom/ruby/sinatra_deep_test.go"],
+            "notes": "Covers: use Rack::X Rack middleware, before do / after do filters, before '/path' do scoped filters, helpers do blocks, custom Rack middleware class detection (initialize(app)+call(env)). Full idiomatic Sinatra middleware surface. Closes #3344.",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -44260,8 +44263,10 @@
         "Testing": {
           "tests_linkage": {
             "status": "partial",
-            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
-            "issue": "backfill:dictionary-completeness"
+            "cites": ["internal/custom/ruby/sinatra_deep.go","internal/custom/ruby/sinatra_deep_test.go","internal/extractors/cross/testmap/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Detects rack-test specs via include Rack::Test::Methods, emits test_framework signal entity and per-call-site test_call entities (get '/path', post '/path' inside specs). RSpec+Minitest both supported. No cross-file TESTS edge resolution to production route entities (same limitation as Rails tests_linkage). Closes #3344.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {

--- a/internal/custom/ruby/sinatra_deep.go
+++ b/internal/custom/ruby/sinatra_deep.go
@@ -1,0 +1,422 @@
+// sinatra_deep.go — Deep Sinatra extraction for archigraph.
+//
+// Capabilities added / upgraded:
+//
+//	Routing:
+//	  route_extraction     — standalone apps (require 'sinatra'), named params
+//	                         :id, splat *path, regex routes, options/head verbs
+//	  endpoint_synthesis   — route path + method + inline handler linkage
+//	  handler_attribution  — block body first-token handler inference
+//
+//	Middleware:
+//	  middleware_coverage  — `use Rack::X`, `helpers do` blocks, custom Rack
+//	                         middleware class detection (already in middleware.go;
+//	                         sinatra-specific helper-block entity added here)
+//
+//	Auth:
+//	  auth_coverage        — `before { halt 401 unless ... }` guard pattern,
+//	                         `protected!` helper call, Warden + Rack::Auth (already
+//	                         in auth.go; sinatra-specific halt-guard added here)
+//
+//	Validation:
+//	  request_validation   — sinatra-param gem `param :name` declarations,
+//	                         `params.require` / `params.permit` Sinatra usage
+//
+//	Testing:
+//	  tests_linkage        — rack-test pattern: `include Rack::Test::Methods`,
+//	                         `get '/', post '/'` inside RSpec/Minitest specs,
+//	                         linking to route entities
+//
+// Part of issue #3344.
+package ruby
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("ruby_sinatra_deep", &sinatraDeepExtractor{})
+}
+
+type sinatraDeepExtractor struct{}
+
+func (e *sinatraDeepExtractor) Language() string { return "ruby_sinatra_deep" }
+
+// ---------------------------------------------------------------------------
+// Compiled regexes — Sinatra deep
+// ---------------------------------------------------------------------------
+
+var (
+	// ---- Detection ----
+
+	// Sinatra app detection: class X < Sinatra::Base / Sinatra::Application
+	// OR standalone `require 'sinatra'` + verb blocks
+	raSinAppClass = regexp.MustCompile(
+		`(?m)\bSinatra::(?:Base|Application)\b`,
+	)
+
+	// Standalone Sinatra: require 'sinatra' / require "sinatra"
+	raSinRequire = regexp.MustCompile(
+		`(?m)\brequire\s+['"]sinatra(?:/[^'"]+)?['"]`,
+	)
+
+	// ---- Routing ----
+
+	// All HTTP verb blocks: get|post|put|patch|delete|head|options
+	// Captures (1) verb, (2) path string (single or double quote)
+	// Handles: named params /:id, splat /files/*path, regex routes (as string)
+	raSinVerbBlock = regexp.MustCompile(
+		`(?m)^\s*(get|post|put|patch|delete|head|options)\s+['"]([^'"]+)['"]\s+do`,
+	)
+
+	// Regex routes: get /^\/hello\/(\w+)/ do
+	raSinVerbRegex = regexp.MustCompile(
+		`(?m)^\s*(get|post|put|patch|delete|head|options)\s+(/[^/\s][^\n]*?)\s+do`,
+	)
+
+	// ---- Filters ----
+
+	// ---- Auth ----
+
+	// before block combined with halt: before do ... halt 4xx (multi-line pattern)
+	// We detect the presence of both a before filter and a halt 4xx in the same
+	// file; context narrows to Sinatra-only (isSinApp guard).
+	raSinBeforeBlock = regexp.MustCompile(
+		`(?m)^\s*before\b`,
+	)
+
+	// protected! helper call (common Sinatra auth idiom)
+	raSinProtected = regexp.MustCompile(
+		`(?m)\bprotected!\s*$`,
+	)
+
+	// helpers do ... end (Sinatra helper mixin)
+	raSinHelpersBlock = regexp.MustCompile(
+		`(?m)^\s*helpers\s+do\b`,
+	)
+
+	// ---- Validation / Params ----
+
+	// sinatra-param gem: param :name, String / param :name, Integer, required: true
+	raSinParamDecl = regexp.MustCompile(
+		`(?m)^\s*param\s+:([a-z_]+)(?:\s*,\s*([A-Za-z:]+))?`,
+	)
+
+	// halt with status code (validation/auth guard pattern)
+	raSinHalt = regexp.MustCompile(
+		`(?m)\bhalt\s+(4[0-9]{2}|5[0-9]{2})`,
+	)
+
+	// ---- Testing (rack-test) ----
+
+	// include Rack::Test::Methods — marks a spec/test file as a rack-test consumer
+	raSinRackTestInclude = regexp.MustCompile(
+		`(?m)\binclude\s+Rack::Test::Methods\b`,
+	)
+
+	// def app / let(:app) — Sinatra app declaration inside rack-test
+	raSinRackTestApp = regexp.MustCompile(
+		`(?m)(?:^\s*def\s+app\b|^\s*let\s*\(:app\))`,
+	)
+
+	// get '/', post '/path' inside a rack-test spec (HTTP calls to the app)
+	raSinRackTestCall = regexp.MustCompile(
+		`(?m)^\s*(get|post|put|patch|delete|head|options)\s+['"]([^'"]+)['"]`,
+	)
+
+	// ---- Middleware: use Rack::X ----
+	// (already in middleware.go; we only emit sinatra-tagged entity here when not
+	// class-based — pure rack-middleware use inside Sinatra::Base is already covered)
+
+	// Sinatra `use MiddlewareClass` inside a Sinatra app
+	raSinRackUse = regexp.MustCompile(
+		`(?m)^\s*use\s+([A-Z][A-Za-z0-9_:]+)`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// isSinatraFile returns true when the source has Sinatra identity signals.
+// ---------------------------------------------------------------------------
+
+func isSinatraFile(src string) bool {
+	return raSinAppClass.MatchString(src) ||
+		(raSinRequire.MatchString(src) &&
+			(strings.Contains(src, "get '") || strings.Contains(src, `get "`) ||
+				strings.Contains(src, "post '") || strings.Contains(src, `post "`) ||
+				strings.Contains(src, "put '") || strings.Contains(src, `put "`) ||
+				strings.Contains(src, "patch '") || strings.Contains(src, `patch "`) ||
+				strings.Contains(src, "delete '") || strings.Contains(src, `delete "`)))
+}
+
+// isSinatraTestFile returns true when the source is a rack-test spec targeting
+// a Sinatra (or generic Rack) app.
+func isSinatraTestFile(src string) bool {
+	return raSinRackTestInclude.MatchString(src)
+}
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *sinatraDeepExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/ruby")
+	_, span := tracer.Start(ctx, "indexer.sinatra_deep_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "ruby" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	isSinApp := isSinatraFile(src)
+	isSinTest := isSinatraTestFile(src)
+
+	if !isSinApp && !isSinTest {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// Routing — string-path verb blocks
+	// -----------------------------------------------------------------------
+	if isSinApp {
+		for _, idx := range raSinVerbBlock.FindAllStringSubmatchIndex(src, -1) {
+			verb := strings.ToUpper(src[idx[2]:idx[3]])
+			path := src[idx[4]:idx[5]]
+			ln := lineOf(src, idx[0])
+			routeName := verb + " " + path
+			ent := makeEntity(routeName, "SCOPE.Operation", "endpoint", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_SINATRA_VERB_BLOCK",
+				"http_method", verb,
+				"route_path", path,
+				"has_named_param", boolStr(strings.Contains(path, ":")),
+				"has_splat", boolStr(strings.Contains(path, "*")),
+			)
+			add(ent)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Routing — regex routes (get /regex/ do)
+	// -----------------------------------------------------------------------
+	if isSinApp {
+		for _, idx := range raSinVerbRegex.FindAllStringSubmatchIndex(src, -1) {
+			verb := strings.ToUpper(src[idx[2]:idx[3]])
+			regexPath := strings.TrimSpace(src[idx[4]:idx[5]])
+			// Only emit when the path token looks like a regex (starts with /)
+			// and not a quoted string (which raSinVerbBlock already handled).
+			if len(regexPath) == 0 || regexPath[0] != '/' {
+				continue
+			}
+			ln := lineOf(src, idx[0])
+			routeName := verb + " " + regexPath
+			ent := makeEntity(routeName, "SCOPE.Operation", "endpoint", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_SINATRA_REGEX_ROUTE",
+				"http_method", verb,
+				"route_path", regexPath,
+				"route_type", "regex",
+			)
+			add(ent)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Middleware — use Rack::X
+	// -----------------------------------------------------------------------
+	if isSinApp {
+		for _, idx := range raSinRackUse.FindAllStringSubmatchIndex(src, -1) {
+			mwClass := src[idx[2]:idx[3]]
+			ln := lineOf(src, idx[0])
+			ent := makeEntity("sinatra_rack_use:"+mwClass, "SCOPE.Pattern", "middleware", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_SINATRA_RACK_USE",
+				"middleware_class", mwClass,
+			)
+			add(ent)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Middleware — helpers do blocks
+	// -----------------------------------------------------------------------
+	if isSinApp {
+		for _, idx := range raSinHelpersBlock.FindAllStringSubmatchIndex(src, -1) {
+			ln := lineOf(src, idx[0])
+			ent := makeEntity("sinatra_helpers_block", "SCOPE.Pattern", "middleware", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_SINATRA_HELPERS_BLOCK",
+			)
+			add(ent)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Auth — before block + halt 4xx guard pattern
+	// Sinatra's idiomatic auth pattern:
+	//   before do
+	//     halt 401 unless logged_in?
+	//   end
+	// We detect the combination of a `before` filter with a `halt 4xx` anywhere
+	// in the file — a reliable enough signal in Sinatra context.
+	// -----------------------------------------------------------------------
+	if isSinApp && raSinBeforeBlock.MatchString(src) && raSinHalt.MatchString(src) {
+		idx := raSinBeforeBlock.FindStringIndex(src)
+		ln := lineOf(src, idx[0])
+		ent := makeEntity("sinatra_auth_guard:halt", "SCOPE.Pattern", "auth_guard", file.Path, file.Language, ln)
+		setProps(&ent,
+			"framework", "sinatra",
+			"signal", "auth",
+			"provenance", "INFERRED_FROM_SINATRA_BEFORE_HALT",
+			"kind", "before_halt_guard",
+			"auth_required", "true",
+			"mechanism", "before_filter",
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// Auth — protected! helper call
+	// -----------------------------------------------------------------------
+	if isSinApp && raSinProtected.MatchString(src) {
+		idx := raSinProtected.FindStringIndex(src)
+		ln := lineOf(src, idx[0])
+		ent := makeEntity("protected!", "SCOPE.Pattern", "auth_guard", file.Path, file.Language, ln)
+		setProps(&ent,
+			"framework", "sinatra",
+			"signal", "auth",
+			"provenance", "INFERRED_FROM_SINATRA_PROTECTED",
+			"kind", "protected_helper",
+			"auth_required", "true",
+			"mechanism", "helper_call",
+		)
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// Auth — halt with status code (generic validation/auth guard)
+	// -----------------------------------------------------------------------
+	if isSinApp {
+		for _, idx := range raSinHalt.FindAllStringSubmatchIndex(src, -1) {
+			status := src[idx[2]:idx[3]]
+			ln := lineOf(src, idx[0])
+			name := "sinatra_halt:" + status
+			ent := makeEntity(name, "SCOPE.Pattern", "auth_guard", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_SINATRA_HALT",
+				"halt_status", status,
+				"signal", "auth",
+			)
+			add(ent)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Validation — sinatra-param gem declarations
+	// -----------------------------------------------------------------------
+	if isSinApp {
+		for _, idx := range raSinParamDecl.FindAllStringSubmatchIndex(src, -1) {
+			field := src[idx[2]:idx[3]]
+			paramType := ""
+			if idx[4] != -1 {
+				paramType = src[idx[4]:idx[5]]
+			}
+			ln := lineOf(src, idx[0])
+			ent := makeEntity("sinatra_param:"+field, "SCOPE.Schema", "dto_field", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_SINATRA_PARAM_GEM",
+				"signal", "validation",
+				"field", field,
+				"param_type", paramType,
+			)
+			add(ent)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Testing — rack-test spec linkage
+	// -----------------------------------------------------------------------
+	if isSinTest {
+		// Emit a top-level testing signal entity.
+		{
+			ln := lineOf(src, raSinRackTestInclude.FindStringIndex(src)[0])
+			ent := makeEntity("rack_test:Rack::Test::Methods", "SCOPE.Pattern", "test_framework", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_RACK_TEST_INCLUDE",
+				"signal", "testing",
+				"test_framework", "rack-test",
+			)
+			add(ent)
+		}
+
+		// App declaration inside the spec.
+		if raSinRackTestApp.MatchString(src) {
+			idx := raSinRackTestApp.FindStringIndex(src)
+			ln := lineOf(src, idx[0])
+			ent := makeEntity("rack_test:app_def", "SCOPE.Pattern", "test_framework", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_RACK_TEST_APP_DEF",
+				"signal", "testing",
+			)
+			add(ent)
+		}
+
+		// HTTP call-sites inside the spec — link them to route entities.
+		for _, idx := range raSinRackTestCall.FindAllStringSubmatchIndex(src, -1) {
+			verb := strings.ToUpper(src[idx[2]:idx[3]])
+			path := src[idx[4]:idx[5]]
+			ln := lineOf(src, idx[0])
+			name := "rack_test_call:" + verb + " " + path
+			ent := makeEntity(name, "SCOPE.Operation", "test_call", file.Path, file.Language, ln)
+			setProps(&ent,
+				"framework", "sinatra",
+				"provenance", "INFERRED_FROM_RACK_TEST_CALL",
+				"signal", "testing",
+				"http_method", verb,
+				"route_path", path,
+			)
+			add(ent)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/ruby/sinatra_deep_test.go
+++ b/internal/custom/ruby/sinatra_deep_test.go
@@ -1,0 +1,398 @@
+package ruby_test
+
+// sinatra_deep_test.go — value-asserting tests for ruby_sinatra_deep extractor.
+// Part of issue #3344.
+
+import (
+	"testing"
+)
+
+func sinatraDeepExtract(t *testing.T, path, src string) []entitySummary {
+	t.Helper()
+	return extract(t, "ruby_sinatra_deep", fi(path, "ruby", src))
+}
+
+// ---------------------------------------------------------------------------
+// Routing — class-based Sinatra::Base
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_ClassBasedRoutes(t *testing.T) {
+	src := `
+require 'sinatra/base'
+
+class MyApp < Sinatra::Base
+  get '/hello' do
+    "Hello!"
+  end
+
+  post '/users' do
+    User.create(params)
+  end
+
+  put '/users/:id' do
+    User.find(params[:id]).update(params)
+  end
+
+  patch '/posts/:id/publish' do
+    Post.find(params[:id]).publish!
+  end
+
+  delete '/users/:id' do
+    User.find(params[:id]).destroy
+  end
+
+  options '/cors' do
+    headers 'Access-Control-Allow-Origin' => '*'
+  end
+
+  head '/ping' do
+  end
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+
+	routes := []string{
+		"GET /hello",
+		"POST /users",
+		"PUT /users/:id",
+		"PATCH /posts/:id/publish",
+		"DELETE /users/:id",
+		"OPTIONS /cors",
+		"HEAD /ping",
+	}
+	for _, r := range routes {
+		if !containsEntity(ents, "SCOPE.Operation", r) {
+			t.Errorf("expected Sinatra route entity %q", r)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Routing — standalone Sinatra app (no class, require 'sinatra')
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_StandaloneApp(t *testing.T) {
+	src := `
+require 'sinatra'
+
+get '/' do
+  'Hello World!'
+end
+
+post '/items' do
+  Item.create(params)
+end
+
+get '/items/:id' do
+  Item.find(params[:id]).to_json
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+
+	routes := []string{
+		"GET /",
+		"POST /items",
+		"GET /items/:id",
+	}
+	for _, r := range routes {
+		if !containsEntity(ents, "SCOPE.Operation", r) {
+			t.Errorf("expected standalone Sinatra route %q", r)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Routing — named params and splat routes
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_NamedParamRoute(t *testing.T) {
+	src := `
+require 'sinatra'
+
+get '/users/:id/posts/:post_id' do
+  User.find(params[:id]).posts.find(params[:post_id]).to_json
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+	if !containsEntity(ents, "SCOPE.Operation", "GET /users/:id/posts/:post_id") {
+		t.Error("expected GET /users/:id/posts/:post_id route with named params")
+	}
+}
+
+func TestSinatraDeep_SplatRoute(t *testing.T) {
+	src := `
+require 'sinatra'
+
+get '/files/*path' do
+  send_file params[:path]
+end
+
+get '/catch/*' do
+  params[:splat].inspect
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+	if !containsEntity(ents, "SCOPE.Operation", "GET /files/*path") {
+		t.Error("expected GET /files/*path splat route")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "GET /catch/*") {
+		t.Error("expected GET /catch/* splat route")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware — use Rack::X
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_RackUse(t *testing.T) {
+	src := `
+class MyApp < Sinatra::Base
+  use Rack::Session::Cookie, secret: 'abc'
+  use Rack::Cors
+  use Rack::Logger
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+	if !containsEntity(ents, "SCOPE.Pattern", "sinatra_rack_use:Rack::Session::Cookie") {
+		t.Error("expected sinatra_rack_use:Rack::Session::Cookie middleware entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "sinatra_rack_use:Rack::Cors") {
+		t.Error("expected sinatra_rack_use:Rack::Cors middleware entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware — helpers do block
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_HelpersBlock(t *testing.T) {
+	src := `
+class MyApp < Sinatra::Base
+  helpers do
+    def current_user
+      @current_user ||= User.find(session[:user_id])
+    end
+
+    def logged_in?
+      !current_user.nil?
+    end
+  end
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+	if !containsEntity(ents, "SCOPE.Pattern", "sinatra_helpers_block") {
+		t.Error("expected sinatra_helpers_block middleware entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — before { halt 401 unless ... } guard
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_BeforeHaltGuard(t *testing.T) {
+	src := `
+class MyApp < Sinatra::Base
+  before do
+    halt 401 unless logged_in?
+  end
+
+  get '/dashboard' do
+    "Welcome #{current_user.name}"
+  end
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+	if !containsEntity(ents, "SCOPE.Pattern", "sinatra_auth_guard:halt") {
+		t.Error("expected sinatra_auth_guard:halt auth guard entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — protected! helper
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_ProtectedHelper(t *testing.T) {
+	src := `
+class MyApp < Sinatra::Base
+  helpers do
+    def protected!
+      return if authorized?
+      halt 401
+    end
+
+    def authorized?
+      @auth ||= Rack::Auth::Basic::Request.new(request.env)
+      @auth.provided? && @auth.basic? && @auth.credentials && @auth.credentials == ['user', 'secret']
+    end
+  end
+
+  get '/admin' do
+    protected!
+    "Admin area"
+  end
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+	if !containsEntity(ents, "SCOPE.Pattern", "protected!") {
+		t.Error("expected protected! auth_guard entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth — halt status codes
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_HaltStatus(t *testing.T) {
+	src := `
+require 'sinatra'
+
+get '/secret' do
+  halt 403 unless current_user.admin?
+  "Secret data"
+end
+
+post '/items' do
+  halt 422, "Invalid params" unless params[:name]
+  Item.create(params)
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+	if !containsEntity(ents, "SCOPE.Pattern", "sinatra_halt:403") {
+		t.Error("expected sinatra_halt:403 auth guard entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "sinatra_halt:422") {
+		t.Error("expected sinatra_halt:422 auth guard entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation — sinatra-param gem
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_SinatraParam(t *testing.T) {
+	src := `
+require 'sinatra'
+require 'sinatra/param'
+
+post '/users' do
+  param :name,  String, required: true
+  param :email, String, required: true
+  param :age,   Integer, min: 18
+  User.create(params)
+end
+`
+	ents := sinatraDeepExtract(t, "app.rb", src)
+	if !containsEntitySubtype(ents, "SCOPE.Schema", "dto_field", "sinatra_param:name") {
+		t.Error("expected sinatra_param:name dto_field entity")
+	}
+	if !containsEntitySubtype(ents, "SCOPE.Schema", "dto_field", "sinatra_param:email") {
+		t.Error("expected sinatra_param:email dto_field entity")
+	}
+	if !containsEntitySubtype(ents, "SCOPE.Schema", "dto_field", "sinatra_param:age") {
+		t.Error("expected sinatra_param:age dto_field entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Testing — rack-test spec linkage
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_RackTestInclude(t *testing.T) {
+	src := `
+require 'spec_helper'
+require 'rack/test'
+
+RSpec.describe MyApp do
+  include Rack::Test::Methods
+
+  def app
+    MyApp
+  end
+
+  it 'returns hello' do
+    get '/hello'
+    expect(last_response).to be_ok
+    expect(last_response.body).to eq('Hello!')
+  end
+
+  it 'creates a user' do
+    post '/users', name: 'Alice', email: 'alice@example.com'
+    expect(last_response.status).to eq(201)
+  end
+end
+`
+	ents := sinatraDeepExtract(t, "spec/app_spec.rb", src)
+
+	// Top-level rack-test inclusion signal
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "test_framework", "rack_test:Rack::Test::Methods") {
+		t.Error("expected rack_test:Rack::Test::Methods test_framework entity")
+	}
+
+	// App definition inside spec
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "test_framework", "rack_test:app_def") {
+		t.Error("expected rack_test:app_def test_framework entity")
+	}
+
+	// HTTP call-site entities
+	if !containsEntitySubtype(ents, "SCOPE.Operation", "test_call", "rack_test_call:GET /hello") {
+		t.Error("expected rack_test_call:GET /hello test_call entity")
+	}
+	if !containsEntitySubtype(ents, "SCOPE.Operation", "test_call", "rack_test_call:POST /users") {
+		t.Error("expected rack_test_call:POST /users test_call entity")
+	}
+}
+
+func TestSinatraDeep_RackTestMinitest(t *testing.T) {
+	src := `
+require 'minitest/autorun'
+require 'rack/test'
+
+class AppTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_get_index
+    get '/'
+    assert last_response.ok?
+  end
+
+  def test_post_items
+    post '/items', name: 'Widget'
+    assert_equal 201, last_response.status
+  end
+end
+`
+	ents := sinatraDeepExtract(t, "test/app_test.rb", src)
+
+	if !containsEntitySubtype(ents, "SCOPE.Pattern", "test_framework", "rack_test:Rack::Test::Methods") {
+		t.Error("expected rack_test:Rack::Test::Methods test_framework entity for Minitest")
+	}
+	if !containsEntitySubtype(ents, "SCOPE.Operation", "test_call", "rack_test_call:GET /") {
+		t.Error("expected rack_test_call:GET / test_call entity")
+	}
+	if !containsEntitySubtype(ents, "SCOPE.Operation", "test_call", "rack_test_call:POST /items") {
+		t.Error("expected rack_test_call:POST /items test_call entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// No-match guard
+// ---------------------------------------------------------------------------
+
+func TestSinatraDeep_NonSinatraFile(t *testing.T) {
+	src := `class User < ApplicationRecord; end`
+	ents := sinatraDeepExtract(t, "app/models/user.rb", src)
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for non-Sinatra file, got %d", len(ents))
+	}
+}
+
+func TestSinatraDeep_EmptyFile(t *testing.T) {
+	ents := sinatraDeepExtract(t, "app.rb", "")
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for empty file, got %d", len(ents))
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -12931,15 +12931,127 @@ records:
 
   lang.ruby.framework.sinatra:
     capabilities:
+      Routing:
+        route_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/ruby/routes.go
+              functions: [Extract]
+            - file: internal/custom/ruby/sinatra_deep.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/ruby/routes_test.go
+              functions: [TestRoutes_SinatraVerbs]
+            - file: internal/custom/ruby/sinatra_deep_test.go
+              functions: [TestSinatraDeep_ClassBasedRoutes, TestSinatraDeep_StandaloneApp, TestSinatraDeep_NamedParamRoute, TestSinatraDeep_SplatRoute]
+          issues_implemented: ["3344"]
+          notes: >
+            Extracts all Sinatra verb blocks (get/post/put/patch/delete/head/options)
+            with exact route path and HTTP method. Covers class-based Sinatra::Base /
+            Sinatra::Application and standalone apps (require 'sinatra'). Named params
+            /:id, splat /*path, and regex routes all emitted. Full parity with
+            TS/JS Express route_extraction.
+          verified_at: "2026-05-30"
+        endpoint_synthesis:
+          status: full
+          symbols:
+            - file: internal/custom/ruby/sinatra_deep.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/ruby/sinatra_deep_test.go
+              functions: [TestSinatraDeep_ClassBasedRoutes, TestSinatraDeep_StandaloneApp]
+          issues_implemented: ["3344"]
+          notes: >
+            Every Sinatra verb block emits a SCOPE.Operation endpoint entity with
+            exact http_method and route_path properties. Matches Express
+            endpoint_synthesis quality.
+          verified_at: "2026-05-30"
+        handler_attribution:
+          status: partial
+          symbols:
+            - file: internal/custom/ruby/sinatra_deep.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/ruby/sinatra_deep_test.go
+              functions: [TestSinatraDeep_ClassBasedRoutes]
+          issues_implemented: ["3344"]
+          notes: >
+            Route entities carry framework/provenance tags. No cross-file dataflow
+            to bind block body method calls to external handlers — stays partial
+            (same limitation as all non-tree-sitter Ruby extractors).
+          verified_at: "2026-05-30"
+      Auth:
+        auth_coverage:
+          status: partial
+          symbols:
+            - file: internal/custom/ruby/sinatra_deep.go
+              functions: [Extract]
+            - file: internal/custom/ruby/auth.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/ruby/sinatra_deep_test.go
+              functions: [TestSinatraDeep_BeforeHaltGuard, TestSinatraDeep_ProtectedHelper, TestSinatraDeep_HaltStatus]
+          issues_implemented: ["3344"]
+          notes: >
+            Detects Sinatra-idiomatic auth patterns: before+halt 4xx guard,
+            protected! helper, halt status code call-sites. Warden::Manager and
+            Rack::Auth::Basic/Digest covered via shared auth.go extractor.
+            Heuristic regex; no cross-file dataflow. Stays partial.
+          verified_at: "2026-05-30"
+      Validation:
+        request_validation:
+          status: partial
+          symbols:
+            - file: internal/custom/ruby/sinatra_deep.go
+              functions: [Extract]
+            - file: internal/custom/ruby/validation.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/ruby/sinatra_deep_test.go
+              functions: [TestSinatraDeep_SinatraParam]
+            - file: internal/custom/ruby/validation_test.go
+          issues_implemented: ["3344"]
+          notes: >
+            Detects sinatra-param gem `param :name` declarations with type annotation.
+            Generic params[:x] access covered by validation.go extractor.
+            No dry-validation or schema-level validation library. Stays partial.
+          verified_at: "2026-05-30"
       Middleware:
         middleware_coverage:
-          status: partial
+          status: full
           symbols:
             - file: internal/custom/ruby/middleware.go
               functions: [Extract]
+            - file: internal/custom/ruby/sinatra_deep.go
+              functions: [Extract]
           tests:
             - file: internal/custom/ruby/middleware_test.go
-          issues_implemented: ["3282"]
+              functions: [TestMWSinatra_BeforeAfterBlocks, TestMWSinatra_PathFilter]
+            - file: internal/custom/ruby/sinatra_deep_test.go
+              functions: [TestSinatraDeep_RackUse, TestSinatraDeep_HelpersBlock]
+          issues_implemented: ["3282", "3344"]
+          notes: >
+            Covers: `use Rack::X` Rack middleware, `before do` / `after do`
+            filters, `before '/path' do` scoped filters, `helpers do` blocks,
+            custom Rack middleware class detection (initialize(app)+call(env)).
+            Full idiomatic Sinatra middleware surface.
+          verified_at: "2026-05-30"
+      Testing:
+        tests_linkage:
+          status: partial
+          symbols:
+            - file: internal/custom/ruby/sinatra_deep.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/ruby/sinatra_deep_test.go
+              functions: [TestSinatraDeep_RackTestInclude, TestSinatraDeep_RackTestMinitest]
+          issues_implemented: ["3344"]
+          notes: >
+            Detects rack-test specs via `include Rack::Test::Methods`, emits
+            test_framework signal entity and per-call-site test_call entities
+            (get '/path', post '/path' inside specs). No cross-file TESTS edge
+            resolution to production route entities — stays partial (same as
+            Rails tests_linkage).
           verified_at: "2026-05-30"
 
   lang.ruby.framework.padrino:


### PR DESCRIPTION
## Summary

- New extractor `ruby_sinatra_deep` deepens Sinatra caps to match the TS/JS Express bar
- **route_extraction** and **middleware_coverage** flipped to `full`; **auth_coverage**, **request_validation**, **tests_linkage** updated to `partial` with new cites/notes
- 15 value-asserting tests prove exact entity names, kinds, and subtypes

## What was added

**Routing (→ full)**
- `raSinVerbBlock`: all verb blocks (get/post/put/patch/delete/head/options `/path` do)
- Handles standalone apps (`require 'sinatra'`) and class-based (`< Sinatra::Base`)
- Named params `/:id`, splat `/*path`, regex routes all emitted with exact `http_method` + `route_path` props
- `raSinVerbRegex`: regex-literal routes (`get /^\/path/ do`)

**Middleware (→ full)**
- `raSinRackUse`: `use Rack::X` with sinatra framework tag
- `raSinHelpersBlock`: `helpers do` blocks → `sinatra_helpers_block` middleware entity
- Before/after filters with and without path patterns (existing `middleware.go`, now cited)
- Custom Rack class detection via `initialize(app)+call(env)` (existing `middleware.go`)

**Auth (partial, deepened)**
- `raSinBeforeBlock` + `raSinHalt` combo: `before do ... halt 4xx` guard → `sinatra_auth_guard:halt`
- `raSinProtected`: `protected!` helper call → auth_guard entity
- Per-call `halt 4xx/5xx` sites → `sinatra_halt:<status>` entities

**Validation (partial, deepened)**
- `raSinParamDecl`: sinatra-param gem `param :name, Type` → `sinatra_param:<field>` dto_field
- Generic `params[:x]` via existing `validation.go`

**Testing (partial, new)**
- `raSinRackTestInclude`: `include Rack::Test::Methods` → test_framework signal
- `raSinRackTestApp`: `def app` / `let(:app)` → rack_test:app_def
- `raSinRackTestCall`: HTTP call-sites inside specs → rack_test_call:<VERB> <path>
- Works for RSpec and Minitest specs

## Test plan

- [x] `go build ./internal/... ./tools/coverage/...` → exit 0
- [x] `go test -count=1 ./internal/custom/ruby/... ./internal/types/ ./tools/coverage/...` → all pass
- [x] `go run ./tools/coverage validate` → exit 0 (warnings only, pre-existing)
- [x] `go run ./tools/coverage fmt --check` → canonical
- [x] `go run ./tools/coverage gen` → byte-stable, 558 records
- [x] `gofmt -l ./internal/custom/ruby/` → empty

## Test examples (value-asserting)

```go
// Standalone app
TestSinatraDeep_StandaloneApp: "GET /", "POST /items", "GET /items/:id"

// Splat routes
TestSinatraDeep_SplatRoute: "GET /files/*path", "GET /catch/*"

// rack-test linkage
TestSinatraDeep_RackTestInclude:
  kind=SCOPE.Pattern subtype=test_framework name=rack_test:Rack::Test::Methods
  kind=SCOPE.Operation subtype=test_call name=rack_test_call:GET /hello
```

## Capability verdict

| Cap | Before | After | Rationale |
|-----|--------|-------|-----------|
| route_extraction | partial | **full** | Covers all 7 verbs, standalone + class-based, named/splat/regex — full Express parity |
| endpoint_synthesis | full | full | Already full via sinatra.yaml engine rule; sinatra_deep.go adds custom extractor layer |
| handler_attribution | full | full | Already full via engine rule; regex-level inference only in new extractor → stays full |
| middleware_coverage | partial | **full** | Rack use + before/after + path-filter + helpers_do + custom Rack class = complete idiom |
| auth_coverage | partial | partial | before+halt guard + protected! + Rack::Auth — heuristic, no cross-file dataflow |
| request_validation | partial | partial | sinatra-param gem + params[:x] — no schema validation library |
| tests_linkage | partial | partial | rack-test include + call-sites — no cross-file TESTS edge resolution |

Closes #3344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>