### PR TITLE
fix(routes): NestJS multi-@Controller-per-file route attribution

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -3447,10 +3447,10 @@ func isInlineExpressHandler(fullMatch, raw string) bool {
 // with the composed canonical path, mirroring the Spring/JAX-RS shape.
 //
 // This is a regex pass (no AST) consistent with the other framework
-// synthesizers. It handles the single-controller-per-file convention that
-// NestJS overwhelmingly follows; a file with two @Controller classes will
-// attribute all methods to the first prefix (acceptable — the cross-repo
-// linker matches on path, and split controllers are rare).
+// synthesizers. It is multi-controller aware: a file with several @Controller
+// classes attributes each HTTP-verb method to the base path of the nearest
+// PRECEDING @Controller (by source position), so two controllers in one file
+// keep their own prefixes instead of collapsing onto the first.
 
 // nestControllerRe captures the class-level @Controller('prefix') value.
 // The prefix is optional (`@Controller()` → root prefix ""). Accepts single,
@@ -3590,15 +3590,35 @@ func nestjsBracketDelta(line string) int {
 	return delta
 }
 
+// nestController records one @Controller occurrence: the line index it appears
+// on and the base-path prefix it declares (empty for `@Controller()`).
+type nestController struct {
+	lineIdx int
+	prefix  string
+}
+
 func synthesizeNestJS(content string, emit emitFn) {
 	if !strings.Contains(content, "@Controller") {
 		return
 	}
-	prefix := ""
-	if m := nestControllerRe.FindStringSubmatch(content); len(m) >= 2 {
-		prefix = m[1]
-	}
 	lines := strings.Split(content, "\n")
+	// Collect EVERY @Controller declaration with the line it sits on, so each
+	// HTTP-verb method can be attributed to the base path of the nearest
+	// PRECEDING controller. A file with two @Controller classes no longer
+	// folds the second controller's routes under the first's prefix. The line
+	// index is used (rather than a byte offset) because the verb loop below is
+	// line-oriented; an @Controller decorator and its prefix sit on the same
+	// line in every practical NestJS source.
+	var controllers []nestController
+	for lineIdx, line := range lines {
+		for _, m := range nestControllerRe.FindAllStringSubmatch(line, -1) {
+			prefix := ""
+			if len(m) >= 2 {
+				prefix = m[1]
+			}
+			controllers = append(controllers, nestController{lineIdx: lineIdx, prefix: prefix})
+		}
+	}
 	// Map each byte offset's line to an index for the forward scan. We re-find
 	// the verb decorators on a per-line basis so the handler scan starts from
 	// the line AFTER the verb decorator line.
@@ -3616,6 +3636,9 @@ func synthesizeNestJS(content string, emit emitFn) {
 		if methodName == "" {
 			continue
 		}
+		// Attribute this method to the nearest preceding @Controller. Methods
+		// before any @Controller (rare) fall back to the root prefix "".
+		prefix := nestjsPrefixForLine(controllers, lineIdx)
 		full := joinPathFragments("/"+strings.Trim(prefix, "/"), methodPath)
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, full)
 		if canonical == "" {
@@ -3623,6 +3646,20 @@ func synthesizeNestJS(content string, emit emitFn) {
 		}
 		emit(verb, canonical, "nestjs", "Controller", methodName)
 	}
+}
+
+// nestjsPrefixForLine returns the base-path prefix of the @Controller nearest
+// above `lineIdx`. `controllers` is in ascending line order (built by a forward
+// line scan). Returns "" when no controller precedes the line.
+func nestjsPrefixForLine(controllers []nestController, lineIdx int) string {
+	prefix := ""
+	for _, c := range controllers {
+		if c.lineIdx > lineIdx {
+			break
+		}
+		prefix = c.prefix
+	}
+	return prefix
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/http_endpoint_synthesis_nestjs_undercount_test.go
+++ b/internal/engine/http_endpoint_synthesis_nestjs_undercount_test.go
@@ -304,6 +304,71 @@ for (const p of REQUIRED_PATHS) {
 	requireNotContains(t, got, []string{"http:GET:/health"}, "defect3b build script")
 }
 
+// ---------------------------------------------------------------------------
+// Multi-controller-per-file — each @Controller keeps its own base path.
+// ---------------------------------------------------------------------------
+//
+// Before the fix synthesizeNestJS took the FIRST @Controller prefix in the file
+// and folded EVERY verb method under it, so a second controller's routes were
+// mis-attributed to the first's base path. The fix attributes each method to
+// the nearest PRECEDING @Controller. This asserts BOTH controllers' routes land
+// under their own prefixes (not both under the first).
+func TestNestJS_TwoControllersOneFile_EachKeepsOwnPrefix(t *testing.T) {
+	src := `import { Controller, Get, Post } from '@nestjs/common';
+
+@Controller('api/v1/users')
+export class UsersController {
+  @Get(':id')
+  findOne() {
+    return this.usersService.findOne();
+  }
+}
+
+@Controller('api/v1/orders')
+export class OrdersController {
+  @Post()
+  create() {
+    return this.ordersService.create();
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "src/modules/mixed.controller.ts", src)
+	requireContains(t, got, []string{
+		"http:GET:/api/v1/users/{id}",
+		"http:POST:/api/v1/orders",
+	}, "two controllers one file")
+	// The second controller's POST must NOT be mis-attributed to the first
+	// controller's prefix (the pre-fix bug).
+	requireNotContains(t, got, []string{
+		"http:POST:/api/v1/users",
+	}, "two controllers — orders route must not land under users prefix")
+}
+
+// Single-controller regression — the common case still attributes every method
+// to the sole controller's prefix.
+func TestNestJS_SingleController_Regression(t *testing.T) {
+	src := `import { Controller, Get, Post } from '@nestjs/common';
+
+@Controller('api/v1/users')
+export class UsersController {
+  @Get(':id')
+  findOne() {
+    return this.usersService.findOne();
+  }
+
+  @Post()
+  create() {
+    return this.usersService.create();
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "src/modules/users.controller.ts", src)
+	requireContains(t, got, []string{
+		"http:GET:/api/v1/users/{id}",
+		"http:POST:/api/v1/users",
+	}, "single controller regression")
+}
+
 // isNonAppSourceFile unit table — conservative exclusion, real app code kept.
 func TestIsNonAppSourceFile(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Problem

`synthesizeNestJS` (`internal/engine/http_endpoint_synthesis.go`) took the **first** `@Controller('prefix')` match in a file via `nestControllerRe.FindStringSubmatch(content)` and applied that single prefix to **every** HTTP-verb method in the file. A file with two `@Controller` classes attributed the second controller's routes to the first controller's base path.

## Fix

Make `synthesizeNestJS` multi-controller aware:

- Collect **every** `@Controller(...)` declaration with the line it appears on (`controllers []nestController`).
- Attribute each HTTP-verb method to the base path of the **nearest preceding** `@Controller` (new helper `nestjsPrefixForLine`).
- Methods before any `@Controller` (rare) fall back to the root prefix `""`.

Preserves all existing behavior:
- `@Controller()` empty → `""` prefix
- the parens-immune handler line-scan from #3417 (`nestjsFindHandlerName`)
- `@All` → `ANY`
- `joinPathFragments` + `Canonicalize(FrameworkExpress, ...)`
- the `emit(verb, canonical, "nestjs", "Controller", methodName)` call

Still a regex pass, no AST — consistent with the file's style.

## Tests

`internal/engine/http_endpoint_synthesis_nestjs_undercount_test.go`:
- `TestNestJS_TwoControllersOneFile_EachKeepsOwnPrefix` — two controllers in one file; asserts BOTH `http:GET:/api/v1/users/{id}` AND `http:POST:/api/v1/orders` are emitted, and that the orders POST is NOT mis-attributed to the users prefix (`http:POST:/api/v1/users` absent).
- `TestNestJS_SingleController_Regression` — the common single-controller case still attributes every method to the sole controller's prefix.

Asserts specific IDs (not `len > 0`).

### Verification
- `go test ./internal/engine/` green (full package)
- `gofmt -l` empty
- `go vet ./internal/engine/` clean

## DEPLOY-DEFERRED

Graph-extraction change. Requires a coordinated live-daemon rebuild + restart and a re-index of affected repos before the corrected multi-controller attribution appears in the graph. Not deployed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)