### PR TITLE
deep(rust): auth + middleware partial->full (axum/actix/rocket/tower) (#3414)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -105,14 +105,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [ruby](../by-language/ruby.md) | [Ruby on Rails](../detail/lang.ruby.framework.rails.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [Sinatra](../detail/lang.ruby.framework.sinatra.md) | ✅ 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ruby](../by-language/ruby.md) | [dry-rb (ecosystem)](../detail/lang.ruby.framework.dry-rb.md) | 🟢 2/2 | — | 🟢 1/1 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
-| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -26,14 +26,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Axum](../detail/lang.rust.framework.axum.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Poem](../detail/lang.rust.framework.poem.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 

--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | HttpAuthentication::bearer/basic(validator) binds validator_name + auth_method + auth_required; custom Transform middleware impls classified. Validator symbol is bound by name, not resolved cross-file. |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/actix_web.go`<br>`internal/custom/rust/auth.go`<br>`internal/custom/rust/axum.go` | — |
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/actix_web.go`<br>`internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | custom Transform<S,ServiceRequest> impls + .wrap() registrations captured with middleware_name/middleware_trait |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | from_fn(auth_fn) guards, .route_layer auth, FromRequestParts extractor guards, tower-http ValidateRequestHeaderLayer::bearer; records guard_name + auth_method + auth_required. Cross-file resolution of the from_fn handler body is not chased. |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/actix_web.go`<br>`internal/custom/rust/auth.go`<br>`internal/custom/rust/axum.go` | — |
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go`<br>`internal/custom/rust/axum.go` | .layer/.route_layer + tower ServiceBuilder ordered layer chains enumerated in source order (layer_order + layer_order_list) |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for gotham |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but gotham layer chains are not ordered/enumerated like tower |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | tower-http auth layers detected when present; hyper itself has no first-class auth surface, so guard-to-route binding is not modelled |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | hyper services compose via tower ServiceBuilder::new().layer() chains, enumerated in order (layer_order + layer_chain) by the shared tower matcher |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for poem |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but poem layer chains are not ordered/enumerated like tower |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go`<br>`internal/custom/rust/rocket.go` | Fairing impls and FromRequest request guards captured with guard_name + auth_method + auth_required (auth-shaped guards only) |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go`<br>`internal/custom/rust/rocket.go` | impl Fairing for X middleware captured with middleware_name + middleware_trait=Fairing; .attach() registration captured |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for salvo |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but salvo layer chains are not ordered/enumerated like tower |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for tide |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but tide layer chains are not ordered/enumerated like tower |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | tower-http ValidateRequestHeaderLayer::bearer/basic and RequireAuthorizationLayer::bearer/basic captured with auth_method + auth_required + layer_order |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go`<br>`internal/custom/rust/auth_policy_test.go` | ServiceBuilder::new().layer(..).layer(..) chains enumerated in source order: per-layer layer_order plus a layer_chain entity with layer_count + layer_order_list |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for warp |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go` | — |
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but warp layer chains are not ordered/enumerated like tower |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -45126,8 +45126,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
+            "notes": "HttpAuthentication::bearer/basic(validator) binds validator_name + auth_method + auth_required; custom Transform middleware impls classified. Validator symbol is bound by name, not resolved cross-file.",
             "verified_at": "2026-05-30"
           }
         },
@@ -45147,8 +45148,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/actix_web.go","internal/custom/rust/auth.go","internal/custom/rust/axum.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/actix_web.go","internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
+            "notes": "custom Transform\u003cS,ServiceRequest\u003e impls + .wrap() registrations captured with middleware_name/middleware_trait",
             "verified_at": "2026-05-30"
           }
         },
@@ -45340,8 +45342,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
+            "notes": "from_fn(auth_fn) guards, .route_layer auth, FromRequestParts extractor guards, tower-http ValidateRequestHeaderLayer::bearer; records guard_name + auth_method + auth_required. Cross-file resolution of the from_fn handler body is not chased.",
             "verified_at": "2026-05-30"
           }
         },
@@ -45361,8 +45364,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/actix_web.go","internal/custom/rust/auth.go","internal/custom/rust/axum.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go","internal/custom/rust/axum.go"],
+            "notes": ".layer/.route_layer + tower ServiceBuilder ordered layer chains enumerated in source order (layer_order + layer_order_list)",
             "verified_at": "2026-05-30"
           }
         },
@@ -45555,7 +45559,8 @@
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for gotham",
             "verified_at": "2026-05-30"
           }
         },
@@ -45578,7 +45583,8 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but gotham layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
           }
         },
@@ -45772,7 +45778,8 @@
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "tower-http auth layers detected when present; hyper itself has no first-class auth surface, so guard-to-route binding is not modelled",
             "verified_at": "2026-05-30"
           }
         },
@@ -45794,8 +45801,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
+            "notes": "hyper services compose via tower ServiceBuilder::new().layer() chains, enumerated in order (layer_order + layer_chain) by the shared tower matcher",
             "verified_at": "2026-05-30"
           }
         },
@@ -45988,7 +45996,8 @@
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for poem",
             "verified_at": "2026-05-30"
           }
         },
@@ -46011,7 +46020,8 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but poem layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
           }
         },
@@ -46203,8 +46213,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go","internal/custom/rust/rocket.go"],
+            "notes": "Fairing impls and FromRequest request guards captured with guard_name + auth_method + auth_required (auth-shaped guards only)",
             "verified_at": "2026-05-30"
           }
         },
@@ -46224,8 +46235,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go","internal/custom/rust/rocket.go"],
+            "notes": "impl Fairing for X middleware captured with middleware_name + middleware_trait=Fairing; .attach() registration captured",
             "verified_at": "2026-05-30"
           }
         },
@@ -46418,7 +46430,8 @@
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for salvo",
             "verified_at": "2026-05-30"
           }
         },
@@ -46441,7 +46454,8 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but salvo layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
           }
         },
@@ -46715,7 +46729,8 @@
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for tide",
             "verified_at": "2026-05-30"
           }
         },
@@ -46738,7 +46753,8 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but tide layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
           }
         },
@@ -46932,8 +46948,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
+            "notes": "tower-http ValidateRequestHeaderLayer::bearer/basic and RequireAuthorizationLayer::bearer/basic captured with auth_method + auth_required + layer_order",
             "verified_at": "2026-05-30"
           }
         },
@@ -46955,8 +46972,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "status": "full",
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go","internal/custom/rust/auth_policy_test.go"],
+            "notes": "ServiceBuilder::new().layer(..).layer(..) chains enumerated in source order: per-layer layer_order plus a layer_chain entity with layer_count + layer_order_list",
             "verified_at": "2026-05-30"
           }
         },
@@ -47149,7 +47167,8 @@
         "Auth": {
           "auth_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for warp",
             "verified_at": "2026-05-30"
           }
         },
@@ -47172,7 +47191,8 @@
         "Middleware": {
           "middleware_coverage": {
             "status": "partial",
-            "cites": ["internal/custom/rust/auth.go"],
+            "cites": ["internal/custom/rust/auth.go","internal/custom/rust/auth_policy.go"],
+            "notes": "framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but warp layer chains are not ordered/enumerated like tower",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/rust/auth.go
+++ b/internal/custom/rust/auth.go
@@ -188,6 +188,7 @@ func (e *rustAuthExtractor) Extract(ctx context.Context, file extractor.FileInpu
 				"provenance", "INFERRED_FROM_RUST_AUTH",
 				"pattern_kind", "auth",
 				"auth_subtype", sig.atype,
+				"auth_method", authPolicyMethod(sig.atype+" "+detail),
 			)
 			add(ent)
 		}
@@ -229,6 +230,11 @@ func (e *rustAuthExtractor) Extract(ctx context.Context, file extractor.FileInpu
 			}
 		}
 	}
+
+	// --- Deep auth policy + middleware/guard/layer-chain extraction ---
+	// Recovers specific guard/middleware names and the enforced auth policy
+	// (auth_method + auth_required) and enumerates tower layer chains in order.
+	emitAuthPolicy(src, file.Path, file.Language, framework, add)
 
 	span.SetAttributes(
 		attribute.String("framework", framework),

--- a/internal/custom/rust/auth_policy.go
+++ b/internal/custom/rust/auth_policy.go
@@ -1,0 +1,346 @@
+package rust
+
+// auth_policy.go — deep auth + middleware extraction for Rust HTTP services
+// (issue #3414, epic #3409). Where auth.go performs a broad heuristic signal
+// scan, this file recovers the *specific* middleware/guard names and the auth
+// *policy* they enforce — auth_method (bearer|jwt|basic|apikey|oauth|session)
+// and auth_required (bool) — and enumerates tower ServiceBuilder layer chains
+// in source order. This is the value that lifts auth_coverage /
+// middleware_coverage from heuristic-partial to value-asserting-full for the
+// flagship frameworks (axum, actix-web, rocket).
+//
+// Honesty boundary: these matchers bind a guard/middleware to its *declared*
+// name and the auth method named at the call/impl site. Cross-file resolution
+// of a from_fn handler or actix validator to its definition is NOT performed;
+// when a guard is bound to a validator symbol we record validator_name but do
+// not chase it across files. That residual is documented per-framework in the
+// coverage registry notes.
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// auth method classification
+// ---------------------------------------------------------------------------
+
+// authPolicyMethod maps an auth expression / type name to a canonical auth
+// method token. Order matters: more specific tokens are tested first.
+func authPolicyMethod(expr string) string {
+	l := strings.ToLower(expr)
+	switch {
+	case strings.Contains(l, "bearer"):
+		return "bearer"
+	case strings.Contains(l, "basic"):
+		return "basic"
+	case strings.Contains(l, "jwt") || strings.Contains(l, "jsonwebtoken") ||
+		strings.Contains(l, "decodingkey") || strings.Contains(l, "encodingkey") ||
+		strings.Contains(l, "claims"):
+		return "jwt"
+	case strings.Contains(l, "apikey") || strings.Contains(l, "api_key") ||
+		strings.Contains(l, "x-api-key"):
+		return "apikey"
+	case strings.Contains(l, "oauth"):
+		return "oauth"
+	case strings.Contains(l, "session") || strings.Contains(l, "identity"):
+		return "session"
+	default:
+		return "unknown"
+	}
+}
+
+// ---------------------------------------------------------------------------
+// axum / tower deep matchers
+// ---------------------------------------------------------------------------
+
+var (
+	// middleware::from_fn(auth_fn) and from_fn_with_state(state, auth_fn) —
+	// captures the named middleware fn so it can be bound as a guard.
+	reAxumFromFn = regexp.MustCompile(
+		`\bfrom_fn(?:_with_state)?\s*\(\s*(?:[A-Za-z_]\w*\s*,\s*)?([A-Za-z_]\w*)\s*\)`,
+	)
+	// .route_layer(<expr>) — per-route layer (auth typically applied here).
+	reAxumRouteLayer = regexp.MustCompile(
+		`\.route_layer\s*\(\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)`,
+	)
+	// tower_http ValidateRequestHeaderLayer::bearer(token) / ::basic(..) /
+	// ::custom(..) — a concrete header-validation auth layer.
+	reValidateRequestHeader = regexp.MustCompile(
+		`\bValidateRequestHeaderLayer::([A-Za-z_]\w*)\s*\(`,
+	)
+	// tower_http RequireAuthorizationLayer::bearer(..) / ::basic(..).
+	reRequireAuthLayer = regexp.MustCompile(
+		`\bRequireAuthorizationLayer::([A-Za-z_]\w*)\s*\(`,
+	)
+	// Custom extractor guard: `impl FromRequestParts for AuthUser` /
+	// `impl<S> FromRequestParts<S> for CurrentUser` / async-trait FromRequest.
+	reFromRequestPartsImpl = regexp.MustCompile(
+		`impl\s*(?:<[^>]*>\s*)?FromRequestParts(?:<[^>]*>)?\s+for\s+([A-Za-z_]\w*)`,
+	)
+	reFromRequestImpl = regexp.MustCompile(
+		`impl\s*(?:<[^>]*>\s*)?FromRequest(?:<[^>]*>)?\s+for\s+([A-Za-z_]\w*)`,
+	)
+	// tower ServiceBuilder layer chain: a ServiceBuilder::new() followed by the
+	// run of method calls up to the statement terminator. We capture the chain
+	// body then enumerate the .layer(...) calls within it in source order.
+	// [^;]* tolerates the nested parens of each layer constructor (e.g.
+	// .layer(TraceLayer::new_for_http())) which a per-.layer lazy match cannot.
+	reServiceBuilderChain = regexp.MustCompile(
+		`ServiceBuilder::new\s*\(\s*\)([^;]*)`,
+	)
+	// One .layer(Type...) inside a ServiceBuilder chain — captures the leading
+	// type path of the layer argument.
+	reChainLayer = regexp.MustCompile(
+		`\.layer\s*\(\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// actix-web deep matchers
+// ---------------------------------------------------------------------------
+
+var (
+	// HttpAuthentication::bearer(validator) / ::basic(validator) — bind the
+	// validator symbol and the method.
+	reActixHttpAuth = regexp.MustCompile(
+		`\bHttpAuthentication::([A-Za-z_]\w*)\s*\(\s*([A-Za-z_]\w*)`,
+	)
+	// Custom actix middleware: `impl<S, B> Transform<S, ServiceRequest> for X`.
+	reActixTransform = regexp.MustCompile(
+		`impl\s*(?:<[^>]*>\s*)?Transform\s*<[^>]*>\s+for\s+([A-Za-z_]\w*)`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// rocket deep matchers
+// ---------------------------------------------------------------------------
+
+// Rocket fairing (reRocketFairing) regex is already declared in rocket.go and
+// reused here. rocket.go's reRocketGuard requires whitespace after `impl`; we
+// use a no-space-tolerant variant so `impl<'r> FromRequest<'r> for X` matches.
+var reRocketGuardAuth = regexp.MustCompile(
+	`impl\s*(?:<[^>]*>\s*)?FromRequest(?:<[^>]*>)?\s+for\s+([A-Za-z_]\w*)`,
+)
+
+// stripCtor trims a trailing associated-constructor call segment from a
+// captured layer/middleware type path so the recorded name is the type, not the
+// constructor. Rust convention: type segments are UpperCamel and constructor
+// methods (new, new_for_http, default, bearer, basic, builder) are snake_case
+// starting lowercase. We therefore strip the final `::segment` iff that segment
+// begins with a lowercase letter, leaving multi-segment type paths
+// (tower_http::trace::TraceLayer) intact since their last segment is uppercase.
+func stripCtor(name string) string {
+	idx := strings.LastIndex(name, "::")
+	if idx < 0 {
+		return name
+	}
+	last := name[idx+2:]
+	if last == "" {
+		return name
+	}
+	c := last[0]
+	if c >= 'a' && c <= 'z' {
+		return name[:idx]
+	}
+	return name
+}
+
+// emitAuthPolicy walks the deep matchers and appends the enriched
+// guard/middleware/layer-chain entities. add() is the dedup-aware appender from
+// rustAuthExtractor.Extract; it shares the same `seen` set so policy entities
+// never collide with the broad-signal entities.
+func emitAuthPolicy(src, filePath, language, framework string, add func(types.EntityRecord)) {
+	authEnt := func(name, subtype string, line int, kv ...string) {
+		ent := makeEntity(name, "SCOPE.Pattern", "", filePath, language, line)
+		setProps(&ent,
+			"framework", framework,
+			"provenance", "INFERRED_FROM_RUST_AUTH",
+			"pattern_kind", "auth",
+			"auth_subtype", subtype,
+		)
+		setProps(&ent, kv...)
+		add(ent)
+	}
+	mwEnt := func(name, mwKind string, line int, kv ...string) {
+		ent := makeEntity(name, "SCOPE.Pattern", "", filePath, language, line)
+		setProps(&ent,
+			"framework", framework,
+			"provenance", "INFERRED_FROM_RUST_MIDDLEWARE",
+			"pattern_kind", "middleware",
+			"middleware_kind", mwKind,
+		)
+		setProps(&ent, kv...)
+		add(ent)
+	}
+
+	// --- axum: middleware::from_fn(auth_fn) ---
+	for _, m := range reAxumFromFn.FindAllStringSubmatchIndex(src, -1) {
+		fn := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		method := authPolicyMethod(fn)
+		// from_fn is a generic middleware surface; classify as auth only when the
+		// fn name looks auth-shaped, else record a plain middleware guard.
+		mwEnt("middleware:from_fn:"+fn, "from_fn", line,
+			"middleware_name", fn, "guard_fn", fn)
+		if isAuthMiddleware(fn) {
+			authEnt("auth:from_fn:"+fn, "middleware_auth", line,
+				"guard_name", fn, "auth_method", method, "auth_required", "true")
+		}
+	}
+
+	// --- axum: .route_layer(X) ---
+	for _, m := range reAxumRouteLayer.FindAllStringSubmatchIndex(src, -1) {
+		layer := stripCtor(src[m[2]:m[3]])
+		line := lineOf(src, m[0])
+		mwEnt("middleware:route_layer:"+layer, "route_layer", line,
+			"middleware_name", layer, "layer_scope", "route")
+		if isAuthMiddleware(layer) {
+			authEnt("auth:route_layer:"+layer, "middleware_auth", line,
+				"guard_name", layer, "auth_method", authPolicyMethod(layer),
+				"auth_required", "true")
+		}
+	}
+
+	// --- tower-http: ValidateRequestHeaderLayer::bearer/basic/custom ---
+	for _, m := range reValidateRequestHeader.FindAllStringSubmatchIndex(src, -1) {
+		variant := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		method := authPolicyMethod(variant)
+		if method == "unknown" {
+			method = strings.ToLower(variant)
+		}
+		authEnt("auth:validate_request_header:"+variant, "middleware_auth", line,
+			"guard_name", "ValidateRequestHeaderLayer::"+variant,
+			"auth_method", method, "auth_required", "true")
+	}
+
+	// --- tower-http: RequireAuthorizationLayer::bearer/basic ---
+	for _, m := range reRequireAuthLayer.FindAllStringSubmatchIndex(src, -1) {
+		variant := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		method := authPolicyMethod(variant)
+		if method == "unknown" {
+			method = strings.ToLower(variant)
+		}
+		authEnt("auth:require_authorization:"+variant, "middleware_auth", line,
+			"guard_name", "RequireAuthorizationLayer::"+variant,
+			"auth_method", method, "auth_required", "true")
+	}
+
+	// --- axum custom extractor guards: impl FromRequestParts for X ---
+	for _, m := range reFromRequestPartsImpl.FindAllStringSubmatchIndex(src, -1) {
+		guard := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		authEnt("auth:extractor_guard:"+guard, "middleware_auth", line,
+			"guard_name", guard, "guard_kind", "from_request_parts",
+			"auth_method", authPolicyMethod(guard),
+			"auth_required", "true")
+	}
+	// FromRequest (non-Parts) guards — only when auth-shaped, to avoid catching
+	// every body extractor.
+	for _, m := range reFromRequestImpl.FindAllStringSubmatchIndex(src, -1) {
+		guard := src[m[2]:m[3]]
+		if !isAuthMiddleware(guard) {
+			continue
+		}
+		line := lineOf(src, m[0])
+		authEnt("auth:extractor_guard:"+guard, "middleware_auth", line,
+			"guard_name", guard, "guard_kind", "from_request",
+			"auth_method", authPolicyMethod(guard),
+			"auth_required", "true")
+	}
+
+	// --- tower ServiceBuilder ordered layer chain ---
+	for _, cm := range reServiceBuilderChain.FindAllStringSubmatchIndex(src, -1) {
+		chainBody := src[cm[2]:cm[3]]
+		chainLine := lineOf(src, cm[0])
+		order := 0
+		var names []string
+		for _, lm := range reChainLayer.FindAllStringSubmatch(chainBody, -1) {
+			layer := stripCtor(lm[1])
+			names = append(names, layer)
+			mwEnt("middleware:tower_layer:"+layer, "tower_layer", chainLine,
+				"middleware_name", layer,
+				"layer_order", itoa(order),
+				"layer_chain", "service_builder")
+			if isAuthMiddleware(layer) {
+				authEnt("auth:tower_layer:"+layer, "middleware_auth", chainLine,
+					"guard_name", layer, "auth_method", authPolicyMethod(layer),
+					"auth_required", "true", "layer_order", itoa(order))
+			}
+			order++
+		}
+		if len(names) > 0 {
+			ent := makeEntity("middleware:layer_chain:"+strings.Join(names, ">"),
+				"SCOPE.Pattern", "", filePath, language, chainLine)
+			setProps(&ent,
+				"framework", framework,
+				"provenance", "INFERRED_FROM_RUST_MIDDLEWARE",
+				"pattern_kind", "middleware",
+				"middleware_kind", "layer_chain",
+				"layer_count", itoa(len(names)),
+				"layer_order_list", strings.Join(names, ">"),
+			)
+			add(ent)
+		}
+	}
+
+	// --- actix: HttpAuthentication::bearer(validator) ---
+	for _, m := range reActixHttpAuth.FindAllStringSubmatchIndex(src, -1) {
+		variant := src[m[2]:m[3]]
+		validator := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		method := authPolicyMethod(variant)
+		if method == "unknown" {
+			method = strings.ToLower(variant)
+		}
+		authEnt("auth:http_authentication:"+variant, "middleware_auth", line,
+			"guard_name", "HttpAuthentication::"+variant,
+			"validator_name", validator,
+			"auth_method", method, "auth_required", "true")
+	}
+
+	// --- actix: custom Transform middleware ---
+	for _, m := range reActixTransform.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		mwEnt("middleware:transform:"+name, "transform", line,
+			"middleware_name", name, "middleware_trait", "Transform")
+		if isAuthMiddleware(name) {
+			authEnt("auth:transform:"+name, "middleware_auth", line,
+				"guard_name", name, "auth_method", authPolicyMethod(name),
+				"auth_required", "true")
+		}
+	}
+
+	// --- rocket: fairings ---
+	for _, m := range reRocketFairing.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		mwEnt("middleware:fairing:"+name, "fairing", line,
+			"middleware_name", name, "middleware_trait", "Fairing")
+		if isAuthMiddleware(name) {
+			authEnt("auth:fairing:"+name, "middleware_auth", line,
+				"guard_name", name, "auth_method", authPolicyMethod(name),
+				"auth_required", "true")
+		}
+	}
+
+	// --- rocket: request guards (auth-shaped) ---
+	for _, m := range reRocketGuardAuth.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		if !isAuthMiddleware(name) {
+			continue
+		}
+		// Skip if axum FromRequest already handled this in an axum file; the
+		// shared `seen` set dedups by name anyway, so re-emit is harmless and
+		// keeps rocket-only files covered.
+		line := lineOf(src, m[0])
+		authEnt("auth:request_guard:"+name, "middleware_auth", line,
+			"guard_name", name, "guard_kind", "from_request",
+			"auth_method", authPolicyMethod(name), "auth_required", "true")
+	}
+}

--- a/internal/custom/rust/auth_policy_test.go
+++ b/internal/custom/rust/auth_policy_test.go
@@ -1,0 +1,300 @@
+package rust_test
+
+// auth_policy_test.go — value-asserting tests for the deep auth + middleware
+// extraction (issue #3414). These assert SPECIFIC guard/middleware/layer names
+// and the recovered auth policy (auth_method + auth_required) — not len>0 — so
+// they justify flipping auth_coverage / middleware_coverage to `full` for the
+// flagship Rust frameworks.
+
+import "testing"
+
+// findEntity returns the first entity matching name (and kind, if non-empty).
+func findEntity(ents []entitySummary, kind, name string) (entitySummary, bool) {
+	for _, e := range ents {
+		if e.Name == name && (kind == "" || e.Kind == kind) {
+			return e, true
+		}
+	}
+	return entitySummary{}, false
+}
+
+func assertProp(t *testing.T, e entitySummary, key, want string) {
+	t.Helper()
+	got := e.Props[key]
+	if got != want {
+		t.Errorf("entity %q prop %q = %q, want %q", e.Name, key, got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// axum — middleware::from_fn auth guard
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_AxumFromFnGuard(t *testing.T) {
+	src := `
+use axum::{Router, middleware};
+fn app() -> Router {
+    Router::new()
+        .route("/admin", get(admin))
+        .route_layer(middleware::from_fn(jwt_auth));
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("app.rs", "rust", src))
+
+	// from_fn binds the named middleware fn.
+	e, ok := findEntity(ents, "SCOPE.Pattern", "middleware:from_fn:jwt_auth")
+	if !ok {
+		t.Fatal("expected middleware:from_fn:jwt_auth entity")
+	}
+	assertProp(t, e, "middleware_name", "jwt_auth")
+	assertProp(t, e, "guard_fn", "jwt_auth")
+
+	// And the auth policy for the auth-shaped fn.
+	a, ok := findEntity(ents, "SCOPE.Pattern", "auth:from_fn:jwt_auth")
+	if !ok {
+		t.Fatal("expected auth:from_fn:jwt_auth entity")
+	}
+	assertProp(t, a, "guard_name", "jwt_auth")
+	assertProp(t, a, "auth_method", "jwt")
+	assertProp(t, a, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// axum — .route_layer with auth-shaped layer
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_AxumRouteLayer(t *testing.T) {
+	src := `
+use axum::Router;
+fn app() -> Router {
+    Router::new().route_layer(RequireBearerToken::new());
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("app.rs", "rust", src))
+	e, ok := findEntity(ents, "SCOPE.Pattern", "middleware:route_layer:RequireBearerToken")
+	if !ok {
+		t.Fatal("expected middleware:route_layer:RequireBearerToken")
+	}
+	assertProp(t, e, "layer_scope", "route")
+
+	a, ok := findEntity(ents, "SCOPE.Pattern", "auth:route_layer:RequireBearerToken")
+	if !ok {
+		t.Fatal("expected auth:route_layer:RequireBearerToken")
+	}
+	assertProp(t, a, "auth_method", "bearer")
+	assertProp(t, a, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// tower-http — ValidateRequestHeaderLayer::bearer
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_ValidateRequestHeaderBearer(t *testing.T) {
+	src := `
+use tower_http::validate_request::ValidateRequestHeaderLayer;
+fn app() {
+    let layer = ValidateRequestHeaderLayer::bearer("secret-token");
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("app.rs", "rust", src))
+	a, ok := findEntity(ents, "SCOPE.Pattern", "auth:validate_request_header:bearer")
+	if !ok {
+		t.Fatal("expected auth:validate_request_header:bearer")
+	}
+	assertProp(t, a, "guard_name", "ValidateRequestHeaderLayer::bearer")
+	assertProp(t, a, "auth_method", "bearer")
+	assertProp(t, a, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// axum — custom extractor guard via FromRequestParts
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_AxumExtractorGuard(t *testing.T) {
+	src := `
+use axum::extract::FromRequestParts;
+#[async_trait]
+impl<S> FromRequestParts<S> for AuthUser
+where S: Send + Sync {
+    type Rejection = StatusCode;
+    async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        // validate bearer token
+        Ok(AuthUser{})
+    }
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("guard.rs", "rust", src))
+	a, ok := findEntity(ents, "SCOPE.Pattern", "auth:extractor_guard:AuthUser")
+	if !ok {
+		t.Fatal("expected auth:extractor_guard:AuthUser")
+	}
+	assertProp(t, a, "guard_name", "AuthUser")
+	assertProp(t, a, "guard_kind", "from_request_parts")
+	assertProp(t, a, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// tower — ServiceBuilder ordered layer chain
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_TowerLayerChainOrder(t *testing.T) {
+	src := `
+use tower::ServiceBuilder;
+fn app() {
+    let svc = ServiceBuilder::new()
+        .layer(TraceLayer::new_for_http())
+        .layer(CompressionLayer::new())
+        .layer(RequireAuthorizationLayer::bearer("tok"));
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("svc.rs", "rust", src))
+
+	// Each layer is enumerated with its source-order index.
+	trace, ok := findEntity(ents, "SCOPE.Pattern", "middleware:tower_layer:TraceLayer")
+	if !ok {
+		t.Fatal("expected middleware:tower_layer:TraceLayer")
+	}
+	assertProp(t, trace, "layer_order", "0")
+
+	comp, ok := findEntity(ents, "SCOPE.Pattern", "middleware:tower_layer:CompressionLayer")
+	if !ok {
+		t.Fatal("expected middleware:tower_layer:CompressionLayer")
+	}
+	assertProp(t, comp, "layer_order", "1")
+
+	authL, ok := findEntity(ents, "SCOPE.Pattern", "middleware:tower_layer:RequireAuthorizationLayer")
+	if !ok {
+		t.Fatal("expected middleware:tower_layer:RequireAuthorizationLayer")
+	}
+	assertProp(t, authL, "layer_order", "2")
+
+	// The whole chain is recorded in source order.
+	chain, ok := findEntity(ents, "SCOPE.Pattern",
+		"middleware:layer_chain:TraceLayer>CompressionLayer>RequireAuthorizationLayer")
+	if !ok {
+		t.Fatal("expected ordered layer_chain entity")
+	}
+	assertProp(t, chain, "layer_count", "3")
+	assertProp(t, chain, "layer_order_list", "TraceLayer>CompressionLayer>RequireAuthorizationLayer")
+
+	// The bearer authorization layer also yields an auth policy entity.
+	a, ok := findEntity(ents, "SCOPE.Pattern", "auth:require_authorization:bearer")
+	if !ok {
+		t.Fatal("expected auth:require_authorization:bearer")
+	}
+	assertProp(t, a, "auth_method", "bearer")
+	assertProp(t, a, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// actix-web — HttpAuthentication::bearer(validator)
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_ActixHttpAuthBearer(t *testing.T) {
+	src := `
+use actix_web_httpauth::middleware::HttpAuthentication;
+fn app() {
+    let auth = HttpAuthentication::bearer(validate_token);
+    App::new().wrap(auth);
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("main.rs", "rust", src))
+	a, ok := findEntity(ents, "SCOPE.Pattern", "auth:http_authentication:bearer")
+	if !ok {
+		t.Fatal("expected auth:http_authentication:bearer")
+	}
+	assertProp(t, a, "guard_name", "HttpAuthentication::bearer")
+	assertProp(t, a, "validator_name", "validate_token")
+	assertProp(t, a, "auth_method", "bearer")
+	assertProp(t, a, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// actix-web — custom Transform middleware
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_ActixTransform(t *testing.T) {
+	src := `
+use actix_web::dev::{Service, ServiceRequest, Transform};
+impl<S, B> Transform<S, ServiceRequest> for JwtAuthMiddleware
+where S: Service<ServiceRequest> {
+    type Transform = JwtAuthMiddlewareService<S>;
+    fn new_transform(&self, service: S) -> Self::Future { todo!() }
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("mw.rs", "rust", src))
+	e, ok := findEntity(ents, "SCOPE.Pattern", "middleware:transform:JwtAuthMiddleware")
+	if !ok {
+		t.Fatal("expected middleware:transform:JwtAuthMiddleware")
+	}
+	assertProp(t, e, "middleware_trait", "Transform")
+
+	a, ok := findEntity(ents, "SCOPE.Pattern", "auth:transform:JwtAuthMiddleware")
+	if !ok {
+		t.Fatal("expected auth:transform:JwtAuthMiddleware")
+	}
+	assertProp(t, a, "auth_method", "jwt")
+	assertProp(t, a, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// rocket — fairing + request guard
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_RocketFairingAndGuard(t *testing.T) {
+	src := `
+use rocket::fairing::{Fairing, Info};
+use rocket::request::FromRequest;
+
+#[rocket::async_trait]
+impl Fairing for AuthFairing {
+    fn info(&self) -> Info { todo!() }
+}
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for BearerToken {
+    type Error = ();
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> { todo!() }
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("guards.rs", "rust", src))
+
+	mw, ok := findEntity(ents, "SCOPE.Pattern", "middleware:fairing:AuthFairing")
+	if !ok {
+		t.Fatal("expected middleware:fairing:AuthFairing")
+	}
+	assertProp(t, mw, "middleware_trait", "Fairing")
+
+	af, ok := findEntity(ents, "SCOPE.Pattern", "auth:fairing:AuthFairing")
+	if !ok {
+		t.Fatal("expected auth:fairing:AuthFairing")
+	}
+	assertProp(t, af, "auth_required", "true")
+
+	g, ok := findEntity(ents, "SCOPE.Pattern", "auth:request_guard:BearerToken")
+	if !ok {
+		t.Fatal("expected auth:request_guard:BearerToken")
+	}
+	assertProp(t, g, "guard_name", "BearerToken")
+	assertProp(t, g, "auth_method", "bearer")
+	assertProp(t, g, "auth_required", "true")
+}
+
+// ---------------------------------------------------------------------------
+// negative — a body extractor is NOT mistaken for an auth guard
+// ---------------------------------------------------------------------------
+
+func TestRustAuthPolicy_NonAuthExtractorIgnored(t *testing.T) {
+	src := `
+impl<S> FromRequest<S> for JsonBody {
+    type Rejection = StatusCode;
+}
+`
+	ents := extract(t, "custom_rust_auth", fi("body.rs", "rust", src))
+	if _, ok := findEntity(ents, "SCOPE.Pattern", "auth:extractor_guard:JsonBody"); ok {
+		t.Error("non-auth extractor JsonBody should not be an auth guard")
+	}
+	if _, ok := findEntity(ents, "SCOPE.Pattern", "auth:request_guard:JsonBody"); ok {
+		t.Error("non-auth extractor JsonBody should not be a request guard")
+	}
+}


### PR DESCRIPTION
Closes #3414 (epic #3409).

Deepens the framework-agnostic Rust auth/middleware scanner to the TS/JS quality bar: recovers **specific** guard/middleware/layer names and the enforced **auth policy** (`auth_method` + `auth_required`), proven by value-asserting tests (specific names + method + required — never `len>0`).

## Extractor
New module `internal/custom/rust/auth_policy.go`, wired into the existing `custom_rust_auth` extractor via `emitAuthPolicy`:

- **axum** — `middleware::from_fn(auth_fn)` / `from_fn_with_state` (named guard fn); `.route_layer(X)` per-route layers; custom extractor guards `impl FromRequestParts for AuthUser` and auth-shaped `impl FromRequest` → `guard_name` + `guard_kind` + `auth_method` + `auth_required`.
- **tower / tower-http** — `ServiceBuilder::new().layer(..).layer(..)` chains enumerated in **source order** (`layer_order` per layer + a `layer_chain` entity with `layer_count` + `layer_order_list`); `ValidateRequestHeaderLayer::bearer/basic` and `RequireAuthorizationLayer::bearer/basic` concrete auth layers.
- **actix-web** — `HttpAuthentication::bearer/basic(validator)` binds `validator_name` + `auth_method` + `auth_required`; custom `Transform<S, ServiceRequest>` middleware impls.
- **rocket** — `impl Fairing for X` middleware; auth-shaped `FromRequest` request guards with `auth_method` + `auth_required`.

Broad-signal auth entities in `auth.go` now also carry `auth_method`.

## Honesty
`full` only with a value-asserting proving test. `from_fn` handler bodies / actix validator symbols are bound by **name**, not resolved cross-file — documented in registry notes.

## Coverage disposition (auth_coverage + middleware_coverage)
| framework | auth | middleware |
|---|---|---|
| axum, actix, rocket, tower | **full** | **full** |
| hyper | partial (no first-class auth surface) | **full** (shares tower ServiceBuilder chain matcher) |
| poem, salvo, warp, tide, gotham | partial | partial |

Minor frameworks kept honest-partial with documented gap notes (heuristic signals; no fw-specific guard-to-validator binding / ordered chains).

## Verification
- `go test ./internal/custom/rust/ ./internal/types/ ./tools/coverage/` — pass (9 new value-asserting tests incl. a negative case ensuring body extractors aren't mistaken for auth guards).
- `coverage gen` + `validate` (0 errors) + `fmt --check` (canonical) clean; `gofmt -l` empty; `go vet` clean.

Note: registry framework records (axum/actix/rocket) are concurrently edited by sibling Rust PRs; updates were made via `coverage update` so a merge rebase stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)