### PR TITLE
deep(rust): observability per-call-site name capture; metric/trace partial->full (#3416)

### DIFF
--- a/docs/coverage/detail/lang.rust.framework.actix.md
+++ b/docs/coverage/detail/lang.rust.framework.actix.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.axum.md
+++ b/docs/coverage/detail/lang.rust.framework.axum.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.gotham.md
+++ b/docs/coverage/detail/lang.rust.framework.gotham.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.hyper.md
+++ b/docs/coverage/detail/lang.rust.framework.hyper.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.poem.md
+++ b/docs/coverage/detail/lang.rust.framework.poem.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.rocket.md
+++ b/docs/coverage/detail/lang.rust.framework.rocket.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.salvo.md
+++ b/docs/coverage/detail/lang.rust.framework.salvo.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.tide.md
+++ b/docs/coverage/detail/lang.rust.framework.tide.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.tower.md
+++ b/docs/coverage/detail/lang.rust.framework.tower.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/detail/lang.rust.framework.warp.md
+++ b/docs/coverage/detail/lang.rust.framework.warp.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go` | — |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -45184,20 +45184,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -45398,20 +45399,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -45614,20 +45616,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -45831,20 +45834,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -46047,20 +46051,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -46261,20 +46266,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -46477,20 +46483,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -46774,20 +46781,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -46992,20 +47000,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },
@@ -47208,20 +47217,21 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
             "issue": "backfill:dictionary-completeness",
+            "notes": "tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger-\u003esubscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells)",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "metrics crate counter!/gauge!/histogram!(\"name\"), prometheus register_*!/IntCounter::new/Opts::new(\"name\"), opentelemetry meter.u64_counter(\"name\"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter-\u003eexporter stays out of scope",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/rust/observability.go"],
-            "issue": "backfill:dictionary-completeness",
+            "status": "full",
+            "cites": ["internal/custom/rust/observability.go","internal/custom/rust/observability_auth_test.go"],
+            "notes": "tracing span!(Level,\"name\")/info_span!(\"name\"), opentelemetry global::tracer(\"svc\")/tracer.start(\"name\")/span_builder(\"name\"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer-\u003eexporter binding stay out of scope",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/rust/observability.go
+++ b/internal/custom/rust/observability.go
@@ -1,26 +1,47 @@
 package rust
 
 // observability.go — framework-agnostic observability scanner for Rust HTTP
-// services (issue #3269). Detects three families of observability
-// instrumentation across the 10 Rust HTTP frameworks:
+// services (issues #3269, #3416). Detects three families of observability
+// instrumentation across the 10 Rust HTTP frameworks and captures the
+// *specific name* at each call site where the source provides a string
+// literal:
 //
-//   - logging  : tracing::info!/warn!/error!/debug! macro calls,
-//                tracing::span! / tracing::event! constructs, and the
-//                #[instrument] attribute.
-//   - metrics  : metrics::counter!/histogram!/gauge! macro calls, and
-//                prometheus::Counter/Histogram/Gauge/IntCounter declarations
-//                (prometheus crate).
-//   - tracing  : opentelemetry::global::tracer(), otel span start
-//                (tracer.start()), #[instrument] (already in logging too —
-//                counted for both since it serves both purposes).
+//   - logging  : tracing crate info!/warn!/error!/debug!/trace! (qualified
+//                `tracing::info!` and bare `info!`), `log` crate `log::info!`,
+//                `event!(Level::INFO, ...)`, `slog::info!`, and the
+//                #[instrument] attribute. Captures the static message head
+//                when present.
+//   - metrics  : `metrics` crate counter!/gauge!/histogram!("name", ...),
+//                `prometheus` register_*!("name") macros and
+//                IntCounter/Counter/Histogram::new("name") ctors / Opts::new,
+//                and opentelemetry meter.u64_counter("name") builders.
+//                Captures the metric NAME (first string-literal arg).
+//   - tracing  : `tracing` span!(Level::INFO, "name") / info_span!("name"),
+//                opentelemetry global::tracer("svc"), tracer.start("name")
+//                and tracer.span_builder("name"), plus #[instrument]. Captures
+//                the span / tracer NAME.
 //
-// Honesty:
+// Each entity carries observability_library, observability_kind (macro level /
+// metric kind) and observability_name (the captured concrete value) props.
 //
-//	partial — detection is a heuristic regex/identifier match on source text.
-//	It does NOT perform import-resolution or data-flow analysis to confirm a
-//	value is wired into a request handler/middleware, and it does not bind a
-//	logger/metric/span to a specific route. Fixtures prove the detection
-//	surface; wiring to routes requires semantic analysis beyond this scanner.
+// Honesty (per-capability, see registry notes):
+//
+//	metric_extraction / trace_extraction — the metric name and span name are
+//	literal string arguments at the call site, so they are captured exactly
+//	and asserted by value-asserting tests. These do NOT require cross-file
+//	resolution and are recorded `full`.
+//
+//	log_extraction — stays `partial`. The static message head is captured when
+//	it is a leading string literal, but log messages are frequently format
+//	strings with interpolated/structured fields, and binding a logger to its
+//	subscriber/appender is a cross-file concern (the same limitation recorded
+//	for PHP/Java/Ruby per-framework log cells). The detection surface is
+//	proven by fixtures; wiring to subscribers requires semantic analysis
+//	beyond this scanner.
+//
+//	No capability binds a logger/metric/span to a specific route or to its
+//	exporter/subscriber across files — that cross-file dataflow stays out of
+//	scope for this call-site scanner.
 //
 // Framework attribution: the scanner attributes files to a Rust HTTP
 // framework using framework-specific import/usage markers (use actix_web, use
@@ -88,32 +109,67 @@ type rustObsSignal struct {
 	re      *regexp.Regexp
 	otype   string // logging | metrics | tracing
 	subtype string // e.g. tracing_macro | instrument | prometheus | otel_span
-	// nameGroup: which submatch carries the distinguishing detail (0=whole match)
-	nameGroup int
+	library string // tracing | log | slog | metrics | prometheus | opentelemetry
+	// kindGroup: submatch carrying the macro/level distinguisher (0=none).
+	kindGroup int
+	// valueGroup: submatch carrying the specific captured VALUE — the log
+	// message, metric name, or span name (0=none). This is the per-call-site
+	// detail that lets metric/trace extraction assert a concrete name.
+	valueGroup int
 }
 
+// rustObsSignals is the per-call-site signal catalog. For each family the
+// regexes try to capture the *specific name* (metric name / span name) or the
+// *static message head* (logging) as a submatch, so the emitted entity carries
+// a concrete value rather than just a macro kind.
 var rustObsSignals = []rustObsSignal{
-	// --- logging: tracing crate macros ------------------------------------
-	{regexp.MustCompile(`\btracing::(info|warn|error|debug|trace)!\s*\(`), "logging", "tracing_macro", 1},
-	{regexp.MustCompile(`\btracing::span!\s*\(`), "logging", "tracing_span", 0},
-	{regexp.MustCompile(`\btracing::event!\s*\(`), "logging", "tracing_event", 0},
-	// #[instrument] attribute — serves both logging and tracing
-	{regexp.MustCompile(`#\[(?:tracing::)?instrument(?:\s*\([^)]*\))?\]`), "logging", "instrument", 0},
+	// ===================================================================
+	// logging
+	// ===================================================================
+	// tracing crate, fully-qualified: tracing::info!("msg"...) — capture
+	// level (group 1) + leading string-literal message head (group 2, opt).
+	{regexp.MustCompile(`\btracing::(info|warn|error|debug|trace)!\s*\(\s*(?:target\s*:\s*"[^"]*"\s*,\s*)?(?:"([^"]*)")?`), "logging", "tracing_macro", "tracing", 1, 2},
+	// tracing crate, bare macro after `use tracing::...`: info!("msg").
+	{regexp.MustCompile(`(?m)(?:^|[;{}\s])(info|warn|error|debug|trace)!\s*\(\s*(?:target\s*:\s*"[^"]*"\s*,\s*)?(?:"([^"]*)")?`), "logging", "tracing_macro_bare", "tracing", 1, 2},
+	// log crate: log::info!("msg") / log::error!(target: "t", "msg").
+	{regexp.MustCompile(`\blog::(info|warn|error|debug|trace)!\s*\(\s*(?:target\s*:\s*"[^"]*"\s*,\s*)?(?:"([^"]*)")?`), "logging", "log_macro", "log", 1, 2},
+	// tracing event! macro: event!(Level::INFO, "msg") — capture level + msg.
+	{regexp.MustCompile(`\b(?:tracing::)?event!\s*\(\s*(?:tracing::)?Level::([A-Z]+)\s*,\s*(?:target\s*:\s*"[^"]*"\s*,\s*)?(?:"([^"]*)")?`), "logging", "tracing_event", "tracing", 1, 2},
+	// slog crate: info!(logger, "msg") / slog::info!(log, "msg").
+	{regexp.MustCompile(`\bslog::(info|warn|error|debug|trace)!\s*\(\s*[A-Za-z_]\w*\s*,\s*(?:"([^"]*)")?`), "logging", "slog_macro", "slog", 1, 2},
+	// #[instrument] attribute — serves both logging and tracing.
+	{regexp.MustCompile(`#\[(?:tracing::)?instrument(?:\s*\([^)]*\))?\]`), "logging", "instrument", "tracing", 0, 0},
 
-	// --- metrics: metrics crate macros -----------------------------------
-	{regexp.MustCompile(`\bmetrics::(counter|histogram|gauge)!\s*\(`), "metrics", "metrics_macro", 1},
-	// prometheus crate: register_counter / register_histogram / register_gauge
-	{regexp.MustCompile(`\bprometheus::(?:IntCounter|Counter|Histogram|Gauge|CounterVec|HistogramVec|GaugeVec)\b`), "metrics", "prometheus", 0},
-	// prometheus register_* helpers
-	{regexp.MustCompile(`\b(?:register_counter|register_histogram|register_gauge)(?:_with_registry)?\s*!\s*\(`), "metrics", "prometheus_macro", 0},
+	// ===================================================================
+	// metrics — capture the metric NAME (first string-literal positional arg)
+	// ===================================================================
+	// metrics crate: counter!/gauge!/histogram!("name", ...).
+	{regexp.MustCompile(`\b(?:metrics::)?(counter|gauge|histogram)!\s*\(\s*"([^"]+)"`), "metrics", "metrics_macro", "metrics", 1, 2},
+	// prometheus register_* macros: register_counter!("name", "help").
+	{regexp.MustCompile(`\b(?:prometheus::)?register_(counter|gauge|histogram|int_counter|int_gauge)(?:_vec)?(?:_with_registry)?\s*!\s*\(\s*"([^"]+)"`), "metrics", "prometheus_macro", "prometheus", 1, 2},
+	// prometheus typed ctor: IntCounter::new("name", "help") / Counter::new(...).
+	{regexp.MustCompile(`\b(?:prometheus::)?(IntCounter|IntGauge|Counter|Gauge|Histogram)(?:Vec)?::new\s*\(\s*"([^"]+)"`), "metrics", "prometheus_ctor", "prometheus", 1, 2},
+	// prometheus Opts::new("name", "help") — name-bearing opts builder.
+	{regexp.MustCompile(`\b(?:prometheus::)?(?:Opts|HistogramOpts)::new\s*\(\s*"([^"]+)"`), "metrics", "prometheus_opts", "prometheus", 0, 1},
+	// opentelemetry metrics: meter.u64_counter("name") / f64_histogram("name").
+	{regexp.MustCompile(`\b(?:meter|metrics?)\.(?:[uif]64_)?(counter|gauge|histogram|up_down_counter|observable_counter|observable_gauge)\s*\(\s*"([^"]+)"`), "metrics", "otel_meter", "opentelemetry", 1, 2},
 
-	// --- tracing: opentelemetry crate ------------------------------------
-	{regexp.MustCompile(`\bopentelemetry(?:_sdk)?::global::tracer\s*\(`), "tracing", "otel_tracer", 0},
-	{regexp.MustCompile(`\bopentelemetry(?:_sdk)?::[a-z_]+::tracer\s*\(`), "tracing", "otel_tracer", 0},
-	// tracer.start() / span builder
-	{regexp.MustCompile(`\btracer\.start(?:_with_context)?\s*\(\s*(?:[^,)]+,\s*)?"([^"]+)"`), "tracing", "otel_span_start", 1},
-	// #[instrument] again — also a tracing signal
-	{regexp.MustCompile(`#\[(?:tracing::)?instrument(?:\s*\([^)]*\))?\]`), "tracing", "instrument", 0},
+	// ===================================================================
+	// tracing — capture the span NAME
+	// ===================================================================
+	// tracing span!(Level::INFO, "name") — capture level + span name.
+	{regexp.MustCompile(`\b(?:tracing::)?span!\s*\(\s*(?:tracing::)?Level::([A-Z]+)\s*,\s*"([^"]+)"`), "tracing", "tracing_span", "tracing", 1, 2},
+	// level-specific span macros: info_span!("name") / error_span!("name").
+	{regexp.MustCompile(`\b(?:tracing::)?(info|warn|error|debug|trace)_span!\s*\(\s*"([^"]+)"`), "tracing", "tracing_level_span", "tracing", 1, 2},
+	// opentelemetry tracer: global::tracer("svc") — capture tracer name.
+	{regexp.MustCompile(`\bopentelemetry(?:_sdk)?::global::tracer\s*\(\s*"([^"]+)"`), "tracing", "otel_tracer", "opentelemetry", 0, 1},
+	{regexp.MustCompile(`\bopentelemetry(?:_sdk)?::[a-z_]+::tracer\s*\(\s*"([^"]+)"`), "tracing", "otel_tracer", "opentelemetry", 0, 1},
+	// otel span start: tracer.start("name") / start_with_context(cx, "name").
+	{regexp.MustCompile(`\btracer\.start(?:_with_context)?\s*\(\s*(?:[^,)"]+,\s*)?"([^"]+)"`), "tracing", "otel_span_start", "opentelemetry", 0, 1},
+	// otel span builder: tracer.span_builder("name").
+	{regexp.MustCompile(`\.span_builder\s*\(\s*"([^"]+)"`), "tracing", "otel_span_builder", "opentelemetry", 0, 1},
+	// #[instrument] again — also a tracing signal (span name derived from fn).
+	{regexp.MustCompile(`#\[(?:tracing::)?instrument(?:\s*\([^)]*\))?\]`), "tracing", "instrument", "tracing", 0, 0},
 }
 
 func (e *rustObsExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -147,22 +203,39 @@ func (e *rustObsExtractor) Extract(ctx context.Context, file extractor.FileInput
 		entities = append(entities, ent)
 	}
 
+	grp := func(m []int, g int) string {
+		if g <= 0 || len(m) < (g+1)*2 {
+			return ""
+		}
+		s, e := m[g*2], m[g*2+1]
+		if s < 0 || e < 0 {
+			return ""
+		}
+		return strings.TrimSpace(src[s:e])
+	}
+
 	for _, sig := range rustObsSignals {
 		for _, m := range sig.re.FindAllStringSubmatchIndex(src, -1) {
-			detail := ""
-			if sig.nameGroup > 0 && len(m) >= (sig.nameGroup+1)*2 {
-				start := m[sig.nameGroup*2]
-				end := m[sig.nameGroup*2+1]
-				if start >= 0 && end >= 0 {
-					detail = src[start:end]
-				}
-			}
+			kind := grp(m, sig.kindGroup)   // macro level / metric kind
+			value := grp(m, sig.valueGroup) // log message / metric name / span name
+
+			// The disambiguating detail in the entity name prefers the macro
+			// kind (info/counter/...); the captured value is carried as a
+			// dedicated property so downstream consumers can assert on the
+			// concrete metric/span name without parsing the entity name.
+			detail := kind
 			if detail == "" {
 				detail = src[m[0]:m[1]]
+				detail = strings.TrimSpace(detail)
 			}
-			detail = strings.TrimSpace(detail)
 
 			name := "obs:" + sig.otype + ":" + sig.subtype + ":" + detail
+			// Append the captured concrete name so two metrics/spans that
+			// share a macro kind but differ by name remain distinct entities
+			// (and survive the Kind+Name dedup below).
+			if value != "" {
+				name += ":" + value
+			}
 			ent := makeEntity(name, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
 			setProps(&ent,
 				"framework", framework,
@@ -170,7 +243,18 @@ func (e *rustObsExtractor) Extract(ctx context.Context, file extractor.FileInput
 				"pattern_kind", "observability",
 				"observability_type", sig.otype,
 				"observability_subtype", sig.subtype,
+				"observability_library", sig.library,
 			)
+			if kind != "" {
+				setProps(&ent, "observability_kind", kind)
+			}
+			// observability_name carries the captured concrete value:
+			//   metrics  -> metric name     (e.g. "requests_total")
+			//   tracing  -> span/tracer name (e.g. "db_query")
+			//   logging  -> static message head (heuristic, may be empty)
+			if value != "" {
+				setProps(&ent, "observability_name", value)
+			}
 			add(ent)
 		}
 	}

--- a/internal/custom/rust/observability_auth_test.go
+++ b/internal/custom/rust/observability_auth_test.go
@@ -34,11 +34,11 @@ fn handler() {
 }
 `
 	ents := extract(t, "custom_rust_observability", fi("handler.rs", "rust", src))
-	if !containsEntity(ents, "SCOPE.Pattern", "obs:logging:tracing_macro:info") {
-		t.Error("expected obs:logging:tracing_macro:info")
+	if !containsEntity(ents, "SCOPE.Pattern", "obs:logging:tracing_macro:info:user logged in") {
+		t.Error("expected obs:logging:tracing_macro:info:user logged in")
 	}
-	if !containsEntity(ents, "SCOPE.Pattern", "obs:logging:tracing_macro:warn") {
-		t.Error("expected obs:logging:tracing_macro:warn")
+	if !containsEntity(ents, "SCOPE.Pattern", "obs:logging:tracing_macro:warn:low memory") {
+		t.Error("expected obs:logging:tracing_macro:warn:low memory")
 	}
 }
 
@@ -75,11 +75,11 @@ fn record() {
 }
 `
 	ents := extract(t, "custom_rust_observability", fi("metrics.rs", "rust", src))
-	if !containsEntity(ents, "SCOPE.Pattern", "obs:metrics:metrics_macro:counter") {
-		t.Error("expected obs:metrics:metrics_macro:counter")
+	if !containsEntity(ents, "SCOPE.Pattern", "obs:metrics:metrics_macro:counter:requests_total") {
+		t.Error("expected obs:metrics:metrics_macro:counter:requests_total")
 	}
-	if !containsEntity(ents, "SCOPE.Pattern", "obs:metrics:metrics_macro:histogram") {
-		t.Error("expected obs:metrics:metrics_macro:histogram")
+	if !containsEntity(ents, "SCOPE.Pattern", "obs:metrics:metrics_macro:histogram:latency_seconds") {
+		t.Error("expected obs:metrics:metrics_macro:histogram:latency_seconds")
 	}
 }
 
@@ -102,6 +102,176 @@ fn setup() {
 	}
 	if !found {
 		t.Error("expected prometheus metric entity")
+	}
+}
+
+// obsNameOf returns the observability_name prop of the first entity whose Name
+// matches, or "" if absent. Used by value-asserting tests.
+func obsNameOf(ents []entitySummary, entName string) string {
+	for _, e := range ents {
+		if e.Name == entName {
+			return e.Props["observability_name"]
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Observability — metric_extraction (value-asserting; basis for `full`)
+// ---------------------------------------------------------------------------
+
+func TestRustObs_MetricsMacro_CapturesName_Issue3416(t *testing.T) {
+	src := `
+use axum::Router;
+fn record() {
+    metrics::counter!("http_requests_total", 1);
+    gauge!("queue_depth", 7.0);
+    metrics::histogram!("request_latency_seconds", 0.05);
+}
+`
+	ents := extract(t, "custom_rust_observability", fi("m.rs", "rust", src))
+	cases := map[string]string{
+		"obs:metrics:metrics_macro:counter:http_requests_total":       "http_requests_total",
+		"obs:metrics:metrics_macro:gauge:queue_depth":                 "queue_depth",
+		"obs:metrics:metrics_macro:histogram:request_latency_seconds": "request_latency_seconds",
+	}
+	for name, want := range cases {
+		if got := obsNameOf(ents, name); got != want {
+			t.Errorf("metric %q: observability_name = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestRustObs_PrometheusName_Issue3416(t *testing.T) {
+	src := `
+use axum::Router;
+use prometheus::{IntCounter, Opts, register_counter};
+fn setup() {
+    let c = prometheus::IntCounter::new("api_calls", "total api calls").unwrap();
+    register_counter!("jobs_processed", "jobs done").unwrap();
+    let opts = Opts::new("build_info", "build metadata");
+}
+`
+	ents := extract(t, "custom_rust_observability", fi("p.rs", "rust", src))
+	for _, want := range []string{"api_calls", "jobs_processed", "build_info"} {
+		found := false
+		for _, e := range ents {
+			if e.Props["observability_type"] == "metrics" && e.Props["observability_name"] == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a metric entity with observability_name=%q", want)
+		}
+	}
+}
+
+func TestRustObs_OtelMeter_Issue3416(t *testing.T) {
+	src := `
+use axum::Router;
+fn setup(meter: Meter) {
+    let c = meter.u64_counter("orders_created");
+    let h = meter.f64_histogram("payment_amount");
+}
+`
+	ents := extract(t, "custom_rust_observability", fi("otelm.rs", "rust", src))
+	for _, want := range []string{"orders_created", "payment_amount"} {
+		found := false
+		for _, e := range ents {
+			if e.Props["observability_type"] == "metrics" && e.Props["observability_name"] == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected otel meter metric with observability_name=%q", want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Observability — trace_extraction (value-asserting; basis for `full`)
+// ---------------------------------------------------------------------------
+
+func TestRustObs_SpanName_Issue3416(t *testing.T) {
+	src := `
+use axum::Router;
+use tracing::{span, info_span, Level};
+fn work() {
+    let s1 = span!(Level::INFO, "db_query");
+    let s2 = info_span!("handle_request");
+    let s3 = tracing::error_span!("recover_panic");
+}
+`
+	ents := extract(t, "custom_rust_observability", fi("s.rs", "rust", src))
+	cases := map[string]string{
+		"obs:tracing:tracing_span:INFO:db_query":             "db_query",
+		"obs:tracing:tracing_level_span:info:handle_request": "handle_request",
+		"obs:tracing:tracing_level_span:error:recover_panic": "recover_panic",
+	}
+	for name, want := range cases {
+		if got := obsNameOf(ents, name); got != want {
+			t.Errorf("span %q: observability_name = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestRustObs_OtelSpanName_Issue3416(t *testing.T) {
+	src := `
+use axum::Router;
+fn setup() {
+    let tracer = opentelemetry::global::tracer("checkout_service");
+    let span = tracer.start("process_order");
+    let b = tracer.span_builder("validate_cart");
+}
+`
+	ents := extract(t, "custom_rust_observability", fi("ot.rs", "rust", src))
+	for _, want := range []string{"checkout_service", "process_order", "validate_cart"} {
+		found := false
+		for _, e := range ents {
+			if e.Props["observability_type"] == "tracing" && e.Props["observability_name"] == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected tracing entity with observability_name=%q", want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Observability — log crate + bare macros + event! + slog (call-site surface)
+// ---------------------------------------------------------------------------
+
+func TestRustObs_LogCrateAndVariants_Issue3416(t *testing.T) {
+	src := `
+use axum::Router;
+fn handlers() {
+    info!("bare tracing macro");
+    log::error!("disk full");
+    event!(Level::WARN, "deprecated path");
+    slog::info!(logger, "slog message");
+}
+`
+	ents := extract(t, "custom_rust_observability", fi("logs.rs", "rust", src))
+	wantNames := []string{
+		"obs:logging:tracing_macro_bare:info:bare tracing macro",
+		"obs:logging:log_macro:error:disk full",
+		"obs:logging:tracing_event:WARN:deprecated path",
+		"obs:logging:slog_macro:info:slog message",
+	}
+	for _, n := range wantNames {
+		if !containsEntity(ents, "SCOPE.Pattern", n) {
+			t.Errorf("expected log entity %q", n)
+		}
+	}
+	// library prop must be set per call site.
+	for _, e := range ents {
+		if e.Props["observability_type"] == "logging" && e.Props["observability_library"] == "" {
+			t.Errorf("logging entity %q missing observability_library", e.Name)
+		}
 	}
 }
 

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -7448,6 +7448,34 @@ records:
               functions: [Extract, parseValidateRules, parseDTOFields]
           issues_implemented: ["3413"]
           verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
+          verified_at: "2026-05-30"
 
   lang.rust.framework.actix:
     capabilities:
@@ -7688,6 +7716,34 @@ records:
               functions: [Extract, parseValidateRules, parseDTOFields]
           issues_implemented: ["3413"]
           verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
+          verified_at: "2026-05-30"
 
   lang.rust.framework.gotham:
     capabilities:
@@ -7904,6 +7960,34 @@ records:
             - file: internal/extractors/cross/testmap/extractor_test.go
               functions: [TestRust_TestAttribute]
           issues_implemented: ["3268"]
+          verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
           verified_at: "2026-05-30"
 
   lang.rust.framework.hyper:
@@ -8123,6 +8207,34 @@ records:
               functions: [TestRust_TestAttribute]
           issues_implemented: ["3268"]
           verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
+          verified_at: "2026-05-30"
 
   lang.rust.framework.poem:
     capabilities:
@@ -8339,6 +8451,34 @@ records:
             - file: internal/extractors/cross/testmap/extractor_test.go
               functions: [TestRust_TestAttribute]
           issues_implemented: ["3268"]
+          verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
           verified_at: "2026-05-30"
 
   lang.rust.framework.rocket:
@@ -8572,6 +8712,34 @@ records:
               functions: [Extract, parseValidateRules, parseDTOFields]
           issues_implemented: ["3413"]
           verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
+          verified_at: "2026-05-30"
 
   lang.rust.framework.salvo:
     capabilities:
@@ -8789,6 +8957,34 @@ records:
               functions: [TestRust_TestAttribute]
           issues_implemented: ["3268"]
           verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
+          verified_at: "2026-05-30"
 
   lang.rust.framework.tide:
     capabilities:
@@ -9005,6 +9201,34 @@ records:
             - file: internal/extractors/cross/testmap/extractor_test.go
               functions: [TestRust_TestAttribute]
           issues_implemented: ["3268"]
+          verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
           verified_at: "2026-05-30"
 
   lang.rust.framework.tower:
@@ -9224,6 +9448,34 @@ records:
               functions: [TestRust_TestAttribute]
           issues_implemented: ["3268"]
           verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
+          verified_at: "2026-05-30"
 
   lang.rust.framework.warp:
     capabilities:
@@ -9440,6 +9692,34 @@ records:
             - file: internal/extractors/cross/testmap/extractor_test.go
               functions: [TestRust_TestAttribute]
           issues_implemented: ["3268"]
+          verified_at: "2026-05-30"
+      Observability:
+        metric_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        trace_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework, rustObsProvenance]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416", "3409"]
+          verified_at: "2026-05-30"
+        log_extraction:
+          status: partial
+          symbols:
+            - file: internal/custom/rust/observability.go
+              functions: [Extract, detectRustObsFramework]
+          tests:
+            - file: internal/custom/rust/observability_auth_test.go
+          issues_implemented: ["3416"]
           verified_at: "2026-05-30"
 
   lang.rust.framework.tauri:


### PR DESCRIPTION
Assess + honestly deepen Rust OBSERVABILITY extraction (`internal/custom/rust/observability.go`). Closes #3416 (epic #3409).

## What changed
Deepened the per-call-site scanner to capture the **specific name** at each site and broadened the signal catalog across the `tracing` / `log` / `slog` / `metrics` / `prometheus` / `opentelemetry` crates:

- **logging**: `tracing` `info!/warn!/error!/debug!/trace!` (qualified **and** bare), `log::*`, `event!(Level::X, ..)`, `slog::*`, `#[instrument]`. Captures level + library and the static message head when it is a leading string literal.
- **metrics**: `metrics` `counter!/gauge!/histogram!("name")`, `prometheus` `register_*!`/`IntCounter::new`/`Opts::new("name")`, `opentelemetry` `meter.u64_counter("name")`. Captures the metric **name**.
- **tracing**: `span!(Level, "name")` / `info_span!("name")`, `opentelemetry` `global::tracer("svc")` / `tracer.start("name")` / `span_builder("name")`. Captures the span / tracer **name**.

Entities now carry `observability_library` / `observability_kind` / `observability_name` props; distinct names yield distinct entities. Value-asserting tests added.

## Honest per-capability verdict
| Capability | Verdict | Why |
|---|---|---|
| `metric_extraction` | **partial → full** | Metric name is a literal first arg, captured exactly; value-asserting tests (`TestRustObs_MetricsMacro_CapturesName_Issue3416`, `…PrometheusName…`, `…OtelMeter…`) assert the concrete name. No cross-file resolution needed. |
| `trace_extraction` | **partial → full** | Span/tracer name is a literal arg, captured exactly; value-asserting tests (`TestRustObs_SpanName_Issue3416`, `…OtelSpanName…`). `#[instrument]`-derived names and tracer→exporter binding stay out of scope. |
| `log_extraction` | **stays partial (honest)** | Log messages are frequently format strings with interpolated/structured fields, and logger→subscriber/appender binding is cross-file — the **same limitation recorded for PHP/Java/Ruby** per-framework log cells. Detection surface proven; cross-file wiring out of scope. |

Applied across all **10 Rust HTTP framework records** (axum, actix, gotham, hyper, poem, rocket, salvo, tide, tower, warp) in both `registry.json` and `capability-map.yaml`.

## Validation
- `go test ./internal/custom/rust/ ./internal/types/ ./tools/coverage/` — pass
- `go run ./tools/coverage gen` — 558 records
- `go run ./tools/coverage validate` — **0 errors** (rust-obs map warnings cleared)
- `go run ./tools/coverage fmt --check` — canonical
- `gofmt -l` empty, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)