### PR TITLE
perf(mcp): terse format + top-N + token_budget on the measured heavy tools (auth_coverage first)

### DIFF
--- a/internal/mcp/auth_coverage.go
+++ b/internal/mcp/auth_coverage.go
@@ -48,7 +48,10 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -230,6 +233,91 @@ var idorParams = []string{
 }
 
 // ---------------------------------------------------------------------------
+// EndpointRecord — one auth-coverage finding (package-scoped for #2828 terse).
+// ---------------------------------------------------------------------------
+
+// EndpointRecord is a single endpoint's auth-coverage finding. It is the wire
+// shape emitted under "endpoints" in format=full; in format=terse it is
+// rendered to a single line via terse().
+type EndpointRecord struct {
+	EntityID       string `json:"entity_id"`
+	Name           string `json:"name"`
+	Repo           string `json:"repo"`
+	SourceFile     string `json:"source_file,omitempty"`
+	StartLine      int    `json:"start_line,omitempty"`
+	Method         string `json:"method,omitempty"`
+	Path           string `json:"path,omitempty"`
+	HasAuth        bool   `json:"has_auth"`
+	AuthEvidence   string `json:"auth_evidence,omitempty"`
+	Severity       string `json:"severity"`
+	SensitiveOp    bool   `json:"sensitive_op,omitempty"`
+	IDORRisk       bool   `json:"idor_risk,omitempty"`
+	SensitiveTerms string `json:"sensitive_terms,omitempty"`
+}
+
+// terse renders one finding as a compact single line, e.g.
+//
+//	error DELETE /users/{user_id} NO-AUTH idor,sensitive(delete) routes/u.py:42 (repo1)
+//	info  GET /dashboard auth(login_required) views/dashboard.py:10 (repo1)
+//
+// It keeps every fact a reviewer acts on (severity, verb, path, auth state +
+// evidence, IDOR/sensitive flags, location, repo) and drops only the JSON
+// envelope and the redundant entity_id/name.
+func (r EndpointRecord) terse() string {
+	var b strings.Builder
+	b.WriteString(r.Severity)
+	b.WriteByte(' ')
+	if r.Method != "" {
+		b.WriteString(r.Method)
+		b.WriteByte(' ')
+	}
+	if r.Path != "" {
+		b.WriteString(r.Path)
+	} else if r.Name != "" {
+		b.WriteString(r.Name)
+	}
+	if r.HasAuth {
+		b.WriteString(" auth")
+		if r.AuthEvidence != "" {
+			b.WriteString("(")
+			b.WriteString(r.AuthEvidence)
+			b.WriteString(")")
+		}
+	} else {
+		b.WriteString(" NO-AUTH")
+		var flags []string
+		if r.IDORRisk {
+			flags = append(flags, "idor")
+		}
+		if r.SensitiveOp {
+			if r.SensitiveTerms != "" {
+				flags = append(flags, "sensitive("+r.SensitiveTerms+")")
+			} else {
+				flags = append(flags, "sensitive")
+			}
+		}
+		if len(flags) > 0 {
+			b.WriteByte(' ')
+			b.WriteString(strings.Join(flags, ","))
+		}
+	}
+	if r.SourceFile != "" {
+		b.WriteByte(' ')
+		b.WriteString(r.SourceFile)
+		if r.StartLine > 0 {
+			b.WriteByte(':')
+			b.WriteString(strconv.Itoa(r.StartLine))
+		}
+	}
+	if r.Repo != "" {
+		b.WriteString(" (")
+		b.WriteString(r.Repo)
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
 // handleAuthCoverage — the MCP tool handler
 // ---------------------------------------------------------------------------
 
@@ -240,24 +328,30 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 		return errRes, nil
 	}
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
-	limit := argInt(req, "limit", 200)
-	onlyMissing := argBool(req, "only_missing", false)
 
-	type EndpointRecord struct {
-		EntityID       string `json:"entity_id"`
-		Name           string `json:"name"`
-		Repo           string `json:"repo"`
-		SourceFile     string `json:"source_file,omitempty"`
-		StartLine      int    `json:"start_line,omitempty"`
-		Method         string `json:"method,omitempty"`
-		Path           string `json:"path,omitempty"`
-		HasAuth        bool   `json:"has_auth"`
-		AuthEvidence   string `json:"auth_evidence,omitempty"`
-		Severity       string `json:"severity"`
-		SensitiveOp    bool   `json:"sensitive_op,omitempty"`
-		IDORRisk       bool   `json:"idor_risk,omitempty"`
-		SensitiveTerms string `json:"sensitive_terms,omitempty"`
+	// #2828 token-cost optimisation. Live telemetry flagged auth_coverage as the
+	// single biggest token hog (~7.5K tok/call): the old default limit of 200
+	// full per-endpoint records plus a ~340-byte static note on every call.
+	//
+	//   - format="terse" (default): emit one compact line per finding instead of
+	//     a verbose object, and drop the static note. Same security-essential
+	//     facts (repo, verb, path, severity, has_auth, location), far fewer bytes.
+	//   - format="full": the legacy structured `endpoints` array (every field),
+	//     for callers that machine-parse individual records.
+	//   - limit default lowered 200→50 with an explicit truncation marker.
+	//   - token_budget: optional hard byte cap (token_budget*4) on the returned
+	//     list, truncating with a marker so the agent can opt into more.
+	format := strings.ToLower(argString(req, "format", ""))
+	verbose := argBool(req, "verbose", false)
+	switch format {
+	case "full":
+		verbose = true
+	case "terse":
+		verbose = false
 	}
+	limit := argInt(req, "limit", 50)
+	tokenBudget := argInt(req, "token_budget", 0)
+	onlyMissing := argBool(req, "only_missing", false)
 
 	type RepoSummary struct {
 		Repo          string  `json:"repo"`
@@ -405,6 +499,12 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 	if limit > 0 && len(endpoints) > limit {
 		endpoints = endpoints[:limit]
 	}
+	// #2828: optional hard token budget. Trim further (after the limit cap) so
+	// the rendered list fits ~token_budget*4 bytes, always leaving a marker.
+	if tokenBudget > 0 {
+		endpoints = capAuthByBudget(endpoints, tokenBudget*4, verbose)
+	}
+	shown := len(endpoints)
 
 	totalEndpoints := 0
 	totalCovered := 0
@@ -418,18 +518,80 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 		overallRate = float64(totalCovered) / float64(totalEndpoints)
 	}
 
-	return jsonResult(map[string]any{
-		"endpoints":        endpoints,
-		"count":            len(endpoints),
+	resp := map[string]any{
+		"count":            shown,
 		"total":            total,
-		"truncated":        total > len(endpoints),
+		"truncated":        total > shown,
 		"repo_summaries":   summaries,
 		"overall_coverage": overallRate,
-		"note": "has_auth=false with severity=error indicates an unprotected endpoint " +
+		"format":           formatLabel(verbose),
+	}
+	if total > shown {
+		resp["truncated_count"] = total - shown
+		resp["truncation_note"] = fmt.Sprintf(
+			"%d more findings omitted — pass a larger limit or token_budget, or only_missing=true to focus on uncovered endpoints",
+			total-shown,
+		)
+	}
+	if verbose {
+		// Legacy structured array + the explanatory note (full mode only).
+		resp["endpoints"] = endpoints
+		resp["note"] = "has_auth=false with severity=error indicates an unprotected endpoint " +
 			"performing a sensitive operation or accepting user-scoped parameters (IDOR risk). " +
 			"has_auth=false with severity=warn indicates a potentially public endpoint — " +
-			"verify intentional exposure.",
-	}), nil
+			"verify intentional exposure."
+	} else {
+		// Terse: one compact line per finding. severity=error first (already
+		// sorted). Format: "<SEV> <verb> <path> [auth|NO-AUTH] file:line (repo)".
+		resp["findings"] = renderTerseAuthFindings(endpoints)
+	}
+	return jsonResult(resp), nil
+}
+
+// renderTerseAuthFindings serialises auth findings as one compact line each,
+// preserving the security-essential facts (severity, verb, path, auth state,
+// IDOR/sensitive flags, location) while dropping the verbose per-record JSON
+// envelope (entity_id, repeated keys). #2828.
+func renderTerseAuthFindings(recs []EndpointRecord) []string {
+	out := make([]string, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.terse())
+	}
+	return out
+}
+
+// capAuthByBudget returns the largest prefix of recs whose rendered form fits
+// maxBytes. Verbose mode measures the JSON array; terse mode measures the
+// joined terse lines. Always returns at least one record when recs is non-empty
+// and a single record already exceeds the budget (so the marker is meaningful).
+func capAuthByBudget(recs []EndpointRecord, maxBytes int, verbose bool) []EndpointRecord {
+	if maxBytes <= 0 || len(recs) == 0 {
+		return recs
+	}
+	size := func(n int) int {
+		if verbose {
+			b, _ := json.Marshal(recs[:n])
+			return len(b)
+		}
+		total := 0
+		for i := 0; i < n; i++ {
+			total += len(recs[i].terse()) + 1
+		}
+		return total
+	}
+	if size(len(recs)) <= maxBytes {
+		return recs
+	}
+	lo, hi := 1, len(recs)
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		if size(mid) <= maxBytes {
+			lo = mid
+		} else {
+			hi = mid - 1
+		}
+	}
+	return recs[:lo]
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/auth_coverage_2828_test.go
+++ b/internal/mcp/auth_coverage_2828_test.go
@@ -1,0 +1,231 @@
+package mcp
+
+// auth_coverage_2828_test.go — #2828 token-cost optimisation tests.
+//
+// Live telemetry flagged archigraph_auth_coverage as the single biggest token
+// hog (~7.5K tok/call). These tests prove the new format=terse default + the
+// lowered limit + the token_budget arg cut payload bytes substantially while
+// preserving the security-essential facts an agent acts on, and that the
+// legacy format=full structured shape is still available + unchanged.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildManyEndpointDoc builds a doc with n unprotected endpoints (half sensitive
+// DELETEs, half plain GETs) so the finding list is large enough to exercise
+// limit/budget truncation and to measure terse-vs-full byte deltas.
+func buildManyEndpointDoc(n int) *graph.Document {
+	ents := make([]graph.Entity, 0, n)
+	for i := 0; i < n; i++ {
+		if i%2 == 0 {
+			ents = append(ents, graph.Entity{
+				ID:         fmt.Sprintf("ep_del_%d", i),
+				Name:       fmt.Sprintf("delete_user_%d", i),
+				Kind:       "http_endpoint_definition",
+				SourceFile: fmt.Sprintf("routes/users_%d.py", i),
+				StartLine:  10 + i,
+				Properties: map[string]string{"verb": "DELETE", "path": fmt.Sprintf("/users/{user_id}/%d", i)},
+			})
+		} else {
+			ents = append(ents, graph.Entity{
+				ID:         fmt.Sprintf("ep_get_%d", i),
+				Name:       fmt.Sprintf("list_things_%d", i),
+				Kind:       "http_endpoint_definition",
+				SourceFile: fmt.Sprintf("routes/things_%d.py", i),
+				StartLine:  20 + i,
+				Properties: map[string]string{"verb": "GET", "path": fmt.Sprintf("/things/%d", i)},
+			})
+		}
+	}
+	return &graph.Document{Entities: ents}
+}
+
+// rawAuthBytes calls the handler and returns the raw wire payload length plus
+// the decoded map, so a test can assert a concrete byte reduction.
+func rawAuthBytes(t *testing.T, s *Server, args map[string]any) (int, map[string]any) {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := s.handleAuthCoverage(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("tool error: %+v", res)
+	}
+	text := extractResultText(t, res)
+	var out map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, text)
+	}
+	return len(text), out
+}
+
+func TestAuthCoverage_2828_TerseIsDefaultAndSmaller(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, buildManyEndpointDoc(40))
+
+	terseBytes, terseOut := rawAuthBytes(t, s, map[string]any{"group": "test"})
+	fullBytes, fullOut := rawAuthBytes(t, s, map[string]any{"group": "test", "format": "full"})
+
+	// Default must be terse.
+	if got := terseOut["format"]; got != "terse" {
+		t.Errorf("default format: got %v, want terse", got)
+	}
+	if got := fullOut["format"]; got != "full" {
+		t.Errorf("format=full: got %v, want full", got)
+	}
+
+	// Terse must be substantially smaller than full on the same data.
+	if terseBytes >= fullBytes {
+		t.Fatalf("terse (%d B) not smaller than full (%d B)", terseBytes, fullBytes)
+	}
+	reduction := 100.0 * float64(fullBytes-terseBytes) / float64(fullBytes)
+	if reduction < 30.0 {
+		t.Errorf("terse reduction only %.1f%% (terse=%d full=%d); want >=30%%", reduction, terseBytes, fullBytes)
+	}
+	t.Logf("auth_coverage bytes: terse=%d full=%d (%.1f%% smaller); est tokens terse=%d full=%d",
+		terseBytes, fullBytes, reduction, terseBytes/4, fullBytes/4)
+
+	// Terse shape: findings present, endpoints/note absent.
+	if _, ok := terseOut["findings"]; !ok {
+		t.Error("terse missing `findings`")
+	}
+	if _, ok := terseOut["endpoints"]; ok {
+		t.Error("terse must not include the verbose `endpoints` array")
+	}
+	if _, ok := terseOut["note"]; ok {
+		t.Error("terse must not include the static `note` blob")
+	}
+	// Full shape: endpoints + note present.
+	if _, ok := fullOut["endpoints"]; !ok {
+		t.Error("full missing `endpoints`")
+	}
+	if _, ok := fullOut["note"]; !ok {
+		t.Error("full missing `note`")
+	}
+}
+
+func TestAuthCoverage_2828_TersePreservesEssentialFacts(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, buildManyEndpointDoc(4))
+	_, out := rawAuthBytes(t, s, map[string]any{"group": "test"})
+
+	findings, ok := out["findings"].([]any)
+	if !ok || len(findings) == 0 {
+		t.Fatalf("findings is %T (len?)", out["findings"])
+	}
+	joined := ""
+	for _, f := range findings {
+		joined += f.(string) + "\n"
+	}
+	// A sensitive unprotected DELETE on /users/{user_id} must surface severity,
+	// verb, path, the NO-AUTH state and the IDOR + sensitive flags.
+	for _, want := range []string{"error", "DELETE", "/users/{user_id}", "NO-AUTH", "idor", "sensitive"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("terse findings missing %q\n%s", want, joined)
+		}
+	}
+	// Repo summaries / overall coverage must survive in terse mode (the agent
+	// relies on these for the default-allow/deny posture).
+	if _, ok := out["repo_summaries"].([]any); !ok {
+		t.Error("terse dropped repo_summaries")
+	}
+	if _, ok := out["overall_coverage"]; !ok {
+		t.Error("terse dropped overall_coverage")
+	}
+}
+
+func TestAuthCoverage_2828_DefaultLimitCapsAt50WithMarker(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, buildManyEndpointDoc(120))
+	_, out := rawAuthBytes(t, s, map[string]any{"group": "test"})
+
+	count := int(out["count"].(float64))
+	total := int(out["total"].(float64))
+	if count != 50 {
+		t.Errorf("default limit: count=%d, want 50", count)
+	}
+	if total != 120 {
+		t.Errorf("total: got %d, want 120", total)
+	}
+	if out["truncated"] != true {
+		t.Error("expected truncated=true")
+	}
+	if tc, ok := out["truncated_count"].(float64); !ok || int(tc) != 70 {
+		t.Errorf("truncated_count: got %v, want 70", out["truncated_count"])
+	}
+	if _, ok := out["truncation_note"].(string); !ok {
+		t.Error("expected a truncation_note marker")
+	}
+	findings := out["findings"].([]any)
+	if len(findings) != 50 {
+		t.Errorf("findings len=%d, want 50", len(findings))
+	}
+}
+
+func TestAuthCoverage_2828_LimitOptInReturnsMore(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, buildManyEndpointDoc(120))
+	_, out := rawAuthBytes(t, s, map[string]any{"group": "test", "limit": 200})
+	if int(out["count"].(float64)) != 120 {
+		t.Errorf("limit=200: count=%d, want 120 (all)", int(out["count"].(float64)))
+	}
+	if out["truncated"] != false {
+		t.Error("limit=200 over 120 items should not be truncated")
+	}
+}
+
+func TestAuthCoverage_2828_TokenBudgetTruncatesWithMarker(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, buildManyEndpointDoc(120))
+	// A tight budget forces truncation well below the 50-row limit.
+	rawBytes, out := rawAuthBytes(t, s, map[string]any{"group": "test", "limit": 200, "token_budget": 300})
+
+	count := int(out["count"].(float64))
+	total := int(out["total"].(float64))
+	if count >= total {
+		t.Fatalf("token_budget did not truncate: count=%d total=%d", count, total)
+	}
+	if out["truncated"] != true {
+		t.Error("expected truncated=true under token_budget")
+	}
+	if _, ok := out["truncation_note"].(string); !ok {
+		t.Error("expected truncation_note marker under token_budget")
+	}
+	// The findings list (the budgeted part) must fit roughly within the budget.
+	findings := out["findings"].([]any)
+	findingsBytes := 0
+	for _, f := range findings {
+		findingsBytes += len(f.(string))
+	}
+	if findingsBytes > 300*4 {
+		t.Errorf("findings bytes %d exceed token_budget*4=%d", findingsBytes, 300*4)
+	}
+	t.Logf("token_budget=300: returned %d/%d findings, raw payload %d B", count, total, rawBytes)
+}
+
+func TestAuthCoverage_2828_FullShapeUnchanged(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, buildManyEndpointDoc(2))
+	_, out := rawAuthBytes(t, s, map[string]any{"group": "test", "format": "full"})
+	eps, ok := out["endpoints"].([]any)
+	if !ok || len(eps) == 0 {
+		t.Fatalf("full mode endpoints is %T", out["endpoints"])
+	}
+	ep := eps[0].(map[string]any)
+	// The legacy per-record keys the structured callers depend on.
+	for _, k := range []string{"entity_id", "has_auth", "severity", "repo"} {
+		if _, ok := ep[k]; !ok {
+			t.Errorf("full endpoint record missing key %q", k)
+		}
+	}
+}

--- a/internal/mcp/auth_coverage_test.go
+++ b/internal/mcp/auth_coverage_test.go
@@ -123,6 +123,16 @@ func buildAuthCoverageDoc() *graph.Document {
 
 func callAuthCoverageTool(t *testing.T, s *Server, args map[string]any) map[string]any {
 	t.Helper()
+	// #2828: terse is now the production default. The legacy structural tests in
+	// this file assert on the full per-endpoint `endpoints` array, so default
+	// these calls to format=full unless the test explicitly chooses a format.
+	// Dedicated terse/limit/budget assertions live in auth_coverage_2828_test.go
+	// and pass their own format/args.
+	if _, ok := args["format"]; !ok {
+		if _, ok := args["verbose"]; !ok {
+			args["format"] = "full"
+		}
+	}
 	req := mcpapi.CallToolRequest{}
 	req.Params.Arguments = args
 	res, err := s.handleAuthCoverage(context.Background(), req)

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -732,6 +733,13 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
 	minConfidence := argMinConfidence(req) // #2769 Phase 1C
 	ql := strings.ToLower(query)
+	// #2828: optional terse output + token budget for this high-volume tool
+	// (248 calls in live telemetry). format="terse" emits one compact line per
+	// hit under `lines` (id, name, kind, file:line) instead of the per-record
+	// object map; the default shape (`results` array) is unchanged for callers
+	// that machine-parse fields. token_budget caps the returned list bytes.
+	terse := strings.EqualFold(argString(req, "format", ""), "terse")
+	tokenBudget := argInt(req, "token_budget", 0)
 
 	type item struct {
 		EntityID      string `json:"entity_id"`
@@ -794,12 +802,39 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 	if limit > 0 && len(out) > limit {
 		out = out[:limit]
 	}
-	return jsonResult(map[string]any{
-		"results":   out,
+	if tokenBudget > 0 {
+		out = capByRenderedBytes(out, tokenBudget*4, terse)
+	}
+	resp := map[string]any{
 		"count":     len(out),
 		"total":     total,
 		"truncated": total > len(out),
-	}), nil
+	}
+	if terse {
+		lines := make([]string, 0, len(out))
+		for _, it := range out {
+			var b strings.Builder
+			b.WriteString(it.EntityID)
+			b.WriteString("  ")
+			b.WriteString(it.EntityName)
+			b.WriteString("  ")
+			b.WriteString(stripScopePrefix(it.Kind))
+			if it.SourceFile != "" {
+				b.WriteString("  ")
+				b.WriteString(it.SourceFile)
+				if it.StartLine > 0 {
+					b.WriteByte(':')
+					b.WriteString(strconv.Itoa(it.StartLine))
+				}
+			}
+			lines = append(lines, b.String())
+		}
+		resp["format"] = "terse"
+		resp["lines"] = lines
+	} else {
+		resp["results"] = out
+	}
+	return jsonResult(resp), nil
 }
 
 // reverseTraversalEdgeKinds is the set of edge kinds where the BFS in

--- a/internal/mcp/search_entities_2828_test.go
+++ b/internal/mcp/search_entities_2828_test.go
@@ -1,0 +1,102 @@
+package mcp
+
+// search_entities_2828_test.go — #2828 token-cost optimisation for the
+// high-volume archigraph_search_entities tool (248 calls in live telemetry).
+// Verifies the opt-in format=terse compact-line output is smaller than the
+// default `results` array while preserving id/name/kind/location, and that
+// token_budget caps the returned list with a truncation marker.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+func buildSearchDoc(n int) *graph.Document {
+	ents := make([]graph.Entity, 0, n)
+	for i := 0; i < n; i++ {
+		ents = append(ents, graph.Entity{
+			ID:            fmt.Sprintf("svc_%d", i),
+			Name:          fmt.Sprintf("OrderService%d", i),
+			QualifiedName: fmt.Sprintf("app.services.OrderService%d", i),
+			Kind:          "SCOPE.Class",
+			SourceFile:    fmt.Sprintf("app/services/order_%d.py", i),
+			StartLine:     5 + i,
+		})
+	}
+	return &graph.Document{Entities: ents}
+}
+
+func rawSearchBytes(t *testing.T, s *Server, args map[string]any) (int, map[string]any) {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := s.handleSearchEntities(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("tool error: %+v", res)
+	}
+	text := extractResultText(t, res)
+	var out map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, text)
+	}
+	return len(text), out
+}
+
+func TestSearchEntities_2828_TerseSmallerPreservesFacts(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, buildSearchDoc(30))
+
+	defBytes, defOut := rawSearchBytes(t, s, map[string]any{"group": "test", "query": "OrderService"})
+	terseBytes, terseOut := rawSearchBytes(t, s, map[string]any{"group": "test", "query": "OrderService", "format": "terse"})
+
+	// Default shape unchanged (results array present, no format key forced).
+	if _, ok := defOut["results"]; !ok {
+		t.Error("default search shape lost `results`")
+	}
+	if terseBytes >= defBytes {
+		t.Fatalf("terse (%d B) not smaller than default results (%d B)", terseBytes, defBytes)
+	}
+	t.Logf("search_entities bytes: terse=%d default=%d (%.1f%% smaller)",
+		terseBytes, defBytes, 100*float64(defBytes-terseBytes)/float64(defBytes))
+
+	lines, ok := terseOut["lines"].([]any)
+	if !ok || len(lines) == 0 {
+		t.Fatalf("terse lines is %T", terseOut["lines"])
+	}
+	first := lines[0].(string)
+	// Essential facts: prefixed id, name, kind (scope-stripped), file:line.
+	for _, want := range []string{"OrderService", "Class", "app/services/order_", ":"} {
+		if !strings.Contains(first, want) {
+			t.Errorf("terse line missing %q: %s", want, first)
+		}
+	}
+	if strings.Contains(first, "SCOPE.") {
+		t.Errorf("terse kind should be scope-stripped: %s", first)
+	}
+}
+
+func TestSearchEntities_2828_TokenBudgetTruncates(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, buildSearchDoc(60))
+	_, out := rawSearchBytes(t, s, map[string]any{
+		"group": "test", "query": "OrderService", "format": "terse",
+		"limit": 100, "token_budget": 200,
+	})
+	count := int(out["count"].(float64))
+	total := int(out["total"].(float64))
+	if count >= total {
+		t.Fatalf("token_budget did not truncate: count=%d total=%d", count, total)
+	}
+	if out["truncated"] != true {
+		t.Error("expected truncated=true under token_budget")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -380,7 +380,7 @@ func (s *Server) registerTools() {
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_source",
 		mcpapi.WithDescription("Return source for a node; accepts id, qualified_name, or label."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
-		mcpapi.WithNumber("context_lines", mcpapi.DefaultNumber(20)),
+		mcpapi.WithNumber("context_lines", mcpapi.DefaultNumber(8)), // #2828: was 20
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_get_source", s.handleGetNodeSource))
@@ -691,6 +691,8 @@ func (s *Server) registerTools() {
 		mcpapi.WithBoolean("include_noise", mcpapi.DefaultBool(false)),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithArray("fields"),
+		mcpapi.WithString("format"),                                // #2828: "terse" → compact `lines`
+		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(0)), // #2828: 0 = unbounded
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 		mcpapi.WithNumber("min_confidence", mcpapi.DefaultNumber(0)), // #2769 Phase 1C
@@ -836,10 +838,13 @@ func (s *Server) registerTools() {
 	// Walk all http_endpoint_definition entities and flag those without auth
 	// decorators/middleware.  Severity: error (sensitive/IDOR), warn (public), info (covered).
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_auth_coverage",
-		mcpapi.WithDescription("Security audit: flag HTTP endpoints missing auth (severity, IDOR risk)."),
+		mcpapi.WithDescription("Flag endpoints missing auth (severity, IDOR). format=terse|full, token_budget."),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithBoolean("only_missing", mcpapi.DefaultBool(false)),
-		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200)),
+		mcpapi.WithString("format"), // #2828: "terse" (default) | "full"
+		mcpapi.WithBoolean("verbose", mcpapi.DefaultBool(false)),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(50)),
+		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(0)), // #2828: 0 = unbounded
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 		mcpapi.WithAny("ref"), // PH1c: optional git ref

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1876,7 +1876,11 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 	if nodeID == "" {
 		return mcpapi.NewToolResultError("missing required argument: entity_id"), nil
 	}
-	contextLines := argInt(req, "context_lines", 20)
+	// #2828: default context_lines lowered 20→8. Live telemetry showed
+	// get_source at ~1,035 tok/call; 40 lines of surrounding padding per call
+	// dominated the cost while the entity's own span is what callers read.
+	// Callers that need more surrounding context pass context_lines explicitly.
+	contextLines := argInt(req, "context_lines", 8)
 	_, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil


### PR DESCRIPTION
Part of #2828. Data-driven by live rewrite-agent telemetry, not the stale plan: the actual token hogs were auth_coverage (7,465 tok/CALL — 18% of ALL payload tokens, the #1 target by far), get_source (1,035 tok/call ×86), and search_entities (371 tok/call ×248 by volume). This PR trims exactly those, hardest on auth_coverage.

## auth_coverage (biggest win)
Why it was 7.5K/call: default `limit=200` full per-endpoint records + a ~340-byte static `note` blob on every call.

- **format=terse (new default)** — one compact line per finding under `findings`, drops the static note. `format=full` (or `verbose=true`) returns the legacy structured `endpoints` array + note, unchanged.
  - Terse line keeps every fact a reviewer acts on: `error DELETE /users/{user_id} NO-AUTH idor,sensitive(delete) routes/u.py:42 (repo1)`.
  - `repo_summaries` + `overall_coverage` (the default-allow/deny posture) preserved in both modes.
- **top-N default lowered 200 → 50** with explicit `truncated`, `truncated_count`, and `truncation_note` markers — never silently drops.
- **token_budget** arg — hard byte cap (`token_budget*4`) on the returned list, truncates gracefully with a marker.

Fixture measurement (40 endpoints): **terse = 3,370 B vs full = 9,757 B → 65.5% smaller** (est. 842 vs 2,439 tokens). On real payloads the 200→50 cap compounds this further.

## search_entities (volume target, 248 calls)
- opt-in **format=terse** → compact `lines` (`id  name  kind  file:line`); default `results` array shape unchanged (no regression for field-parsing callers). **token_budget** caps the list with a truncation marker. Fixture: **terse 64.4% smaller** (2,073 vs 5,828 B).

## get_source (1,035 tok/call ×86)
- default **context_lines lowered 20 → 8** — 40 lines of surrounding padding per call was the dominant avoidable cost; callers needing more pass context_lines explicitly. Hard max-lines cap unchanged.

## What terse drops vs keeps
Drops: JSON envelope per record, redundant `entity_id`/`name`, the static explanatory `note`. Keeps: severity, verb, path, has_auth + evidence, IDOR/sensitive flags, file:line, repo, and all summary/coverage fields.

## New args
`auth_coverage`: `format` (terse|full), `verbose`, `token_budget`, `limit` (default 50). `search_entities`: `format` (terse), `token_budget`.

## Tests (sandboxed, ./internal/mcp scoped)
New `auth_coverage_2828_test.go` + `search_entities_2828_test.go` assert: terse substantially smaller than full (>=30%, observed ~65%); essential security facts preserved; top-N caps at 50 + truncation marker; limit opt-in returns more; token_budget truncates within budget + marker; full shape unchanged. Existing structural auth_coverage tests pinned to `format=full`.

Validation: `go build ./internal/... ./cmd/...` clean; `go test ./internal/mcp/... ./internal/types/` green; `gofmt -l` empty on touched files. Deploy-deferred (needs daemon rebuild) — not deployed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)