### PR TITLE
deep(rust): serde DTO + validator-crate constraint extraction → full (axum/actix/rocket)

### DIFF
--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[derive(Deserialize)] and #[derive(Validate)] structs; actix web::Json/Query/Form/Path<T> extractors |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] field attrs, .validate() calls, actix extractor types |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/fw_validation.go` | Detects #[derive(Deserialize)] and #[derive(Validate)] structs; actix web::Json/Query/Form/Path<T> extractors |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/fw_validation.go` | Detects #[validate(...)] field attrs, .validate() calls, actix extractor types |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects serde Deserialize/Validate structs; axum Json/Query/Form/Path<T> extractors |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] field attrs and axum extractor types |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/fw_validation.go` | Detects serde Deserialize/Validate structs; axum Json/Query/Form/Path<T> extractors |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/fw_validation.go` | Detects #[validate(...)] field attrs and axum extractor types |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Json/Form/MsgPack<T> extractors and Deserialize derives |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects impl FromRequest guards, Json/Form extractors, validator derives |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/fw_validation.go` | Detects Json/Form/MsgPack<T> extractors and Deserialize derives |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/fw_validation.go` | Detects impl FromRequest guards, Json/Form extractors, validator derives |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; serde_json body deserialization |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate] attrs and serde_json deserialization in tower handlers |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects Deserialize/Validate derives; framework-specific body extraction |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/custom/rust/fw_validation_test.go` | Detects #[validate(...)] attrs, .validate() calls, framework body extraction |
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
 
 ### Middleware
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -45134,16 +45134,14 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "notes": "Detects #[derive(Deserialize)] and #[derive(Validate)] structs; actix web::Json/Query/Form/Path\u003cT\u003e extractors",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "notes": "Detects #[validate(...)] field attrs, .validate() calls, actix extractor types",
             "verified_at": "2026-05-30"
           }
@@ -45352,16 +45350,14 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "notes": "Detects serde Deserialize/Validate structs; axum Json/Query/Form/Path\u003cT\u003e extractors",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "notes": "Detects #[validate(...)] field attrs and axum extractor types",
             "verified_at": "2026-05-30"
           }
@@ -45571,16 +45567,16 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           }
         },
@@ -45789,16 +45785,16 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           }
         },
@@ -46007,16 +46003,16 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           }
         },
@@ -46224,16 +46220,14 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "notes": "Detects Json/Form/MsgPack\u003cT\u003e extractors and Deserialize derives",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "notes": "Detects impl FromRequest guards, Json/Form extractors, validator derives",
             "verified_at": "2026-05-30"
           }
@@ -46443,16 +46437,16 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           }
         },
@@ -46742,16 +46736,16 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           }
         },
@@ -46961,16 +46955,16 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects Deserialize/Validate derives; serde_json body deserialization",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects #[validate] attrs and serde_json deserialization in tower handlers",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           }
         },
@@ -47179,16 +47173,16 @@
         "Validation": {
           "dto_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects Deserialize/Validate derives; framework-specific body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/rust/fw_validation.go","internal/custom/rust/fw_validation_test.go"],
+            "cites": ["internal/custom/rust/fw_validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Detects #[validate(...)] attrs, .validate() calls, framework body extraction",
+            "notes": "serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow.",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/rust/extractors_test.go
+++ b/internal/custom/rust/extractors_test.go
@@ -25,12 +25,20 @@ func extract(t *testing.T, name string, file extreg.FileInput) []entitySummary {
 	}
 	var out []entitySummary
 	for _, ent := range ents {
-		out = append(out, entitySummary{Kind: ent.Kind, Subtype: ent.Subtype, Name: ent.Name})
+		out = append(out, entitySummary{
+			Kind:    ent.Kind,
+			Subtype: ent.Subtype,
+			Name:    ent.Name,
+			Props:   ent.Properties,
+		})
 	}
 	return out
 }
 
-type entitySummary struct{ Kind, Subtype, Name string }
+type entitySummary struct {
+	Kind, Subtype, Name string
+	Props               map[string]string
+}
 
 func containsEntity(ents []entitySummary, kind, name string) bool {
 	for _, e := range ents {

--- a/internal/custom/rust/fw_validation.go
+++ b/internal/custom/rust/fw_validation.go
@@ -33,6 +33,7 @@ package rust
 import (
 	"context"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -48,6 +49,9 @@ func init() {
 }
 
 type rustValidationExtractor struct{}
+
+// itoa is a local int→string helper to avoid pulling fmt for one conversion.
+func itoa(n int) string { return strconv.Itoa(n) }
 
 func (e *rustValidationExtractor) Language() string { return "custom_rust_validation" }
 
@@ -141,7 +145,296 @@ var (
 	reHyperBodyDeser = regexp.MustCompile(
 		`hyper::body::to_bytes|body::to_bytes|serde_json::from_slice`,
 	)
+
+	// ---- deep field/constraint parsing (#3413) ----
+
+	// container-level #[serde(rename_all = "camelCase")]
+	reSerdeRenameAll = regexp.MustCompile(
+		`#\[serde\s*\([^)]*\brename_all\s*=\s*"([^"]+)"`,
+	)
+
+	// field-level #[serde(rename = "x")]
+	reSerdeFieldRename = regexp.MustCompile(
+		`#\[serde\s*\([^)]*\brename\s*=\s*"([^"]+)"`,
+	)
+
+	// field-level serde flags: default / skip / flatten
+	reSerdeDefault = regexp.MustCompile(`#\[serde\s*\([^)]*\bdefault\b`)
+	reSerdeSkip    = regexp.MustCompile(`#\[serde\s*\([^)]*\bskip(?:_serializing|_deserializing)?\b`)
+	reSerdeFlatten = regexp.MustCompile(`#\[serde\s*\([^)]*\bflatten\b`)
+
+	// a single struct field:  [pub] name: Type,
+	// captures (1) field name, (2) type up to the line/field terminator.
+	reStructField = regexp.MustCompile(
+		`(?m)^\s*(?:pub(?:\s*\([^)]*\))?\s+)?([a-z_]\w*)\s*:\s*([^,\n}]+)`,
+	)
+
+	// each #[validate(...)] attribute, capturing the inner rule list.
+	reValidateInner = regexp.MustCompile(
+		`#\[validate\s*\(([^\]]*)\)\]`,
+	)
 )
+
+// ---------------------------------------------------------------------------
+// Deep struct-body parsing: fields, serde attrs, validator constraints (#3413)
+// ---------------------------------------------------------------------------
+
+// dtoField is one parsed struct field with its serde + validator metadata.
+type dtoField struct {
+	name        string
+	typ         string
+	serdeRename string // explicit #[serde(rename="...")]
+	wireName    string // effective JSON key after rename / rename_all
+	hasDefault  bool
+	skip        bool
+	flatten     bool
+	constraints []valConstraint
+	offset      int // absolute offset of the field within src
+}
+
+// valConstraint is one validator-crate rule with its specific bound(s).
+type valConstraint struct {
+	kind  string // length | email | range | url | regex | custom | contains | must_match | nested | phone | credit_card | non_control_character | ip
+	min   string // for length/range
+	max   string // for length/range
+	value string // regex path, custom fn, contains needle, must_match peer, etc.
+}
+
+// rustStructBody returns the brace-delimited body of the struct that begins at
+// or after startOff, plus the absolute offset where that body starts. Returns
+// ok=false if no balanced body is found.
+func rustStructBody(src string, startOff int) (body string, bodyStart int, ok bool) {
+	open := strings.IndexByte(src[startOff:], '{')
+	if open < 0 {
+		return "", 0, false
+	}
+	open += startOff
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[open+1 : i], open + 1, true
+			}
+		}
+	}
+	return "", 0, false
+}
+
+// applyRenameAll converts a Rust field name per a serde rename_all convention.
+func applyRenameAll(name, convention string) string {
+	switch convention {
+	case "camelCase":
+		return snakeToCamel(name, false)
+	case "PascalCase":
+		return snakeToCamel(name, true)
+	case "SCREAMING_SNAKE_CASE":
+		return strings.ToUpper(name)
+	case "kebab-case":
+		return strings.ReplaceAll(name, "_", "-")
+	case "SCREAMING-KEBAB-CASE":
+		return strings.ToUpper(strings.ReplaceAll(name, "_", "-"))
+	case "lowercase":
+		return strings.ToLower(strings.ReplaceAll(name, "_", ""))
+	case "UPPERCASE":
+		return strings.ToUpper(strings.ReplaceAll(name, "_", ""))
+	case "snake_case":
+		return name
+	default:
+		return name
+	}
+}
+
+// snakeToCamel converts snake_case to camelCase (upperFirst=false) or
+// PascalCase (upperFirst=true).
+func snakeToCamel(s string, upperFirst bool) string {
+	parts := strings.Split(s, "_")
+	var b strings.Builder
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		if i == 0 && !upperFirst {
+			b.WriteString(p)
+			continue
+		}
+		b.WriteString(strings.ToUpper(p[:1]))
+		b.WriteString(p[1:])
+	}
+	return b.String()
+}
+
+// parseValidateRules parses the inner text of a single #[validate(...)] attr
+// into zero or more typed constraints. Handles:
+//
+//	length(min = 1, max = 20)   range(min = 0.0, max = 100.0)
+//	email   url   phone   credit_card   non_control_character
+//	regex = "PATH" / regex(path = "PATH")
+//	custom = "fn" / custom(function = "fn")
+//	contains = "x" / contains(pattern = "x")
+//	must_match = "other" / must_match(other = "field")
+//	nested  (bare — recurse into the field's own type)
+func parseValidateRules(inner string) []valConstraint {
+	var out []valConstraint
+	for _, rule := range splitTopLevel(inner) {
+		rule = strings.TrimSpace(rule)
+		if rule == "" {
+			continue
+		}
+		head := rule
+		var args string
+		if p := strings.IndexByte(rule, '('); p >= 0 {
+			head = strings.TrimSpace(rule[:p])
+			if c := strings.LastIndexByte(rule, ')'); c > p {
+				args = rule[p+1 : c]
+			}
+		} else if eq := strings.IndexByte(rule, '='); eq >= 0 {
+			// keyword form: regex = "...", custom = "...", contains = "..."
+			head = strings.TrimSpace(rule[:eq])
+			args = strings.TrimSpace(rule[eq+1:])
+		}
+		c := valConstraint{kind: head}
+		switch head {
+		case "length", "range":
+			c.min = kwArg(args, "min")
+			c.max = kwArg(args, "max")
+		case "regex":
+			c.value = firstStringArg(args, "path")
+		case "custom":
+			c.value = firstStringArg(args, "function")
+		case "contains":
+			c.value = firstStringArg(args, "pattern")
+		case "must_match":
+			c.value = firstStringArg(args, "other")
+		case "email", "url", "phone", "credit_card",
+			"non_control_character", "ip", "nested", "required":
+			// no bound
+		default:
+			// unknown rule kind — still record it by name
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// splitTopLevel splits a comma-separated rule list, ignoring commas nested
+// inside parentheses (e.g. length(min = 1, max = 20)).
+func splitTopLevel(s string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
+// kwArg extracts an unquoted keyword argument value: kwArg("min = 1, max = 20",
+// "max") == "20". Returns "" when absent.
+func kwArg(args, key string) string {
+	for _, part := range strings.Split(args, ",") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, key) {
+			rest := strings.TrimSpace(part[len(key):])
+			if strings.HasPrefix(rest, "=") {
+				return strings.TrimSpace(strings.Trim(strings.TrimSpace(rest[1:]), `"`))
+			}
+		}
+	}
+	return ""
+}
+
+// firstStringArg returns the value of a quoted argument. It accepts both the
+// bare form (`"foo"`) and the keyword form (`path = "foo"`). key names the
+// keyword for the keyword form.
+func firstStringArg(args, key string) string {
+	args = strings.TrimSpace(args)
+	// keyword form: key = "value"
+	if v := kwArg(args, key); v != "" {
+		return v
+	}
+	// bare quoted form
+	if i := strings.IndexByte(args, '"'); i >= 0 {
+		if j := strings.IndexByte(args[i+1:], '"'); j >= 0 {
+			return args[i+1 : i+1+j]
+		}
+	}
+	// bare identifier form: custom = my_fn (no quotes) — args already stripped
+	return strings.Trim(args, `"`)
+}
+
+// parseDTOFields parses one struct body into ordered fields with their serde
+// and validator metadata. renameAll is the container-level rename_all value
+// ("" when absent). bodyStart is the absolute offset of the body in src (for
+// line numbers).
+func parseDTOFields(body string, bodyStart int, renameAll string) []dtoField {
+	var out []dtoField
+
+	// We walk field declarations. For each field we look BACK across the
+	// preceding attribute lines (which sit between the previous field end and
+	// this field's name) to collect its #[serde(...)] / #[validate(...)] attrs.
+	matches := reStructField.FindAllStringSubmatchIndex(body, -1)
+	prevEnd := 0
+	for _, m := range matches {
+		name := body[m[2]:m[3]]
+		typ := strings.TrimSpace(body[m[4]:m[5]])
+		// Skip Rust keywords that the field regex may catch (e.g. `where`).
+		if name == "where" || name == "impl" || name == "fn" {
+			prevEnd = m[1]
+			continue
+		}
+		// Attribute window: from end of previous field to start of this one.
+		attrWin := body[prevEnd:m[0]]
+		prevEnd = m[1]
+
+		f := dtoField{name: name, typ: typ, offset: bodyStart + m[0]}
+
+		if rm := reSerdeFieldRename.FindStringSubmatch(attrWin); rm != nil {
+			f.serdeRename = rm[1]
+		}
+		if reSerdeDefault.MatchString(attrWin) {
+			f.hasDefault = true
+		}
+		if reSerdeSkip.MatchString(attrWin) {
+			f.skip = true
+		}
+		if reSerdeFlatten.MatchString(attrWin) {
+			f.flatten = true
+		}
+
+		switch {
+		case f.serdeRename != "":
+			f.wireName = f.serdeRename
+		case renameAll != "":
+			f.wireName = applyRenameAll(name, renameAll)
+		default:
+			f.wireName = name
+		}
+
+		for _, vm := range reValidateInner.FindAllStringSubmatch(attrWin, -1) {
+			f.constraints = append(f.constraints, parseValidateRules(vm[1])...)
+		}
+
+		out = append(out, f)
+	}
+	return out
+}
 
 // dtoStructsFromSrc scans src for Deserialize or Validate derives and returns
 // the struct names, derive list, and source offset for each.
@@ -150,6 +443,8 @@ type dtoInfo struct {
 	deriveList  string
 	offset      int
 	hasValidate bool
+	hasDeser    bool
+	fields      []dtoField // deep-parsed fields (#3413)
 }
 
 func extractDTOs(src string) []dtoInfo {
@@ -161,7 +456,8 @@ func extractDTOs(src string) []dtoInfo {
 	for _, dm := range allDerive {
 		attrText := src[dm[0]:dm[1]]
 		deriveList := src[dm[2]:dm[3]]
-		isDeser := strings.Contains(deriveList, "Deserialize")
+		isDeser := strings.Contains(deriveList, "Deserialize") ||
+			strings.Contains(deriveList, "Serialize")
 		isVal := strings.Contains(deriveList, "Validate")
 		if !isDeser && !isVal {
 			continue
@@ -180,11 +476,31 @@ func extractDTOs(src string) []dtoInfo {
 			continue
 		}
 		seen[sname] = true
+
+		// Container-level #[serde(rename_all = "...")] lives in the attribute
+		// block between this derive and the struct keyword.
+		var renameAll string
+		structKwOff := dm[1] + sm[0]
+		if structKwOff <= len(src) {
+			containerAttrs := src[dm[0]:structKwOff]
+			if ra := reSerdeRenameAll.FindStringSubmatch(containerAttrs); ra != nil {
+				renameAll = ra[1]
+			}
+		}
+
+		// Deep-parse the struct body for fields + constraints.
+		var fields []dtoField
+		if body, bodyStart, ok := rustStructBody(src, structKwOff); ok {
+			fields = parseDTOFields(body, bodyStart, renameAll)
+		}
+
 		out = append(out, dtoInfo{
 			structName:  sname,
 			deriveList:  attrText,
 			offset:      dm[0],
 			hasValidate: isVal,
+			hasDeser:    isDeser,
+			fields:      fields,
 		})
 	}
 	return out
@@ -234,8 +550,61 @@ func (e *rustValidationExtractor) Extract(ctx context.Context, file extractor.Fi
 		setProps(&ent,
 			"provenance", "INFERRED_FROM_SERDE_DESERIALIZE",
 			"struct_name", dto.structName,
+			"field_count", itoa(len(dto.fields)),
 		)
 		add(ent)
+
+		// --- deep field + constraint entities (#3413) ---
+		for _, f := range dto.fields {
+			fieldEnt := makeEntity(
+				"dto_field:"+dto.structName+"."+f.name,
+				"SCOPE.Schema", "dto_field",
+				file.Path, file.Language, lineOf(src, f.offset))
+			setProps(&fieldEnt,
+				"provenance", "INFERRED_FROM_SERDE_FIELD",
+				"struct_name", dto.structName,
+				"field_name", f.name,
+				"field_type", f.typ,
+				"wire_name", f.wireName,
+			)
+			if f.serdeRename != "" {
+				setProps(&fieldEnt, "serde_rename", f.serdeRename)
+			}
+			if f.hasDefault {
+				setProps(&fieldEnt, "serde_default", "true")
+			}
+			if f.skip {
+				setProps(&fieldEnt, "serde_skip", "true")
+			}
+			if f.flatten {
+				setProps(&fieldEnt, "serde_flatten", "true")
+			}
+			add(fieldEnt)
+
+			// One SCOPE.Constraint per validator-crate rule on this field,
+			// carrying the SPECIFIC field + constraint kind + bound(s).
+			for _, c := range f.constraints {
+				cName := "validation:" + dto.structName + "." + f.name + ":" + c.kind
+				cEnt := makeEntity(cName, "SCOPE.Constraint", "field_constraint",
+					file.Path, file.Language, lineOf(src, f.offset))
+				setProps(&cEnt,
+					"provenance", "INFERRED_FROM_VALIDATE_ATTR",
+					"struct_name", dto.structName,
+					"field_name", f.name,
+					"constraint_kind", c.kind,
+				)
+				if c.min != "" {
+					setProps(&cEnt, "min", c.min)
+				}
+				if c.max != "" {
+					setProps(&cEnt, "max", c.max)
+				}
+				if c.value != "" {
+					setProps(&cEnt, "value", c.value)
+				}
+				add(cEnt)
+			}
+		}
 	}
 
 	// -----------------------------------------------------------------------

--- a/internal/custom/rust/fw_validation_test.go
+++ b/internal/custom/rust/fw_validation_test.go
@@ -175,6 +175,17 @@ func TestValidation_FixtureFile(t *testing.T) {
 	if !containsEntity(ents, "SCOPE.Pattern", "warp_body_json") {
 		t.Error("expected warp body json pattern")
 	}
+	// Deep field + constraint assertions on the fixture (#3413).
+	mustProp(t, ents, "dto_field:UpdateUserRequest.display_name",
+		map[string]string{"field_name": "display_name", "wire_name": "displayName"})
+	mustProp(t, ents, "validation:UpdateUserRequest.display_name:length",
+		map[string]string{"min": "1", "max": "100"})
+	mustProp(t, ents, "validation:UpdateUserRequest.age:range",
+		map[string]string{"min": "0", "max": "150"})
+	mustProp(t, ents, "dto_field:UpdateUserRequest.password",
+		map[string]string{"serde_rename": "pwd", "wire_name": "pwd"})
+	mustProp(t, ents, "validation:UpdateUserRequest.password:length",
+		map[string]string{"min": "8"})
 }
 
 // containsEntitySubtype checks for matching kind+subtype regardless of name.
@@ -185,4 +196,239 @@ func containsEntitySubtype(ents []entitySummary, kind, subtype string) bool {
 		}
 	}
 	return false
+}
+
+// ---------------------------------------------------------------------------
+// Deep value-asserting tests (#3413): specific field + constraint + bound.
+// These prove dto_extraction / request_validation to the TS/JS bar — every
+// assertion names a concrete field and a concrete constraint with its bound.
+// ---------------------------------------------------------------------------
+
+// TestValidation_DTOFieldNamesAndTypes proves serde structs are decomposed into
+// per-field entities carrying the concrete field name + Rust type.
+func TestValidation_DTOFieldNamesAndTypes(t *testing.T) {
+	src := `
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct CreateUserRequest {
+    pub name: String,
+    pub age: u32,
+    pub email: String,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("dto.rs", "rust", src))
+	mustProp(t, ents, "dto_field:CreateUserRequest.name",
+		map[string]string{"field_name": "name", "field_type": "String"})
+	mustProp(t, ents, "dto_field:CreateUserRequest.age",
+		map[string]string{"field_name": "age", "field_type": "u32"})
+	mustProp(t, ents, "dto_field:CreateUserRequest.email",
+		map[string]string{"field_name": "email", "field_type": "String"})
+}
+
+// TestValidation_LengthConstraintBounds proves #[validate(length(min=1,max=20))]
+// is parsed into a constraint with the SPECIFIC min and max bounds — not len>0.
+func TestValidation_LengthConstraintBounds(t *testing.T) {
+	src := `
+#[derive(Deserialize, Validate)]
+pub struct SignupRequest {
+    #[validate(length(min = 1, max = 20))]
+    pub username: String,
+    #[validate(email)]
+    pub email: String,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("signup.rs", "rust", src))
+	mustProp(t, ents, "validation:SignupRequest.username:length",
+		map[string]string{
+			"constraint_kind": "length",
+			"field_name":      "username",
+			"min":             "1",
+			"max":             "20",
+		})
+	mustProp(t, ents, "validation:SignupRequest.email:email",
+		map[string]string{
+			"constraint_kind": "email",
+			"field_name":      "email",
+		})
+}
+
+// TestValidation_RangeConstraintBounds proves #[validate(range(min=0,max=120))].
+func TestValidation_RangeConstraintBounds(t *testing.T) {
+	src := `
+#[derive(Deserialize, Validate)]
+pub struct Profile {
+    #[validate(range(min = 0, max = 120))]
+    pub age: u8,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("profile.rs", "rust", src))
+	mustProp(t, ents, "validation:Profile.age:range",
+		map[string]string{
+			"constraint_kind": "range",
+			"field_name":      "age",
+			"min":             "0",
+			"max":             "120",
+		})
+}
+
+// TestValidation_RegexAndCustom proves regex="..." and custom="fn" capture the
+// concrete pattern path / function name.
+func TestValidation_RegexAndCustom(t *testing.T) {
+	src := `
+#[derive(Deserialize, Validate)]
+pub struct Creds {
+    #[validate(regex = "RE_USERNAME")]
+    pub handle: String,
+    #[validate(custom = "validate_password_strength")]
+    pub password: String,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("creds.rs", "rust", src))
+	mustProp(t, ents, "validation:Creds.handle:regex",
+		map[string]string{"constraint_kind": "regex", "value": "RE_USERNAME"})
+	mustProp(t, ents, "validation:Creds.password:custom",
+		map[string]string{"constraint_kind": "custom", "value": "validate_password_strength"})
+}
+
+// TestValidation_NestedValidation proves a bare #[validate] / #[validate(nested)]
+// on a field whose type is another DTO is captured as a nested constraint.
+func TestValidation_NestedValidation(t *testing.T) {
+	src := `
+#[derive(Deserialize, Validate)]
+pub struct Order {
+    #[validate(length(min = 1))]
+    pub id: String,
+    #[validate(nested)]
+    pub shipping: Address,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("order.rs", "rust", src))
+	mustProp(t, ents, "validation:Order.shipping:nested",
+		map[string]string{"constraint_kind": "nested", "field_name": "shipping"})
+}
+
+// TestValidation_SerdeRename proves #[serde(rename="...")] and container
+// rename_all="camelCase" set the effective wire_name.
+func TestValidation_SerdeRename(t *testing.T) {
+	src := `
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiRequest {
+    pub user_id: u64,
+    #[serde(rename = "EmailAddress")]
+    pub email: String,
+    #[serde(default)]
+    pub is_active: bool,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("api.rs", "rust", src))
+	// rename_all camelCase: user_id -> userId
+	mustProp(t, ents, "dto_field:ApiRequest.user_id",
+		map[string]string{"field_name": "user_id", "wire_name": "userId"})
+	// explicit rename wins over rename_all
+	mustProp(t, ents, "dto_field:ApiRequest.email",
+		map[string]string{"wire_name": "EmailAddress", "serde_rename": "EmailAddress"})
+	// is_active -> isActive, plus serde_default flag
+	mustProp(t, ents, "dto_field:ApiRequest.is_active",
+		map[string]string{"wire_name": "isActive", "serde_default": "true"})
+}
+
+// TestValidation_SerdeFlattenSkip proves flatten/skip flags are captured.
+func TestValidation_SerdeFlattenSkip(t *testing.T) {
+	src := `
+#[derive(Deserialize)]
+pub struct Page {
+    #[serde(flatten)]
+    pub paging: Pagination,
+    #[serde(skip)]
+    pub internal: String,
+}
+`
+	ents := extract(t, "custom_rust_validation", fi("page.rs", "rust", src))
+	mustProp(t, ents, "dto_field:Page.paging",
+		map[string]string{"serde_flatten": "true"})
+	mustProp(t, ents, "dto_field:Page.internal",
+		map[string]string{"serde_skip": "true"})
+}
+
+// TestValidation_AxumActixRocketPayloadTie proves DTO fields + constraints are
+// extracted alongside the flagship extractor payload that carries them.
+func TestValidation_AxumActixRocketPayloadTie(t *testing.T) {
+	// axum: Json<T>
+	axum := `
+#[derive(Deserialize, Validate)]
+pub struct LoginForm {
+    #[validate(email)]
+    pub email: String,
+    #[validate(length(min = 8))]
+    pub password: String,
+}
+async fn login(Json(form): Json<LoginForm>) -> impl IntoResponse { todo!() }
+`
+	ents := extract(t, "custom_rust_validation", fi("axum_login.rs", "rust", axum))
+	mustEntity(t, ents, "SCOPE.Schema", "axum_extractor:Json<LoginForm>")
+	mustProp(t, ents, "validation:LoginForm.email:email",
+		map[string]string{"constraint_kind": "email"})
+	mustProp(t, ents, "validation:LoginForm.password:length",
+		map[string]string{"min": "8"})
+
+	// actix: web::Json<T>
+	actix := `
+#[derive(Deserialize, Validate)]
+pub struct CreatePost {
+    #[validate(length(min = 1, max = 280))]
+    pub body: String,
+}
+async fn create(item: web::Json<CreatePost>) -> impl Responder { todo!() }
+`
+	ents2 := extract(t, "custom_rust_validation", fi("actix_post.rs", "rust", actix))
+	mustEntity(t, ents2, "SCOPE.Schema", "actix_extractor:Json<CreatePost>")
+	mustProp(t, ents2, "validation:CreatePost.body:length",
+		map[string]string{"min": "1", "max": "280"})
+
+	// rocket: Form<T>
+	rocket := `
+#[derive(FromForm, Validate)]
+pub struct Contact {
+    #[validate(email)]
+    pub email: String,
+}
+#[post("/contact", data = "<form>")]
+fn submit(form: Form<Contact>) -> Status { Status::Ok }
+`
+	ents3 := extract(t, "custom_rust_validation", fi("rocket_contact.rs", "rust", rocket))
+	mustEntity(t, ents3, "SCOPE.Schema", "rocket_extractor:Contact")
+	mustProp(t, ents3, "validation:Contact.email:email",
+		map[string]string{"constraint_kind": "email"})
+}
+
+// --- property-asserting helpers ---
+
+func mustEntity(t *testing.T, ents []entitySummary, kind, name string) {
+	t.Helper()
+	if !containsEntity(ents, kind, name) {
+		t.Errorf("expected entity %s %q", kind, name)
+	}
+}
+
+func mustProp(t *testing.T, ents []entitySummary, name string, want map[string]string) {
+	t.Helper()
+	for _, e := range ents {
+		if e.Name != name {
+			continue
+		}
+		for k, v := range want {
+			got, ok := e.Props[k]
+			if !ok {
+				t.Errorf("entity %q: missing prop %q (want %q)", name, k, v)
+				continue
+			}
+			if got != v {
+				t.Errorf("entity %q: prop %q = %q, want %q", name, k, got, v)
+			}
+		}
+		return
+	}
+	t.Errorf("entity %q not found", name)
 }

--- a/internal/custom/rust/testdata/validation_dto.rs
+++ b/internal/custom/rust/testdata/validation_dto.rs
@@ -11,13 +11,19 @@ pub struct CreateUserRequest {
     pub email: String,
 }
 
-/// DTO with serde + Validate
+/// DTO with serde + Validate, rename_all + per-field rules
 #[derive(Debug, Deserialize, Validate)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateUserRequest {
     #[validate(length(min = 1, max = 100))]
-    pub name: String,
+    pub display_name: String,
     #[validate(email)]
     pub email: String,
+    #[validate(range(min = 0, max = 150))]
+    pub age: u8,
+    #[serde(rename = "pwd")]
+    #[validate(length(min = 8))]
+    pub password: String,
 }
 
 /// Axum-style handler with Json extractor

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -7424,11 +7424,18 @@ records:
           verified_at: "2026-05-30"
       Validation:
         dto_extraction:
-          status: partial
+          status: full
           symbols:
-            - file: internal/custom/rust/axum.go
-              functions: [Extract]
-          issues_implemented: ["3268"]
+            - file: internal/custom/rust/fw_validation.go
+              functions: [Extract, extractDTOs, parseDTOFields, applyRenameAll]
+          issues_implemented: ["3268", "3413"]
+          verified_at: "2026-05-30"
+        request_validation:
+          status: full
+          symbols:
+            - file: internal/custom/rust/fw_validation.go
+              functions: [Extract, parseValidateRules, parseDTOFields]
+          issues_implemented: ["3413"]
           verified_at: "2026-05-30"
 
   lang.rust.framework.actix:
@@ -7646,11 +7653,18 @@ records:
           verified_at: "2026-05-30"
       Validation:
         dto_extraction:
-          status: partial
+          status: full
           symbols:
-            - file: internal/custom/rust/actix_web.go
-              functions: [Extract]
-          issues_implemented: ["3268"]
+            - file: internal/custom/rust/fw_validation.go
+              functions: [Extract, extractDTOs, parseDTOFields, applyRenameAll]
+          issues_implemented: ["3268", "3413"]
+          verified_at: "2026-05-30"
+        request_validation:
+          status: full
+          symbols:
+            - file: internal/custom/rust/fw_validation.go
+              functions: [Extract, parseValidateRules, parseDTOFields]
+          issues_implemented: ["3413"]
           verified_at: "2026-05-30"
 
   lang.rust.framework.gotham:
@@ -8445,6 +8459,21 @@ records:
           tests:
             - file: internal/custom/rust/extractors_test.go
           issues_implemented: ["3268"]
+          verified_at: "2026-05-30"
+      Validation:
+        dto_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/fw_validation.go
+              functions: [Extract, extractDTOs, parseDTOFields, applyRenameAll]
+          issues_implemented: ["3413"]
+          verified_at: "2026-05-30"
+        request_validation:
+          status: full
+          symbols:
+            - file: internal/custom/rust/fw_validation.go
+              functions: [Extract, parseValidateRules, parseDTOFields]
+          issues_implemented: ["3413"]
           verified_at: "2026-05-30"
 
   lang.rust.framework.salvo:


### PR DESCRIPTION
Closes #3413 (part of epic #3409).

Deepens `internal/custom/rust/fw_validation.go` from heuristic struct/attr matching to true **field- and constraint-level** decomposition for serde + `validator`-crate request DTOs, to the TS/JS quality bar.

## dto_extraction
- Balanced-brace scan of `#[derive(Deserialize|Serialize|Validate)]` struct bodies → one `SCOPE.Schema` `dto_field` entity per field, carrying `field_name`, `field_type`, effective `wire_name`.
- serde attrs: container `#[serde(rename_all = "camelCase|PascalCase|kebab-case|SCREAMING_SNAKE_CASE|...")]`, field `#[serde(rename = "...")]` (precedence over rename_all), `default` / `skip` / `flatten` flags.

## request_validation
- Each `#[validate(...)]` rule parsed into a typed `SCOPE.Constraint` `field_constraint` entity with the **specific** bound:
  `length(min,max)`, `range(min,max)`, `email`, `url`, `phone`, `credit_card`, `regex="PATH"`, `custom="fn"`, `contains`, `must_match`, `nested`.
- Top-level comma splitter handles nested parens (`length(min=1, max=20)`); keyword + bare-quoted argument forms both supported.

Tied to flagship typed extractor payloads: axum `Json<T>`, actix `web::Json<T>`, rocket `Json<T>`/`Form<T>`.

## Tests (value-asserting)
8 new tests assert concrete field + constraint + bound (e.g. `username: length(min=1,max=20)`, `email: validate(email)`, `age: range(min=0,max=120)`, `regex="RE_USERNAME"`, `custom="validate_password_strength"`, `nested`, `rename_all` camelCase, explicit `serde(rename)`, flatten/skip), plus axum/actix/rocket payload-tie tests and a deepened fixture. All targeted suites green (`internal/custom/rust`, `internal/types`, `tools/coverage`). gofmt clean on changed files, `go vet` clean.

## Coverage disposition
| Capability | axum / actix / rocket | gotham / hyper / poem / salvo / tide / tower / warp |
|---|---|---|
| `Validation.dto_extraction` | **partial → full** | partial (honest, noted) |
| `Validation.request_validation` | **partial → full** | partial (honest, noted) |

Flagship flips are backed by value-asserting tests where DTOs are typed extractor payloads. The 7 non-flagship frameworks stay **honest-partial** with a documented gap: their body-deser site (`serde_json::from_slice` / `req.body_json`) is value-untyped, so DTO↔extractor binding is not statically proven without cross-file type-flow.

`capability-map.yaml` proof entries added/corrected (axum/actix repointed to `fw_validation.go`, rocket Validation group added). `coverage validate` → 0 errors (rust validation mapping warnings cleared), `fmt --check` canonical, docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)