### PR TITLE
deep(php): Laravel auth + validation + middleware to TS/JS bar

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -72,7 +72,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -30,7 +30,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Drupal](../detail/lang.php.framework.drupal.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Laravel](../detail/lang.php.framework.laravel.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Lumen](../detail/lang.php.framework.lumen.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Magento](../detail/lang.php.framework.magento.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -23,20 +23,20 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Regex-based auth detection: Auth facades, middleware, ACL, capabilities, nonces |
+| Auth coverage | ✅ `full` | — | — | `internal/custom/php/laravel_authval.go` | Deep Laravel auth extraction: route middleware (auth/sanctum/api guards), Gate::define/authorize/policy, $this->authorize(), Policy classes+methods, @can/@cannot/@auth/@guest Blade directives, auth() helper, Auth:: facade, Sanctum/Passport HasApiTokens traits |
 
 ### Validation
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Validator/InputFilter/FormRequest class detection as DTO shapes |
-| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | Validation rule calls detected: FormRequest, InputFilter, $this->validate(), setRules |
+| DTO extraction | ✅ `full` | — | — | `internal/custom/php/laravel_authval.go` | FormRequest subclasses extracted with per-field validation rules from rules() method body; authorize()/messages()/prepareForValidation hooks detected |
+| Request validation | ✅ `full` | — | — | `internal/custom/php/laravel_authval.go` | Inline $request->validate([field=>rules]) with per-field extraction, Validator::make(), $this->validate(); withValidator/prepareForValidation hooks |
 
 ### Middleware
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/php/frameworks.go` | Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns |
+| Middleware coverage | ✅ `full` | — | — | `internal/custom/php/laravel_authval.go` | Full Kernel.php coverage ($middleware/$middlewareGroups/$routeMiddleware/$middlewareAliases arrays with per-entry class+alias extraction); custom middleware class via handle(Closure $next) with terminate() detection; route ->middleware() attachment and ->withoutMiddleware() exclusion |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -34470,30 +34470,28 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go"],
-            "notes": "Regex-based auth detection: Auth facades, middleware, ACL, capabilities, nonces"
+            "status": "full",
+            "cites": ["internal/custom/php/laravel_authval.go"],
+            "notes": "Deep Laravel auth extraction: route middleware (auth/sanctum/api guards), Gate::define/authorize/policy, $this-\u003eauthorize(), Policy classes+methods, @can/@cannot/@auth/@guest Blade directives, auth() helper, Auth:: facade, Sanctum/Passport HasApiTokens traits"
           }
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Validator/InputFilter/FormRequest class detection as DTO shapes"
+            "status": "full",
+            "cites": ["internal/custom/php/laravel_authval.go"],
+            "notes": "FormRequest subclasses extracted with per-field validation rules from rules() method body; authorize()/messages()/prepareForValidation hooks detected"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Validation rule calls detected: FormRequest, InputFilter, $this-\u003evalidate(), setRules"
+            "status": "full",
+            "cites": ["internal/custom/php/laravel_authval.go"],
+            "notes": "Inline $request-\u003evalidate([field=\u003erules]) with per-field extraction, Validator::make(), $this-\u003evalidate(); withValidator/prepareForValidation hooks"
           }
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go"],
-            "notes": "Middleware class detection via implements/extends MiddlewareInterface/ActionFilter/Plugin patterns"
+            "status": "full",
+            "cites": ["internal/custom/php/laravel_authval.go"],
+            "notes": "Full Kernel.php coverage ($middleware/$middlewareGroups/$routeMiddleware/$middlewareAliases arrays with per-entry class+alias extraction); custom middleware class via handle(Closure $next) with terminate() detection; route -\u003emiddleware() attachment and -\u003ewithoutMiddleware() exclusion"
           }
         },
         "Type System": {

--- a/internal/custom/php/laravel_authval.go
+++ b/internal/custom/php/laravel_authval.go
@@ -1,0 +1,876 @@
+// Package php — Laravel deep extraction: Auth, Validation, Middleware.
+//
+// Namespaced lrAuth / lrVal / lrMw to avoid collisions with laravel.go /
+// frameworks.go.  Registers three extractors:
+//
+//	custom_php_laravel_auth       — auth_coverage (full)
+//	custom_php_laravel_validation — dto_extraction + request_validation (full)
+//	custom_php_laravel_middleware — middleware_coverage (full)
+package php
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Auth regexes  (lrAuth prefix)
+// ---------------------------------------------------------------------------
+
+var (
+	// ->middleware('auth') / ->middleware('auth:sanctum') / ->middleware('auth:api')
+	// Also matches Route::middleware('auth:api') (static call using ::)
+	lrAuthRouteMiddleware = regexp.MustCompile(
+		`(?m)(?:->|::)middleware\s*\(\s*['"]auth(?::([a-zA-Z0-9_]+))?['"]`,
+	)
+	// ->middleware(['auth', 'auth:sanctum', ...]) — array form
+	lrAuthRouteMiddlewareArray = regexp.MustCompile(
+		`(?m)(?:->|::)middleware\s*\(\s*\[[^\]]*['"]auth(?::([a-zA-Z0-9_]+))?['"][^\]]*\]`,
+	)
+
+	// Gate::define('ability', ...)
+	lrAuthGateDefine = regexp.MustCompile(
+		`(?m)Gate::define\s*\(\s*['"]([^'"]+)['"]`,
+	)
+	// Gate::authorize('ability', $model)
+	lrAuthGateAuthorize = regexp.MustCompile(
+		`(?m)Gate::(?:authorize|allows|denies|check|inspect|any|none)\s*\(\s*['"]([^'"]+)['"]`,
+	)
+	// Gate::policy(Model::class, Policy::class)
+	lrAuthGatePolicy = regexp.MustCompile(
+		`(?m)Gate::policy\s*\(\s*(\w+)::class\s*,\s*(\w+)::class`,
+	)
+
+	// $this->authorize('update', $post)
+	lrAuthControllerAuthorize = regexp.MustCompile(
+		`(?m)\$this->authorize\s*\(\s*['"]([^'"]+)['"]`,
+	)
+
+	// Policy class: class PostPolicy { ... }  (must have policy action methods)
+	lrAuthPolicyClass = regexp.MustCompile(
+		`(?m)class\s+(\w+Policy)\s*(?:extends\s+\w+)?\s*\{`,
+	)
+	// Policy action methods (beyond the ones in laravel.go which are SCOPE.Pattern;
+	// here we stamp them with the guard context)
+	lrAuthPolicyMethod = regexp.MustCompile(
+		`(?m)public\s+function\s+(viewAny|view|create|update|delete|restore|forceDelete|before)\s*\(`,
+	)
+
+	// @can('ability') Blade directive
+	lrAuthBladeCan = regexp.MustCompile(
+		`(?m)@can\s*\(\s*['"]([^'"]+)['"]`,
+	)
+	// @cannot('ability')
+	lrAuthBladeCannotRaw = regexp.MustCompile(
+		`(?m)@cannot\s*\(\s*['"]([^'"]+)['"]`,
+	)
+
+	// auth()->user() / auth()->check() / auth()->guard('api')
+	lrAuthHelperCall = regexp.MustCompile(
+		`(?m)\bauth\(\)\s*->(?:user|check|id|guard|login|logout|attempt|viaRemember)\s*\(`,
+	)
+	// Auth::guard('api') / Auth::user() / Auth::check()
+	lrAuthFacade = regexp.MustCompile(
+		`(?m)\bAuth::\s*(?:guard|user|check|id|login|logout|attempt|viaRemember)\s*\(`,
+	)
+
+	// @auth / @guest Blade sections
+	lrAuthBladeSection = regexp.MustCompile(
+		`(?m)@(auth|guest)\b`,
+	)
+
+	// HasApiTokens / Sanctum trait on User model
+	lrAuthSanctumTrait = regexp.MustCompile(
+		`(?m)use\s+(?:Laravel\\Sanctum\\HasApiTokens|HasApiTokens)\s*;`,
+	)
+	// Passport: use HasApiTokens (from Passport namespace)
+	lrAuthPassportTrait = regexp.MustCompile(
+		`(?m)use\s+(?:Laravel\\Passport\\HasApiTokens)\s*;`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Auth extractor
+// ---------------------------------------------------------------------------
+
+func init() {
+	extractor.Register("custom_php_laravel_auth", &lrAuthExtractor{})
+}
+
+type lrAuthExtractor struct{}
+
+func (e *lrAuthExtractor) Language() string { return "custom_php_laravel_auth" }
+
+func (e *lrAuthExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "indexer.laravel_auth_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "laravel"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if !seen[key] {
+			seen[key] = true
+			entities = append(entities, ent)
+		}
+	}
+
+	// 1. Route-level auth middleware: ->middleware('auth') / 'auth:sanctum' / 'auth:api'
+	for _, m := range lrAuthRouteMiddleware.FindAllStringSubmatchIndex(src, -1) {
+		guard := "session" // default guard when no suffix
+		if m[2] >= 0 {
+			guard = src[m[2]:m[3]]
+		}
+		name := "auth:middleware:" + guard
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_AUTH_MIDDLEWARE",
+			"mechanism", "middleware",
+			"guard", guard,
+			"protected_scope", "route")
+		add(ent)
+	}
+	// Array form of middleware
+	for _, m := range lrAuthRouteMiddlewareArray.FindAllStringSubmatchIndex(src, -1) {
+		guard := "session"
+		if m[2] >= 0 {
+			guard = src[m[2]:m[3]]
+		}
+		name := "auth:middleware:" + guard
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_AUTH_MIDDLEWARE_ARRAY",
+			"mechanism", "middleware",
+			"guard", guard,
+			"protected_scope", "route")
+		add(ent)
+	}
+
+	// 2. Gate::define
+	for _, m := range lrAuthGateDefine.FindAllStringSubmatchIndex(src, -1) {
+		ability := src[m[2]:m[3]]
+		name := "gate:define:" + ability
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_GATE_DEFINE",
+			"mechanism", "gate",
+			"ability", ability)
+		add(ent)
+	}
+
+	// 3. Gate::authorize / Gate::allows / Gate::denies etc.
+	for _, m := range lrAuthGateAuthorize.FindAllStringSubmatchIndex(src, -1) {
+		ability := src[m[2]:m[3]]
+		name := "gate:authorize:" + ability
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_GATE_AUTHORIZE",
+			"mechanism", "gate",
+			"ability", ability)
+		add(ent)
+	}
+
+	// 4. Gate::policy(Model::class, PolicyClass::class)
+	for _, m := range lrAuthGatePolicy.FindAllStringSubmatchIndex(src, -1) {
+		model := src[m[2]:m[3]]
+		policy := src[m[4]:m[5]]
+		name := "gate:policy:" + model + ":" + policy
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_GATE_POLICY",
+			"mechanism", "policy",
+			"model", model,
+			"policy_class", policy)
+		add(ent)
+	}
+
+	// 5. $this->authorize('update', $post) in controllers
+	for _, m := range lrAuthControllerAuthorize.FindAllStringSubmatchIndex(src, -1) {
+		ability := src[m[2]:m[3]]
+		name := "authorize:" + ability
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_CONTROLLER_AUTHORIZE",
+			"mechanism", "policy",
+			"ability", ability,
+			"protected_scope", "controller_action")
+		add(ent)
+	}
+
+	// 6. Policy class declaration: class PostPolicy
+	for _, m := range lrAuthPolicyClass.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		ent := makeEntity("policy_class:"+className, "SCOPE.Component", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_POLICY_CLASS",
+			"mechanism", "policy",
+			"policy_class", className)
+		add(ent)
+
+		// Extract policy action methods within the same file
+		for _, pm := range lrAuthPolicyMethod.FindAllStringSubmatchIndex(src, -1) {
+			method := src[pm[2]:pm[3]]
+			mEnt := makeEntity("policy:"+className+":"+method, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, pm[0]))
+			setProps(&mEnt, "framework", "laravel",
+				"provenance", "INFERRED_FROM_LARAVEL_POLICY_METHOD",
+				"mechanism", "policy",
+				"policy_class", className,
+				"policy_action", method)
+			add(mEnt)
+		}
+	}
+
+	// 7. @can / @cannot Blade directives
+	for _, m := range lrAuthBladeCan.FindAllStringSubmatchIndex(src, -1) {
+		ability := src[m[2]:m[3]]
+		name := "blade:can:" + ability
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_BLADE_CAN",
+			"mechanism", "blade_directive",
+			"ability", ability,
+			"protected_scope", "view")
+		add(ent)
+	}
+	for _, m := range lrAuthBladeCannotRaw.FindAllStringSubmatchIndex(src, -1) {
+		ability := src[m[2]:m[3]]
+		name := "blade:cannot:" + ability
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_BLADE_CANNOT",
+			"mechanism", "blade_directive",
+			"ability", ability,
+			"protected_scope", "view")
+		add(ent)
+	}
+
+	// 8. @auth / @guest Blade sections
+	for _, m := range lrAuthBladeSection.FindAllStringSubmatchIndex(src, -1) {
+		directive := src[m[2]:m[3]]
+		name := "blade:" + directive
+		ent := makeEntity(name, "SCOPE.Pattern", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_BLADE_SECTION",
+			"mechanism", "blade_directive",
+			"directive", directive)
+		add(ent)
+	}
+
+	// 9. auth() helper calls
+	if lrAuthHelperCall.MatchString(src) {
+		ent := makeEntity("laravel:auth_helper", "SCOPE.Pattern", "auth", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_AUTH_HELPER",
+			"mechanism", "auth_helper")
+		add(ent)
+	}
+
+	// 10. Auth:: facade
+	if lrAuthFacade.MatchString(src) {
+		ent := makeEntity("laravel:auth_facade", "SCOPE.Pattern", "auth", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_AUTH_FACADE",
+			"mechanism", "facade")
+		add(ent)
+	}
+
+	// 11. Sanctum HasApiTokens trait
+	if lrAuthSanctumTrait.MatchString(src) {
+		ent := makeEntity("laravel:sanctum_has_api_tokens", "SCOPE.Pattern", "auth", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_SANCTUM_TRAIT",
+			"mechanism", "sanctum",
+			"guard", "sanctum")
+		add(ent)
+	}
+
+	// 12. Passport HasApiTokens trait
+	if lrAuthPassportTrait.MatchString(src) {
+		ent := makeEntity("laravel:passport_has_api_tokens", "SCOPE.Pattern", "auth", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_PASSPORT_TRAIT",
+			"mechanism", "passport",
+			"guard", "api")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Validation regexes  (lrVal prefix)
+// ---------------------------------------------------------------------------
+
+var (
+	// class StorePostRequest extends FormRequest
+	lrValFormRequestClass = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s+extends\s+FormRequest\b`,
+	)
+	// rules() method body: return ['field' => 'rule1|rule2', ...]
+	// We capture individual field => rules pairs inside a rules() return block.
+	lrValRulesMethod = regexp.MustCompile(
+		`(?m)public\s+function\s+rules\s*\(\s*\)\s*(?::\s*array\s*)?\{`,
+	)
+	// Individual field => 'required|max:255' inside rules()
+	lrValRuleEntry = regexp.MustCompile(
+		`(?m)['"]([a-zA-Z0-9_.*]+)['"]\s*=>\s*['"]([^'"]+)['"]`,
+	)
+	// Array rule: 'field' => ['required', Rule::in([...]), ...]
+	lrValRuleEntryArray = regexp.MustCompile(
+		`(?m)['"]([a-zA-Z0-9_.*]+)['"]\s*=>\s*\[`,
+	)
+
+	// $request->validate(['field' => 'rules', ...])
+	lrValRequestValidate = regexp.MustCompile(
+		`(?m)\$request->validate\s*\(\s*\[`,
+	)
+	// Inline rule pairs inside $request->validate([...])
+	// (reuse lrValRuleEntry above)
+
+	// Validator::make($data, $rules)
+	lrValMake = regexp.MustCompile(
+		`(?m)Validator::make\s*\(`,
+	)
+	// $this->validate($request, [...])  — controller shorthand
+	lrValThisValidate = regexp.MustCompile(
+		`(?m)\$this->validate\s*\(\s*\$\w+\s*,\s*\[`,
+	)
+
+	// After blocks: ->after(function ($validator) { ... })
+	lrValAfterHook = regexp.MustCompile(
+		`(?m)->after\s*\(\s*function`,
+	)
+	// withValidator hook in FormRequest
+	lrValWithValidator = regexp.MustCompile(
+		`(?m)public\s+function\s+withValidator\s*\(`,
+	)
+	// prepareForValidation hook (public or protected visibility)
+	lrValPrepareForValidation = regexp.MustCompile(
+		`(?m)(?:public|protected)\s+function\s+prepareForValidation\s*\(`,
+	)
+	// authorize() method in FormRequest
+	lrValAuthorizeMethod = regexp.MustCompile(
+		`(?m)public\s+function\s+authorize\s*\(\s*\)`,
+	)
+	// messages() method in FormRequest
+	lrValMessagesMethod = regexp.MustCompile(
+		`(?m)public\s+function\s+messages\s*\(\s*\)`,
+	)
+)
+
+// lrValExtractRulesBlock extracts field => 'rule' pairs from the rules() method body.
+// It finds the opening { of rules() and scans forward collecting pairs until
+// a matching } is reached.
+func lrValExtractRulesBlock(src string, rulesMethodStart int) []struct{ field, rules string } {
+	// find the opening { after the match offset
+	bodyStart := strings.Index(src[rulesMethodStart:], "{")
+	if bodyStart < 0 {
+		return nil
+	}
+	bodyStart += rulesMethodStart + 1 // skip past {
+
+	// scan to matching }
+	depth := 1
+	i := bodyStart
+	for i < len(src) && depth > 0 {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+		}
+		i++
+	}
+	if depth != 0 {
+		return nil
+	}
+	body := src[bodyStart : i-1]
+
+	var pairs []struct{ field, rules string }
+	for _, m := range lrValRuleEntry.FindAllStringSubmatchIndex(body, -1) {
+		field := body[m[2]:m[3]]
+		rules := body[m[4]:m[5]]
+		pairs = append(pairs, struct{ field, rules string }{field, rules})
+	}
+	return pairs
+}
+
+// ---------------------------------------------------------------------------
+// Validation extractor
+// ---------------------------------------------------------------------------
+
+func init() {
+	extractor.Register("custom_php_laravel_validation", &lrValExtractor{})
+}
+
+type lrValExtractor struct{}
+
+func (e *lrValExtractor) Language() string { return "custom_php_laravel_validation" }
+
+func (e *lrValExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "indexer.laravel_validation_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "laravel"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if !seen[key] {
+			seen[key] = true
+			entities = append(entities, ent)
+		}
+	}
+
+	// 1. FormRequest subclasses (dto_extraction)
+	for _, m := range lrValFormRequestClass.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		ent := makeEntity(className, "SCOPE.Component", "form_request", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_FORM_REQUEST_CLASS",
+			"pattern_type", "form_request")
+		add(ent)
+	}
+
+	// 2. rules() method — extract per-field validation rules
+	for _, m := range lrValRulesMethod.FindAllStringSubmatchIndex(src, -1) {
+		// Find parent class name from this file (look backwards from match position)
+		classMatch := ""
+		for _, cm := range lrValFormRequestClass.FindAllStringSubmatchIndex(src, -1) {
+			if cm[0] <= m[0] {
+				classMatch = src[cm[2]:cm[3]]
+			}
+		}
+		pairs := lrValExtractRulesBlock(src, m[0])
+		for _, p := range pairs {
+			name := "validation_rule:" + p.field
+			if classMatch != "" {
+				name = "validation_rule:" + classMatch + ":" + p.field
+			}
+			ent := makeEntity(name, "SCOPE.Schema", "validation_rule", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "laravel",
+				"provenance", "INFERRED_FROM_LARAVEL_FORM_REQUEST_RULES",
+				"field", p.field,
+				"rules", p.rules)
+			if classMatch != "" {
+				setProps(&ent, "form_request", classMatch)
+			}
+			add(ent)
+		}
+	}
+
+	// 3. $request->validate([...]) — inline controller validation (request_validation)
+	for _, m := range lrValRequestValidate.FindAllStringSubmatchIndex(src, -1) {
+		// Mark the validation call site
+		ent := makeEntity("laravel:request_validate", "SCOPE.Pattern", "validator", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_REQUEST_VALIDATE",
+			"pattern_type", "inline_validation")
+		add(ent)
+
+		// Extract field => rules pairs from the array argument
+		// Find opening [ after position
+		arrayStart := strings.Index(src[m[0]:], "[")
+		if arrayStart < 0 {
+			continue
+		}
+		arrayStart += m[0] + 1
+		// scan to closing ]
+		depth := 1
+		i := arrayStart
+		for i < len(src) && depth > 0 {
+			switch src[i] {
+			case '[':
+				depth++
+			case ']':
+				depth--
+			}
+			i++
+		}
+		if depth != 0 {
+			continue
+		}
+		body := src[arrayStart : i-1]
+		for _, pm := range lrValRuleEntry.FindAllStringSubmatchIndex(body, -1) {
+			field := body[pm[2]:pm[3]]
+			rules := body[pm[4]:pm[5]]
+			name := "validation_rule:" + field
+			rEnt := makeEntity(name, "SCOPE.Schema", "validation_rule", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&rEnt, "framework", "laravel",
+				"provenance", "INFERRED_FROM_LARAVEL_REQUEST_VALIDATE_RULE",
+				"field", field,
+				"rules", rules,
+				"pattern_type", "inline_validation")
+			add(rEnt)
+		}
+	}
+
+	// 4. Validator::make($data, $rules) (request_validation)
+	if lrValMake.MatchString(src) {
+		ent := makeEntity("laravel:validator_make", "SCOPE.Pattern", "validator", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_VALIDATOR_MAKE",
+			"pattern_type", "manual_validator")
+		add(ent)
+	}
+
+	// 5. $this->validate($request, [...])
+	if lrValThisValidate.MatchString(src) {
+		ent := makeEntity("laravel:this_validate", "SCOPE.Pattern", "validator", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_THIS_VALIDATE",
+			"pattern_type", "controller_validate")
+		add(ent)
+	}
+
+	// 6. ->after() hook
+	if lrValAfterHook.MatchString(src) {
+		ent := makeEntity("laravel:validator_after_hook", "SCOPE.Pattern", "validator", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_VALIDATOR_AFTER_HOOK",
+			"pattern_type", "validator_hook")
+		add(ent)
+	}
+
+	// 7. withValidator hook
+	if lrValWithValidator.MatchString(src) {
+		ent := makeEntity("laravel:with_validator", "SCOPE.Pattern", "validator", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_WITH_VALIDATOR",
+			"pattern_type", "validator_hook")
+		add(ent)
+	}
+
+	// 8. prepareForValidation hook
+	if lrValPrepareForValidation.MatchString(src) {
+		ent := makeEntity("laravel:prepare_for_validation", "SCOPE.Pattern", "validator", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_PREPARE_FOR_VALIDATION",
+			"pattern_type", "validator_hook")
+		add(ent)
+	}
+
+	// 9. authorize() method in FormRequest (auth gate check)
+	if lrValAuthorizeMethod.MatchString(src) && lrValFormRequestClass.MatchString(src) {
+		ent := makeEntity("laravel:form_request_authorize", "SCOPE.Pattern", "auth", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_FORM_REQUEST_AUTHORIZE",
+			"mechanism", "policy",
+			"pattern_type", "form_request_auth")
+		add(ent)
+	}
+
+	// 10. messages() override in FormRequest
+	if lrValMessagesMethod.MatchString(src) && lrValFormRequestClass.MatchString(src) {
+		ent := makeEntity("laravel:form_request_messages", "SCOPE.Pattern", "validator", file.Path, file.Language, 1)
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_FORM_REQUEST_MESSAGES",
+			"pattern_type", "form_request_messages")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Middleware regexes  (lrMw prefix)
+// ---------------------------------------------------------------------------
+
+var (
+	// Kernel.php: protected $middleware = [...] / $middlewareGroups / $routeMiddleware / $middlewareAliases
+	lrMwKernelGlobal = regexp.MustCompile(
+		`(?m)protected\s+\$middleware\s*=\s*\[`,
+	)
+	lrMwKernelGroups = regexp.MustCompile(
+		`(?m)protected\s+\$middlewareGroups\s*=\s*\[`,
+	)
+	lrMwKernelRoute = regexp.MustCompile(
+		`(?m)protected\s+\$(?:routeMiddleware|middlewareAliases)\s*=\s*\[`,
+	)
+	// Class entries inside Kernel arrays: SomeMiddleware::class
+	lrMwKernelEntry = regexp.MustCompile(
+		`(?m)(\w+(?:\\\w+)*)::class`,
+	)
+	// String keys in routeMiddleware: 'auth' => \App\Http\Middleware\Auth::class
+	// Class names may be fully-qualified with leading backslash + namespace separators
+	lrMwRouteAlias = regexp.MustCompile(
+		`(?m)['"]([a-zA-Z0-9_.:-]+)['"]\s*=>\s*([^:,\s]+)::class`,
+	)
+
+	// Custom middleware class: class X { public function handle($request, Closure $next) }
+	lrMwHandleClass = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s*(?:extends\s+\w+\s*)?(?:implements\s+[\w\\,\s]+)?\{`,
+	)
+	// Matches both:
+	//   handle($request, Closure $next)              — no type-hint on $request
+	//   handle(Request $request, Closure $next)      — typed Request hint (common in Laravel)
+	lrMwHandleMethod = regexp.MustCompile(
+		`(?m)public\s+function\s+handle\s*\([^)]*Closure\s+\$\w+`,
+	)
+	// terminate() method on middleware
+	lrMwTerminateMethod = regexp.MustCompile(
+		`(?m)public\s+function\s+terminate\s*\(\s*\$\w+\s*,\s*\$\w+`,
+	)
+
+	// Route middleware attachment: ->middleware('name') / ->middleware('throttle:60,1')
+	// Includes comma to support rate-limiter syntax like throttle:60,1
+	lrMwRouteAttach = regexp.MustCompile(
+		`(?m)->middleware\s*\(\s*['"]([a-zA-Z0-9_.,:-]+)['"]`,
+	)
+	lrMwRouteAttachArray = regexp.MustCompile(
+		`(?m)->middleware\s*\(\s*\[([^\]]+)\]`,
+	)
+	lrMwRouteWithout = regexp.MustCompile(
+		`(?m)->withoutMiddleware\s*\(\s*['"]?([a-zA-Z0-9_.:\\\s]+?)['"]?\s*\)`,
+	)
+
+	// Group middleware in route groups: ->middleware([...])
+	lrMwGroupMiddleware = regexp.MustCompile(
+		`(?m)Route::(?:group|middleware)\s*\(\s*(?:\[[^\]]*['"]middleware['"]\s*=>\s*\[?|['"]([a-zA-Z0-9_.:-]+)['"])`,
+	)
+)
+
+// lrMwExtractArrayBlock returns the string content between opening [ and matching ].
+func lrMwExtractArrayBlock(src string, start int) string {
+	i := start
+	for i < len(src) && src[i] != '[' {
+		i++
+	}
+	if i >= len(src) {
+		return ""
+	}
+	i++ // skip [
+	depth := 1
+	begin := i
+	for i < len(src) && depth > 0 {
+		switch src[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		}
+		i++
+	}
+	if depth != 0 {
+		return ""
+	}
+	return src[begin : i-1]
+}
+
+// ---------------------------------------------------------------------------
+// Middleware extractor
+// ---------------------------------------------------------------------------
+
+func init() {
+	extractor.Register("custom_php_laravel_middleware", &lrMwExtractor{})
+}
+
+type lrMwExtractor struct{}
+
+func (e *lrMwExtractor) Language() string { return "custom_php_laravel_middleware" }
+
+func (e *lrMwExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "indexer.laravel_middleware_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "laravel"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if !seen[key] {
+			seen[key] = true
+			entities = append(entities, ent)
+		}
+	}
+
+	// Helper to stamp class entries from a Kernel array block
+	extractKernelEntries := func(block, stackKind string) {
+		for _, em := range lrMwKernelEntry.FindAllStringSubmatchIndex(block, -1) {
+			cls := block[em[2]:em[3]]
+			// Skip common non-middleware tokens
+			if cls == "class" || cls == "true" || cls == "false" || cls == "null" {
+				continue
+			}
+			name := "kernel_middleware:" + stackKind + ":" + cls
+			ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, 1)
+			setProps(&ent, "framework", "laravel",
+				"provenance", "INFERRED_FROM_LARAVEL_KERNEL_MIDDLEWARE",
+				"stack", stackKind,
+				"middleware_class", cls)
+			add(ent)
+		}
+	}
+
+	// 1. Kernel $middleware global stack
+	for _, m := range lrMwKernelGlobal.FindAllStringSubmatchIndex(src, -1) {
+		block := lrMwExtractArrayBlock(src, m[0])
+		extractKernelEntries(block, "global")
+		if block != "" {
+			ent := makeEntity("laravel:kernel_global_stack", "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "laravel",
+				"provenance", "INFERRED_FROM_LARAVEL_KERNEL_GLOBAL",
+				"stack", "global")
+			add(ent)
+		}
+	}
+
+	// 2. Kernel $middlewareGroups
+	for _, m := range lrMwKernelGroups.FindAllStringSubmatchIndex(src, -1) {
+		block := lrMwExtractArrayBlock(src, m[0])
+		extractKernelEntries(block, "group")
+		if block != "" {
+			ent := makeEntity("laravel:kernel_middleware_groups", "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "laravel",
+				"provenance", "INFERRED_FROM_LARAVEL_KERNEL_GROUPS",
+				"stack", "group")
+			add(ent)
+		}
+	}
+
+	// 3. Kernel $routeMiddleware / $middlewareAliases
+	for _, m := range lrMwKernelRoute.FindAllStringSubmatchIndex(src, -1) {
+		block := lrMwExtractArrayBlock(src, m[0])
+		if block != "" {
+			// Extract alias => class pairs
+			for _, am := range lrMwRouteAlias.FindAllStringSubmatchIndex(block, -1) {
+				alias := block[am[2]:am[3]]
+				cls := block[am[4]:am[5]]
+				name := "route_middleware:" + alias
+				ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+				setProps(&ent, "framework", "laravel",
+					"provenance", "INFERRED_FROM_LARAVEL_ROUTE_MIDDLEWARE_ALIAS",
+					"alias", alias,
+					"middleware_class", cls,
+					"stack", "route")
+				add(ent)
+			}
+		}
+	}
+
+	// 4. Custom middleware class (has handle(Closure $next) method)
+	if lrMwHandleMethod.MatchString(src) {
+		for _, m := range lrMwHandleClass.FindAllStringSubmatchIndex(src, -1) {
+			// Check handle method is within range of this class
+			classStart := m[0]
+			className := src[m[2]:m[3]]
+			// Find next class start to delimit scope
+			nextClass := len(src)
+			for _, nm := range lrMwHandleClass.FindAllStringSubmatchIndex(src, -1) {
+				if nm[0] > classStart {
+					nextClass = nm[0]
+					break
+				}
+			}
+			classBody := src[classStart:nextClass]
+			if lrMwHandleMethod.MatchString(classBody) {
+				ent := makeEntity("middleware_class:"+className, "SCOPE.Component", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+				setProps(&ent, "framework", "laravel",
+					"provenance", "INFERRED_FROM_LARAVEL_MIDDLEWARE_CLASS",
+					"middleware_class", className)
+				add(ent)
+
+				// Check for terminate()
+				if lrMwTerminateMethod.MatchString(classBody) {
+					tEnt := makeEntity("middleware_terminate:"+className, "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+					setProps(&tEnt, "framework", "laravel",
+						"provenance", "INFERRED_FROM_LARAVEL_MIDDLEWARE_TERMINATE",
+						"middleware_class", className)
+					add(tEnt)
+				}
+			}
+		}
+	}
+
+	// 5. Route ->middleware('name') attachments (non-auth ones)
+	for _, m := range lrMwRouteAttach.FindAllStringSubmatchIndex(src, -1) {
+		alias := src[m[2]:m[3]]
+		// Skip pure 'auth*' — those are covered by auth extractor
+		if strings.HasPrefix(alias, "auth") {
+			continue
+		}
+		name := "route_apply_middleware:" + alias
+		ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_ROUTE_ATTACH_MIDDLEWARE",
+			"alias", alias)
+		add(ent)
+	}
+
+	// 6. Route ->middleware([...]) array form
+	for _, m := range lrMwRouteAttachArray.FindAllStringSubmatchIndex(src, -1) {
+		inner := src[m[2]:m[3]]
+		// extract each quoted value
+		reInner := regexp.MustCompile(`['"]([a-zA-Z0-9_.:-]+)['"]`)
+		for _, im := range reInner.FindAllStringSubmatchIndex(inner, -1) {
+			alias := inner[im[2]:im[3]]
+			if strings.HasPrefix(alias, "auth") {
+				continue
+			}
+			name := "route_apply_middleware:" + alias
+			ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "laravel",
+				"provenance", "INFERRED_FROM_LARAVEL_ROUTE_ATTACH_MIDDLEWARE_ARRAY",
+				"alias", alias)
+			add(ent)
+		}
+	}
+
+	// 7. ->withoutMiddleware(...)
+	for _, m := range lrMwRouteWithout.FindAllStringSubmatchIndex(src, -1) {
+		alias := strings.TrimSpace(src[m[2]:m[3]])
+		name := "route_exclude_middleware:" + alias
+		ent := makeEntity(name, "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "laravel",
+			"provenance", "INFERRED_FROM_LARAVEL_WITHOUT_MIDDLEWARE",
+			"alias", alias)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/php/laravel_authval_test.go
+++ b/internal/custom/php/laravel_authval_test.go
@@ -1,0 +1,619 @@
+package php_test
+
+// laravel_authval_test.go — value-asserting tests for the three deep Laravel
+// extractors: custom_php_laravel_auth, custom_php_laravel_validation,
+// custom_php_laravel_middleware.
+
+import "testing"
+
+// ============================================================================
+// Auth — route-level middleware
+// ============================================================================
+
+func TestLaravelAuthMiddlewareSession(t *testing.T) {
+	src := `<?php
+Route::get('/dashboard', [DashboardController::class, 'index'])->middleware('auth');
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("web.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "auth:middleware:session") {
+		t.Error("expected auth:middleware:session from ->middleware('auth')")
+	}
+}
+
+func TestLaravelAuthMiddlewareSanctum(t *testing.T) {
+	src := `<?php
+Route::get('/api/user', [UserController::class, 'me'])->middleware('auth:sanctum');
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("api.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "auth:middleware:sanctum") {
+		t.Error("expected auth:middleware:sanctum guard")
+	}
+}
+
+func TestLaravelAuthMiddlewareAPI(t *testing.T) {
+	src := `<?php
+Route::middleware('auth:api')->group(function () {
+    Route::get('/profile', [ProfileController::class, 'show']);
+});
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("api.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "auth:middleware:api") {
+		t.Error("expected auth:middleware:api guard")
+	}
+}
+
+func TestLaravelAuthMiddlewareArray(t *testing.T) {
+	src := `<?php
+Route::get('/orders', [OrderController::class, 'index'])->middleware(['auth:sanctum', 'verified']);
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("api.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "auth:middleware:sanctum") {
+		t.Error("expected auth:middleware:sanctum from array form")
+	}
+}
+
+// ============================================================================
+// Auth — Gate
+// ============================================================================
+
+func TestLaravelGateDefine(t *testing.T) {
+	src := `<?php
+Gate::define('update-post', function (User $user, Post $post) {
+    return $user->id === $post->user_id;
+});
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("AuthServiceProvider.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "gate:define:update-post") {
+		t.Error("expected gate:define:update-post entity")
+	}
+}
+
+func TestLaravelGateAuthorize(t *testing.T) {
+	src := `<?php
+Gate::authorize('admin-access');
+Gate::allows('view-analytics', $user);
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("AdminController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "gate:authorize:admin-access") {
+		t.Error("expected gate:authorize:admin-access entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "gate:authorize:view-analytics") {
+		t.Error("expected gate:authorize:view-analytics entity")
+	}
+}
+
+func TestLaravelGatePolicy(t *testing.T) {
+	src := `<?php
+Gate::policy(Post::class, PostPolicy::class);
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("AuthServiceProvider.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "gate:policy:Post:PostPolicy") {
+		t.Error("expected gate:policy:Post:PostPolicy entity")
+	}
+}
+
+// ============================================================================
+// Auth — controller authorize
+// ============================================================================
+
+func TestLaravelControllerAuthorize(t *testing.T) {
+	src := `<?php
+class PostController extends Controller
+{
+    public function update(Request $request, Post $post)
+    {
+        $this->authorize('update', $post);
+        $post->update($request->all());
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("PostController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "authorize:update") {
+		t.Error("expected authorize:update entity from $this->authorize('update',...)")
+	}
+}
+
+// ============================================================================
+// Auth — Policy class
+// ============================================================================
+
+func TestLaravelPolicyClass(t *testing.T) {
+	src := `<?php
+class PostPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+    public function update(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+    public function delete(User $user, Post $post): bool
+    {
+        return $user->isAdmin();
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("PostPolicy.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "policy_class:PostPolicy") {
+		t.Error("expected policy_class:PostPolicy component")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "policy:PostPolicy:viewAny") {
+		t.Error("expected policy:PostPolicy:viewAny")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "policy:PostPolicy:update") {
+		t.Error("expected policy:PostPolicy:update")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "policy:PostPolicy:delete") {
+		t.Error("expected policy:PostPolicy:delete")
+	}
+}
+
+// ============================================================================
+// Auth — Blade @can / @cannot / @auth / @guest
+// ============================================================================
+
+func TestLaravelBladeCan(t *testing.T) {
+	src := `@can('update', $post)
+    <a href="{{ route('posts.edit', $post) }}">Edit</a>
+@endcan
+@cannot('delete', $post)
+    <span>No delete</span>
+@endcannot`
+	ents := extract(t, "custom_php_laravel_auth", fi("show.blade.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "blade:can:update") {
+		t.Error("expected blade:can:update entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "blade:cannot:delete") {
+		t.Error("expected blade:cannot:delete entity")
+	}
+}
+
+func TestLaravelBladeAuthSection(t *testing.T) {
+	src := `@auth
+    <nav>Logged in nav</nav>
+@endauth
+@guest
+    <a href="/login">Login</a>
+@endguest`
+	ents := extract(t, "custom_php_laravel_auth", fi("layout.blade.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "blade:auth") {
+		t.Error("expected blade:auth entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "blade:guest") {
+		t.Error("expected blade:guest entity")
+	}
+}
+
+// ============================================================================
+// Auth — auth() helper / Auth:: facade / Sanctum trait
+// ============================================================================
+
+func TestLaravelAuthHelper(t *testing.T) {
+	src := `<?php
+$user = auth()->user();
+if (!auth()->check()) {
+    return redirect('/login');
+}
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("SomeController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:auth_helper") {
+		t.Error("expected laravel:auth_helper entity")
+	}
+}
+
+func TestLaravelAuthFacade(t *testing.T) {
+	src := `<?php
+$user = Auth::user();
+if (Auth::check()) {
+    Auth::logout();
+}
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("AuthController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:auth_facade") {
+		t.Error("expected laravel:auth_facade entity")
+	}
+}
+
+func TestLaravelSanctumTrait(t *testing.T) {
+	src := `<?php
+use Laravel\Sanctum\HasApiTokens;
+
+class User extends Authenticatable
+{
+    use HasApiTokens, HasFactory, Notifiable;
+}
+`
+	ents := extract(t, "custom_php_laravel_auth", fi("User.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:sanctum_has_api_tokens") {
+		t.Error("expected laravel:sanctum_has_api_tokens entity")
+	}
+}
+
+func TestLaravelAuthNoMatch(t *testing.T) {
+	src := `<?php $x = 42; echo "hello";`
+	ents := extract(t, "custom_php_laravel_auth", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no auth entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// Validation — FormRequest
+// ============================================================================
+
+func TestLaravelFormRequestClass(t *testing.T) {
+	src := `<?php
+class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+    public function rules(): array
+    {
+        return [
+            'title'   => 'required|max:255',
+            'content' => 'required|min:10',
+            'status'  => 'in:draft,published',
+        ];
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_validation", fi("StorePostRequest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "StorePostRequest") {
+		t.Error("expected StorePostRequest form_request component")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "validation_rule:StorePostRequest:title") {
+		t.Error("expected validation_rule:StorePostRequest:title with rules 'required|max:255'")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "validation_rule:StorePostRequest:content") {
+		t.Error("expected validation_rule:StorePostRequest:content")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "validation_rule:StorePostRequest:status") {
+		t.Error("expected validation_rule:StorePostRequest:status")
+	}
+	// authorize() in FormRequest → form_request_authorize
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:form_request_authorize") {
+		t.Error("expected laravel:form_request_authorize entity")
+	}
+}
+
+func TestLaravelFormRequestMessages(t *testing.T) {
+	src := `<?php
+class UpdateUserRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email',
+            'name'  => 'required|max:100',
+        ];
+    }
+    public function messages(): array
+    {
+        return [
+            'email.required' => 'Email is required.',
+        ];
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_validation", fi("UpdateUserRequest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Schema", "validation_rule:UpdateUserRequest:email") {
+		t.Error("expected validation_rule:UpdateUserRequest:email")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:form_request_messages") {
+		t.Error("expected laravel:form_request_messages entity")
+	}
+}
+
+// ============================================================================
+// Validation — $request->validate
+// ============================================================================
+
+func TestLaravelRequestValidateInline(t *testing.T) {
+	src := `<?php
+class PostController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title'   => 'required|string|max:255',
+            'body'    => 'required',
+            'user_id' => 'required|integer|exists:users,id',
+        ]);
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_validation", fi("PostController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:request_validate") {
+		t.Error("expected laravel:request_validate pattern")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "validation_rule:title") {
+		t.Error("expected validation_rule:title")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "validation_rule:body") {
+		t.Error("expected validation_rule:body")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "validation_rule:user_id") {
+		t.Error("expected validation_rule:user_id")
+	}
+}
+
+// ============================================================================
+// Validation — Validator::make
+// ============================================================================
+
+func TestLaravelValidatorMake(t *testing.T) {
+	src := `<?php
+$validator = Validator::make($request->all(), [
+    'title' => 'required|unique:posts|max:255',
+    'body'  => 'required',
+]);
+if ($validator->fails()) {
+    return redirect()->back()->withErrors($validator);
+}
+`
+	ents := extract(t, "custom_php_laravel_validation", fi("PostController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:validator_make") {
+		t.Error("expected laravel:validator_make entity")
+	}
+}
+
+// ============================================================================
+// Validation — withValidator / prepareForValidation
+// ============================================================================
+
+func TestLaravelWithValidator(t *testing.T) {
+	src := `<?php
+class StoreOrderRequest extends FormRequest
+{
+    public function rules(): array { return ['total' => 'required|numeric']; }
+    public function withValidator($validator)
+    {
+        $validator->after(function ($v) {
+            if ($this->somethingElseIsInvalid()) {
+                $v->errors()->add('field', 'Something is wrong.');
+            }
+        });
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_validation", fi("StoreOrderRequest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:with_validator") {
+		t.Error("expected laravel:with_validator entity")
+	}
+}
+
+func TestLaravelPrepareForValidation(t *testing.T) {
+	src := `<?php
+class StoreUserRequest extends FormRequest
+{
+    public function rules(): array { return ['name' => 'required']; }
+    protected function prepareForValidation()
+    {
+        $this->merge(['slug' => Str::slug($this->slug)]);
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_validation", fi("StoreUserRequest.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:prepare_for_validation") {
+		t.Error("expected laravel:prepare_for_validation entity")
+	}
+}
+
+func TestLaravelValidationNoMatch(t *testing.T) {
+	src := `<?php $x = 1; echo "no validation here";`
+	ents := extract(t, "custom_php_laravel_validation", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no validation entities, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// Middleware — Kernel $middleware, $middlewareGroups, $routeMiddleware
+// ============================================================================
+
+func TestLaravelKernelGlobalMiddleware(t *testing.T) {
+	src := `<?php
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middleware = [
+        \App\Http\Middleware\TrustProxies::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
+        \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+    ];
+}
+`
+	ents := extract(t, "custom_php_laravel_middleware", fi("Kernel.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:kernel_global_stack") {
+		t.Error("expected laravel:kernel_global_stack entity")
+	}
+	// At least one class stamped
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "middleware" &&
+			len(e.Name) > len("kernel_middleware:global:") &&
+			e.Name[:len("kernel_middleware:global:")] == "kernel_middleware:global:" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected at least one kernel_middleware:global:X entry")
+	}
+}
+
+func TestLaravelKernelMiddlewareGroups(t *testing.T) {
+	src := `<?php
+class Kernel extends HttpKernel
+{
+    protected $middlewareGroups = [
+        'web' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+        ],
+        'api' => [
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Illuminate\Routing\Middleware\ThrottleRequests::class . ':api',
+        ],
+    ];
+}
+`
+	ents := extract(t, "custom_php_laravel_middleware", fi("Kernel.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "laravel:kernel_middleware_groups") {
+		t.Error("expected laravel:kernel_middleware_groups entity")
+	}
+}
+
+func TestLaravelRouteMiddlewareAlias(t *testing.T) {
+	src := `<?php
+class Kernel extends HttpKernel
+{
+    protected $routeMiddleware = [
+        'auth'             => \App\Http\Middleware\Authenticate::class,
+        'auth.basic'       => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'cache.headers'    => \Illuminate\Http\Middleware\SetCacheHeaders::class,
+        'can'              => \Illuminate\Auth\Middleware\Authorize::class,
+        'guest'            => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'throttle'         => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'verified'         => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+    ];
+}
+`
+	ents := extract(t, "custom_php_laravel_middleware", fi("Kernel.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "route_middleware:auth") {
+		t.Error("expected route_middleware:auth alias entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "route_middleware:throttle") {
+		t.Error("expected route_middleware:throttle alias entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "route_middleware:verified") {
+		t.Error("expected route_middleware:verified alias entity")
+	}
+}
+
+func TestLaravelMiddlewareAliases(t *testing.T) {
+	// Laravel 10+ uses $middlewareAliases instead of $routeMiddleware
+	src := `<?php
+class Kernel extends HttpKernel
+{
+    protected $middlewareAliases = [
+        'auth'      => \App\Http\Middleware\Authenticate::class,
+        'signed'    => \Illuminate\Routing\Middleware\ValidateSignature::class,
+    ];
+}
+`
+	ents := extract(t, "custom_php_laravel_middleware", fi("Kernel.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "route_middleware:auth") {
+		t.Error("expected route_middleware:auth from $middlewareAliases")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "route_middleware:signed") {
+		t.Error("expected route_middleware:signed from $middlewareAliases")
+	}
+}
+
+// ============================================================================
+// Middleware — Custom middleware class with handle(Closure $next)
+// ============================================================================
+
+func TestLaravelCustomMiddlewareClass(t *testing.T) {
+	src := `<?php
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureTokenIsValid
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->input('token') !== 'my-secret-token') {
+            return redirect('home');
+        }
+        return $next($request);
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_middleware", fi("EnsureTokenIsValid.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "middleware_class:EnsureTokenIsValid") {
+		t.Error("expected middleware_class:EnsureTokenIsValid component")
+	}
+}
+
+func TestLaravelCustomMiddlewareWithTerminate(t *testing.T) {
+	src := `<?php
+class LogAfterResponse
+{
+    public function handle($request, Closure $next)
+    {
+        return $next($request);
+    }
+
+    public function terminate($request, $response)
+    {
+        // log after response is sent
+    }
+}
+`
+	ents := extract(t, "custom_php_laravel_middleware", fi("LogAfterResponse.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Component", "middleware_class:LogAfterResponse") {
+		t.Error("expected middleware_class:LogAfterResponse")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "middleware_terminate:LogAfterResponse") {
+		t.Error("expected middleware_terminate:LogAfterResponse for terminate() method")
+	}
+}
+
+// ============================================================================
+// Middleware — Route attachment / withoutMiddleware
+// ============================================================================
+
+func TestLaravelRouteAttachMiddleware(t *testing.T) {
+	src := `<?php
+Route::get('/admin', [AdminController::class, 'index'])->middleware('throttle:60,1');
+Route::post('/upload', [UploadController::class, 'store'])->middleware('verified');
+`
+	ents := extract(t, "custom_php_laravel_middleware", fi("web.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "route_apply_middleware:throttle:60,1") {
+		t.Error("expected route_apply_middleware:throttle:60,1")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "route_apply_middleware:verified") {
+		t.Error("expected route_apply_middleware:verified")
+	}
+}
+
+func TestLaravelRouteWithoutMiddleware(t *testing.T) {
+	src := `<?php
+Route::post('/webhook', [WebhookController::class, 'handle'])
+    ->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+`
+	ents := extract(t, "custom_php_laravel_middleware", fi("web.php", "php", src))
+	// withoutMiddleware entity should exist
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && len(e.Name) > len("route_exclude_middleware:") &&
+			e.Name[:len("route_exclude_middleware:")] == "route_exclude_middleware:" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected route_exclude_middleware:X entity from withoutMiddleware()")
+	}
+}
+
+func TestLaravelMiddlewareNoMatch(t *testing.T) {
+	src := `<?php $x = 1; echo "no middleware here";`
+	ents := extract(t, "custom_php_laravel_middleware", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no middleware entities, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3395

Deep extraction for three Laravel capability areas in a new collision-safe file `internal/custom/php/laravel_authval.go` (namespaced `lrAuth`/`lrVal`/`lrMw`). Three extractors registered, 38 value-asserting tests added.

### Auth (`auth_coverage` → **full**)
- Route-level `->middleware('auth')` / `'auth:sanctum'` / `'auth:api'` + `Route::middleware()` static form — guard extracted
- `Gate::define` / `Gate::authorize` / `Gate::allows` / `Gate::denies` / `Gate::policy`
- `$this->authorize('ability', $model)` in controllers
- Policy class declarations (`class PostPolicy`) + action methods (`viewAny`/`view`/`create`/`update`/`delete`/`restore`/`forceDelete`/`before`)
- `@can` / `@cannot` Blade directives with per-ability name extraction
- `@auth` / `@guest` Blade section directives
- `auth()->user()/check()/id()` helper + `Auth::` facade
- `Laravel\Sanctum\HasApiTokens` + `Laravel\Passport\HasApiTokens` trait detection

### Validation (`dto_extraction` + `request_validation` → **full**)
- `class StoreXRequest extends FormRequest` class detection
- Per-field `rules()` body extraction: exact `field` + `rules_string` pairs (e.g. `validation_rule:StorePostRequest:title`)
- Inline `$request->validate([field => rules])` with per-field extraction
- `Validator::make()` call detection
- `$this->validate($request, [...])` controller shorthand
- `withValidator` / `prepareForValidation` (public or protected) / `->after()` hooks
- `authorize()` + `messages()` presence in FormRequest

### Middleware (`middleware_coverage` → **full**)
- `Kernel.php` `$middleware` global stack with per-class stamps
- `$middlewareGroups` with per-class stamps
- `$routeMiddleware` / `$middlewareAliases` — alias→class pairs extracted (`route_middleware:auth`, `route_middleware:throttle`, etc.)
- Custom middleware class detection via `handle([Type ]$req, Closure $next)` signature
- `terminate()` detection on terminable middleware
- Route `->middleware('alias')` and `->middleware([...])` array form (comma-tolerant for `throttle:60,1`)
- `->withoutMiddleware()` exclusion

## Test plan
- [x] `go build ./internal/... ./tools/coverage/...` — clean
- [x] `go test ./internal/custom/php/... ./internal/types/ ./tools/coverage/...` — 38 new tests + all existing pass
- [x] `go run ./tools/coverage validate` — exit 0
- [x] `go run ./tools/coverage fmt --check` — canonical
- [x] `gofmt -l` — empty (no unformatted files)
- [x] Registry caps flipped: `auth_coverage`, `dto_extraction`, `request_validation`, `middleware_coverage` → `full` for `lang.php.framework.laravel`
- [x] No collision with existing `laravel.go` / `frameworks.go` — separate file, `lrAuth`/`lrVal`/`lrMw` namespaced vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>