### PR TITLE
fix(routes): never resolve a route handler to a build/tooling script (#3426)

### DIFF
--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -119,6 +119,11 @@ type ResolveHTTPEndpointStats struct {
 // resolver to look up entities by their stable in-file identity.
 type httpResolveKey struct{ kind, name, sourceFile string }
 
+// httpResolveNameKey is the (kind, name) index key used by the global
+// bare-name fallback and the multi-match candidate list. Package-level so
+// helpers such as firstAppCandidate (#3426) can take it by value.
+type httpResolveNameKey struct{ kind, name string }
+
 func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
 	var stats ResolveHTTPEndpointStats
 
@@ -134,7 +139,7 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 	// dispatcher. Falling back to a global (kind, name) match keeps
 	// those endpoints alive so the corpus-wide response-shape pass
 	// can locate and scan the actual handler body.
-	type knKey struct{ kind, name string }
+	type knKey = httpResolveNameKey
 	globalIdx := make(map[knKey]int, len(merged))
 	// #2692 — multi-match index for the Phoenix-style `name@file_hint`
 	// resolution path. Routes-file frameworks (Phoenix router) declare
@@ -361,6 +366,30 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 				}
 			}
 		}
+		// #3426 — same-file CROSS-KIND lookup BEFORE the global bare-name
+		// fallback. The exact-kind same-file lookup (above) misses for
+		// annotation-based frameworks (NestJS @Controller, Spring, JAX-RS)
+		// because the synthesizer emits the handler ref as `Controller:check`
+		// while the real handler method `check()` is indexed as a
+		// SCOPE.Operation (or another method kind) in the SAME file. Without
+		// this step the resolver falls to the GLOBAL bare-name index, where a
+		// common method name like `check` collides repo-wide (e.g. a
+		// `function check(...)` in scripts/docs-check.mjs) and mis-sources the
+		// route to an unrelated tooling file. Same-file resolution is the
+		// correct default for annotation frameworks: the handler is emitted in
+		// the same file as the route synthetic by construction, so a same-file
+		// hit is strictly more precise than any global match. Only attempt this
+		// when no handler_file hint redirected lookupFile elsewhere; with a hint
+		// the global hint-substring branch above already covered cross-kind.
+		if !found && handlerFileHint == "" {
+			for _, altKind := range resolverKindEquivalents[hk] {
+				if hi, ok := idx[key{altKind, hn, lookupFile}]; ok {
+					handlerIdx = hi
+					found = true
+					break
+				}
+			}
+		}
 		if !found {
 			// Cross-file fallback (#753). Django composed routes record
 			// a `View:<ViewSet>` handler reference whose entity lives in
@@ -395,21 +424,24 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 				stats.NoHandlerProp++
 				continue
 			}
-			handlerIdx, found = globalIdx[knKey{hk, hn}]
+			// #3426 — GLOBAL bare-name fallback, with a non-app/tooling
+			// exclusion. A route handler must NEVER resolve to a build/CLI
+			// script: a common method name like `check` collides with a
+			// `function check(...)` in scripts/docs-check.mjs and the old
+			// globalIdx (first-writer-wins) could bind the route to it,
+			// mis-sourcing the endpoint to a tooling file. We iterate the
+			// globalMulti candidate LIST (across the declared kind + its
+			// equivalence classes) and pick the FIRST candidate whose
+			// SourceFile is NOT isNonAppSourceFile. If every candidate is a
+			// non-app file we leave `found` false so the synthetic keeps its
+			// own (correct) source instead of being rebound to a script.
+			// Try the declared kind first, then the cross-kind equivalents
+			// (Flask/FastAPI/Express function handlers land as SCOPE.Operation
+			// while the synthesizer emits Controller:<name> — #753).
+			handlerIdx, found = firstAppCandidate(merged, globalMulti, knKey{hk, hn})
 			if !found {
-				// Cross-kind fallback. Synthesizers historically emit
-				// `Controller:<name>` but the Python YAML rules + the
-				// generic SCOPE extractor produce `SCOPE.Operation`
-				// for function-shaped handlers (Flask def, FastAPI
-				// def, Express function expressions). Likewise the
-				// Java AST pass emits `SCOPE.Operation:Class.method`
-				// while older synthesizers still emit `Controller:method`.
-				// Try the known equivalence classes before dropping —
-				// without this fallback every Flask synthetic with a
-				// Controller-shaped ref gets dropped because the
-				// matching entity has kind SCOPE.Operation. #753.
 				for _, altKind := range resolverKindEquivalents[hk] {
-					if hi, ok := globalIdx[knKey{altKind, hn}]; ok {
+					if hi, ok := firstAppCandidate(merged, globalMulti, knKey{altKind, hn}); ok {
 						handlerIdx = hi
 						found = true
 						break
@@ -417,6 +449,19 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 				}
 			}
 			if !found {
+				// #3426 — distinguish "no candidate at all" (genuine orphan →
+				// drop) from "the only global candidate(s) live in non-app /
+				// tooling files" (e.g. the bare name `check` exists ONLY in
+				// scripts/docs-check.mjs). In the latter case we must NOT drop
+				// a real route just because its handler couldn't be cross-
+				// linked to an app entity — and we must NOT rebind it to the
+				// build script. Keep the synthetic with its own (controller)
+				// source and source_handler intact, mirroring the
+				// handler_file-hint miss path (#2851).
+				if hasGlobalCandidate(globalMulti, knKey{hk, hn}, resolverKindEquivalents[hk]) {
+					stats.NoHandlerProp++
+					continue
+				}
 				stats.HandlerDropped++
 				drop[i] = true
 				continue
@@ -605,6 +650,42 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 		out = append(out, merged[i])
 	}
 	return out, stats
+}
+
+// firstAppCandidate looks up the globalMulti candidate list for `gk`
+// (kind, name) and returns the index of the FIRST candidate whose
+// SourceFile is NOT a non-app/tooling file (per isNonAppSourceFile in
+// http_endpoint_synthesis.go). #3426: the global bare-name fallback must
+// never bind a route handler to a build/CLI script — a common method name
+// like `check` collides with `function check(...)` in
+// scripts/docs-check.mjs and would mis-source the endpoint to tooling. When
+// every candidate is a non-app file (or none exist) it returns ok=false so
+// the caller skips the rebind and the synthetic keeps its own source.
+func firstAppCandidate(merged []types.EntityRecord, globalMulti map[httpResolveNameKey][]int, gk httpResolveNameKey) (int, bool) {
+	for _, ci := range globalMulti[gk] {
+		if !isNonAppSourceFile(merged[ci].SourceFile) {
+			return ci, true
+		}
+	}
+	return 0, false
+}
+
+// hasGlobalCandidate reports whether ANY global (kind, name) candidate
+// exists for the base kind or one of its equivalence kinds, regardless of
+// whether that candidate is an app or non-app file. #3426: used to tell a
+// genuine unresolved orphan (no candidate anywhere → drop) apart from a
+// tooling-only collision (a candidate exists but only in a build/CLI
+// script → keep the synthetic, don't rebind, don't drop).
+func hasGlobalCandidate(globalMulti map[httpResolveNameKey][]int, base httpResolveNameKey, altKinds []string) bool {
+	if len(globalMulti[base]) > 0 {
+		return true
+	}
+	for _, ak := range altKinds {
+		if len(globalMulti[httpResolveNameKey{ak, base.name}]) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // splitHandlerRef parses "<Kind>:<Name>" into its parts. Returns ok=false

--- a/internal/engine/http_endpoint_resolve_test.go
+++ b/internal/engine/http_endpoint_resolve_test.go
@@ -289,3 +289,190 @@ func TestResolveCallers_NoMatchKeepsSynthetic(t *testing.T) {
 		t.Errorf("expected synthetic preserved despite unresolved caller, got %d", len(out))
 	}
 }
+
+// findImplementsTo returns the index of the entity in out that owns an
+// IMPLEMENTS edge pointing at toID, or -1.
+func findImplementsTo(out []types.EntityRecord, toID string) int {
+	for i := range out {
+		for _, r := range out[i].Relationships {
+			if r.Kind == implementsEdgeKind && r.ToID == toID {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// TestResolveHandlers_NestHealthNotBoundToToolingScript (#3426) is the
+// parity-oracle bug: a NestJS `GET /health` definition emitted from
+// health.controller.ts with source_handler="Controller:check" must resolve
+// to the SAME-FILE `check` method (indexed as SCOPE.Operation), NOT to the
+// repo-wide `function check(...)` in scripts/docs-check.mjs. Before the fix
+// the exact-kind same-file lookup missed (real method is SCOPE.Operation,
+// not Controller) and the global bare-name fallback bound `check` to the
+// build script, mis-sourcing the route to scripts/docs-check.mjs:28.
+func TestResolveHandlers_NestHealthNotBoundToToolingScript(t *testing.T) {
+	const ctrlFile = "src/modules/health/health.controller.ts"
+	// Real handler method `check()` in the controller file, indexed as a
+	// method kind (SCOPE.Operation), NOT kind Controller.
+	realHandler := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "check",
+		SourceFile: ctrlFile,
+		StartLine:  17,
+		EndLine:    20,
+		Language:   "typescript",
+	}
+	// Collision: a same-named function in a build/tooling script.
+	toolingHandler := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "check",
+		SourceFile: "scripts/docs-check.mjs",
+		StartLine:  28,
+		EndLine:    35,
+		Language:   "javascript",
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointKind,
+		Name:       "http:GET:/health",
+		SourceFile: ctrlFile,
+		StartLine:  12,
+		Language:   "typescript",
+		Properties: map[string]string{
+			"source_handler": "Controller:check",
+			"framework":      "nestjs",
+		},
+	}
+	// Order toolingHandler FIRST so the old globalIdx (first-writer-wins)
+	// would have bound to it — proving the fix, not index ordering.
+	merged := []types.EntityRecord{toolingHandler, realHandler, synth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.HandlerResolved != 1 {
+		t.Fatalf("expected handler_resolved=1, got %+v", stats)
+	}
+	// Locate the synthetic in the output.
+	var endpoint *types.EntityRecord
+	for i := range out {
+		if out[i].Kind == httpEndpointDefinitionKind {
+			endpoint = &out[i]
+		}
+	}
+	if endpoint == nil {
+		t.Fatalf("endpoint definition not found in out")
+	}
+	if endpoint.SourceFile != ctrlFile {
+		t.Errorf("endpoint mis-sourced: got SourceFile=%q, want %q (must NOT be the tooling script)",
+			endpoint.SourceFile, ctrlFile)
+	}
+	if endpoint.StartLine != realHandler.StartLine {
+		t.Errorf("endpoint StartLine=%d, want %d (real handler body, not docs-check.mjs:28)",
+			endpoint.StartLine, realHandler.StartLine)
+	}
+	// IMPLEMENTS edge must point at the real same-file handler.
+	owner := findImplementsTo(out, httpEndpointDefinitionKind+":http:GET:/health")
+	if owner < 0 {
+		t.Fatalf("no IMPLEMENTS edge to the endpoint found")
+	}
+	if out[owner].SourceFile != ctrlFile {
+		t.Errorf("IMPLEMENTS edge owned by %q (line %d), want the real handler in %q",
+			out[owner].SourceFile, out[owner].StartLine, ctrlFile)
+	}
+}
+
+// TestResolveHandlers_ToolingOnlyCollisionNotRebound (#3426) verifies that
+// when there is NO same-file handler and the ONLY global match for the
+// bare name lives in a tooling script, the resolver does NOT rebind the
+// endpoint to that script. The synthetic keeps its own (controller) source.
+func TestResolveHandlers_ToolingOnlyCollisionNotRebound(t *testing.T) {
+	const ctrlFile = "src/a.controller.ts"
+	// Only the tooling script has a `check` symbol; the controller file has
+	// none.
+	toolingHandler := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "check",
+		SourceFile: "scripts/docs-check.mjs",
+		StartLine:  28,
+		Language:   "javascript",
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointKind,
+		Name:       "http:GET:/health",
+		SourceFile: ctrlFile,
+		StartLine:  9,
+		Language:   "typescript",
+		Properties: map[string]string{
+			"source_handler": "Controller:check",
+			"framework":      "nestjs",
+		},
+	}
+	merged := []types.EntityRecord{toolingHandler, synth}
+	out, _ := ResolveHTTPEndpointHandlers(merged)
+
+	var endpoint *types.EntityRecord
+	for i := range out {
+		if out[i].Kind == httpEndpointDefinitionKind {
+			endpoint = &out[i]
+		}
+	}
+	if endpoint == nil {
+		t.Fatalf("endpoint definition not found (should be kept, not dropped)")
+	}
+	if endpoint.SourceFile != ctrlFile {
+		t.Errorf("endpoint rebound to a tooling script: SourceFile=%q, want %q",
+			endpoint.SourceFile, ctrlFile)
+	}
+	if endpoint.SourceFile == "scripts/docs-check.mjs" || endpoint.StartLine == 28 {
+		t.Errorf("endpoint must never resolve to the build script (got %q:%d)",
+			endpoint.SourceFile, endpoint.StartLine)
+	}
+}
+
+// TestResolveHandlers_ExpressCrossFileStillResolves (#3426 regression
+// guard) verifies the legitimate cross-file Express case (#753) is NOT
+// regressed: a handler `index` in controllers/users.js, route synthetic in
+// routes.js, with NO tooling-file collision, still resolves cross-file via
+// the global fallback.
+func TestResolveHandlers_ExpressCrossFileStillResolves(t *testing.T) {
+	handler := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "index",
+		SourceFile: "controllers/users.js",
+		StartLine:  4,
+		Language:   "javascript",
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointKind,
+		Name:       "http:GET:/users",
+		SourceFile: "routes.js",
+		StartLine:  11,
+		Language:   "javascript",
+		Properties: map[string]string{
+			"source_handler": "Controller:index",
+			"framework":      "express",
+		},
+	}
+	merged := []types.EntityRecord{handler, synth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.HandlerResolved != 1 {
+		t.Fatalf("expected handler_resolved=1 (cross-file Express), got %+v", stats)
+	}
+	var endpoint *types.EntityRecord
+	for i := range out {
+		if out[i].Kind == httpEndpointDefinitionKind {
+			endpoint = &out[i]
+		}
+	}
+	if endpoint == nil {
+		t.Fatalf("endpoint definition not found")
+	}
+	if endpoint.SourceFile != "controllers/users.js" {
+		t.Errorf("Express cross-file resolution regressed: SourceFile=%q, want controllers/users.js",
+			endpoint.SourceFile)
+	}
+	owner := findImplementsTo(out, httpEndpointDefinitionKind+":http:GET:/users")
+	if owner < 0 || out[owner].SourceFile != "controllers/users.js" {
+		t.Errorf("IMPLEMENTS edge not on the real cross-file handler")
+	}
+}


### PR DESCRIPTION
## The bug (parity oracle)

A NestJS `GET /health` endpoint was sourced to `scripts/docs-check.mjs:28` instead of its real `HealthController`. Deterministic, survives reindex.

## Root cause — `internal/engine/http_endpoint_resolve.go` (Phase-2 handler-resolution loop)

- The synthesizer emits `http:GET:/health` from `health.controller.ts` with `source_handler="Controller:check"`, correct `SourceFile`, and **no** `handler_file` hint.
- The exact-kind same-file lookup `idx[{Controller, check, health.controller.ts}]` **misses**, because the real `check()` method is indexed as `SCOPE.Operation`, not kind `Controller`.
- With no hint it fell to the **global bare-name fallback** `globalIdx[{Controller|altKind, check}]`. `check` is an extremely common name — `scripts/docs-check.mjs` has `function check(...)` (a `SCOPE.Operation` named `check`), which first-writer-wins resolved to. The #2678 rebind then set the endpoint's `SourceFile`/`StartLine` to the build script.

**Why #3417 didn't catch it:** that PR's `isNonAppSourceFile` guard is on the definition-**emit** path (wrong layer). It stops a tooling file from emitting a phantom definition, but does nothing when a real route's handler **name** merely collides with a function in a tooling file. The mis-attribution happens at **resolve** time, so the guard must live there.

## The fix (two parts, both needed)

1. **Same-file cross-kind lookup BEFORE the global fallback.** After the exact-kind same-file miss (and the `handler_file`-hint branches), try each `altKind` in `resolverKindEquivalents[hk]` against `idx[{altKind, hn, lookupFile}]`. Resolves `HealthController.check` correctly in `health.controller.ts` regardless of its indexed kind — strictly more precise than any global match. Annotation frameworks (NestJS/Spring/JAX-RS) emit the handler in the **same file** as the route synthetic, so same-file resolution is the correct default.
2. **Exclude non-app/tooling files from the global bare-name fallback.** The global `(kind,name)` / cross-kind-global match now iterates the `globalMulti` candidate **list** and picks the first candidate that is **not** `isNonAppSourceFile`. If every candidate is a non-app file, the rebind is skipped and the synthetic keeps its own source. New `hasGlobalCandidate` helper distinguishes a genuine orphan (no candidate anywhere → drop) from a tooling-only collision (keep, don't rebind, don't drop). A route handler must never resolve to a build script.

No regression to legitimate cross-file cases: Express imported controllers (#753), Django `View:<ViewSet>` in `views.py`, Rails/Phoenix `handler_file` hints (#2691/#2692).

## Tests (`http_endpoint_resolve_test.go`) — value-asserting, FAIL before / PASS after

- `TestResolveHandlers_NestHealthNotBoundToToolingScript` — same-file `check` (SCOPE.Operation) + tooling `check` ordered first; asserts endpoint SourceFile = health.controller.ts and IMPLEMENTS edge on the real handler.
- `TestResolveHandlers_ToolingOnlyCollisionNotRebound` — only a tooling-file `check`; asserts endpoint is kept and NOT rebound to `.mjs`.
- `TestResolveHandlers_ExpressCrossFileStillResolves` — regression guard; cross-file Express still resolves to `controllers/users.js`.

Verified: the two bug tests fail on `origin/main`, the Express guard passes both ways. `go test ./internal/engine/` green, `gofmt -l` empty, `go vet ./internal/engine/` clean.

## DEPLOY-DEFERRED

Needs a live-daemon rebuild + reindex of upvate-v2 before the graph reflects the fix.