### PR TITLE
perf(mcp): whoami reads indexed_sha from graph metadata, not a git subprocess

### DIFF
--- a/internal/mcp/docstate_test.go
+++ b/internal/mcp/docstate_test.go
@@ -797,6 +797,74 @@ func TestHandleWhoami_explicitGroup_indexState(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Fix #3372 — whoami indexed_sha must come from the loaded graph, not git
+// ---------------------------------------------------------------------------
+
+// TestHandleWhoami_indexedSHAFromGraph asserts that indexed_sha / indexed_ref
+// in the whoami response are read from the loaded graph's Doc.IndexedSHA /
+// Doc.IndexedRef fields (O(1), no subprocess) rather than from a live
+// gitmeta.Capture call. The test stores a known SHA in the graph document and
+// checks that the same value appears verbatim in the whoami output — proving
+// the value is graph-sourced (a live git call would return a different or empty
+// SHA in the test directory which is not a real git worktree).
+func TestHandleWhoami_indexedSHAFromGraph(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "")
+
+	const wantSHA = "cafebabe1234"
+	const wantRef = "feat/perf-fix-3372"
+
+	repoDir := filepath.Join(tmp, "repo-sha-test")
+	doc := &graph.Document{
+		Repo:       "repo-sha-test",
+		IndexedSHA: wantSHA,
+		IndexedRef: wantRef,
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "SomeFunc", Kind: "function", SourceFile: "main.go", StartLine: 1, EndLine: 5},
+		},
+	}
+	writeGraph(t, repoDir, doc)
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"sha-group": {"repo-sha-test": repoDir},
+	})
+
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "sha-group"}
+	res, herr := srv.handleWhoami(context.Background(), req)
+	if herr != nil {
+		t.Fatalf("handleWhoami: %v", herr)
+	}
+	out := extractResultJSON(t, res)
+
+	// Top-level fields.
+	if got, _ := out["indexed_sha"].(string); got != wantSHA {
+		t.Errorf("indexed_sha: got %q want %q (must come from graph metadata, not git subprocess)", got, wantSHA)
+	}
+	if got, _ := out["indexed_ref"].(string); got != wantRef {
+		t.Errorf("indexed_ref: got %q want %q (must come from graph metadata, not git subprocess)", got, wantRef)
+	}
+
+	// index{} block must mirror the same values.
+	idx, _ := out["index"].(map[string]any)
+	if idx == nil {
+		t.Fatal("index block missing from whoami response")
+	}
+	if got, _ := idx["indexed_sha"].(string); got != wantSHA {
+		t.Errorf("index.indexed_sha: got %q want %q", got, wantSHA)
+	}
+	if got, _ := idx["indexed_ref"].(string); got != wantRef {
+		t.Errorf("index.indexed_ref: got %q want %q", got, wantRef)
+	}
+}
+
 // makeLoadedGroupWithFile builds a minimal LoadedGroup with one repo whose
 // entity graph has the given source file path relative to repoDir.
 func makeLoadedGroupWithFile(t *testing.T, groupName, repoName, repoDir, relFile string) *LoadedGroup {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -422,16 +422,53 @@ func groupIndexCounts(lg *LoadedGroup) (entities, relationships, testsEdges int)
 // that an explicit group= query returns the queried group's ref/sha rather than
 // the cwd's ref/sha.
 //
+// Performance (#3372): the loaded graph already stores the ref/SHA it was
+// indexed at in Doc.IndexedRef / Doc.IndexedSHA. Reading those fields is O(1)
+// with no subprocess. This is also MORE correct: indexed_sha should reflect
+// the SHA the graph was actually built from, not the current HEAD (which may
+// be ahead of what is indexed).
+//
+// gitmeta.Capture is retained ONLY as a fallback for graphs built before the
+// IndexedSHA field was added (pre-PH0, #2088) — those will have an empty SHA.
+//
 // Returns ("", "") when the group is unknown or has no loaded repos.
 func groupIndexedRefSHA(s *State, groupName string) (ref, sha string) {
 	if s == nil {
 		return "", ""
 	}
+
+	// Fast path: read ref/SHA from the resident loaded graph (O(1), no subprocess).
+	lg := s.Group(groupName)
+	if lg != nil && len(lg.Repos) > 0 {
+		slugs := make([]string, 0, len(lg.Repos))
+		for slug := range lg.Repos {
+			slugs = append(slugs, slug)
+		}
+		sort.Strings(slugs)
+		for _, slug := range slugs {
+			lr := lg.Repos[slug]
+			if lr == nil || lr.Doc == nil {
+				continue
+			}
+			if lr.Doc.IndexedSHA != "" {
+				// Graph was indexed after PH0 (#2088) — use the stored values.
+				return lr.Doc.IndexedRef, lr.Doc.IndexedSHA
+			}
+			// Graph predates the IndexedSHA field — fall through to gitmeta.
+			if lr.Path != "" {
+				meta := gitmeta.Capture(lr.Path)
+				return meta.Ref, meta.SHA
+			}
+		}
+	}
+
+	// Fallback: no loaded group yet (graph not yet read into memory). Resolve
+	// via the registry entry so the first-ever whoami call before graph load
+	// still returns something meaningful.
 	gentry, ok := s.registry.Groups[groupName]
 	if !ok {
 		return "", ""
 	}
-	// Pick the first repo alphabetically for deterministic output.
 	slugs := make([]string, 0, len(gentry.Repos))
 	for slug := range gentry.Repos {
 		slugs = append(slugs, slug)


### PR DESCRIPTION
## Summary

Closes #3372.

`groupIndexedRefSHA` previously called `gitmeta.Capture` (a `git rev-parse` subprocess) on the queried group's repo on every `archigraph_whoami` call, adding ~300 ms of latency vs the 1–6 ms baseline of cheap tools like `archigraph_stats`.

**Fix:** read `Doc.IndexedSHA` / `Doc.IndexedRef` from the resident `LoadedGroup` (O(1), no subprocess). This is also semantically correct: `indexed_sha` should reflect the commit the graph was **built from**, not the current `HEAD` (which may be ahead of the indexed commit).

`gitmeta.Capture` is retained as a fallback only when:
1. The loaded `Doc.IndexedSHA` is empty (graph predates PH0 / #2088).
2. No loaded group is available yet (first whoami call before graph reload).

## Changes

- `internal/mcp/tools.go` — `groupIndexedRefSHA`: fast path reads `lr.Doc.IndexedSHA`/`lr.Doc.IndexedRef` from the resident `LoadedRepo`; gitmeta subprocess becomes a narrow fallback for legacy/unloaded graphs.
- `internal/mcp/docstate_test.go` — `TestHandleWhoami_indexedSHAFromGraph`: stores a known SHA (`cafebabe1234`) in the graph `Document` and asserts the verbatim value appears in both the top-level and `index{}` block of the whoami response. A live `git` call in the (non-git) test directory would return a different or empty value, making the source of the value unambiguous.

## Test plan

- [x] `go build ./internal/... ./cmd/...` — clean
- [x] `go test ./internal/mcp/... ./internal/graph/... ./internal/types/...` — all pass
- [x] `gofmt -l` empty on touched files
- [x] New test `TestHandleWhoami_indexedSHAFromGraph` passes
- [x] All existing `TestHandleWhoami_*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>