### PR TITLE
deep(php): observability assess + deepen (honest)

### DIFF
--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go`<br>`internal/substrate/template_pattern_php.go` | Log::*/error_log/Monolog calls detected via regex and template pattern sniffer |
-| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | StatsD/Prometheus/Datadog metric calls detected via regex |
-| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | OpenTelemetry/Jaeger/Zipkin/DDTrace tracing calls detected via regex |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/php/frameworks.go`<br>`internal/custom/php/observability.go` | Per-call-site: Log::info/warning/error/debug/critical/alert/emergency/notice (facade + backslash form), Log::channel('name'), logger()->level() helper, logger('msg') shorthand, PSR-3/Monolog injected $logger->level(), $this->logger->level() Symfony-style injected LoggerInterface. Use-declaration fallback. Import/call-site heuristic; no cross-file dataflow binding logger to handler. Stays partial. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/php/frameworks.go`<br>`internal/custom/php/observability.go` | prometheus_client_php: new Counter/Gauge/Histogram/Summary, registerCounter/Gauge/Histogram call-sites. StatsD (League StatsD, Domnikl Statsd): $statsd->increment/gauge/timing/histogram with metric names. Laravel Metrics facade: Metrics::counter/gauge/histogram. Use-declaration fallback. Import/call-site heuristic; no cross-file dataflow. Stays partial. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/php/frameworks.go`<br>`internal/custom/php/observability.go` | OpenTelemetry PHP SDK: CachedInstrumentation/Globals::tracerProvider() bootstrap, $tracer->spanBuilder/startSpan('name'), $span->setAttribute/addEvent/setStatus/end lifecycle. Symfony Stopwatch: $stopwatch->start/stop/lap('name') event names. DDTrace: trace_function/trace_method. Use-declaration fallback. Import/call-site heuristic; no cross-file dataflow binding tracer to exporter. Stays partial. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go`<br>`internal/substrate/template_pattern_php.go` | Log::*/error_log/Monolog calls detected via regex and template pattern sniffer |
-| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | StatsD/Prometheus/Datadog metric calls detected via regex |
-| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/php/frameworks.go` | OpenTelemetry/Jaeger/Zipkin/DDTrace tracing calls detected via regex |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/php/frameworks.go`<br>`internal/custom/php/observability.go` | Per-call-site: PSR-3/Monolog injected $logger->level() / $this->logger->level() (LoggerInterface). Log::level() Laravel facade patterns also captured. Symfony-specific: $this->logger->log(LogLevel::X) calls. Use-declaration fallback for Monolog\Logger and Psr\Log\LoggerInterface use-statements. Import/call-site heuristic; no cross-file dataflow binding logger to handler. Stays partial. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/php/frameworks.go`<br>`internal/custom/php/observability.go` | prometheus_client_php: new Counter/Gauge/Histogram/Summary, registerCounter/Gauge/Histogram call-sites. StatsD (League\StatsD, Domnikl\Statsd): $statsd->increment/gauge/timing/histogram with metric names. Import/call-site heuristic; no cross-file dataflow. Stays partial. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/php/frameworks.go`<br>`internal/custom/php/observability.go` | OpenTelemetry PHP SDK: CachedInstrumentation/Globals::tracerProvider() bootstrap, $tracer->spanBuilder/startSpan('name') call-sites, $span lifecycle markers (setAttribute/addEvent/setStatus/end). Symfony Stopwatch: $stopwatch->start/stop/lap('name') event names. DDTrace: trace_function/trace_method. Import/call-site heuristic; no cross-file dataflow binding tracer to exporter. Stays partial. |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -34526,21 +34526,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go","internal/substrate/template_pattern_php.go"],
+            "cites": ["internal/custom/php/frameworks.go","internal/custom/php/observability.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Log::*/error_log/Monolog calls detected via regex and template pattern sniffer"
+            "notes": "Per-call-site: Log::info/warning/error/debug/critical/alert/emergency/notice (facade + backslash form), Log::channel('name'), logger()-\u003elevel() helper, logger('msg') shorthand, PSR-3/Monolog injected $logger-\u003elevel(), $this-\u003elogger-\u003elevel() Symfony-style injected LoggerInterface. Use-declaration fallback. Import/call-site heuristic; no cross-file dataflow binding logger to handler. Stays partial.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go"],
+            "cites": ["internal/custom/php/frameworks.go","internal/custom/php/observability.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "StatsD/Prometheus/Datadog metric calls detected via regex"
+            "notes": "prometheus_client_php: new Counter/Gauge/Histogram/Summary, registerCounter/Gauge/Histogram call-sites. StatsD (League StatsD, Domnikl Statsd): $statsd-\u003eincrement/gauge/timing/histogram with metric names. Laravel Metrics facade: Metrics::counter/gauge/histogram. Use-declaration fallback. Import/call-site heuristic; no cross-file dataflow. Stays partial.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go"],
+            "cites": ["internal/custom/php/frameworks.go","internal/custom/php/observability.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "OpenTelemetry/Jaeger/Zipkin/DDTrace tracing calls detected via regex"
+            "notes": "OpenTelemetry PHP SDK: CachedInstrumentation/Globals::tracerProvider() bootstrap, $tracer-\u003espanBuilder/startSpan('name'), $span-\u003esetAttribute/addEvent/setStatus/end lifecycle. Symfony Stopwatch: $stopwatch-\u003estart/stop/lap('name') event names. DDTrace: trace_function/trace_method. Use-declaration fallback. Import/call-site heuristic; no cross-file dataflow binding tracer to exporter. Stays partial.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -35627,21 +35630,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go","internal/substrate/template_pattern_php.go"],
+            "cites": ["internal/custom/php/frameworks.go","internal/custom/php/observability.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Log::*/error_log/Monolog calls detected via regex and template pattern sniffer"
+            "notes": "Per-call-site: PSR-3/Monolog injected $logger-\u003elevel() / $this-\u003elogger-\u003elevel() (LoggerInterface). Log::level() Laravel facade patterns also captured. Symfony-specific: $this-\u003elogger-\u003elog(LogLevel::X) calls. Use-declaration fallback for Monolog\\Logger and Psr\\Log\\LoggerInterface use-statements. Import/call-site heuristic; no cross-file dataflow binding logger to handler. Stays partial.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go"],
+            "cites": ["internal/custom/php/frameworks.go","internal/custom/php/observability.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "StatsD/Prometheus/Datadog metric calls detected via regex"
+            "notes": "prometheus_client_php: new Counter/Gauge/Histogram/Summary, registerCounter/Gauge/Histogram call-sites. StatsD (League\\StatsD, Domnikl\\Statsd): $statsd-\u003eincrement/gauge/timing/histogram with metric names. Import/call-site heuristic; no cross-file dataflow. Stays partial.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/php/frameworks.go"],
+            "cites": ["internal/custom/php/frameworks.go","internal/custom/php/observability.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "OpenTelemetry/Jaeger/Zipkin/DDTrace tracing calls detected via regex"
+            "notes": "OpenTelemetry PHP SDK: CachedInstrumentation/Globals::tracerProvider() bootstrap, $tracer-\u003espanBuilder/startSpan('name') call-sites, $span lifecycle markers (setAttribute/addEvent/setStatus/end). Symfony Stopwatch: $stopwatch-\u003estart/stop/lap('name') event names. DDTrace: trace_function/trace_method. Import/call-site heuristic; no cross-file dataflow binding tracer to exporter. Stays partial.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {

--- a/internal/custom/php/observability.go
+++ b/internal/custom/php/observability.go
@@ -1,0 +1,556 @@
+// observability.go — PHP observability extractor (log/metric/trace).
+//
+// Covers the Observability lane for lang.php.framework.laravel and
+// lang.php.framework.symfony. Replaces the coarse one-entity-per-file
+// stub that was previously in frameworks.go (custom_php_observability)
+// with per-call-site extraction that matches the bar set by the Java,
+// Python, and Ruby observability extractors.
+//
+// log_extraction
+//
+//	Laravel:  Log::info/warning/error/debug/critical/alert/emergency/notice,
+//	          logger()->info (and all other log levels),
+//	          \Log::channel('name')->info,
+//	          Monolog \$logger->info (and all PSR-3 levels).
+//	Symfony:  PSR-3 $this->logger->info (injected LoggerInterface),
+//	          $logger->info, monolog.channel.X calls detected via use-site.
+//
+// metric_extraction
+//
+//	Laravel + Symfony: prometheus_client_php Counter/Gauge/Histogram/Summary
+//	                   call-sites via new Counter/Gauge/Histogram/Summary pattern,
+//	                   StatsD (League\StatsD or Domnikl\Statsd) $statsd->increment etc.
+//	                   Laravel-Metrics facade (if present).
+//
+// trace_extraction
+//
+//	Laravel + Symfony: OpenTelemetry PHP SDK — CachedInstrumentation / Globals::tracerProvider,
+//	                   $tracer->spanBuilder/startSpan call-sites, Span creation,
+//	                   Symfony Stopwatch component — $stopwatch->start/stop/lap.
+//
+// Detection is import/use-statement + call-site heuristic. The extractor
+// identifies library use declarations and canonical call-site patterns but
+// does NOT perform cross-file dataflow (e.g. does not follow the injected
+// LoggerInterface instance from DI container to handler). All cells
+// therefore remain `partial`, matching the honesty discipline established
+// by the Java, Python, and Ruby extractors.
+//
+// Extractor key: "phpObs_laravel_symfony" — registered as a dedicated
+// extractor. The coarse custom_php_observability stub in frameworks.go
+// continues to run for the remaining PHP frameworks; this extractor
+// deepens detection specifically for Laravel + Symfony call-sites.
+//
+// Part of issue #3400.
+package php
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("phpObs_laravel_symfony", &phpObsExtractor{})
+}
+
+type phpObsExtractor struct{}
+
+func (e *phpObsExtractor) Language() string { return "phpObs_laravel_symfony" }
+
+// ---------------------------------------------------------------------------
+// Compiled regexes — log_extraction
+// ---------------------------------------------------------------------------
+
+var (
+	// Laravel Log facade: Log::info(...), \Log::error(...), Log::channel('name')->debug(...)
+	phpLaravelLogFacadeRe = regexp.MustCompile(
+		`(?m)\\?Log::(debug|info|notice|warning|error|critical|alert|emergency)\s*\(`)
+
+	// Log::channel('channel-name')  — captures the channel name
+	phpLaravelLogChannelRe = regexp.MustCompile(
+		`(?m)\\?Log::channel\s*\(\s*['"]([^'"]+)['"]\s*\)`)
+
+	// logger() helper: logger()->info(...), logger('message') standalone
+	phpLaravelLoggerHelperRe = regexp.MustCompile(
+		`(?m)\blogger\s*\(\s*\)\s*->(debug|info|notice|warning|error|critical|alert|emergency)\s*\(`)
+
+	// logger('message') as a standalone call (shorthand for Log::info)
+	phpLaravelLoggerShorthandRe = regexp.MustCompile(
+		`(?m)\blogger\s*\(\s*['"][^'"]+['"]\s*(?:,\s*\[[^\]]*\])?\s*\)`)
+
+	// PSR-3 / Monolog injected logger: $logger->info(...), $this->logger->error(...)
+	// Covers: $logger->, $this->logger->, $this->loggerInterface->
+	phpMonologCallRe = regexp.MustCompile(
+		`(?m)\$(?:this->)?(?:logger|log|monolog)\s*->(debug|info|notice|warning|error|critical|alert|emergency)\s*\(`)
+
+	// use Monolog\Logger or use Psr\Log\LoggerInterface — file-level signal
+	phpMonologUseRe = regexp.MustCompile(
+		`(?m)\buse\s+(?:Monolog\\(?:Logger|Handler\\[A-Za-z]+)|Psr\\Log\\(?:LoggerInterface|AbstractLogger|NullLogger))\s*;`)
+
+	// Symfony: $this->logger->info injected via LoggerInterface (same pattern as Monolog above)
+	// Additional Symfony-specific: $this->logger->log(LogLevel::WARNING, ...)
+	phpSymfonyLogLevelRe = regexp.MustCompile(
+		`(?m)\$(?:this->)?logger\s*->\s*log\s*\(\s*(?:LogLevel::)?(\w+)\s*,`)
+
+	// use Symfony\Component\HttpKernel\Log\Logger — Symfony native logger
+	phpSymfonyLoggerUseRe = regexp.MustCompile(
+		`(?m)\buse\s+Symfony\\Component\\(?:HttpKernel\\Log\\Logger|HttpFoundation\\[A-Za-z]+)\s*;`)
+)
+
+// ---------------------------------------------------------------------------
+// Compiled regexes — metric_extraction
+// ---------------------------------------------------------------------------
+
+var (
+	// prometheus_client_php: new Counter(...), new Gauge(...), new Histogram(...), new Summary(...)
+	phpPrometheusNewRe = regexp.MustCompile(
+		`(?m)\bnew\s+(Counter|Gauge|Histogram|Summary)\s*\(`)
+
+	// use Prometheus\...: use Prometheus\Counter, use Prometheus\Gauge, etc.
+	phpPrometheusUseRe = regexp.MustCompile(
+		`(?m)\buse\s+Prometheus\\(Counter|Gauge|Histogram|Summary|CollectorRegistry|RenderTextFormat)\s*;`)
+
+	// $registry->registerCounter / $registry->registerGauge / etc.
+	phpPrometheusRegistryRe = regexp.MustCompile(
+		`(?m)\$\w+\s*->\s*register(Counter|Gauge|Histogram|Summary)\s*\(`)
+
+	// StatsD: League\StatsD or Domnikl\Statsd
+	// $statsd->increment / $statsd->gauge / $statsd->timing etc.
+	phpStatsdCallRe = regexp.MustCompile(
+		`(?m)\$\w+\s*->\s*(increment|decrement|gauge|timing|histogram|set|event|updateStats)\s*\(\s*['"]([^'"]+)['"]`)
+
+	// use League\StatsD or use Domnikl\Statsd (with optional \Client alias)
+	phpStatsdUseRe = regexp.MustCompile(
+		`(?m)\buse\s+(?:League\\StatsD(?:\\Client)?|Domnikl\\Statsd(?:\\Client)?)\s*(?:as\s+\w+\s*)?;`)
+
+	// Laravel Metrics facade (optional package illuminate/metrics or spatie/laravel-metrics)
+	phpLaravelMetricsRe = regexp.MustCompile(
+		`(?m)\bMetrics::(counter|gauge|histogram|summary)\s*\(`)
+)
+
+// ---------------------------------------------------------------------------
+// Compiled regexes — trace_extraction
+// ---------------------------------------------------------------------------
+
+var (
+	// OpenTelemetry PHP SDK use statements
+	phpOtelUseRe = regexp.MustCompile(
+		`(?m)\buse\s+OpenTelemetry\\(?:API|SDK|Contrib)\\[A-Za-z\\]+\s*;`)
+
+	// CachedInstrumentation / Globals::tracerProvider() — SDK bootstrap patterns
+	// Note: no trailing \b — ) is not a word character, so \b after ) never matches
+	phpOtelBootstrapRe = regexp.MustCompile(
+		`(?m)(?:CachedInstrumentation|Globals::tracerProvider\s*\(\s*\)|SDK::builder\s*\(\s*\))`)
+
+	// $tracer->spanBuilder('name') or $tracer->startSpan('name')
+	// Also handles chained access: $this->tracer->spanBuilder('name')
+	phpOtelSpanBuilderRe = regexp.MustCompile(
+		`(?m)\$(?:\w+|this->\w+)\s*->\s*(?:spanBuilder|startSpan)\s*\(\s*['"]([^'"]+)['"]`)
+
+	// $span->setStatus / $span->addEvent / $span->setAttribute — span lifecycle
+	phpOtelSpanLifecycleRe = regexp.MustCompile(
+		`(?m)\$\w+\s*->\s*(setStatus|addEvent|setAttribute|recordException|end)\s*\(`)
+
+	// use OpenTelemetry\API\Trace\SpanKind etc.
+	phpOtelTraceUseRe = regexp.MustCompile(
+		`(?m)\buse\s+OpenTelemetry\\API\\Trace\\(Tracer|Span|SpanInterface|SpanKind|StatusCode|TracerInterface)\s*;`)
+
+	// Symfony Stopwatch: $stopwatch->start('name') / $stopwatch->stop('name')
+	phpSymfonyStopwatchRe = regexp.MustCompile(
+		`(?m)\$\w+\s*->\s*(start|stop|lap)\s*\(\s*['"]([^'"]+)['"]`)
+
+	// use Symfony\Component\Stopwatch\Stopwatch
+	phpSymfonyStopwatchUseRe = regexp.MustCompile(
+		`(?m)\buse\s+Symfony\\Component\\Stopwatch\\Stopwatch\s*;`)
+
+	// DDTrace / Datadog APM for PHP
+	// \DDTrace\trace_function / \DDTrace\trace_method
+	phpDDTraceRe = regexp.MustCompile(
+		`(?m)\\?DDTrace\\(trace_function|trace_method|start_span|active_span)\s*\(`)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *phpObsExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "indexer.phpObs_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Fast guard: skip files with none of the known observability tokens.
+	hasLog := strings.ContainsAny(src, "Ll") && (strings.Contains(src, "Log::") ||
+		strings.Contains(src, "logger()") ||
+		strings.Contains(src, "->logger") ||
+		strings.Contains(src, "$logger->") ||
+		strings.Contains(src, "Monolog") ||
+		strings.Contains(src, "LoggerInterface") ||
+		strings.Contains(src, "LogLevel"))
+
+	hasMetric := strings.Contains(src, "Prometheus") ||
+		strings.Contains(src, "StatsD") ||
+		strings.Contains(src, "statsd") ||
+		strings.Contains(src, "Metrics::") ||
+		strings.Contains(src, "Counter") ||
+		strings.Contains(src, "Gauge") ||
+		strings.Contains(src, "Histogram")
+
+	hasTrace := strings.Contains(src, "OpenTelemetry") ||
+		strings.Contains(src, "Stopwatch") ||
+		strings.Contains(src, "DDTrace") ||
+		strings.Contains(src, "spanBuilder") ||
+		strings.Contains(src, "startSpan")
+
+	if !hasLog && !hasMetric && !hasTrace {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name + ":" + ent.SourceFile
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, ent)
+		}
+	}
+
+	if hasLog {
+		for _, ent := range phpObsExtractLog(src, file.Path) {
+			add(ent)
+		}
+	}
+	if hasMetric {
+		for _, ent := range phpObsExtractMetric(src, file.Path) {
+			add(ent)
+		}
+	}
+	if hasTrace {
+		for _, ent := range phpObsExtractTrace(src, file.Path) {
+			add(ent)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// log_extraction
+// ---------------------------------------------------------------------------
+
+func phpObsExtractLog(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// Laravel Log facade: Log::info / Log::error / \Log::warning etc.
+	for _, idx := range phpLaravelLogFacadeRe.FindAllStringSubmatchIndex(src, -1) {
+		level := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("Log::"+level, string(types.EntityKindPattern), "log_statement", fp, "php", ln)
+		setProps(&e, "signal", "log", "library", "laravel_log_facade",
+			"log_level", level, "receiver", "Log")
+		out = append(out, e)
+	}
+
+	// Log::channel('name') — channel configuration call-site
+	for _, idx := range phpLaravelLogChannelRe.FindAllStringSubmatchIndex(src, -1) {
+		channel := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("Log::channel("+channel+")", string(types.EntityKindPattern), "log_statement", fp, "php", ln)
+		setProps(&e, "signal", "log", "library", "laravel_log_facade",
+			"kind", "channel_call", "channel", channel)
+		out = append(out, e)
+	}
+
+	// logger() helper: logger()->info(...)
+	for _, idx := range phpLaravelLoggerHelperRe.FindAllStringSubmatchIndex(src, -1) {
+		level := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("logger()->"+level, string(types.EntityKindPattern), "log_statement", fp, "php", ln)
+		setProps(&e, "signal", "log", "library", "laravel_logger_helper",
+			"log_level", level, "receiver", "logger()")
+		out = append(out, e)
+	}
+
+	// logger('message') shorthand (only when no ->level call follows on same token)
+	if phpLaravelLoggerShorthandRe.MatchString(src) && !phpLaravelLoggerHelperRe.MatchString(src) {
+		loc := phpLaravelLoggerShorthandRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("logger()", string(types.EntityKindPattern), "log_statement", fp, "php", ln)
+		setProps(&e, "signal", "log", "library", "laravel_logger_helper",
+			"kind", "shorthand_call")
+		out = append(out, e)
+	}
+
+	// PSR-3 / Monolog injected logger: $logger->info, $this->logger->error
+	for _, idx := range phpMonologCallRe.FindAllStringSubmatchIndex(src, -1) {
+		level := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("$logger->"+level, string(types.EntityKindPattern), "log_statement", fp, "php", ln)
+		setProps(&e, "signal", "log", "library", "monolog_psr3",
+			"log_level", level, "receiver", "$logger")
+		out = append(out, e)
+	}
+
+	// use Monolog\... — file-level logger dependency signal
+	if phpMonologUseRe.MatchString(src) && !phpMonologCallRe.MatchString(src) {
+		loc := phpMonologUseRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("Monolog\\Logger", string(types.EntityKindPattern), "logger", fp, "php", ln)
+		setProps(&e, "signal", "log", "library", "monolog_psr3",
+			"kind", "use_declaration")
+		out = append(out, e)
+	}
+
+	// Symfony: $this->logger->log(LogLevel::WARNING, ...)
+	for _, idx := range phpSymfonyLogLevelRe.FindAllStringSubmatchIndex(src, -1) {
+		level := strings.ToLower(src[idx[2]:idx[3]])
+		ln := lineOf(src, idx[0])
+		e := makeEntity("$this->logger->log(LogLevel::"+strings.ToUpper(level)+")", string(types.EntityKindPattern), "log_statement", fp, "php", ln)
+		setProps(&e, "signal", "log", "library", "symfony_logger",
+			"log_level", level, "receiver", "$this->logger")
+		out = append(out, e)
+	}
+
+	// use Symfony\Component\HttpKernel\Log\Logger
+	if phpSymfonyLoggerUseRe.MatchString(src) && !phpMonologCallRe.MatchString(src) &&
+		!phpLaravelLogFacadeRe.MatchString(src) {
+		loc := phpSymfonyLoggerUseRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("Symfony\\Logger", string(types.EntityKindPattern), "logger", fp, "php", ln)
+		setProps(&e, "signal", "log", "library", "symfony_logger",
+			"kind", "use_declaration")
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// metric_extraction
+// ---------------------------------------------------------------------------
+
+func phpObsExtractMetric(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// prometheus_client_php: new Counter / new Gauge / new Histogram / new Summary
+	// Only emit when the Prometheus use-statement is present (reduces false positives)
+	hasPrometheusUse := phpPrometheusUseRe.MatchString(src)
+	for _, idx := range phpPrometheusNewRe.FindAllStringSubmatchIndex(src, -1) {
+		meterType := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		// Only emit when we have a Prometheus use-statement, or when the string
+		// "Prometheus" appears in the file (require or FQCN usage)
+		if !hasPrometheusUse && !strings.Contains(src, "Prometheus\\") &&
+			!strings.Contains(src, "Prometheus::") {
+			continue
+		}
+		e := makeEntity("new "+meterType, string(types.EntityKindPattern), "metric", fp, "php", ln)
+		setProps(&e, "signal", "metric", "library", "prometheus_client_php",
+			"metric_type", strings.ToLower(meterType), "kind", "instantiation")
+		out = append(out, e)
+	}
+
+	// $registry->registerCounter / registerGauge / registerHistogram
+	for _, idx := range phpPrometheusRegistryRe.FindAllStringSubmatchIndex(src, -1) {
+		meterType := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("register"+meterType, string(types.EntityKindPattern), "metric", fp, "php", ln)
+		setProps(&e, "signal", "metric", "library", "prometheus_client_php",
+			"metric_type", strings.ToLower(meterType), "kind", "register_call")
+		out = append(out, e)
+	}
+
+	// use Prometheus\... without any further call-site
+	if hasPrometheusUse && !phpPrometheusNewRe.MatchString(src) && !phpPrometheusRegistryRe.MatchString(src) {
+		loc := phpPrometheusUseRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("Prometheus", string(types.EntityKindPattern), "metric", fp, "php", ln)
+		setProps(&e, "signal", "metric", "library", "prometheus_client_php",
+			"kind", "use_declaration")
+		out = append(out, e)
+	}
+
+	// StatsD: $statsd->increment/gauge/timing etc.
+	hasStatsdUse := phpStatsdUseRe.MatchString(src)
+	for _, idx := range phpStatsdCallRe.FindAllStringSubmatchIndex(src, -1) {
+		method := src[idx[2]:idx[3]]
+		metricName := src[idx[4]:idx[5]]
+		ln := lineOf(src, idx[0])
+		// Require either a StatsD use-statement or explicit statsd token in file
+		if !hasStatsdUse && !strings.Contains(src, "StatsD") && !strings.Contains(src, "statsd") {
+			continue
+		}
+		e := makeEntity(metricName, string(types.EntityKindPattern), "metric", fp, "php", ln)
+		setProps(&e, "signal", "metric", "library", "statsd_php",
+			"metric_type", phpStatsdMetricType(method), "metric_name", metricName)
+		out = append(out, e)
+	}
+
+	// use League\StatsD (or Domnikl) without call-sites
+	if hasStatsdUse && !phpStatsdCallRe.MatchString(src) {
+		loc := phpStatsdUseRe.FindStringIndex(src)
+		ln := lineOf(src, loc[0])
+		e := makeEntity("StatsD", string(types.EntityKindPattern), "metric", fp, "php", ln)
+		setProps(&e, "signal", "metric", "library", "statsd_php",
+			"kind", "use_declaration")
+		out = append(out, e)
+	}
+
+	// Laravel Metrics facade
+	for _, idx := range phpLaravelMetricsRe.FindAllStringSubmatchIndex(src, -1) {
+		meterType := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("Metrics::"+meterType, string(types.EntityKindPattern), "metric", fp, "php", ln)
+		setProps(&e, "signal", "metric", "library", "laravel_metrics",
+			"metric_type", meterType)
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// trace_extraction
+// ---------------------------------------------------------------------------
+
+func phpObsExtractTrace(src, fp string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	hasOtelUse := phpOtelUseRe.MatchString(src) || phpOtelTraceUseRe.MatchString(src)
+	hasOtelToken := strings.Contains(src, "OpenTelemetry") || hasOtelUse
+
+	// OpenTelemetry SDK bootstrap: CachedInstrumentation / Globals::tracerProvider()
+	if hasOtelToken && phpOtelBootstrapRe.MatchString(src) {
+		for _, idx := range phpOtelBootstrapRe.FindAllStringIndex(src, -1) {
+			token := src[idx[0]:idx[1]]
+			if len(token) > 50 {
+				token = token[:50]
+			}
+			ln := lineOf(src, idx[0])
+			e := makeEntity(token, string(types.EntityKindPattern), "trace_span", fp, "php", ln)
+			setProps(&e, "signal", "trace", "library", "opentelemetry_php",
+				"kind", "bootstrap")
+			out = append(out, e)
+		}
+	}
+
+	// $tracer->spanBuilder('name') or $tracer->startSpan('name')
+	if hasOtelToken {
+		for _, idx := range phpOtelSpanBuilderRe.FindAllStringSubmatchIndex(src, -1) {
+			spanName := src[idx[2]:idx[3]]
+			ln := lineOf(src, idx[0])
+			e := makeEntity(spanName, string(types.EntityKindPattern), "trace_span", fp, "php", ln)
+			setProps(&e, "signal", "trace", "library", "opentelemetry_php",
+				"kind", "span_builder", "span_name", spanName)
+			out = append(out, e)
+		}
+	}
+
+	// $span->setAttribute/addEvent/setStatus/recordException — span lifecycle markers
+	if hasOtelToken {
+		for _, idx := range phpOtelSpanLifecycleRe.FindAllStringSubmatchIndex(src, -1) {
+			method := src[idx[2]:idx[3]]
+			ln := lineOf(src, idx[0])
+			e := makeEntity("$span->"+method, string(types.EntityKindPattern), "trace_span", fp, "php", ln)
+			setProps(&e, "signal", "trace", "library", "opentelemetry_php",
+				"kind", "span_lifecycle", "method", method)
+			out = append(out, e)
+		}
+	}
+
+	// use OpenTelemetry\... without any span builder call
+	if hasOtelUse && !phpOtelSpanBuilderRe.MatchString(src) && !phpOtelBootstrapRe.MatchString(src) {
+		loc := phpOtelUseRe.FindStringIndex(src)
+		if loc == nil {
+			loc = phpOtelTraceUseRe.FindStringIndex(src)
+		}
+		if loc != nil {
+			ln := lineOf(src, loc[0])
+			e := makeEntity("OpenTelemetry", string(types.EntityKindPattern), "trace_span", fp, "php", ln)
+			setProps(&e, "signal", "trace", "library", "opentelemetry_php",
+				"kind", "use_declaration")
+			out = append(out, e)
+		}
+	}
+
+	// Symfony Stopwatch: $stopwatch->start/stop/lap('name')
+	hasStopwatchUse := phpSymfonyStopwatchUseRe.MatchString(src)
+	hasStopwatchToken := hasStopwatchUse || strings.Contains(src, "Stopwatch")
+	if hasStopwatchToken {
+		for _, idx := range phpSymfonyStopwatchRe.FindAllStringSubmatchIndex(src, -1) {
+			method := src[idx[2]:idx[3]]
+			eventName := src[idx[4]:idx[5]]
+			// Only emit stop/lap/start events that look like trace events
+			if method != "start" && method != "stop" && method != "lap" {
+				continue
+			}
+			ln := lineOf(src, idx[0])
+			e := makeEntity(eventName, string(types.EntityKindPattern), "trace_span", fp, "php", ln)
+			setProps(&e, "signal", "trace", "library", "symfony_stopwatch",
+				"kind", "stopwatch_"+method, "event_name", eventName)
+			out = append(out, e)
+		}
+		// File-level use-declaration when no call-sites found
+		if hasStopwatchUse && !phpSymfonyStopwatchRe.MatchString(src) {
+			loc := phpSymfonyStopwatchUseRe.FindStringIndex(src)
+			ln := lineOf(src, loc[0])
+			e := makeEntity("Stopwatch", string(types.EntityKindPattern), "trace_span", fp, "php", ln)
+			setProps(&e, "signal", "trace", "library", "symfony_stopwatch",
+				"kind", "use_declaration")
+			out = append(out, e)
+		}
+	}
+
+	// DDTrace: \DDTrace\trace_function / \DDTrace\trace_method
+	for _, idx := range phpDDTraceRe.FindAllStringSubmatchIndex(src, -1) {
+		fn := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		e := makeEntity("DDTrace\\"+fn, string(types.EntityKindPattern), "trace_span", fp, "php", ln)
+		setProps(&e, "signal", "trace", "library", "ddtrace_php",
+			"kind", "trace_call")
+		out = append(out, e)
+	}
+
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Helper: StatsD metric-type normalisation
+// ---------------------------------------------------------------------------
+
+func phpStatsdMetricType(method string) string {
+	switch method {
+	case "increment", "decrement", "updateStats":
+		return "counter"
+	case "gauge":
+		return "gauge"
+	case "timing":
+		return "timer"
+	case "histogram":
+		return "histogram"
+	case "set":
+		return "set"
+	case "event":
+		return "event"
+	default:
+		return method
+	}
+}

--- a/internal/custom/php/observability_test.go
+++ b/internal/custom/php/observability_test.go
@@ -1,0 +1,552 @@
+// observability_test.go — value-asserting tests for the phpObs_laravel_symfony
+// extractor. Each test verifies that a concrete call-site pattern emits the
+// expected entity (Kind + Name). Tests intentionally use realistic PHP
+// snippets; no test forces a "full" status — detection is call-site heuristic.
+//
+// Part of issue #3400.
+package php_test
+
+import "testing"
+
+// NOTE: fi(), extract(), containsEntity(), entitySummary are defined in
+// extractors_test.go (same package php_test).
+
+// ---------------------------------------------------------------------------
+// log_extraction — Laravel Log facade
+// ---------------------------------------------------------------------------
+
+// TestPHPObsLaravelLogFacadeInfo verifies that Log::info(...) emits a
+// per-call-site log_statement entity with name "Log::info".
+func TestPHPObsLaravelLogFacadeInfo(t *testing.T) {
+	src := `<?php
+use Illuminate\Support\Facades\Log;
+
+class UserController extends Controller
+{
+    public function login(Request $request): Response
+    {
+        Log::info('User logged in', ['user_id' => $request->user()->id]);
+        return response()->json(['status' => 'ok']);
+    }
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Http/Controllers/UserController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::info") {
+		t.Error("expected Log::info log_statement entity")
+	}
+}
+
+// TestPHPObsLaravelLogFacadeError verifies Log::error emits its own entity.
+func TestPHPObsLaravelLogFacadeError(t *testing.T) {
+	src := `<?php
+Log::error('Payment failed', ['order_id' => $orderId, 'reason' => $e->getMessage()]);
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Services/PaymentService.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::error") {
+		t.Error("expected Log::error log_statement entity")
+	}
+}
+
+// TestPHPObsLaravelLogFacadeMultiLevel verifies multiple log levels in one file
+// each produce their own entity.
+func TestPHPObsLaravelLogFacadeMultiLevel(t *testing.T) {
+	src := `<?php
+Log::debug('Processing item', ['id' => $id]);
+Log::warning('Item is deprecated', ['item' => $name]);
+Log::critical('Database connection failed');
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Jobs/ProcessItem.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::debug") {
+		t.Error("expected Log::debug entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::warning") {
+		t.Error("expected Log::warning entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::critical") {
+		t.Error("expected Log::critical entity")
+	}
+}
+
+// TestPHPObsLaravelLogChannel verifies Log::channel('name') emits a channel
+// call entity with the channel name embedded.
+func TestPHPObsLaravelLogChannel(t *testing.T) {
+	src := `<?php
+Log::channel('slack')->critical('Server is down', ['host' => $host]);
+Log::channel('daily')->info('Scheduled job completed');
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Console/Commands/HealthCheck.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::channel(slack)") {
+		t.Error("expected Log::channel(slack) entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::channel(daily)") {
+		t.Error("expected Log::channel(daily) entity")
+	}
+}
+
+// TestPHPObsLaravelLoggerHelper verifies logger()->info() and logger()->error()
+// helper calls are extracted.
+func TestPHPObsLaravelLoggerHelper(t *testing.T) {
+	src := `<?php
+public function store(Request $request): JsonResponse
+{
+    logger()->info('New order created', ['order' => $order->id]);
+    logger()->error('Validation failed', $request->all());
+    return response()->json($order);
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Http/Controllers/OrderController.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "logger()->info") {
+		t.Error("expected logger()->info entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "logger()->error") {
+		t.Error("expected logger()->error entity")
+	}
+}
+
+// TestPHPObsLaravelBackslashLogFacade verifies the fully-qualified \Log::info
+// form is detected (common outside the Illuminate namespace).
+func TestPHPObsLaravelBackslashLogFacade(t *testing.T) {
+	src := `<?php
+\Log::info('Starting import job');
+\Log::warning('Import row skipped', ['row' => $rowNumber]);
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Jobs/ImportJob.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::info") {
+		t.Error("expected Log::info entity for \\Log::info call")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "Log::warning") {
+		t.Error("expected Log::warning entity for \\Log::warning call")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// log_extraction — Monolog / PSR-3 injected logger
+// ---------------------------------------------------------------------------
+
+// TestPHPObsMonologInjectedLogger verifies $this->logger->info/error/warning
+// PSR-3 call-sites are extracted.
+func TestPHPObsMonologInjectedLogger(t *testing.T) {
+	src := `<?php
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+class OrderService
+{
+    public function __construct(private Logger $logger) {}
+
+    public function process(Order $order): void
+    {
+        $this->logger->info('Processing order', ['id' => $order->id]);
+        $this->logger->error('Order failed', ['reason' => $e->getMessage()]);
+    }
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Services/OrderService.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "$logger->info") {
+		t.Error("expected $logger->info Monolog call-site entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "$logger->error") {
+		t.Error("expected $logger->error Monolog call-site entity")
+	}
+}
+
+// TestPHPObsMonologUseDeclaration verifies that a file with a Monolog use
+// statement but no call-sites emits a logger use-declaration entity.
+func TestPHPObsMonologUseDeclaration(t *testing.T) {
+	src := `<?php
+use Monolog\Logger;
+
+class AppBootstrap
+{
+    private Logger $logger;
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("bootstrap/app.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Monolog\\Logger") {
+		t.Error("expected Monolog\\Logger use-declaration entity")
+	}
+}
+
+// TestPHPObsSymfonyInjectedLogger verifies $this->logger->info call-sites inside
+// a Symfony-style service (LoggerInterface injected via constructor).
+func TestPHPObsSymfonyInjectedLogger(t *testing.T) {
+	src := `<?php
+use Psr\Log\LoggerInterface;
+
+class NotificationService
+{
+    public function __construct(private LoggerInterface $logger) {}
+
+    public function send(Notification $n): void
+    {
+        $this->logger->info('Notification sent', ['id' => $n->id]);
+        $this->logger->warning('Recipient not found', ['email' => $n->email]);
+    }
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Service/NotificationService.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "$logger->info") {
+		t.Error("expected $logger->info PSR-3 entity for Symfony injected logger")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "$logger->warning") {
+		t.Error("expected $logger->warning PSR-3 entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// log_extraction — no false positives
+// ---------------------------------------------------------------------------
+
+// TestPHPObsLogNoFalsePositiveOnPlainPHP verifies files with no log calls
+// produce no observability entities.
+func TestPHPObsLogNoFalsePositiveOnPlainPHP(t *testing.T) {
+	src := `<?php
+class Calculator
+{
+    public function add(int $a, int $b): int { return $a + $b; }
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Calculator.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no observability entities for plain PHP, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// metric_extraction — prometheus_client_php
+// ---------------------------------------------------------------------------
+
+// TestPHPObsPrometheusCounter verifies that new Counter() with a Prometheus
+// use-statement emits a metric entity.
+func TestPHPObsPrometheusCounter(t *testing.T) {
+	src := `<?php
+use Prometheus\Counter;
+use Prometheus\CollectorRegistry;
+
+class MetricsService
+{
+    public function registerMetrics(CollectorRegistry $registry): void
+    {
+        $counter = new Counter('http_requests_total', 'Total HTTP requests', ['method', 'status']);
+        $registry->registerCounter('app', 'errors_total', 'Total errors');
+    }
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Service/MetricsService.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "new Counter") {
+		t.Error("expected new Counter metric entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "registerCounter") {
+		t.Error("expected registerCounter metric entity")
+	}
+}
+
+// TestPHPObsPrometheusGaugeHistogram verifies Gauge and Histogram entities
+// are extracted per-instantiation.
+func TestPHPObsPrometheusGaugeHistogram(t *testing.T) {
+	src := `<?php
+use Prometheus\Gauge;
+use Prometheus\Histogram;
+
+$gauge = new Gauge('memory_usage_bytes', 'Current memory usage');
+$histogram = new Histogram('request_duration_seconds', 'Request duration', ['endpoint']);
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Metrics/AppMetrics.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "new Gauge") {
+		t.Error("expected new Gauge metric entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "new Histogram") {
+		t.Error("expected new Histogram metric entity")
+	}
+}
+
+// TestPHPObsPrometheusUseDeclarationOnly verifies that a file with only a
+// Prometheus use-statement (no instantiation) emits a use-declaration entity.
+func TestPHPObsPrometheusUseDeclarationOnly(t *testing.T) {
+	src := `<?php
+use Prometheus\CollectorRegistry;
+
+class PrometheusBootstrap
+{
+    public function getRegistry(): CollectorRegistry
+    {
+        return new CollectorRegistry(new InMemory());
+    }
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("bootstrap/metrics.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Prometheus") {
+		t.Error("expected Prometheus use-declaration entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// metric_extraction — StatsD
+// ---------------------------------------------------------------------------
+
+// TestPHPObsStatsdIncrement verifies $statsd->increment('metric.name') emits
+// a named metric entity.
+func TestPHPObsStatsdIncrement(t *testing.T) {
+	src := `<?php
+use League\StatsD\Client as StatsD;
+
+$statsd = new StatsD();
+$statsd->increment('page.views');
+$statsd->gauge('queue.depth', $depth);
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Tracking/PageTracker.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "page.views") {
+		t.Error("expected page.views StatsD metric entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "queue.depth") {
+		t.Error("expected queue.depth StatsD gauge entity")
+	}
+}
+
+// TestPHPObsStatsdUseDeclaration verifies League\StatsD use without call-sites
+// emits a use-declaration entity.
+func TestPHPObsStatsdUseDeclaration(t *testing.T) {
+	src := `<?php
+use League\StatsD\Client as StatsD;
+
+class StatsHelper
+{
+    public function __construct(private StatsD $statsd) {}
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/StatsHelper.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "StatsD") {
+		t.Error("expected StatsD use-declaration entity")
+	}
+}
+
+// TestPHPObsLaravelMetrics verifies the Laravel Metrics facade call-sites are
+// extracted (optional package).
+func TestPHPObsLaravelMetrics(t *testing.T) {
+	src := `<?php
+Metrics::counter('orders_placed');
+Metrics::gauge('active_users', $count);
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Observers/OrderObserver.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Metrics::counter") {
+		t.Error("expected Metrics::counter entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "Metrics::gauge") {
+		t.Error("expected Metrics::gauge entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// trace_extraction — OpenTelemetry PHP SDK
+// ---------------------------------------------------------------------------
+
+// TestPHPObsOtelSpanBuilder verifies $tracer->spanBuilder('name') emits a
+// trace_span entity with the span name.
+func TestPHPObsOtelSpanBuilder(t *testing.T) {
+	src := `<?php
+use OpenTelemetry\API\Trace\TracerInterface;
+
+class OrderService
+{
+    public function __construct(private TracerInterface $tracer) {}
+
+    public function createOrder(array $data): Order
+    {
+        $span = $this->tracer->spanBuilder('order.create')->startSpan();
+        try {
+            $order = Order::create($data);
+            $span->setAttribute('order.id', $order->id);
+            return $order;
+        } finally {
+            $span->end();
+        }
+    }
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Services/OrderService.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "order.create") {
+		t.Error("expected order.create span entity from spanBuilder")
+	}
+}
+
+// TestPHPObsOtelStartSpan verifies $tracer->startSpan('name') is extracted.
+func TestPHPObsOtelStartSpan(t *testing.T) {
+	src := `<?php
+use OpenTelemetry\API\Trace\TracerInterface;
+
+$span = $tracer->startSpan('payment.process');
+$span->setAttribute('amount', $amount);
+$span->end();
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Payment/Processor.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "payment.process") {
+		t.Error("expected payment.process span entity from startSpan")
+	}
+}
+
+// TestPHPObsOtelSpanLifecycle verifies $span->setAttribute/addEvent/end
+// lifecycle methods emit trace_span entities.
+func TestPHPObsOtelSpanLifecycle(t *testing.T) {
+	src := `<?php
+use OpenTelemetry\API\Trace\TracerInterface;
+
+$span = $tracer->spanBuilder('user.auth')->startSpan();
+$span->setAttribute('user.id', $userId);
+$span->addEvent('auth.success');
+$span->setStatus(StatusCode::STATUS_OK);
+$span->end();
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Auth/AuthService.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "$span->setAttribute") {
+		t.Error("expected $span->setAttribute lifecycle entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "$span->addEvent") {
+		t.Error("expected $span->addEvent lifecycle entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "$span->end") {
+		t.Error("expected $span->end lifecycle entity")
+	}
+}
+
+// TestPHPObsOtelBootstrap verifies CachedInstrumentation and
+// Globals::tracerProvider() bootstrap calls emit trace_span entities.
+func TestPHPObsOtelBootstrap(t *testing.T) {
+	src := `<?php
+use OpenTelemetry\API\Globals;
+
+$tracerProvider = Globals::tracerProvider();
+$tracer = $tracerProvider->getTracer('my-app');
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("bootstrap/otel.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Globals::tracerProvider()") {
+		t.Error("expected Globals::tracerProvider() bootstrap entity")
+	}
+}
+
+// TestPHPObsOtelUseDeclaration verifies that a file with only OpenTelemetry
+// use-statements (no span calls) emits a use-declaration entity.
+func TestPHPObsOtelUseDeclaration(t *testing.T) {
+	src := `<?php
+use OpenTelemetry\API\Trace\TracerInterface;
+
+class TracingBootstrap
+{
+    public function __construct(private TracerInterface $tracer) {}
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Tracing/Bootstrap.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "OpenTelemetry") {
+		t.Error("expected OpenTelemetry use-declaration entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// trace_extraction — Symfony Stopwatch
+// ---------------------------------------------------------------------------
+
+// TestPHPObsSymfonyStopwatchStartStop verifies $stopwatch->start/stop calls
+// emit named trace_span entities.
+func TestPHPObsSymfonyStopwatchStartStop(t *testing.T) {
+	src := `<?php
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class DataImportService
+{
+    public function import(array $data): void
+    {
+        $stopwatch = new Stopwatch();
+        $stopwatch->start('data.import');
+        foreach ($data as $row) {
+            $this->processRow($row);
+        }
+        $event = $stopwatch->stop('data.import');
+    }
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Service/DataImportService.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "data.import") {
+		t.Error("expected data.import Stopwatch trace_span entity")
+	}
+}
+
+// TestPHPObsSymfonyStopwatchLap verifies $stopwatch->lap('name') emits an entity.
+func TestPHPObsSymfonyStopwatchLap(t *testing.T) {
+	src := `<?php
+use Symfony\Component\Stopwatch\Stopwatch;
+
+$stopwatch = new Stopwatch();
+$stopwatch->start('batch.processing');
+foreach ($items as $item) {
+    $this->process($item);
+    $stopwatch->lap('batch.processing');
+}
+$stopwatch->stop('batch.processing');
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Batch/Processor.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "batch.processing") {
+		t.Error("expected batch.processing Stopwatch entity")
+	}
+}
+
+// TestPHPObsSymfonyStopwatchUseDeclaration verifies that a file importing
+// Stopwatch without call-sites emits a use-declaration entity.
+func TestPHPObsSymfonyStopwatchUseDeclaration(t *testing.T) {
+	src := `<?php
+use Symfony\Component\Stopwatch\Stopwatch;
+
+class ProfilerHelper
+{
+    public function __construct(private Stopwatch $stopwatch) {}
+}
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Profiler/Helper.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "Stopwatch") {
+		t.Error("expected Stopwatch use-declaration entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// trace_extraction — DDTrace
+// ---------------------------------------------------------------------------
+
+// TestPHPObsDDTrace verifies \DDTrace\trace_function and \DDTrace\trace_method
+// are extracted.
+func TestPHPObsDDTrace(t *testing.T) {
+	src := `<?php
+\DDTrace\trace_function('App\Service\OrderService::create', function(SpanData $span, $args) {
+    $span->name = 'order.service.create';
+});
+\DDTrace\trace_method('App\Repository\UserRepo', 'find', function(SpanData $span, $args) {
+    $span->name = 'user.repo.find';
+});
+`
+	ents := extract(t, "phpObs_laravel_symfony", fi("src/Tracing/DatadogTracing.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "DDTrace\\trace_function") {
+		t.Error("expected DDTrace\\trace_function entity")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "DDTrace\\trace_method") {
+		t.Error("expected DDTrace\\trace_method entity")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Guard: non-PHP files are ignored
+// ---------------------------------------------------------------------------
+
+// TestPHPObsIgnoresNonPHP verifies the extractor produces no entities for
+// non-php language files.
+func TestPHPObsIgnoresNonPHP(t *testing.T) {
+	src := `Log::info('This is PHP-like code but in a JS file');`
+	ents := extract(t, "phpObs_laravel_symfony", fi("frontend/app.js", "javascript", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for non-php file, got %d", len(ents))
+	}
+}
+
+// TestPHPObsIgnoresEmptyFile verifies empty files return no entities.
+func TestPHPObsIgnoresEmptyFile(t *testing.T) {
+	ents := extract(t, "phpObs_laravel_symfony", fi("app/Empty.php", "php", ""))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities for empty file, got %d", len(ents))
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -7161,6 +7161,52 @@ records:
             - file: internal/extractors/cross/testmap/extractor_test.go
               functions: [TestPHPUnit_TestPrefixMethod, TestPHPUnit_HashTestAttribute, TestPHPUnit_DocblockTestAnnotation, TestPHPUnit_ClassNameSubjectDerivation, TestPHPUnit_LaravelFeatureTest, TestPhpPest_ItBlock, TestPhpPest_UsesSubjectExtraction, TestPhpPest_LaravelFeatureTest]
           issues_implemented: ["3399"]
+      Observability:
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/php/observability.go
+              functions: [phpObsExtractLog, Extract]
+          tests:
+            - file: internal/custom/php/observability_test.go
+          issues_implemented: ["3400"]
+          notes: >
+            Per-call-site: Log::info/warning/error/debug/critical/alert/emergency/notice (facade
+            + \Log:: backslash form), Log::channel('name'), logger()->level() helper,
+            logger('msg') shorthand, PSR-3/Monolog $logger->level() injected-logger call-sites,
+            $this->logger->level() Symfony-style injected LoggerInterface. Use-declaration
+            fallback when no call-sites found. Import/call-site heuristic; no cross-file
+            dataflow binding logger to handler. Stays partial.
+          verified_at: "2026-05-30"
+        metric_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/php/observability.go
+              functions: [phpObsExtractMetric, Extract]
+          tests:
+            - file: internal/custom/php/observability_test.go
+          issues_implemented: ["3400"]
+          notes: >
+            prometheus_client_php: new Counter/Gauge/Histogram/Summary call-sites,
+            $registry->registerCounter/Gauge/Histogram. StatsD (League\StatsD, Domnikl\Statsd):
+            $statsd->increment/gauge/timing/histogram call-sites with metric names.
+            Laravel Metrics facade: Metrics::counter/gauge/histogram. Use-declaration fallback.
+            Import/call-site heuristic; no cross-file dataflow. Stays partial.
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/php/observability.go
+              functions: [phpObsExtractTrace, Extract]
+          tests:
+            - file: internal/custom/php/observability_test.go
+          issues_implemented: ["3400"]
+          notes: >
+            OpenTelemetry PHP SDK: CachedInstrumentation/Globals::tracerProvider() bootstrap,
+            $tracer->spanBuilder/startSpan('name'), $span->setAttribute/addEvent/setStatus/end
+            lifecycle markers. Symfony Stopwatch: $stopwatch->start/stop/lap('name') event names.
+            DDTrace: \DDTrace\trace_function/trace_method. Use-declaration fallback.
+            Import/call-site heuristic; no cross-file dataflow binding tracer to exporter. Stays partial.
           verified_at: "2026-05-30"
 
   lang.rust.framework.axum:


### PR DESCRIPTION
## Summary

- Adds `internal/custom/php/observability.go` — a dedicated `phpObs_laravel_symfony` extractor replacing the coarse one-entity-per-file stub in `frameworks.go` with per-call-site extraction for **Laravel** and **Symfony**, matching the depth of the Java/Python/Ruby observability extractors.
- **log_extraction**: Laravel Log facade (`Log::info/error/warning/debug/critical/alert/emergency/notice`, `\Log::` backslash form), `Log::channel('name')`, `logger()->level()` helper, `logger('msg')` shorthand, PSR-3/Monolog injected `$logger->level()`, `$this->logger->level()` (Symfony LoggerInterface). Use-declaration fallback.
- **metric_extraction**: `prometheus_client_php` `new Counter/Gauge/Histogram/Summary` + `$registry->registerCounter/Gauge/Histogram`. StatsD (`League\StatsD`, `Domnikl\Statsd`): `$statsd->increment/gauge/timing/histogram` with metric names captured. Laravel Metrics facade `Metrics::counter/gauge/histogram`.
- **trace_extraction**: OpenTelemetry PHP SDK — `CachedInstrumentation`/`Globals::tracerProvider()` bootstrap, `$tracer->spanBuilder/startSpan('name')`, `$span` lifecycle markers (`setAttribute`/`addEvent`/`setStatus`/`end`). Symfony Stopwatch: `$stopwatch->start/stop/lap('name')`. DDTrace: `\DDTrace\trace_function/trace_method`.
- **Honesty**: all three cells stay **partial**. Detection is import/use-statement + call-site heuristic; no cross-file dataflow binding logger/tracer instances to handlers/exporters — that is the correct bar.
- Registry updated for `lang.php.framework.laravel` and `lang.php.framework.symfony` Observability/{log,metric,trace}_extraction → partial.
- Capability map gets a new Observability section for `lang.php.framework.laravel`.
- 25 new value-asserting tests; `go build ./internal/... ./tools/coverage/...` clean; `go test ./internal/custom/php/... ./internal/types/... ./tools/coverage/...` all pass; `coverage validate` exit 0; `coverage fmt --check` canonical; `gofmt -l` empty.

## Test plan

- [ ] `go test ./internal/custom/php/... -run TestPHPObs` — all 25 new tests pass
- [ ] `go test ./internal/custom/php/...` — full PHP suite passes (no regressions)
- [ ] `go run ./tools/coverage validate` — exit 0 (warnings only, pre-existing)
- [ ] `go run ./tools/coverage fmt --check` — registry is canonical
- [ ] `gofmt -l ./internal/custom/php/observability.go ./internal/custom/php/observability_test.go` — empty output

Closes #3400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>