### PR TITLE
perf(mcp): persist derived indexes to disk (load≠rebuild) + incremental patching

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
 	idiff "github.com/cajasmota/archigraph/internal/indexer/diff"
 	"github.com/cajasmota/archigraph/internal/install/detect"
+	"github.com/cajasmota/archigraph/internal/mcp"
 	"github.com/cajasmota/archigraph/internal/module"
 	"github.com/cajasmota/archigraph/internal/progress"
 	"github.com/cajasmota/archigraph/internal/resolve"
@@ -452,6 +453,17 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 			// propagates below.
 		} else {
 			fmt.Fprintf(os.Stderr, "archigraph: wrote %s\n", fbPath)
+			// #3368: persist the derived traversal indexes (adjacency / CALLS /
+			// STEP / TopKPageRank) into a graph-indexes.bin sidecar next to
+			// graph.fb, stamped with the graph.fb content hash so a stale sidecar
+			// is never served. The MCP lazy getters can reconstruct from it
+			// instead of rebuilding from the Document (consumption gated by
+			// ARCHIGRAPH_MCP_USE_INDEX_SIDECAR — see internal/mcp). Non-fatal: a
+			// missing/failed sidecar only leaves the build-from-Doc path in place.
+			stateDir := filepath.Dir(outPath)
+			if serr := mcp.WriteIndexSidecar(stateDir, repoTag, doc); serr != nil {
+				fmt.Fprintf(os.Stderr, "archigraph: graph-indexes sidecar: %v\n", serr)
+			}
 		}
 
 		if idx.exportJSON {

--- a/internal/daemon/clone/clone.go
+++ b/internal/daemon/clone/clone.go
@@ -64,6 +64,12 @@ var sidecarFiles = []string{
 	"graph-stats.json",
 	"enrichment-candidates.json",
 	"repair.json",
+	// #3368: the derived-index sidecar. Copied so a freshly-cloned ref starts
+	// with SOMETHING on disk; it is then regenerated against the rewritten
+	// graph.fb by cfg.WriteIndexSidecar (the copied one has a stale identity
+	// hash and would be rejected on load). Listed here so cleanup removes it on
+	// any abort after the copy.
+	"graph-indexes.bin",
 }
 
 // Result is returned by TryClone. It describes whether the clone path
@@ -91,6 +97,15 @@ type Config struct {
 	//
 	// Required. If nil, TryClone always returns Result{Done:false}.
 	ReExtractFiles func(repoPath string, changedFiles []string, base *graph.Document) (*graph.Document, error)
+
+	// WriteIndexSidecar regenerates the derived-index sidecar (#3368) for the
+	// just-written graph.fb in stateDir, stamped with that file's identity hash.
+	// Optional: when nil, the clone path leaves the (stale-hash) copied sidecar
+	// in place — the MCP loader rejects it and falls back to build-from-Doc, so
+	// correctness holds either way; wiring this callback only restores the
+	// load≠rebuild fast path for cloned refs. Invoked after the final graph.fb
+	// write; failures are logged, never fatal.
+	WriteIndexSidecar func(stateDir, repoTag string, doc *graph.Document) error
 }
 
 // TryClone attempts the clone-from-parent optimisation for (repoPath, newRef).
@@ -234,6 +249,18 @@ func TryClone(repoPath, newRef string, cfg Config) (Result, error) {
 	if err := fbwriter.WriteAtomic(newGraphFB, doc); err != nil {
 		cleanup()
 		return abort(fmt.Sprintf("write graph.fb: %v", err))
+	}
+
+	// #3368: regenerate the derived-index sidecar against the rewritten graph.fb
+	// so the cloned ref loads its indexes by deserialize, not rebuild. The
+	// sidecar copied from the parent in step 2 has a stale identity hash (we just
+	// rewrote graph.fb with new metadata + re-extracted entities) and would be
+	// rejected on load — overwrite it with a matching-hash one. Best-effort:
+	// failure only forfeits the fast path, never blocks the clone.
+	if cfg.WriteIndexSidecar != nil {
+		if serr := cfg.WriteIndexSidecar(newRefDir, slug, doc); serr != nil {
+			logger.Warn("clone-from-parent: index sidecar regen failed", "repo", slug, "ref", newRef, "err", serr)
+		}
 	}
 
 	took := time.Since(t0)

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -463,6 +463,18 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		return fallback(t0, "write-graph-fb: "+writeErr.Error())
 	}
 
+	// #3368: the derived-index sidecar (graph-indexes.bin) written by the last
+	// full index is now stale — its identity hash no longer matches the graph.fb
+	// we just rewrote. The MCP loader already rejects a hash-mismatched sidecar
+	// and rebuilds from Doc, so leaving it would be correct but wasteful (a
+	// pointless read+hash on every cold load until the next full index). Remove
+	// it so the loader takes the clean build-from-Doc miss path immediately. We
+	// deliberately do NOT regenerate it here: that would require importing the
+	// heavy internal/mcp index-build code into the extractor hot path. The next
+	// full index (cmd/archigraph Index) rewrites a valid sidecar. GOAL 2 of
+	// #3368 (in-memory adjacency patching for these small reindexes) is backlogged.
+	_ = os.Remove(filepath.Join(stateDir, "graph-indexes.bin"))
+
 	// --- Step 9: update manifest ---
 	diff.UpdateManifest(absRepo, allFiles, manifest)
 	if saveErr := diff.SaveManifest(stateDir, absRepo, manifest); saveErr != nil {

--- a/internal/mcp/index_sidecar.go
+++ b/internal/mcp/index_sidecar.go
@@ -1,0 +1,421 @@
+package mcp
+
+// index_sidecar.go — persistence of the derived traversal indexes to disk so a
+// (re)load reconstructs them from a compact binary blob instead of re-deriving
+// them from the graph Document (#3368, the last mile after the lazy/debounce
+// work in #3370).
+//
+// Background: the lazy getters in state.go (getAdjacency/getCallsAdj/getStepAdj/
+// getTopKPageRank) still rebuild from lr.Doc on the FIRST use after every reload
+// (and on every cold-tier load). This file lets the indexer persist a sidecar
+// (graph-indexes.bin) next to graph.fb so those getters CAN reconstruct on first
+// use instead of scanning Doc.Relationships.
+//
+// MEASURED OUTCOME (important): with #3370 already making builds lazy and with
+// PageRank precomputed at index time, reconstructing these four indexes from the
+// sidecar is ~1.5x SLOWER than rebuilding them from the resident Document — the
+// Doc is already structured in RAM, and the sidecar adds file I/O + identity hash
+// + varint decode that build-from-Doc avoids (see the BenchmarkFirstUse_* pair).
+// So consumption is OFF by default (gated by ARCHIGRAPH_MCP_USE_INDEX_SIDECAR in
+// state.go); the WRITE side ships so the artifact exists for external tooling and
+// so a future faster reconstruction (e.g. an mmap'd index FlatBuffer) can flip
+// the default without re-plumbing the indexer. The getter integration + identity
+// validation + equality round-trip are all tested regardless of the gate.
+//
+// FORMAT — why a hand-rolled int-indexed binary, NOT gob:
+//
+//	The build-from-Doc path is already fast because the Document is RESIDENT in
+//	RAM at reload time: every edge's endpoint string (r.FromID/r.ToID) is reused
+//	by value — building adjacency is just map inserts of existing string headers,
+//	zero new string bytes. A naive string-keyed sidecar (gob or otherwise) MUST
+//	materialise a fresh copy of every endpoint string on decode, so it allocates
+//	far MORE than build-from-Doc and loses (measured: gob decode ~2x slower than
+//	build for a 20k-entity graph).
+//
+//	To actually beat build-from-Doc the sidecar stores ENTITY INDICES (int32 into
+//	Doc.Entities), not strings. On load we rehydrate each index back to
+//	doc.Entities[i].ID — reusing the resident Document's string backing exactly
+//	like the build path does — so reconstruction allocates only the slices/maps,
+//	never the strings. This is strictly cheaper than build-from-Doc (no O(R)
+//	relationship scan, no edgeWeight property parsing, no PageRank re-sort) while
+//	allocating the same string-free shape.
+//
+// IDENTITY: the sidecar is stamped with the SHA-256 of the graph.fb bytes it was
+// derived from AND the entity-count/relationship-count. On load the getter
+// recomputes the graph.fb hash and rejects any mismatch (stale / partially
+// written / changed graph) — falling back to the intact build-from-Doc path.
+// Because the payload is index-based, it is ONLY valid against a Doc whose
+// entity/relationship ordering matches the one it was written from; the hash of
+// the canonical graph.fb (written from the SAME sorted Doc) is exactly that
+// identity, so a hash match guarantees index validity.
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// Sidecar on-disk constants. Bump sidecarVersion on ANY wire-format change so a
+// stale-format file is rejected (→ build-from-Doc) rather than mis-decoded.
+const (
+	sidecarMagic   = "AGIDX1\n" // 7 bytes; trailing \n guards against accidental text reads
+	sidecarVersion = 1
+	sidecarName    = "graph-indexes.bin"
+)
+
+// indexSidecarPath returns the sidecar location for a state directory (next to
+// graph.fb).
+func indexSidecarPath(stateDir string) string {
+	return filepath.Join(stateDir, sidecarName)
+}
+
+// hashFile returns the hex SHA-256 of a file's bytes, or "" + error.
+func hashFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// --- binary primitives ------------------------------------------------------
+
+func putUvarint(w *bufio.Writer, v uint64) {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], v)
+	_, _ = w.Write(buf[:n])
+}
+
+func putVarint(w *bufio.Writer, v int64) {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutVarint(buf[:], v)
+	_, _ = w.Write(buf[:n])
+}
+
+func putF64(w *bufio.Writer, f float64) {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], math.Float64bits(f))
+	_, _ = w.Write(buf[:])
+}
+
+// atoiSafe parses a base-10 int, returning 0 on any error (matches the
+// best-effort parse buildStepAdjacency does for step_index).
+func atoiSafe(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}
+
+// --- WRITE ------------------------------------------------------------------
+
+// WriteIndexSidecar builds the derived indexes for doc and writes the validated
+// sidecar next to graph.fb in stateDir. Indexer write hook: call it AFTER
+// graph.fb has been written so the identity hash matches the bytes on disk.
+//
+// repoTag is the slug stamped onto entities (passed to buildAdjacency for parity
+// with the load-time getter). On any failure it returns an error; the indexer
+// logs it non-fatally — a missing/failed sidecar only costs the lazy getters
+// their original build-from-Doc path, never correctness.
+func WriteIndexSidecar(stateDir, repoTag string, doc *graph.Document) error {
+	if doc == nil {
+		return fmt.Errorf("sidecar: nil document")
+	}
+	fbPath := filepath.Join(stateDir, "graph.fb")
+	fbHash, err := hashFile(fbPath)
+	if err != nil {
+		return fmt.Errorf("sidecar: hash graph.fb: %w", err)
+	}
+
+	// Entity ID → dense index, so endpoint strings serialize as int32 indices.
+	idIdx := make(map[string]int32, len(doc.Entities))
+	for i := range doc.Entities {
+		idIdx[doc.Entities[i].ID] = int32(i)
+	}
+
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("sidecar mkdir: %w", err)
+	}
+	out := indexSidecarPath(stateDir)
+	tmp := out + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("sidecar create tmp: %w", err)
+	}
+	w := bufio.NewWriterSize(f, 1<<16)
+
+	// Header: magic, version, hash, counts. Counts let the loader pre-size and
+	// cross-check against the resident Doc.
+	_, _ = w.WriteString(sidecarMagic)
+	putUvarint(w, sidecarVersion)
+	putUvarint(w, uint64(len(fbHash)))
+	_, _ = w.WriteString(fbHash)
+	putUvarint(w, uint64(len(doc.Entities)))
+	putUvarint(w, uint64(len(doc.Relationships)))
+
+	// Adjacency: emit per-source out-edges and in-edges as index lists. We write
+	// the FULL forward/back adjacency by streaming relationships once — the
+	// loader buckets them. This mirrors buildAdjacency exactly (every rel yields
+	// one out-edge from FromID and one in-edge into ToID).
+	//
+	// Per relationship we store: fromIdx, toIdx, kindID, weight, relIdx. Kinds
+	// are interned into a small table so each edge stores a uvarint kind id.
+	kindTable := []string{}
+	kindIdx := map[string]int{}
+	internKind := func(k string) int {
+		if id, ok := kindIdx[k]; ok {
+			return id
+		}
+		id := len(kindTable)
+		kindTable = append(kindTable, k)
+		kindIdx[k] = id
+		return id
+	}
+	// First pass: build the edge records in memory so we can write the kind
+	// table up front (loader needs it before edges).
+	type rec struct {
+		from, to int32
+		kind     int
+		weight   float64
+		relIdx   int
+	}
+	recs := make([]rec, 0, len(doc.Relationships))
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		fi, ok1 := idIdx[r.FromID]
+		ti, ok2 := idIdx[r.ToID]
+		if !ok1 || !ok2 {
+			// Endpoint not in entity table (dangling edge). Skip — buildAdjacency
+			// keeps these as string keys, but they are unreachable via entity
+			// traversal anyway and rare; the hash still validates the graph. To
+			// stay byte-equal with build we instead fall back: mark sidecar
+			// invalid by returning an error so the loader rebuilds from Doc.
+			_ = w.Flush()
+			f.Close()
+			os.Remove(tmp)
+			return fmt.Errorf("sidecar: dangling edge endpoint (from=%q to=%q); skipping persist", r.FromID, r.ToID)
+		}
+		recs = append(recs, rec{from: fi, to: ti, kind: internKind(r.Kind), weight: edgeWeight(r), relIdx: i})
+	}
+
+	// Kind table.
+	putUvarint(w, uint64(len(kindTable)))
+	for _, k := range kindTable {
+		putUvarint(w, uint64(len(k)))
+		_, _ = w.WriteString(k)
+	}
+	// Edge records.
+	putUvarint(w, uint64(len(recs)))
+	for _, e := range recs {
+		putVarint(w, int64(e.from))
+		putVarint(w, int64(e.to))
+		putUvarint(w, uint64(e.kind))
+		putF64(w, e.weight)
+		putVarint(w, int64(e.relIdx))
+	}
+
+	// TopKPageRank: list of entity indices (resolved from the same idIdx).
+	topK := buildTopKPageRank(doc, 64)
+	putUvarint(w, uint64(len(topK)))
+	for _, id := range topK {
+		// topK ids always come from Doc.Entities, so they resolve.
+		putVarint(w, int64(idIdx[id]))
+	}
+
+	if err := w.Flush(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return fmt.Errorf("sidecar flush: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sidecar close: %w", err)
+	}
+	if err := os.Rename(tmp, out); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sidecar rename: %w", err)
+	}
+	return nil
+}
+
+// --- READ -------------------------------------------------------------------
+
+// loadedSidecar is the in-memory reconstruction of a validated sidecar, with
+// every endpoint string rehydrated from the RESIDENT Document (string-reuse, no
+// fresh allocation) — exactly the shape the build-from-Doc getters produce.
+type loadedSidecar struct {
+	adj          *adjacency
+	callsAdj     map[string][]string
+	stepAdj      map[string][]stepEdge
+	topKPageRank []string
+}
+
+// loadValidSidecar reads + validates the sidecar in stateDir against the current
+// graph.fb identity and reconstructs the indexes using doc for string reuse. It
+// returns (nil, nil) — NOT an error — for the common absent / stale / mismatch
+// cases so the caller treats them as a plain cache miss and falls back to
+// build-from-Doc. A non-nil error is reserved for genuinely unexpected failures;
+// the caller still falls back in that case.
+//
+// doc MUST be the resident Document for this repo (the one whose canonical
+// graph.fb produced the validated hash). Endpoint indices are resolved against
+// doc.Entities; a count mismatch is treated as a stale miss.
+func loadValidSidecar(stateDir string, doc *graph.Document) (*loadedSidecar, error) {
+	if doc == nil {
+		return nil, nil
+	}
+	scPath := indexSidecarPath(stateDir)
+	f, err := os.Open(scPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // no sidecar — cache miss
+		}
+		return nil, err
+	}
+	defer f.Close()
+	r := bufio.NewReaderSize(f, 1<<16)
+
+	// Header.
+	magic := make([]byte, len(sidecarMagic))
+	if _, err := io.ReadFull(r, magic); err != nil || string(magic) != sidecarMagic {
+		return nil, nil // wrong/old format — miss
+	}
+	ver, err := binary.ReadUvarint(r)
+	if err != nil || ver != sidecarVersion {
+		return nil, nil
+	}
+	hlen, err := binary.ReadUvarint(r)
+	if err != nil {
+		return nil, nil
+	}
+	hbuf := make([]byte, hlen)
+	if _, err := io.ReadFull(r, hbuf); err != nil {
+		return nil, nil
+	}
+	storedHash := string(hbuf)
+	nEnt, err := binary.ReadUvarint(r)
+	if err != nil {
+		return nil, nil
+	}
+	nRel, err := binary.ReadUvarint(r)
+	if err != nil {
+		return nil, nil
+	}
+
+	// Validate identity against the current graph.fb AND the resident Doc shape.
+	curHash, herr := hashFile(filepath.Join(stateDir, "graph.fb"))
+	if herr != nil {
+		return nil, herr
+	}
+	if curHash != storedHash {
+		return nil, nil // stale: graph.fb changed since the sidecar was written
+	}
+	if int(nEnt) != len(doc.Entities) || int(nRel) > len(doc.Relationships) {
+		return nil, nil // Doc shape diverged from the sidecar — miss
+	}
+
+	// resolveID maps an entity index back to the resident Doc's ID string,
+	// reusing its backing array (no allocation).
+	resolveID := func(i int64) (string, bool) {
+		if i < 0 || int(i) >= len(doc.Entities) {
+			return "", false
+		}
+		return doc.Entities[i].ID, true
+	}
+
+	// Kind table.
+	nk, err := binary.ReadUvarint(r)
+	if err != nil {
+		return nil, nil
+	}
+	kinds := make([]string, nk)
+	for i := range kinds {
+		kl, err := binary.ReadUvarint(r)
+		if err != nil {
+			return nil, nil
+		}
+		kb := make([]byte, kl)
+		if _, err := io.ReadFull(r, kb); err != nil {
+			return nil, nil
+		}
+		kinds[i] = string(kb)
+	}
+
+	// Edge records → adjacency + CALLS adjacency.
+	ne, err := binary.ReadUvarint(r)
+	if err != nil {
+		return nil, nil
+	}
+	adj := &adjacency{
+		out: make(map[string][]edge, len(doc.Entities)),
+		in:  make(map[string][]edge, len(doc.Entities)),
+	}
+	callsAdj := make(map[string][]string)
+	stepAdj := make(map[string][]stepEdge)
+	for i := uint64(0); i < ne; i++ {
+		from, e1 := binary.ReadVarint(r)
+		to, e2 := binary.ReadVarint(r)
+		kid, e3 := binary.ReadUvarint(r)
+		wbuf := make([]byte, 8)
+		_, e4 := io.ReadFull(r, wbuf)
+		relIdx, e5 := binary.ReadVarint(r)
+		if e1 != nil || e2 != nil || e3 != nil || e4 != nil || e5 != nil || int(kid) >= len(kinds) {
+			return nil, nil
+		}
+		fromID, ok1 := resolveID(from)
+		toID, ok2 := resolveID(to)
+		if !ok1 || !ok2 {
+			return nil, nil
+		}
+		weight := math.Float64frombits(binary.LittleEndian.Uint64(wbuf))
+		kind := kinds[kid]
+		adj.out[fromID] = append(adj.out[fromID], edge{target: toID, kind: kind, weight: weight, relIdx: int(relIdx)})
+		adj.in[toID] = append(adj.in[toID], edge{target: fromID, kind: kind, weight: weight, relIdx: int(relIdx)})
+		switch kind {
+		case "CALLS":
+			callsAdj[fromID] = append(callsAdj[fromID], toID)
+		case stepInProcessEdge:
+			// step_index lives in Doc.Relationships[relIdx].Properties — read it
+			// from the resident Doc (cheaper than persisting it again).
+			idx := 0
+			if relIdx >= 0 && int(relIdx) < len(doc.Relationships) {
+				if p := doc.Relationships[relIdx].Properties; p != nil {
+					idx = atoiSafe(p["step_index"])
+				}
+			}
+			stepAdj[fromID] = append(stepAdj[fromID], stepEdge{toID: toID, idx: idx})
+		}
+	}
+	// CALLS targets are pre-sorted by buildCallsAdjacency; match that ordering.
+	for k := range callsAdj {
+		sortStrings(callsAdj[k])
+	}
+
+	// TopKPageRank.
+	ntk, err := binary.ReadUvarint(r)
+	if err != nil {
+		return nil, nil
+	}
+	topK := make([]string, 0, ntk)
+	for i := uint64(0); i < ntk; i++ {
+		v, verr := binary.ReadVarint(r)
+		if verr != nil {
+			return nil, nil
+		}
+		id, ok := resolveID(v)
+		if !ok {
+			return nil, nil
+		}
+		topK = append(topK, id)
+	}
+
+	return &loadedSidecar{adj: adj, callsAdj: callsAdj, stepAdj: stepAdj, topKPageRank: topK}, nil
+}

--- a/internal/mcp/index_sidecar_test.go
+++ b/internal/mcp/index_sidecar_test.go
@@ -1,0 +1,325 @@
+package mcp
+
+// index_sidecar_test.go — correctness tests for the persisted derived-index
+// sidecar (#3368). The contract under test:
+//
+//   1. A sidecar written from a Document, then loaded against that resident
+//      Document, reconstructs indexes equal to the build-from-Doc path.
+//   2. A sidecar whose identity hash no longer matches the on-disk graph.fb is
+//      rejected (treated as a miss) — a stale index is NEVER served.
+//   3. The lazy getters PREFER a valid sidecar: they reconstruct instead of
+//      rebuilding, asserted via the idxBuiltFromDoc build-counter.
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
+)
+
+// sidecarFixtureDoc returns a small but structurally-complete document touching
+// every persisted index: in/out adjacency, CALLS, STEP_IN_PROCESS, and PageRank.
+func sidecarFixtureDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "fix",
+		Entities: []graph.Entity{
+			{ID: "a", Name: "A", Kind: "Function", SourceFile: "a.go", PageRank: pr(0.9)},
+			{ID: "b", Name: "B", Kind: "Function", SourceFile: "b.go", PageRank: pr(0.5)},
+			{ID: "c", Name: "C", Kind: "Function", SourceFile: "c.go", PageRank: pr(0.1)},
+			{ID: "p", Name: "P", Kind: "process_flow", SourceFile: "p.go", PageRank: pr(0.3)},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS", Properties: map[string]string{"count": "3"}},
+			{ID: "r2", FromID: "a", ToID: "c", Kind: "CALLS"},
+			{ID: "r3", FromID: "b", ToID: "c", Kind: "IMPORTS"},
+			{ID: "r4", FromID: "p", ToID: "a", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "0"}},
+			{ID: "r5", FromID: "p", ToID: "b", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "1"}},
+		},
+	}
+}
+
+// withSidecarConsume toggles the package-level sidecar-consume gate for one test
+// and restores it on cleanup. The gate defaults OFF (build-from-Doc is faster);
+// the consume-path tests flip it ON to exercise the deserialize path.
+func withSidecarConsume(t *testing.T, on bool) {
+	t.Helper()
+	prev := sidecarConsumeEnabled
+	sidecarConsumeEnabled = on
+	t.Cleanup(func() { sidecarConsumeEnabled = prev })
+}
+
+// writeFBFixture writes graph.fb into a fresh temp state dir and returns the dir.
+func writeFBFixture(t *testing.T, doc *graph.Document) string {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	return dir
+}
+
+// adjEqual compares two adjacency indexes for out/in equality.
+func adjEqual(t *testing.T, label string, want, got *adjacency) {
+	t.Helper()
+	if !reflect.DeepEqual(want.out, got.out) {
+		t.Errorf("%s adjacency.out mismatch:\nwant %#v\ngot  %#v", label, want.out, got.out)
+	}
+	if !reflect.DeepEqual(want.in, got.in) {
+		t.Errorf("%s adjacency.in mismatch:\nwant %#v\ngot  %#v", label, want.in, got.in)
+	}
+}
+
+// TestSidecar_RoundTripEqualsBuild asserts a written→loaded sidecar reconstructs
+// indexes equal to the build-from-Doc path (GOAL-1 correctness invariant).
+func TestSidecar_RoundTripEqualsBuild(t *testing.T) {
+	doc := sidecarFixtureDoc()
+	dir := writeFBFixture(t, doc)
+
+	if err := WriteIndexSidecar(dir, "fix", doc); err != nil {
+		t.Fatalf("WriteIndexSidecar: %v", err)
+	}
+
+	sc, err := loadValidSidecar(dir, doc)
+	if err != nil {
+		t.Fatalf("loadValidSidecar: %v", err)
+	}
+	if sc == nil {
+		t.Fatal("expected a valid sidecar, got nil")
+	}
+
+	adjEqual(t, "roundtrip", buildAdjacency(doc, "fix"), sc.adj)
+
+	if !reflect.DeepEqual(buildCallsAdjacency(doc), sc.callsAdj) {
+		t.Errorf("callsAdj mismatch:\nwant %#v\ngot  %#v", buildCallsAdjacency(doc), sc.callsAdj)
+	}
+	if !reflect.DeepEqual(buildStepAdjacency(doc), sc.stepAdj) {
+		t.Errorf("stepAdj mismatch:\nwant %#v\ngot  %#v", buildStepAdjacency(doc), sc.stepAdj)
+	}
+	if !reflect.DeepEqual(buildTopKPageRank(doc, 64), sc.topKPageRank) {
+		t.Errorf("topKPageRank mismatch:\nwant %v\ngot  %v", buildTopKPageRank(doc, 64), sc.topKPageRank)
+	}
+}
+
+// TestSidecar_StaleRejected asserts a sidecar is rejected once graph.fb changes
+// (identity hash mismatch) — never serving a stale index.
+func TestSidecar_StaleRejected(t *testing.T) {
+	doc := sidecarFixtureDoc()
+	dir := writeFBFixture(t, doc)
+	if err := WriteIndexSidecar(dir, "fix", doc); err != nil {
+		t.Fatalf("WriteIndexSidecar: %v", err)
+	}
+	if sc, _ := loadValidSidecar(dir, doc); sc == nil {
+		t.Fatal("precondition: sidecar should load before graph.fb changes")
+	}
+
+	// Mutate graph.fb (add an entity + edge) WITHOUT rewriting the sidecar.
+	doc2 := sidecarFixtureDoc()
+	doc2.Entities = append(doc2.Entities, graph.Entity{ID: "z", Name: "Z", Kind: "Function", SourceFile: "z.go"})
+	doc2.Relationships = append(doc2.Relationships, graph.Relationship{ID: "rz", FromID: "a", ToID: "z", Kind: "CALLS"})
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc2); err != nil {
+		t.Fatalf("rewrite graph.fb: %v", err)
+	}
+
+	sc, err := loadValidSidecar(dir, doc2)
+	if err != nil {
+		t.Fatalf("loadValidSidecar after change: unexpected error %v", err)
+	}
+	if sc != nil {
+		t.Fatal("stale sidecar was served after graph.fb changed; expected nil (miss)")
+	}
+}
+
+// TestSidecar_MissingIsCleanMiss asserts a missing sidecar is a quiet miss.
+func TestSidecar_MissingIsCleanMiss(t *testing.T) {
+	doc := sidecarFixtureDoc()
+	dir := writeFBFixture(t, doc)
+	sc, err := loadValidSidecar(dir, doc)
+	if err != nil {
+		t.Fatalf("missing sidecar should not error, got: %v", err)
+	}
+	if sc != nil {
+		t.Fatal("missing sidecar should yield nil")
+	}
+}
+
+// TestSidecar_CorruptIsCleanMiss asserts a garbage sidecar is rejected, not
+// mis-decoded, and falls back cleanly.
+func TestSidecar_CorruptIsCleanMiss(t *testing.T) {
+	doc := sidecarFixtureDoc()
+	dir := writeFBFixture(t, doc)
+	if err := os.WriteFile(indexSidecarPath(dir), []byte("not a valid sidecar stream at all"), 0o644); err != nil {
+		t.Fatalf("write corrupt sidecar: %v", err)
+	}
+	sc, _ := loadValidSidecar(dir, doc)
+	if sc != nil {
+		t.Fatal("corrupt sidecar should yield nil (miss)")
+	}
+}
+
+// TestSidecar_DocShapeMismatchMiss asserts that a sidecar valid by hash but
+// loaded against a Doc with a different entity count is rejected (defense in
+// depth — the hash already catches this, but the count guard is cheap).
+func TestSidecar_DocShapeMismatchMiss(t *testing.T) {
+	doc := sidecarFixtureDoc()
+	dir := writeFBFixture(t, doc)
+	if err := WriteIndexSidecar(dir, "fix", doc); err != nil {
+		t.Fatalf("WriteIndexSidecar: %v", err)
+	}
+	shrunk := sidecarFixtureDoc()
+	shrunk.Entities = shrunk.Entities[:len(shrunk.Entities)-1]
+	sc, _ := loadValidSidecar(dir, shrunk)
+	if sc != nil {
+		t.Fatal("sidecar should be rejected when Doc entity count diverges")
+	}
+}
+
+// TestSidecar_GettersPreferSidecarNoRebuild asserts the lazy getters reconstruct
+// from a valid sidecar and do NOT rebuild from Doc (idxBuiltFromDoc stays 0).
+func TestSidecar_GettersPreferSidecarNoRebuild(t *testing.T) {
+	withSidecarConsume(t, true)
+	doc := sidecarFixtureDoc()
+	dir := writeFBFixture(t, doc)
+	if err := WriteIndexSidecar(dir, "fix", doc); err != nil {
+		t.Fatalf("WriteIndexSidecar: %v", err)
+	}
+
+	lr := &LoadedRepo{Repo: "fix", Doc: doc, GraphFile: filepath.Join(dir, "graph.fb")}
+
+	_ = lr.getAdjacency()
+	_ = lr.getCallsAdj()
+	_ = lr.getStepAdj()
+	_ = lr.getTopKPageRank()
+
+	if lr.idxBuiltFromDoc != 0 {
+		t.Fatalf("expected 0 build-from-Doc with a valid sidecar, got %d", lr.idxBuiltFromDoc)
+	}
+
+	adjEqual(t, "getter", buildAdjacency(doc, "fix"), lr.getAdjacency())
+	if !reflect.DeepEqual(buildCallsAdjacency(doc), lr.getCallsAdj()) {
+		t.Error("getCallsAdj from sidecar diverged from build")
+	}
+	if !reflect.DeepEqual(buildStepAdjacency(doc), lr.getStepAdj()) {
+		t.Error("getStepAdj from sidecar diverged from build")
+	}
+	if !reflect.DeepEqual(buildTopKPageRank(doc, 64), lr.getTopKPageRank()) {
+		t.Error("getTopKPageRank from sidecar diverged from build")
+	}
+}
+
+// TestSidecar_GettersFallBackWhenMissing asserts that with no sidecar the getters
+// rebuild from Doc (idxBuiltFromDoc increments) and still serve correct data.
+func TestSidecar_GettersFallBackWhenMissing(t *testing.T) {
+	doc := sidecarFixtureDoc()
+	dir := writeFBFixture(t, doc) // graph.fb present, but NO sidecar written
+
+	lr := &LoadedRepo{Repo: "fix", Doc: doc, GraphFile: filepath.Join(dir, "graph.fb")}
+
+	_ = lr.getAdjacency()
+	_ = lr.getCallsAdj()
+	_ = lr.getStepAdj()
+	_ = lr.getTopKPageRank()
+
+	if lr.idxBuiltFromDoc != 4 {
+		t.Fatalf("expected 4 build-from-Doc (no sidecar), got %d", lr.idxBuiltFromDoc)
+	}
+	if !reflect.DeepEqual(buildStepAdjacency(doc), lr.getStepAdj()) {
+		t.Error("fallback getStepAdj diverged from build")
+	}
+}
+
+// TestSidecar_ResetRearms asserts resetIndexes re-arms the sidecar load so a
+// cached sidecar cannot survive a reload.
+func TestSidecar_ResetRearms(t *testing.T) {
+	withSidecarConsume(t, true)
+	doc := sidecarFixtureDoc()
+	dir := writeFBFixture(t, doc)
+	if err := WriteIndexSidecar(dir, "fix", doc); err != nil {
+		t.Fatalf("WriteIndexSidecar: %v", err)
+	}
+	lr := &LoadedRepo{Repo: "fix", Doc: doc, GraphFile: filepath.Join(dir, "graph.fb")}
+	_ = lr.getAdjacency()
+	if lr.sidecar == nil {
+		t.Fatal("expected cached sidecar after first access")
+	}
+	lr.resetIndexes()
+	if lr.sidecar != nil {
+		t.Fatal("resetIndexes must clear the cached sidecar")
+	}
+	if lr.idxBuiltFromDoc != 0 {
+		t.Fatal("resetIndexes must zero the build counter")
+	}
+}
+
+// --- timing benchmarks (before/after first-use) ----------------------------
+
+// largeFixtureDoc builds a synthetic doc with n entities and ~2n relationships
+// (CALLS + IMPORTS) plus PageRank, to size the build-vs-load first-use cost.
+func largeFixtureDoc(n int) *graph.Document {
+	doc := &graph.Document{Repo: "big", Entities: make([]graph.Entity, n)}
+	for i := 0; i < n; i++ {
+		id := "e" + itoaTest(i)
+		doc.Entities[i] = graph.Entity{ID: id, Name: id, Kind: "Function", SourceFile: id + ".go", PageRank: pr(float64(i % 97))}
+	}
+	for i := 0; i < n; i++ {
+		from := "e" + itoaTest(i)
+		to := "e" + itoaTest((i*7+1)%n)
+		to2 := "e" + itoaTest((i*13+3)%n)
+		doc.Relationships = append(doc.Relationships,
+			graph.Relationship{ID: "c" + itoaTest(i), FromID: from, ToID: to, Kind: "CALLS"},
+			graph.Relationship{ID: "i" + itoaTest(i), FromID: from, ToID: to2, Kind: "IMPORTS"},
+		)
+	}
+	return doc
+}
+
+func itoaTest(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	p := len(b)
+	for i > 0 {
+		p--
+		b[p] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[p:])
+}
+
+// BenchmarkFirstUse_BuildFromDoc measures the first-use cost the lazy getters
+// pay WITHOUT a sidecar: full build-from-Doc (the pre-#3368 residual cost).
+func BenchmarkFirstUse_BuildFromDoc(b *testing.B) {
+	doc := largeFixtureDoc(20000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = buildAdjacency(doc, "big")
+		_ = buildCallsAdjacency(doc)
+		_ = buildStepAdjacency(doc)
+		_ = buildTopKPageRank(doc, 64)
+	}
+}
+
+// BenchmarkFirstUse_LoadSidecar measures the first-use cost WITH a sidecar:
+// validate identity + reconstruct all four indexes from the int-indexed blob,
+// reusing the resident Doc's strings.
+func BenchmarkFirstUse_LoadSidecar(b *testing.B) {
+	doc := largeFixtureDoc(20000)
+	dir := b.TempDir()
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+		b.Fatalf("write graph.fb: %v", err)
+	}
+	if err := WriteIndexSidecar(dir, "big", doc); err != nil {
+		b.Fatalf("WriteIndexSidecar: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sc, err := loadValidSidecar(dir, doc)
+		if err != nil || sc == nil {
+			b.Fatalf("loadValidSidecar: sc=%v err=%v", sc, err)
+		}
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -258,6 +258,21 @@ type LoadedRepo struct {
 	byID         map[string]*graph.Entity // entity ID -> entity (#1656)
 	topKPageRank []string                 // entity IDs sorted descending by PageRank (#2304)
 
+	// sidecar persistence (#3368). On the first derived-index access after a
+	// reload, sidecarOnce loads + validates the on-disk graph-indexes sidecar
+	// against the current graph.fb identity exactly once. The adjacency / CALLS /
+	// STEP / TopKPageRank getters below then DESERIALIZE from the sidecar (when
+	// valid) instead of rebuilding from Doc. sidecar is nil when the file is
+	// absent / stale / mismatched — the getters fall back to build-from-Doc.
+	// resetIndexes() re-arms sidecarOnce on every reload. All accessed under
+	// idxMu (the same lock the getters already hold).
+	sidecarOnce sync.Once
+	sidecar     *loadedSidecar
+	// idxBuiltFromDoc counts derived indexes that were built from Doc (i.e. NOT
+	// served from the sidecar) since the last reset. Tests assert it stays 0 when
+	// a valid sidecar is present, proving the getters deserialize, not rebuild.
+	idxBuiltFromDoc int
+
 	semMtime time.Time
 	mtime    time.Time
 	loadErr  string // populated when last reload failed; doc may be stale
@@ -282,6 +297,45 @@ func (lr *LoadedRepo) resetIndexes() {
 	lr.stepAdj = nil
 	lr.byID = nil
 	lr.topKPageRank = nil
+	// #3368: re-arm sidecar load so the next access re-validates against the
+	// freshly-written graph.fb. A sidecar loaded for the OLD Doc must never leak
+	// into the new one — the identity hash would reject it on reload, but we also
+	// clear the cached pointer to avoid serving stale neighbor lists.
+	lr.sidecarOnce = sync.Once{}
+	lr.sidecar = nil
+	lr.idxBuiltFromDoc = 0
+}
+
+// sidecarConsumeEnabled gates whether the lazy getters CONSUME the on-disk
+// sidecar (#3368). The sidecar is always WRITTEN by the indexer (cheap, and
+// useful for external tooling + future formats), but consuming it is OFF by
+// default: benchmarking on this branch showed that, once #3370 made index builds
+// lazy and PageRank is precomputed at index time, reconstructing the four
+// derived indexes from the sidecar is ~1.5x SLOWER than rebuilding them from the
+// already-resident Document (the Doc is structured in RAM; the sidecar adds I/O +
+// identity-hash + varint-decode that build-from-Doc avoids). Enabling consumption
+// would regress first-use latency, so it is opt-in via
+// ARCHIGRAPH_MCP_USE_INDEX_SIDECAR=1 for measurement/experimentation. See the
+// BenchmarkFirstUse_* pair and the #3368 PR notes for the numbers. When/if a
+// faster reconstruction (e.g. mmap'd index-typed FlatBuffer) lands, flip the
+// default. Evaluated once and cached so the hot getter path stays branch-cheap.
+var sidecarConsumeEnabled = os.Getenv("ARCHIGRAPH_MCP_USE_INDEX_SIDECAR") == "1"
+
+// loadSidecarLocked loads + validates the on-disk index sidecar exactly once
+// per reload. Caller MUST hold idxMu (every getter does). Returns the validated
+// sidecar, or nil when consumption is disabled / the file is absent / stale /
+// mismatched / unreadable — in which case the caller builds from Doc. The
+// graph.fb identity check lives in loadValidSidecar; a mismatch is a plain miss.
+func (lr *LoadedRepo) loadSidecarLocked() *loadedSidecar {
+	lr.sidecarOnce.Do(func() {
+		if !sidecarConsumeEnabled || lr.GraphFile == "" || lr.Doc == nil {
+			return
+		}
+		stateDir := filepath.Dir(lr.GraphFile)
+		sc, _ := loadValidSidecar(stateDir, lr.Doc)
+		lr.sidecar = sc // nil on any miss; getters fall back to build-from-Doc
+	})
+	return lr.sidecar
 }
 
 // getByID returns the entity-ID → *Entity map, building it on first use.
@@ -313,10 +367,15 @@ func (lr *LoadedRepo) getAdjacency() *adjacency {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
 	lr.adjOnce.Do(func() {
+		if sc := lr.loadSidecarLocked(); sc != nil {
+			lr.adjacency = sc.adj // #3368: reconstructed from sidecar, no rebuild
+			return
+		}
 		if lr.Doc == nil {
 			lr.adjacency = &adjacency{out: map[string][]edge{}, in: map[string][]edge{}}
 			return
 		}
+		lr.idxBuiltFromDoc++
 		lr.adjacency = buildAdjacency(lr.Doc, lr.Repo)
 	})
 	return lr.adjacency
@@ -327,10 +386,15 @@ func (lr *LoadedRepo) getCallsAdj() map[string][]string {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
 	lr.callsOnce.Do(func() {
+		if sc := lr.loadSidecarLocked(); sc != nil {
+			lr.callsAdj = sc.callsAdj // #3368: reconstructed from sidecar, no rebuild
+			return
+		}
 		if lr.Doc == nil {
 			lr.callsAdj = map[string][]string{}
 			return
 		}
+		lr.idxBuiltFromDoc++
 		lr.callsAdj = buildCallsAdjacency(lr.Doc)
 	})
 	return lr.callsAdj
@@ -341,10 +405,15 @@ func (lr *LoadedRepo) getStepAdj() map[string][]stepEdge {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
 	lr.stepOnce.Do(func() {
+		if sc := lr.loadSidecarLocked(); sc != nil {
+			lr.stepAdj = sc.stepAdj // #3368: reconstructed from sidecar, no rebuild
+			return
+		}
 		if lr.Doc == nil {
 			lr.stepAdj = map[string][]stepEdge{}
 			return
 		}
+		lr.idxBuiltFromDoc++
 		lr.stepAdj = buildStepAdjacency(lr.Doc)
 	})
 	return lr.stepAdj
@@ -357,6 +426,11 @@ func (lr *LoadedRepo) getTopKPageRank() []string {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
 	lr.pagerankOnce.Do(func() {
+		if sc := lr.loadSidecarLocked(); sc != nil {
+			lr.topKPageRank = sc.topKPageRank // #3368: reconstructed from sidecar, no rebuild
+			return
+		}
+		lr.idxBuiltFromDoc++
 		lr.topKPageRank = buildTopKPageRank(lr.Doc, 64)
 	})
 	return lr.topKPageRank


### PR DESCRIPTION
Closes #3368. Sidecar-persisted adjacency/CALLS/STEP/PageRank validated by graph identity; lazy getters can deserialize instead of rebuild. Last mile after #3370's lazy/debounce work.

## GOAL 1 — persist derived indexes (DONE)

The indexer writes a `graph-indexes.bin` sidecar next to `graph.fb` holding the four derived traversal indexes (in/out adjacency, CALLS adjacency, STEP adjacency, TopKPageRank ordering).

**Format** — a hand-rolled int-indexed binary codec (not gob). Endpoints serialize as `int32` indices into `Doc.Entities` and rehydrate to the **resident** Doc's ID strings on load, so reconstruction reuses the Document's string backing exactly like `buildAdjacency` does (no fresh string allocation). I started with gob and measured it ~2x slower than build-from-Doc — the int-indexed codec closes most of that gap.

**Identity validation** — sidecar stamped with `SHA-256(graph.fb)` + entity/relationship counts. On load the getter recomputes the graph.fb hash and rejects any mismatch (stale / partially-written / changed graph) → clean miss → `build-from-Doc` fallback (kept fully intact). A loaded-from-sidecar index is asserted equal to a built-from-Doc index on a fixture. **Never serves a stale index.**

**Getter integration** — `state.go` `getAdjacency/getCallsAdj/getStepAdj/getTopKPageRank` call `loadSidecarLocked()` (once per reload, under `idxMu`) and reconstruct from the sidecar when valid, else build. `resetIndexes()` re-arms the sidecar load + clears the cache on every reload.

## Honest perf finding — consumption gated OFF by default

With #3370 already making builds lazy **and** PageRank precomputed at index time, reconstructing the four indexes from the sidecar measured **~1.5x slower** than rebuilding from the in-RAM Document — the Doc is already structured in memory; the sidecar adds file I/O + identity hash + varint decode that build-from-Doc avoids.

```
BenchmarkFirstUse_BuildFromDoc-12    8.47 ms/op   12.9 MB   100k allocs   (20k entities / 40k rels)
BenchmarkFirstUse_LoadSidecar-12    12.69 ms/op   18.0 MB   140k allocs
# 60k-entity scale: build 47ms vs sidecar 70ms — ratio holds
```

So I ship the **write** side (artifact exists for external tooling + a future faster reconstruction e.g. an mmap'd index FlatBuffer) but keep **consumption OFF by default**, gated by `ARCHIGRAPH_MCP_USE_INDEX_SIDECAR=1`. Default first-use latency is unchanged; no regression. The getter integration, identity validation, and build-equality round-trip are all tested regardless of the gate. Flip the default once a faster reconstruction lands.

## GOAL 2 — incremental patching (hooks landed, full impl backlogged)

- `TryIncremental` (the production incremental reindex) removes the now-stale sidecar after rewriting graph.fb, so the loader takes a clean miss instead of a pointless read+hash. Not regenerated inline to avoid importing the heavy `internal/mcp` build code into the extractor hot path.
- `clone.TryClone` gains an optional `WriteIndexSidecar` callback to regenerate a matching-hash sidecar after its final graph.fb write.
- In-memory adjacency/ByID patching for small reindexes (vs full rebuild) is **backlogged on #3368** — it needs changed-entity plumbing into the MCP reload, which today only sees a new graph.fb mtime.

## Tests (sandboxed, scoped, `-race` clean on internal/mcp)

write→load == build equality; stale / missing / corrupt / doc-shape-mismatch rejection; getters prefer a valid sidecar (`idxBuiltFromDoc==0`); `resetIndexes` re-arms; before/after first-use benchmarks. Full `go test -race ./internal/mcp/...` passes. `gofmt` clean on all changed files.

Note: `cmd/archigraph` `TestClassShadowFold_NoLine0Shadows` fails identically on pristine `origin/main` (pre-existing, unrelated to this change — an extractor/resolver fixture test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)