### PR TITLE
fix(hooks): async/debounced reindex enqueue — non-blocking git writes (rebase-safe)

### DIFF
--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -65,9 +65,12 @@ func runIndexClient(cmd *cobra.Command, argv []string) error {
 	quiet := fs.Bool("quiet", false, "suppress progress output; print only the final summary line")
 	jsonProgress := fs.Bool("json-progress", false, "emit one JSON event per line (for scripting; implies --quiet for non-JSON output)")
 	refFlag := fs.String("ref", "", "operate on a specific git ref; @all is refused (index is a destructive write). Use @current for active HEAD (default).")
+	async := fs.Bool("async", false, "enqueue a debounced/coalesced reindex on the daemon and return immediately without waiting for it to finish (used by git hooks; #3366)")
+	noWait := fs.Bool("no-wait", false, "alias for --async")
 	if err := fs.Parse(reorderedArgv); err != nil {
 		return err
 	}
+	asyncMode := *async || *noWait
 
 	// Validate --ref: @all is refused for index (destructive).
 	_, _, refErr := resolveRef(*refFlag, false /* @all NOT ok */)
@@ -110,6 +113,19 @@ func runIndexClient(cmd *cobra.Command, argv []string) error {
 		ExportFB:     *exportFB, // deprecated no-op; kept for back-compat
 		ExportJSON:   *exportJSON,
 		PrintSkipped: *printSkipped,
+		Async:        asyncMode,
+	}
+
+	if asyncMode {
+		// Async enqueue path (#3366): the daemon coalesces this onto its
+		// debounced scheduler and ACKs immediately — we do NOT wait for the
+		// reindex to finish and emit no heartbeat. Used by git hooks so git
+		// writes are never blocked. If the daemon is down the RPC errors,
+		// which the hook swallows via `|| true`.
+		if _, err := c.Index(indexArgs); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	if *quiet || *jsonProgress {

--- a/internal/daemon/index_async_test.go
+++ b/internal/daemon/index_async_test.go
@@ -1,0 +1,181 @@
+package daemon
+
+// White-box tests for the #3366 async Index path. These construct a Service +
+// real Scheduler directly (no socket, no daemon.Run) so they do NOT trip the
+// canonical-socket guard and never disturb a live daemon.
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/daemon/sched"
+)
+
+// newAsyncTestService wires a Service to a started Scheduler whose Index hook
+// is `idxFn`. The synchronous Index entrypoint is `syncFn`.
+func newAsyncTestService(t *testing.T, syncFn IndexFunc, idxFn sched.IndexFn) (*Service, func()) {
+	t.Helper()
+	sc := sched.New(sched.Config{
+		Workers:    1,
+		Index:      idxFn,
+		Links:      func(context.Context, string) error { return nil },
+		Algorithms: func(context.Context, string) error { return nil },
+	})
+	sc.Start()
+	svc := newService(syncFn, nil, nil, "", make(chan struct{}, 1), nil, 1)
+	svc.scheduler = sc
+	return svc, func() { sc.Stop() }
+}
+
+// TestIndexAsync_EnqueuesAndReturnsWithoutBlocking verifies that an Index RPC
+// with Async=true routes to the debounced scheduler and returns immediately,
+// WITHOUT invoking the heavy synchronous Index entrypoint (which here blocks
+// for 30s — if the async path waited on it the test would time out).
+func TestIndexAsync_EnqueuesAndReturnsWithoutBlocking(t *testing.T) {
+	var syncCalls atomic.Int32
+	schedCh := make(chan string, 8)
+
+	svc, stop := newAsyncTestService(t,
+		func(proto.IndexArgs) (string, string, error) {
+			syncCalls.Add(1)
+			time.Sleep(30 * time.Second)
+			return "", "", nil
+		},
+		func(_ context.Context, repo string, _ string) error {
+			schedCh <- repo
+			return nil
+		},
+	)
+	defer stop()
+
+	done := make(chan error, 1)
+	go func() {
+		var reply proto.IndexReply
+		done <- svc.Index(&proto.IndexArgs{RepoPath: "/some/repo", Async: true}, &reply)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("async Index returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("async Index blocked >3s — it must ACK immediately, not wait for the reindex")
+	}
+
+	if got := syncCalls.Load(); got != 0 {
+		t.Errorf("async path invoked the synchronous Index entrypoint %d times; want 0", got)
+	}
+
+	select {
+	case got := <-schedCh:
+		if got != "/some/repo" {
+			t.Errorf("scheduler enqueued repo=%q, want /some/repo", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("async Index did not enqueue a scheduler reindex")
+	}
+}
+
+// TestIndexAsync_FallsBackToSyncWhenNoScheduler verifies the async flag is a
+// no-op when no scheduler is attached (a watcher-less daemon): the RPC runs the
+// synchronous entrypoint so manual/rebuild indexing still works.
+func TestIndexAsync_FallsBackToSyncWhenNoScheduler(t *testing.T) {
+	var syncCalls atomic.Int32
+	svc := newService(
+		func(proto.IndexArgs) (string, string, error) {
+			syncCalls.Add(1)
+			return "/g/graph.fb", "", nil
+		}, nil, nil, "", make(chan struct{}, 1), nil, 1)
+	// svc.scheduler is nil.
+
+	var reply proto.IndexReply
+	if err := svc.Index(&proto.IndexArgs{RepoPath: "/some/repo", Async: true}, &reply); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	if syncCalls.Load() != 1 {
+		t.Errorf("no-scheduler async path should fall back to sync index; sync calls=%d", syncCalls.Load())
+	}
+}
+
+// TestIndexSync_Unchanged verifies the DEFAULT (Async=false) path is unchanged:
+// it runs the synchronous entrypoint and never touches the scheduler enqueue.
+func TestIndexSync_Unchanged(t *testing.T) {
+	var syncCalls atomic.Int32
+	var schedCalls atomic.Int32
+
+	svc, stop := newAsyncTestService(t,
+		func(proto.IndexArgs) (string, string, error) {
+			syncCalls.Add(1)
+			return "/g/graph.fb", "", nil
+		},
+		func(context.Context, string, string) error {
+			schedCalls.Add(1)
+			return nil
+		},
+	)
+	defer stop()
+
+	var reply proto.IndexReply
+	if err := svc.Index(&proto.IndexArgs{RepoPath: "/some/repo"}, &reply); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	if syncCalls.Load() != 1 {
+		t.Errorf("synchronous index entrypoint calls=%d, want 1", syncCalls.Load())
+	}
+	if reply.GraphPath != "/g/graph.fb" {
+		t.Errorf("sync reply.GraphPath=%q, want /g/graph.fb", reply.GraphPath)
+	}
+	// MarkIndexed may touch the scheduler, but the reindex hook itself
+	// (schedCalls) must NOT fire on the synchronous path.
+	if schedCalls.Load() != 0 {
+		t.Errorf("synchronous path must not enqueue a scheduler reindex; got %d", schedCalls.Load())
+	}
+}
+
+// TestIndexAsync_BurstCoalesces verifies a burst of async enqueues for the same
+// repo collapses to a single reindex (#3366) — the guarantee that stops a rebase
+// (N commits) and concurrent worktrees from stampeding the daemon.
+func TestIndexAsync_BurstCoalesces(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	release := make(chan struct{})
+
+	svc, stop := newAsyncTestService(t,
+		func(proto.IndexArgs) (string, string, error) { return "", "", nil },
+		func(context.Context, string, string) error {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+			<-release // hold the first job in-flight so the burst coalesces
+			return nil
+		},
+	)
+	defer stop()
+
+	for i := 0; i < 10; i++ {
+		var reply proto.IndexReply
+		if err := svc.Index(&proto.IndexArgs{RepoPath: "/some/repo", Async: true}, &reply); err != nil {
+			t.Fatalf("async Index %d: %v", i, err)
+		}
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	close(release)
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	// Per-repo dedup: while one run is in-flight, the other 9 enqueues are
+	// coalesced (at most one queued re-run after it completes), never 10.
+	if got == 0 || got > 2 {
+		t.Errorf("burst of 10 async enqueues produced %d reindexes; want coalesced (1-2)", got)
+	}
+}

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -148,6 +148,16 @@ type IndexArgs struct {
 	// per-group names from fleet.json's additional_skip_dirs field.
 	AdditionalSkipDirs []string `json:"additional_skip_dirs,omitempty"`
 	ExportJSON         bool     `json:"export_json,omitempty"` // when true, also write graph.json alongside graph.fb (ADR-0016 flip-day)
+	// Async, when true, makes the Index RPC ENQUEUE the repo onto the
+	// daemon's debounced/coalescing scheduler (the same fast reactive path
+	// the file-watcher uses) and ACK immediately, rather than running a full
+	// synchronous index and blocking until it completes. Used by git hooks
+	// (post-commit/-merge/-checkout) so git writes are never blocked on a
+	// reindex, and so concurrent worktrees + commit bursts coalesce into a
+	// single per-repo reindex instead of stampeding the daemon (#3366).
+	// When false (default) the RPC keeps its synchronous behaviour, used by
+	// `rebuild` and manual `archigraph index`.
+	Async bool `json:"async,omitempty"`
 }
 
 // IndexReply carries the post-index summary. The stats are an opaque

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -312,6 +312,21 @@ func (s *Service) Index(args *proto.IndexArgs, reply *proto.IndexReply) error {
 	if args == nil || args.RepoPath == "" {
 		return errors.New("repo_path is required")
 	}
+
+	// Async fast path (#3366): enqueue onto the debounced/coalescing
+	// scheduler — the SAME reactive path the file-watcher uses — and ACK
+	// immediately. The scheduler dedups per-repo (an enqueue for a repo
+	// already pending or in-flight is coalesced, only the latest ref is
+	// kept), so a commit burst or concurrent worktrees collapse into one
+	// reindex instead of N back-to-back full reindexes. Used by git hooks
+	// so git writes never block on a reindex. Falls back to the synchronous
+	// path below when no scheduler is attached (e.g. a watcher-less daemon).
+	if args.Async && s.scheduler != nil {
+		s.scheduler.Enqueue(args.RepoPath)
+		reply.RepoPath = args.RepoPath
+		return nil
+	}
+
 	atomic.AddInt64(&s.inFlight, 1)
 	defer atomic.AddInt64(&s.inFlight, -1)
 	graphPath, stats, err := s.index(*args)

--- a/internal/install/hooks/hooks.go
+++ b/internal/install/hooks/hooks.go
@@ -81,8 +81,23 @@ func Uninstall(repo string) error {
 }
 
 // BlockFor returns the managed hook body for a single hook name.
-// When group is non-empty the block also refreshes the cross-repo
-// links table by invoking `archigraph links pass <group>`.
+//
+// The reindex is enqueued ASYNCHRONOUSLY (`index --async`, #3366): the
+// daemon coalesces it onto its debounced scheduler and ACKs immediately,
+// so git writes (commit/checkout/merge) are never blocked waiting on a
+// full reindex. Because the call returns instantly we do NOT background it
+// with `&` — and `|| true` keeps the hook a no-op when the daemon is down.
+//
+// Rebase guard: when a rebase is in progress (`rebase-merge`/`rebase-apply`
+// directories exist) the hook does nothing. A rebase replays N commits and
+// would otherwise fire post-commit N times back-to-back; the final HEAD is
+// reindexed by the post-checkout/post-merge that completes the rebase, or
+// by the next ordinary commit.
+//
+// Cross-repo links: `archigraph links pass <group>` is run ONLY by the
+// post-merge hook (and only when group is non-empty). A merge is the point
+// at which cross-repo wiring can change; post-commit/post-checkout skip it
+// to keep ordinary writes cheap.
 //
 // The generated script resolves the repo path at runtime via
 // `git rev-parse --show-toplevel` so that hooks shared through
@@ -93,21 +108,22 @@ func BlockFor(hookName, binPath, repo string, group ...string) string {
 	if len(group) > 0 {
 		g = group[0]
 	}
-	if g == "" {
-		return fmt.Sprintf(`%s
-# archigraph %s — re-index the repo (or worktree) after %s.
-_ag_repo="$(git rev-parse --show-toplevel 2>/dev/null)"
-[ -n "$_ag_repo" ] && %q index "$_ag_repo" >/dev/null 2>&1 || true
-%s
-`, MarkerBegin, hookName, hookName, binPath, MarkerEnd)
+	// Links pass only on post-merge, and only when we know the group.
+	linksLine := ""
+	if hookName == "post-merge" && g != "" {
+		linksLine = fmt.Sprintf("  %q links pass %q >/dev/null 2>&1 || true\n", binPath, g)
 	}
 	return fmt.Sprintf(`%s
-# archigraph %s — re-index the repo (or worktree) and refresh cross-repo links for group %s.
+# archigraph %s — enqueue a debounced async reindex of the repo (or worktree).
+# Skipped mid-rebase so replaying N commits doesn't fire N reindexes (#3366).
 _ag_repo="$(git rev-parse --show-toplevel 2>/dev/null)"
-[ -n "$_ag_repo" ] && %q index "$_ag_repo" >/dev/null 2>&1 || true
-%q links pass %q >/dev/null 2>&1 || true
+_ag_rbm="$(git rev-parse --git-path rebase-merge 2>/dev/null)"
+_ag_rba="$(git rev-parse --git-path rebase-apply 2>/dev/null)"
+if [ -n "$_ag_repo" ] && [ ! -d "$_ag_rbm" ] && [ ! -d "$_ag_rba" ]; then
+  %q index --async "$_ag_repo" >/dev/null 2>&1 || true
+%sfi
 %s
-`, MarkerBegin, hookName, g, binPath, binPath, g, MarkerEnd)
+`, MarkerBegin, hookName, binPath, linksLine, MarkerEnd)
 }
 
 func hooksDir(repo string) (string, error) {

--- a/internal/install/hooks/hooks_test.go
+++ b/internal/install/hooks/hooks_test.go
@@ -59,13 +59,14 @@ func TestBlockForWorktreeResolution(t *testing.T) {
 			if !strings.Contains(block, `git rev-parse --show-toplevel`) {
 				t.Errorf("hook %s: missing git rev-parse --show-toplevel:\n%s", hookName, block)
 			}
-			if !strings.Contains(block, `index "$_ag_repo"`) {
-				t.Errorf("hook %s: missing `index \"$_ag_repo\"`:\n%s", hookName, block)
+			if !strings.Contains(block, `index --async "$_ag_repo"`) {
+				t.Errorf("hook %s: missing `index --async \"$_ag_repo\"`:\n%s", hookName, block)
 			}
 			// Must NOT hardcode the registered repo path as an index argument.
-			if strings.Contains(block, `index "`+registeredRepo+`"`) {
+			if strings.Contains(block, `index --async "`+registeredRepo+`"`) {
 				t.Errorf("hook %s: hardcoded repo path found — worktrees would be mis-indexed:\n%s", hookName, block)
 			}
+			assertRebaseGuard(t, hookName, block)
 		})
 
 		t.Run(hookName+"/with-group", func(t *testing.T) {
@@ -73,17 +74,39 @@ func TestBlockForWorktreeResolution(t *testing.T) {
 			if !strings.Contains(block, `git rev-parse --show-toplevel`) {
 				t.Errorf("hook %s+group: missing git rev-parse --show-toplevel:\n%s", hookName, block)
 			}
-			if !strings.Contains(block, `index "$_ag_repo"`) {
-				t.Errorf("hook %s+group: missing `index \"$_ag_repo\"`:\n%s", hookName, block)
+			if !strings.Contains(block, `index --async "$_ag_repo"`) {
+				t.Errorf("hook %s+group: missing `index --async \"$_ag_repo\"`:\n%s", hookName, block)
 			}
-			if strings.Contains(block, `index "`+registeredRepo+`"`) {
+			if strings.Contains(block, `index --async "`+registeredRepo+`"`) {
 				t.Errorf("hook %s+group: hardcoded repo path found — worktrees would be mis-indexed:\n%s", hookName, block)
 			}
-			// Group links pass must still be present.
-			if !strings.Contains(block, `links pass "`+group+`"`) {
+			assertRebaseGuard(t, hookName, block)
+			// Links pass must be present ONLY for post-merge (#3366): a merge
+			// is the point cross-repo wiring can change; ordinary commits and
+			// checkouts skip it to stay cheap.
+			hasLinks := strings.Contains(block, `links pass "`+group+`"`)
+			if hookName == "post-merge" && !hasLinks {
 				t.Errorf("hook %s+group: links pass line missing:\n%s", hookName, block)
 			}
+			if hookName != "post-merge" && hasLinks {
+				t.Errorf("hook %s+group: links pass must only appear in post-merge:\n%s", hookName, block)
+			}
 		})
+	}
+}
+
+// assertRebaseGuard verifies the managed block refuses to fire mid-rebase so
+// that replaying N commits during a rebase does not trigger N reindexes (#3366).
+func assertRebaseGuard(t *testing.T, hookName, block string) {
+	t.Helper()
+	for _, want := range []string{
+		`_ag_rbm="$(git rev-parse --git-path rebase-merge 2>/dev/null)"`,
+		`_ag_rba="$(git rev-parse --git-path rebase-apply 2>/dev/null)"`,
+		`[ ! -d "$_ag_rbm" ] && [ ! -d "$_ag_rba" ]`,
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("hook %s: missing rebase-guard fragment %q:\n%s", hookName, want, block)
+		}
 	}
 }
 
@@ -104,8 +127,8 @@ func TestInstallWorktreeResolution(t *testing.T) {
 		if !strings.Contains(script, `git rev-parse --show-toplevel`) {
 			t.Errorf("%s: runtime worktree resolution missing:\n%s", name, script)
 		}
-		if !strings.Contains(script, `index "$_ag_repo"`) {
-			t.Errorf("%s: index with runtime var missing:\n%s", name, script)
+		if !strings.Contains(script, `index --async "$_ag_repo"`) {
+			t.Errorf("%s: async index with runtime var missing:\n%s", name, script)
 		}
 		if !strings.Contains(script, MarkerBegin) || !strings.Contains(script, MarkerEnd) {
 			t.Errorf("%s: managed markers missing:\n%s", name, script)


### PR DESCRIPTION
Closes #3366.

## Problem (regression from #3352/#3355)
The git hooks ran `archigraph index <repo>` — a daemon RPC that **waits for a full reindex** — plus a `links pass`, **inline on every commit/checkout/merge**. So git blocked 10-30s per commit; `git rebase` replayed N commits → N back-to-back full reindexes (multi-minute stalls); concurrent agent worktrees stampeded the daemon with overlapping full reindexes.

## Fix
Route the hook reindex through the daemon's **existing** debounced/coalescing `SchedulerIndex` (the same fast reactive path the file-watcher already uses) via a new `archigraph index --async`, instead of a synchronous full reindex.

1. **Async enqueue RPC** — `proto.IndexArgs` gains `Async`. When set, `Service.Index` calls `s.scheduler.Enqueue(repo)` (debounced + per-repo deduped) and ACKs **immediately** instead of invoking the synchronous index entrypoint. Falls back to the synchronous path when no scheduler is attached (watcher-less daemon).
2. **CLI** — `archigraph index` gains `--async` (alias `--no-wait`): sends `Async=true` and returns without heartbeat/waiting. Default (no flag) behaviour is unchanged.
3. **Hook template** (`internal/install/hooks/hooks.go`):
   ```
   _ag_repo="$(git rev-parse --show-toplevel 2>/dev/null)"
   _ag_rbm="$(git rev-parse --git-path rebase-merge 2>/dev/null)"
   _ag_rba="$(git rev-parse --git-path rebase-apply 2>/dev/null)"
   if [ -n "$_ag_repo" ] && [ ! -d "$_ag_rbm" ] && [ ! -d "$_ag_rba" ]; then
     "<bin>" index --async "$_ag_repo" >/dev/null 2>&1 || true
     <links-line: post-merge ONLY> "<bin>" links pass "<group>" >/dev/null 2>&1 || true
   fi
   ```
   Rebase guard skips mid-rebase so replaying N commits doesn't fire N reindexes. `links pass` runs **only on post-merge**. With `--async` the call returns instantly so no `&` backgrounding; `|| true` keeps it a no-op when the daemon is down.

## Coalescing
`Scheduler.Enqueue` already dedups per-repo via `pendingIndex`/`inflight` — a burst (rebase, commit flurry, concurrent worktrees) collapses into a **single** reindex, keeping only the latest ref. The async-enqueue path reuses this exact mechanism, so no new debounce wiring was needed.

## Synchronous path unchanged
`Async` defaults to false. `rebuild` and manual `archigraph index` keep the existing synchronous, heartbeat-driven behaviour.

## Tests
- `internal/install/hooks/hooks_test.go`: asserts the rebase-guard fragments, `index --async "$_ag_repo"`, and that `links pass` appears **only** in post-merge.
- `internal/daemon/index_async_test.go` (white-box): async `Index` returns immediately without invoking a 30s-blocking sync entrypoint; enqueues the scheduler; a 10-enqueue burst coalesces to one reindex; falls back to sync when no scheduler; and the default sync path is unchanged.

Socket-binding daemon integration tests are deploy-deferred (they require an exclusive daemon and cannot run alongside a live one). Build (`go build ./internal/... ./cmd/...`), scoped tests, `gofmt -l`, and `go vet` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)