### PR TITLE
deep(rust): Type System extraction to TS/JS bar (#3411)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -105,16 +105,16 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟢 2/2 | — | 🟢 1/1 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -26,16 +26,16 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Poem](../detail/lang.rust.framework.poem.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Gotham](../detail/lang.rust.framework.gotham.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Poem](../detail/lang.rust.framework.poem.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -42,10 +42,10 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Enum extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Interface extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type alias extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
-| Type extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/rust/rust.go` | — |
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
 
 ### Testing
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -45157,25 +45157,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -45375,25 +45374,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -45593,25 +45591,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -45811,25 +45808,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -46029,25 +46025,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -46247,25 +46242,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -46465,25 +46459,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -46764,25 +46757,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -46983,25 +46975,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {
@@ -47201,25 +47192,24 @@
         },
         "Type System": {
           "enum_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "interface_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           },
           "type_alias_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "type_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/extractors/rust/rust.go"],
-            "issue": "backfill:dictionary-completeness"
+            "verified_at": "2026-05-30"
           }
         },
         "Testing": {

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -2,11 +2,19 @@
 //
 // Extracted entities:
 //   - struct_item     → Kind="SCOPE.Component", Subtype="struct"
+//     (Properties: fields, generics, derives)
 //   - enum_item       → Kind="SCOPE.Component", Subtype="enum"
+//     (Properties: variants, generics, derives)
 //   - trait_item      → Kind="SCOPE.Component", Subtype="trait"
+//     (Properties: methods, supertraits, generics; EXTENDS edges per supertrait)
+//   - type_item       → Kind="SCOPE.Component", Subtype="type_alias"
+//     (Properties: aliased_type, generics)
 //   - impl_item       → Kind="SCOPE.Component", Subtype="impl"
 //   - function_item   → Kind="SCOPE.Operation", Subtype="function"
 //   - use_declaration → IMPORTS relationship
+//
+// The struct/enum/trait/type_alias Properties realise the Type System deep
+// extraction bar (issue #3411), mirroring the JS/TS interface/enum emission.
 //
 // The extractor registers itself via init() and is auto-imported by the
 // generated registry_gen.go.
@@ -407,13 +415,23 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 }
 
 // buildComponent creates a Component entity for struct/enum/trait items.
+//
+// Issue #3411 — Type System deep extraction. Beyond the bare name, structured
+// Properties capture the type's internal shape (mirroring the JS/TS bar in
+// handleInterfaceDeclaration / handleEnumDeclaration):
+//
+//	struct → "fields" (named field idents or "0,1,.." for tuple structs),
+//	          "generics", "derives"
+//	enum   → "variants" (variant idents), "generics", "derives"
+//	trait  → "methods" (signature + default-body fn idents),
+//	          "supertraits", "generics", plus EXTENDS edges per supertrait
 func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
 	}
 
-	return types.EntityRecord{
+	rec := types.EntityRecord{
 		Name:               name,
 		Kind:               "SCOPE.Component",
 		Subtype:            subtype,
@@ -423,7 +441,242 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 		EndLine:            int(node.EndPoint().Row) + 1,
 		Signature:          buildTypeSignature(node, file.Content, name),
 		EnrichmentRequired: false,
-	}, true
+	}
+
+	props := map[string]string{}
+	if g := rustGenerics(node, file.Content); g != "" {
+		props["generics"] = g
+	}
+	switch subtype {
+	case "struct":
+		if f := rustStructFields(node, file.Content); f != "" {
+			props["fields"] = f
+		}
+		if d := rustDerives(node, file.Content); d != "" {
+			props["derives"] = d
+		}
+	case "enum":
+		if v := rustEnumVariants(node, file.Content); v != "" {
+			props["variants"] = v
+		}
+		if d := rustDerives(node, file.Content); d != "" {
+			props["derives"] = d
+		}
+	case "trait":
+		if m := rustTraitMethods(node, file.Content); m != "" {
+			props["methods"] = m
+		}
+		supers := rustSupertraits(node, file.Content)
+		if len(supers) > 0 {
+			props["supertraits"] = strings.Join(supers, ", ")
+			for _, s := range supers {
+				rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+					ToID: s,
+					Kind: "EXTENDS",
+				})
+			}
+		}
+	}
+	if len(props) > 0 {
+		rec.Properties = props
+	}
+	return rec, true
+}
+
+// rustGenerics returns a comma-separated list of generic type-parameter names
+// declared on a struct/enum/trait/type item (the `type_parameters` field).
+// Lifetime params (`'a`) and const params are included as written.
+func rustGenerics(node *sitter.Node, src []byte) string {
+	tp := node.ChildByFieldName("type_parameters")
+	if tp == nil {
+		return ""
+	}
+	var out []string
+	for i := 0; i < int(tp.ChildCount()); i++ {
+		ch := tp.Child(i)
+		switch ch.Type() {
+		case "type_identifier", "lifetime", "constrained_type_parameter":
+			out = append(out, strings.TrimSpace(string(src[ch.StartByte():ch.EndByte()])))
+		case "const_parameter", "optional_type_parameter":
+			out = append(out, strings.TrimSpace(string(src[ch.StartByte():ch.EndByte()])))
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+// rustStructFields returns the field names of a struct_item. For a named-field
+// struct it returns the field identifiers; for a tuple struct it returns the
+// positional indices ("0, 1, ..."); for a unit struct it returns "".
+func rustStructFields(node *sitter.Node, src []byte) string {
+	body := node.ChildByFieldName("body")
+	if body == nil {
+		// Tuple/unit structs place the field list in an unnamed child.
+		for i := 0; i < int(node.ChildCount()); i++ {
+			ch := node.Child(i)
+			if ch.Type() == "ordered_field_declaration_list" {
+				body = ch
+				break
+			}
+		}
+	}
+	if body == nil {
+		return ""
+	}
+	switch body.Type() {
+	case "field_declaration_list":
+		var out []string
+		for i := 0; i < int(body.ChildCount()); i++ {
+			ch := body.Child(i)
+			if ch.Type() == "field_declaration" {
+				if nm := ch.ChildByFieldName("name"); nm != nil {
+					out = append(out, string(src[nm.StartByte():nm.EndByte()]))
+				}
+			}
+		}
+		return strings.Join(out, ", ")
+	case "ordered_field_declaration_list":
+		var out []string
+		idx := 0
+		for i := 0; i < int(body.ChildCount()); i++ {
+			if body.Child(i).ChildByFieldName("type") != nil ||
+				body.Child(i).Type() == "primitive_type" ||
+				isRustTypeNode(body.Child(i)) {
+				out = append(out, strconv.Itoa(idx))
+				idx++
+			}
+		}
+		return strings.Join(out, ", ")
+	}
+	return ""
+}
+
+// isRustTypeNode reports whether a node represents a type expression that would
+// occupy a positional slot in a tuple struct's ordered field list.
+func isRustTypeNode(n *sitter.Node) bool {
+	switch n.Type() {
+	case "(", ")", ",", "visibility_modifier":
+		return false
+	}
+	return true
+}
+
+// rustEnumVariants returns a comma-separated list of variant names declared in
+// an enum_item's enum_variant_list. Tuple (`Foo(i32)`), struct
+// (`Bar { x: u8 }`), and discriminant (`Baz = 1`) variants all contribute their
+// leading identifier.
+func rustEnumVariants(node *sitter.Node, src []byte) string {
+	body := node.ChildByFieldName("body")
+	if body == nil {
+		return ""
+	}
+	var out []string
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		if ch.Type() != "enum_variant" {
+			continue
+		}
+		if nm := ch.ChildByFieldName("name"); nm != nil {
+			out = append(out, string(src[nm.StartByte():nm.EndByte()]))
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+// rustTraitMethods returns a comma-separated list of method names declared in a
+// trait's declaration_list — both required signatures (function_signature_item)
+// and provided/default methods (function_item).
+func rustTraitMethods(node *sitter.Node, src []byte) string {
+	body := findRustDeclList(node)
+	if body == nil {
+		return ""
+	}
+	var out []string
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		if ch.Type() == "function_signature_item" || ch.Type() == "function_item" {
+			if nm := ch.ChildByFieldName("name"); nm != nil {
+				out = append(out, string(src[nm.StartByte():nm.EndByte()]))
+			}
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+// rustSupertraits returns the supertrait names from a trait_item's `bounds`
+// field (e.g. `trait A: B + C` → ["B", "C"]). Lifetime bounds are skipped.
+func rustSupertraits(node *sitter.Node, src []byte) []string {
+	bounds := node.ChildByFieldName("bounds")
+	if bounds == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(bounds.ChildCount()); i++ {
+		ch := bounds.Child(i)
+		switch ch.Type() {
+		case "type_identifier":
+			out = append(out, string(src[ch.StartByte():ch.EndByte()]))
+		case "generic_type", "scoped_type_identifier":
+			if nm := ch.ChildByFieldName("name"); nm != nil {
+				out = append(out, string(src[nm.StartByte():nm.EndByte()]))
+			} else {
+				out = append(out, string(src[ch.StartByte():ch.EndByte()]))
+			}
+		}
+	}
+	return out
+}
+
+// rustDerives returns a comma-separated list of derive-macro names attached to
+// a type via `#[derive(...)]`. Derive attributes are emitted by the grammar as
+// `attribute_item` siblings immediately preceding the type item, so we scan
+// backwards over the previous siblings (skipping other attributes / comments).
+func rustDerives(node *sitter.Node, src []byte) string {
+	var out []string
+	for prev := node.PrevSibling(); prev != nil; prev = prev.PrevSibling() {
+		t := prev.Type()
+		if t == "line_comment" || t == "block_comment" {
+			continue
+		}
+		if t != "attribute_item" {
+			break
+		}
+		out = append(rustParseDerive(prev, src), out...)
+	}
+	return strings.Join(out, ", ")
+}
+
+// rustParseDerive extracts the derive names from a single attribute_item node
+// when it is a `#[derive(...)]`; returns nil for non-derive attributes.
+func rustParseDerive(attr *sitter.Node, src []byte) []string {
+	var inner *sitter.Node
+	for i := 0; i < int(attr.ChildCount()); i++ {
+		if attr.Child(i).Type() == "attribute" {
+			inner = attr.Child(i)
+			break
+		}
+	}
+	if inner == nil {
+		return nil
+	}
+	// First child identifier must be "derive".
+	id := inner.Child(0)
+	if id == nil || id.Type() != "identifier" ||
+		string(src[id.StartByte():id.EndByte()]) != "derive" {
+		return nil
+	}
+	args := inner.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(args.ChildCount()); i++ {
+		ch := args.Child(i)
+		switch ch.Type() {
+		case "identifier", "scoped_identifier", "type_identifier":
+			out = append(out, string(src[ch.StartByte():ch.EndByte()]))
+		}
+	}
+	return out
 }
 
 // buildImpl creates a Component entity for impl blocks.
@@ -506,8 +759,15 @@ func buildTypeAlias(node *sitter.Node, file extractor.FileInput) (types.EntityRe
 		Signature:          buildTypeSignature(node, file.Content, name),
 		EnrichmentRequired: false,
 	}
+	props := map[string]string{}
 	if aliasedType != "" {
-		rec.Properties = map[string]string{"aliased_type": aliasedType}
+		props["aliased_type"] = aliasedType
+	}
+	if g := rustGenerics(node, file.Content); g != "" {
+		props["generics"] = g
+	}
+	if len(props) > 0 {
+		rec.Properties = props
 	}
 	rec.ID = rec.ComputeID()
 	return rec, true

--- a/internal/extractors/rust/rust_test.go
+++ b/internal/extractors/rust/rust_test.go
@@ -730,6 +730,178 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Type System deep extraction — issue #3411
+// ---------------------------------------------------------------------------
+
+// findRustEntity returns the first entity matching subtype+name, or nil.
+func findRustEntity(t *testing.T, src, subtype, name string) map[string]string {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("rust")
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: "ts.rs", Content: []byte(src), Language: "rust", Tree: tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, e := range got {
+		if e.Subtype == subtype && e.Name == name {
+			return e.Properties
+		}
+	}
+	t.Fatalf("entity subtype=%s name=%s not found", subtype, name)
+	return nil
+}
+
+// enum_extraction: assert specific variant names (tuple, struct, discriminant)
+// and derive macros are captured.
+func TestRustExtractor_EnumVariants_Deep(t *testing.T) {
+	src := `
+#[derive(Debug, Clone, PartialEq)]
+enum Shape {
+    Circle(f64),
+    Rect { w: u8, h: u8 },
+    Unit = 1,
+    Empty,
+}
+`
+	props := findRustEntity(t, src, "enum", "Shape")
+	if props["variants"] != "Circle, Rect, Unit, Empty" {
+		t.Errorf("variants = %q, want %q", props["variants"], "Circle, Rect, Unit, Empty")
+	}
+	if props["derives"] != "Debug, Clone, PartialEq" {
+		t.Errorf("derives = %q, want %q", props["derives"], "Debug, Clone, PartialEq")
+	}
+}
+
+func TestRustExtractor_EnumGenerics_Deep(t *testing.T) {
+	src := `
+enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+`
+	props := findRustEntity(t, src, "enum", "Either")
+	if props["variants"] != "Left, Right" {
+		t.Errorf("variants = %q, want %q", props["variants"], "Left, Right")
+	}
+	if props["generics"] != "L, R" {
+		t.Errorf("generics = %q, want %q", props["generics"], "L, R")
+	}
+}
+
+// interface_extraction (trait): assert method names (required + default),
+// supertraits, EXTENDS edges, and generics.
+func TestRustExtractor_TraitMethods_Deep(t *testing.T) {
+	src := `
+trait Animal: Eq + Clone {
+    fn speak(&self) -> String;
+    fn legs(&self) -> u32 { 4 }
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("rust")
+	got, _ := ext.Extract(context.Background(), extractor.FileInput{
+		Path: "animal.rs", Content: []byte(src), Language: "rust", Tree: tree,
+	})
+
+	var props map[string]string
+	var extendsTargets []string
+	for _, e := range got {
+		if e.Subtype == "trait" && e.Name == "Animal" {
+			props = e.Properties
+			for _, r := range e.Relationships {
+				if r.Kind == "EXTENDS" {
+					extendsTargets = append(extendsTargets, r.ToID)
+				}
+			}
+		}
+	}
+	if props == nil {
+		t.Fatal("trait Animal not found")
+	}
+	if props["methods"] != "speak, legs" {
+		t.Errorf("methods = %q, want %q", props["methods"], "speak, legs")
+	}
+	if props["supertraits"] != "Eq, Clone" {
+		t.Errorf("supertraits = %q, want %q", props["supertraits"], "Eq, Clone")
+	}
+	wantExtends := map[string]bool{"Eq": true, "Clone": true}
+	for _, tt := range extendsTargets {
+		delete(wantExtends, tt)
+	}
+	if len(wantExtends) != 0 {
+		t.Errorf("missing EXTENDS edges %v; got %v", wantExtends, extendsTargets)
+	}
+}
+
+func TestRustExtractor_TraitGenerics_Deep(t *testing.T) {
+	src := `
+trait Container<T> {
+    fn get(&self) -> T;
+    fn put(&mut self, item: T);
+}
+`
+	props := findRustEntity(t, src, "trait", "Container")
+	if props["methods"] != "get, put" {
+		t.Errorf("methods = %q, want %q", props["methods"], "get, put")
+	}
+	if props["generics"] != "T" {
+		t.Errorf("generics = %q, want %q", props["generics"], "T")
+	}
+}
+
+// type_alias_extraction: assert alias name, aliased type, and generic params.
+func TestRustExtractor_TypeAliasGenerics_Deep(t *testing.T) {
+	src := `type Pair<T> = (T, T);`
+	props := findRustEntity(t, src, "type_alias", "Pair")
+	if props["generics"] != "T" {
+		t.Errorf("generics = %q, want %q", props["generics"], "T")
+	}
+	if props["aliased_type"] != "(T, T)" {
+		t.Errorf("aliased_type = %q, want %q", props["aliased_type"], "(T, T)")
+	}
+}
+
+// type_extraction (struct): assert named field idents, generics, derives.
+func TestRustExtractor_StructFields_Deep(t *testing.T) {
+	src := `
+#[derive(Serialize, Deserialize)]
+struct User<T> {
+    id: u32,
+    name: String,
+    extra: T,
+}
+`
+	props := findRustEntity(t, src, "struct", "User")
+	if props["fields"] != "id, name, extra" {
+		t.Errorf("fields = %q, want %q", props["fields"], "id, name, extra")
+	}
+	if props["generics"] != "T" {
+		t.Errorf("generics = %q, want %q", props["generics"], "T")
+	}
+	if props["derives"] != "Serialize, Deserialize" {
+		t.Errorf("derives = %q, want %q", props["derives"], "Serialize, Deserialize")
+	}
+}
+
+// type_extraction: tuple struct fields are positional indices; unit struct has none.
+func TestRustExtractor_TupleAndUnitStruct_Deep(t *testing.T) {
+	src := `
+struct Point(i32, i32);
+struct Marker;
+`
+	tuple := findRustEntity(t, src, "struct", "Point")
+	if tuple["fields"] != "0, 1" {
+		t.Errorf("tuple fields = %q, want %q", tuple["fields"], "0, 1")
+	}
+	unit := findRustEntity(t, src, "struct", "Marker")
+	if unit["fields"] != "" {
+		t.Errorf("unit struct should have no fields, got %q", unit["fields"])
+	}
+}
+
 func TestRustExtractor_TypeAlias_Properties(t *testing.T) {
 	src := `type UserId = u64;`
 	tree := parseForTest(t, src)

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -7365,31 +7365,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -7587,31 +7596,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -7809,31 +7827,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -8005,31 +8032,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -8201,31 +8237,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -8397,31 +8442,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -8603,31 +8657,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -8799,31 +8862,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -8995,31 +9067,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:
@@ -9191,31 +9272,40 @@ records:
           verified_at: "2026-05-30"
       Type System:
         interface_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustTraitMethods, rustSupertraits, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
+          verified_at: "2026-05-30"
+        type_alias_extraction:
+          status: full
+          symbols:
+            - file: internal/extractors/rust/rust.go
+              functions: [buildTypeAlias, rustGenerics]
+          tests:
+            - file: internal/extractors/rust/rust_test.go
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         enum_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustEnumVariants, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
         type_extraction:
-          status: partial
+          status: full
           symbols:
             - file: internal/extractors/rust/rust.go
-              functions: [Extract]
+              functions: [buildComponent, rustStructFields, rustDerives, rustGenerics]
           tests:
             - file: internal/extractors/rust/rust_test.go
-          issues_implemented: ["3268"]
+          issues_implemented: ["3268", "3411"]
           verified_at: "2026-05-30"
       Testing:
         tests_linkage:


### PR DESCRIPTION
Closes #3411 (part of epic #3409).

Deepens the Rust tree-sitter extractor's **Type System** coverage from `partial` → `full`, matching the JS/TS interface/enum emission bar (structured Properties + EXTENDS edges, value-asserted by tests).

## Extractor (`internal/extractors/rust/rust.go`)
Structured `Properties` now emitted per type:

| Subtype | Properties | EXTENDS |
|---|---|---|
| `enum` | `variants` (tuple `Foo(i32)` / struct `Bar{x:u8}` / discriminant `Baz=1`), `generics`, `derives` | — |
| `trait` (interface) | `methods` (required sigs + default bodies), `supertraits`, `generics` | one edge per supertrait |
| `struct` (type) | `fields` (named idents, or `0,1,..` for tuple structs, none for unit), `generics`, `derives` | — |
| `type_alias` | `aliased_type`, `generics` | — |

New namespaced helpers: `rustGenerics`, `rustStructFields`, `rustEnumVariants`, `rustTraitMethods`, `rustSupertraits`, `rustDerives`, `rustParseDerive`, `isRustTypeNode`. `#[derive(...)]` is read from preceding `attribute_item` siblings.

## Tests (`rust_test.go`)
Value-asserting (specific names, not `len>0`): enum variants+derives, enum generics, trait methods+supertraits+EXTENDS, trait generics, type-alias generics+aliased_type, struct fields+generics+derives, tuple/unit struct fields.

## Coverage
Flipped `enum_extraction` / `interface_extraction` / `type_alias_extraction` / `type_extraction` to `full` on all 10 Rust `http_framework` records (actix, axum, gotham, hyper, poem, rocket, salvo, tide, tower, warp) in `registry.json` and `capability-map.yaml` (added the previously-missing `type_alias_extraction` mapping entry; pointed all caps at the new helpers).

`go run ./tools/coverage validate` → **0 errors**; `fmt --check` → canonical. `go test ./internal/extractors/rust/ ./internal/types/ ./tools/coverage/` green; `gofmt`/`go vet` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)