### PR TITLE
feat(kotlin): deep DTO + request-validation extraction to TS/JS bar

### DIFF
--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/validation.go` | — |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/validation.go` | — |
 
 ### Middleware
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -30450,15 +30450,13 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },
@@ -30711,15 +30709,13 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },
@@ -31164,15 +31160,13 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },
@@ -31432,15 +31426,13 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },
@@ -31715,15 +31707,13 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },
@@ -31998,15 +31988,13 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/validation.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/kotlin/extractors_test.go
+++ b/internal/custom/kotlin/extractors_test.go
@@ -25,12 +25,25 @@ func extract(t *testing.T, name string, file extreg.FileInput) []entitySummary {
 	}
 	var out []entitySummary
 	for _, ent := range ents {
-		out = append(out, entitySummary{Kind: ent.Kind, Subtype: ent.Subtype, Name: ent.Name})
+		out = append(out, entitySummary{Kind: ent.Kind, Subtype: ent.Subtype, Name: ent.Name, Props: ent.Properties})
 	}
 	return out
 }
 
-type entitySummary struct{ Kind, Subtype, Name string }
+type entitySummary struct {
+	Kind, Subtype, Name string
+	Props               map[string]string
+}
+
+// findEntity returns the first entity matching kind+name, or nil.
+func findEntity(ents []entitySummary, kind, name string) *entitySummary {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
 
 func containsEntity(ents []entitySummary, kind, name string) bool {
 	for _, e := range ents {

--- a/internal/custom/kotlin/validation.go
+++ b/internal/custom/kotlin/validation.go
@@ -1,21 +1,35 @@
 // Package kotlin — validation extractor for Kotlin source files.
 //
-// Detects two validation styles:
+// Detects DTO shape and request-validation rules across three styles:
 //
 //  1. Bean Validation (javax.validation / jakarta.validation):
-//     @Valid/@Validated on handler/controller function parameters.
-//     @NotNull/@Size/@Pattern/@Email/@Min/@Max/@NotBlank/@NotEmpty on data-class
-//     fields or constructor parameters.
-//     Emits SCOPE.Pattern (subtype="request_validation") per annotation site
-//     and SCOPE.Schema (subtype="dto") per data class bearing annotations.
+//     @Valid/@Validated on handler/controller function parameters, and
+//     field-level constraints on data-class properties / constructor params:
+//     @field:NotNull / @field:NotBlank / @field:Email / @field:Size(min,max) /
+//     @field:Min / @field:Max / @field:Pattern(regexp=...) and the bare
+//     (non-`field:`) annotation forms. Each constrained property becomes a
+//     SCOPE.Pattern (subtype="request_validation") named
+//     "validation:rule:<DTO>.<field>:<constraint>" carrying the specific
+//     field, constraint kind and parsed bound(s).
 //
-//  2. Dry::Validation-style contract objects:
-//     Kotlin "contract" DSLs (Valiktor / Arrow Validation contract blocks).
-//     Emits SCOPE.Pattern (subtype="request_validation") for contract schemas
-//     and SCOPE.Schema (subtype="dto") for the parameterised type.
+//  2. konform DSL (io.konform.validation):
+//     Validation<Foo> { Foo::bar { minLength(1); pattern("...") } } — each
+//     property block's constraints become per-field request_validation rules
+//     named "validation:rule:<Foo>.<bar>:<constraint>" with bound(s).
+//
+//  3. Valiktor / Arrow-style contract objects:
+//     validate<T>(x) { ... } DSL blocks — a coarse request_validation pattern
+//     plus the validated DTO schema.
+//
+// DTO extraction additionally walks every Kotlin `data class` and emits one
+// SCOPE.Schema (subtype="dto") per class plus, for each property, the property
+// name, declared type, nullability (`String?`), kotlinx-serialization /
+// Jackson wire-name overrides (@SerialName / @JsonProperty) and any default —
+// recorded as properties of the DTO schema entity (props_json) and asserted by
+// value in tests.
 //
 // These entities cause request_validation and dto_extraction coverage cells to
-// light up for the 6 Kotlin backend framework records:
+// light up for the Kotlin backend framework records:
 // spring-boot, ktor, micronaut, quarkus, http4k, javalin.
 package kotlin
 
@@ -23,6 +37,7 @@ import (
 	"context"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -46,26 +61,52 @@ func (e *kotlinValidationExtractor) Language() string { return "custom_kotlin_va
 
 var (
 	// @Valid or @Validated on a function parameter (handler/controller style).
-	// Matches: @Valid FooRequest, @Validated @RequestBody BarDto, etc.
-	reValidAnnotationParam = regexp.MustCompile(
-		`@(?:Valid|Validated)\b`,
+	reValidAnnotationParam = regexp.MustCompile(`@(?:Valid|Validated)\b`)
+
+	// Field-level Bean Validation annotation, optionally with a Kotlin
+	// use-site target (`@field:`, `@get:`, `@param:`, `@property:`) and an
+	// optional argument list. Submatch 1 = constraint name, submatch 2 = raw
+	// argument text inside parens (may be empty).
+	reBeanConstraint = regexp.MustCompile(
+		`@(?:field:|get:|param:|property:|set:)?` +
+			`(NotNull|NotBlank|NotEmpty|Size|Pattern|Email|Min|Max|Positive|PositiveOrZero|Negative|NegativeOrZero|DecimalMin|DecimalMax|Digits|Future|Past|FutureOrPresent|PastOrPresent|AssertTrue|AssertFalse)` +
+			`\b(?:\s*\(([^)]*)\))?`,
 	)
 
-	// Field-level Bean Validation annotations on data-class constructor params
-	// or body properties.
-	reFieldAnnotation = regexp.MustCompile(
-		`@(?:NotNull|NotBlank|NotEmpty|Size|Pattern|Email|Min|Max|Positive|PositiveOrZero|Negative|NegativeOrZero|DecimalMin|DecimalMax|Digits|Future|Past|FutureOrPresent|PastOrPresent|AssertTrue|AssertFalse)\b`,
-	)
-
-	// data class FooRequest(...) or data class FooDto(...)
+	// data class FooRequest(...) or class FooDto(...). Submatch 1 = class name.
 	reDataClass = regexp.MustCompile(
-		`(?m)^\s*(?:data\s+class|class)\s+([A-Z][A-Za-z0-9_]*)\s*[(:@]`,
+		`(?m)^\s*(?:@\w+(?:\([^)]*\))?\s*)*(?:data\s+class|class)\s+([A-Z][A-Za-z0-9_]*)\s*[(:@]`,
 	)
 
-	// Valiktor / Arrow-style: validate(foo) { ... } or Validator { ... }
-	// Also matches dry-validation Contract blocks.
+	// A constructor/body property declaration carrying optional annotations.
+	// Captures the leading annotation block (g1), val/var (g2), property name
+	// (g3), declared type up to a delimiter (g4) and any default after `=` (g5).
+	reDataProperty = regexp.MustCompile(
+		`(?m)((?:@(?:field:|get:|param:|property:|set:)?\w+(?:\s*\([^)]*\))?\s*)*)` +
+			`\b(val|var)\s+([a-z_][A-Za-z0-9_]*)\s*:\s*` +
+			// type: ident with one optional level of generic args, optional `?`.
+			`([A-Za-z_][A-Za-z0-9_.]*(?:\s*<[^<>]*>)?\??)` +
+			`(?:\s*=\s*([^,)\n]+))?`,
+	)
+
+	// kotlinx.serialization @SerialName("wire") wire-name override.
+	reSerialName = regexp.MustCompile(`@SerialName\s*\(\s*"([^"]+)"\s*\)`)
+	// Jackson @JsonProperty("wire") wire-name override.
+	reJsonProperty = regexp.MustCompile(`@JsonProperty\s*\(\s*"([^"]+)"\s*\)`)
+
+	// Valiktor / Arrow-style: validate(foo) { ... } or Validator { ... }.
 	reValidationContract = regexp.MustCompile(
 		`\b(?:validate|Validator)\s*(?:<\s*([A-Z][A-Za-z0-9_]*)\s*>)?\s*\(`,
+	)
+
+	// konform: Validation<Foo> { ... } — submatch 1 = validated type.
+	reKonformHead = regexp.MustCompile(`\bValidation\s*<\s*([A-Z][A-Za-z0-9_]*)\s*>\s*\{`)
+	// konform property block:  Foo::bar { ... }  — submatch 1 = receiver type,
+	// submatch 2 = property name, submatch 3 = open-brace offset anchor.
+	reKonformProperty = regexp.MustCompile(`([A-Z][A-Za-z0-9_]*)\s*::\s*([a-z_][A-Za-z0-9_]*)\s*(?:\.\s*has)?\s*\{`)
+	// konform constraint call inside a property block:  minLength(1) / pattern("..").
+	reKonformConstraint = regexp.MustCompile(
+		`\b(minLength|maxLength|minItems|maxItems|minimum|maximum|exclusiveMinimum|exclusiveMaximum|pattern|enum|const|notBlank|required|uniqueItems|multipleOf|minimumValue|maximumValue)\b(?:\s*\(\s*([^)]*?)\s*\))?`,
 	)
 )
 
@@ -112,60 +153,82 @@ func (e *kotlinValidationExtractor) Extract(ctx context.Context, file extractor.
 		entities = append(entities, ent)
 	}
 
+	// Index data-class heads by source offset so each property/constraint can
+	// be attributed to its enclosing DTO.
+	classHeads := indexDataClasses(src)
+	classAt := func(off int) string {
+		name := ""
+		for _, h := range classHeads {
+			if h.off <= off {
+				name = h.name
+			} else {
+				break
+			}
+		}
+		return name
+	}
+
 	// -----------------------------------------------------------------------
 	// 1. @Valid / @Validated on handler parameters → request_validation
 	// -----------------------------------------------------------------------
-	if reValidAnnotationParam.MatchString(src) {
-		for _, m := range reValidAnnotationParam.FindAllStringIndex(src, -1) {
-			attrText := src[m[0]:m[1]]
-			line := lineOf(src, m[0])
-			name := "validation:handler:" + attrText + ":" + file.Path + ":" + strconv.Itoa(line)
-			ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "kotlin", line)
-			setProps(&ent,
-				"validation_framework", "BeanValidation",
-				"annotation", attrText,
-				"provenance", "INFERRED_FROM_VALID_ANNOTATION",
-			)
-			add(ent)
-		}
+	for _, m := range reValidAnnotationParam.FindAllStringIndex(src, -1) {
+		attrText := src[m[0]:m[1]]
+		line := lineOf(src, m[0])
+		name := "validation:handler:" + attrText + ":" + file.Path + ":" + strconv.Itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "kotlin", line)
+		setProps(&ent,
+			"validation_framework", "BeanValidation",
+			"validation_kind", "handler_marker",
+			"annotation", attrText,
+			"provenance", "INFERRED_FROM_VALID_ANNOTATION",
+		)
+		add(ent)
 	}
 
 	// -----------------------------------------------------------------------
-	// 2. Field-level annotations (@NotNull, @Size, @Email, etc.) → request_validation
-	//    + emit DTO schema for data classes in the file
+	// 2. Field-level bean-validation constraints → one rule per field+constraint
 	// -----------------------------------------------------------------------
-	if reFieldAnnotation.MatchString(src) {
-		for _, m := range reFieldAnnotation.FindAllStringIndex(src, -1) {
-			attrText := src[m[0]:m[1]]
-			line := lineOf(src, m[0])
-			name := "validation:field:" + attrText + ":" + file.Path + ":" + strconv.Itoa(line)
-			ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "kotlin", line)
-			setProps(&ent,
-				"validation_framework", "BeanValidation",
-				"annotation", attrText,
-				"provenance", "INFERRED_FROM_FIELD_ANNOTATION",
-			)
-			add(ent)
+	for _, m := range reBeanConstraint.FindAllStringSubmatchIndex(src, -1) {
+		constraint := src[m[2]:m[3]]
+		argText := ""
+		if m[4] >= 0 {
+			argText = src[m[4]:m[5]]
 		}
-
-		// Emit DTO schema entities for data classes in this file.
-		for _, m := range reDataClass.FindAllStringSubmatchIndex(src, -1) {
-			className := src[m[2]:m[3]]
-			if kotlinPrimitives[className] {
-				continue
-			}
-			line := lineOf(src, m[0])
-			dtoEnt := makeEntity(className, "SCOPE.Schema", "dto", file.Path, "kotlin", line)
-			setProps(&dtoEnt,
-				"validation_framework", "BeanValidation",
-				"provenance", "INFERRED_FROM_FIELD_ANNOTATION",
-			)
-			add(dtoEnt)
+		line := lineOf(src, m[0])
+		dto := classAt(m[0])
+		field := beanFieldName(src, m[1])
+		fieldRef := dto
+		if field != "" {
+			fieldRef = dto + "." + field
 		}
+		name := "validation:rule:" + fieldRef + ":" + constraint
+		ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "kotlin", line)
+		setProps(&ent,
+			"validation_framework", "BeanValidation",
+			"validation_kind", "rule",
+			"dto", dto,
+			"field_name", field,
+			"constraint", constraint,
+			"provenance", "INFERRED_FROM_FIELD_ANNOTATION",
+		)
+		for k, v := range beanConstraintBounds(constraint, argText) {
+			ent.Properties[k] = v
+		}
+		add(ent)
 	}
 
 	// -----------------------------------------------------------------------
-	// 3. Valiktor / Arrow contract blocks → request_validation + dto
+	// 3. DTO schema + property extraction (every data class)
+	// -----------------------------------------------------------------------
+	emitDataClasses(add, src, classHeads, file.Path)
+
+	// -----------------------------------------------------------------------
+	// 4. konform DSL → per-field request_validation rules + dto
+	// -----------------------------------------------------------------------
+	emitKonform(add, src, file.Path)
+
+	// -----------------------------------------------------------------------
+	// 5. Valiktor / Arrow contract blocks → request_validation + dto
 	// -----------------------------------------------------------------------
 	for _, m := range reValidationContract.FindAllStringSubmatchIndex(src, -1) {
 		line := lineOf(src, m[0])
@@ -177,6 +240,7 @@ func (e *kotlinValidationExtractor) Extract(ctx context.Context, file extractor.
 		ent := makeEntity(name, "SCOPE.Pattern", "request_validation", file.Path, "kotlin", line)
 		setProps(&ent,
 			"validation_framework", "Valiktor",
+			"validation_kind", "contract",
 			"provenance", "INFERRED_FROM_VALIDATION_CONTRACT",
 		)
 		if typeName != "" {
@@ -196,4 +260,245 @@ func (e *kotlinValidationExtractor) Extract(ctx context.Context, file extractor.
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type classHead struct {
+	name string
+	off  int
+}
+
+func indexDataClasses(src string) []classHead {
+	var heads []classHead
+	for _, m := range reDataClass.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		if kotlinPrimitives[className] {
+			continue
+		}
+		heads = append(heads, classHead{name: className, off: m[0]})
+	}
+	return heads
+}
+
+// beanFieldName resolves the property name a bean-validation annotation applies
+// to by scanning forward from the end of the annotation match for the next
+// `val`/`var <name>` declaration on the same logical property. Annotations
+// precede their property in Kotlin constructor/body declarations.
+func beanFieldName(src string, from int) string {
+	// Look ahead a bounded window for the property declaration.
+	end := from + 200
+	if end > len(src) {
+		end = len(src)
+	}
+	window := src[from:end]
+	if m := rePropDeclLookahead.FindStringSubmatch(window); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+var rePropDeclLookahead = regexp.MustCompile(
+	`(?:@(?:field:|get:|param:|property:|set:)?\w+(?:\s*\([^)]*\))?\s*)*` +
+		`(?:val|var)\s+([a-z_][A-Za-z0-9_]*)`,
+)
+
+// beanConstraintBounds parses the parsed bound(s) of a bean-validation
+// constraint argument list into typed property keys.
+func beanConstraintBounds(constraint, argText string) map[string]string {
+	out := map[string]string{}
+	argText = strings.TrimSpace(argText)
+	if argText == "" {
+		return out
+	}
+	switch constraint {
+	case "Size", "Digits", "Length":
+		if v := namedArg(argText, "min"); v != "" {
+			out["min"] = v
+		}
+		if v := namedArg(argText, "max"); v != "" {
+			out["max"] = v
+		}
+		if v := namedArg(argText, "integer"); v != "" {
+			out["integer"] = v
+		}
+		if v := namedArg(argText, "fraction"); v != "" {
+			out["fraction"] = v
+		}
+	case "Min", "Max", "DecimalMin", "DecimalMax":
+		if v := namedArg(argText, "value"); v != "" {
+			out["value"] = v
+		} else if v := firstScalarArg(argText); v != "" {
+			out["value"] = v
+		}
+	case "Pattern":
+		if v := namedArg(argText, "regexp"); v != "" {
+			out["regexp"] = v
+		}
+	}
+	return out
+}
+
+// namedArg extracts a `name = value` argument (value may be quoted) from a
+// comma-separated annotation argument list.
+func namedArg(args, name string) string {
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*=\s*("(?:[^"\\]|\\.)*"|[^,)]+)`)
+	m := re.FindStringSubmatch(args)
+	if m == nil {
+		return ""
+	}
+	return strings.Trim(strings.TrimSpace(m[1]), `"`)
+}
+
+// firstScalarArg returns the first positional scalar argument.
+func firstScalarArg(args string) string {
+	parts := strings.SplitN(args, ",", 2)
+	v := strings.TrimSpace(parts[0])
+	if strings.Contains(v, "=") {
+		return ""
+	}
+	return strings.Trim(v, `"`)
+}
+
+// emitDataClasses emits one SCOPE.Schema(dto) per data class and records each
+// property's name, type, nullability, wire-name override and default into the
+// DTO entity's properties (encoded compactly + per-property keys).
+func emitDataClasses(add func(types.EntityRecord), src string, heads []classHead, filePath string) {
+	for i, h := range heads {
+		// Body span: from this class head to the next class head (or EOF).
+		bodyEnd := len(src)
+		if i+1 < len(heads) {
+			bodyEnd = heads[i+1].off
+		}
+		body := src[h.off:bodyEnd]
+		line := lineOf(src, h.off)
+
+		dtoEnt := makeEntity(h.name, "SCOPE.Schema", "dto", filePath, "kotlin", line)
+		setProps(&dtoEnt, "provenance", "INFERRED_FROM_DATA_CLASS")
+
+		var propList []string
+		for _, pm := range reDataProperty.FindAllStringSubmatchIndex(body, -1) {
+			annoBlock := body[pm[2]:pm[3]]
+			pname := body[pm[6]:pm[7]]
+			ptype := strings.TrimSpace(body[pm[8]:pm[9]])
+			pdefault := ""
+			if pm[10] >= 0 {
+				pdefault = strings.TrimSpace(body[pm[10]:pm[11]])
+			}
+			nullable := strings.HasSuffix(ptype, "?")
+
+			wire := pname
+			if w := reSerialName.FindStringSubmatch(annoBlock); w != nil {
+				wire = w[1]
+			} else if w := reJsonProperty.FindStringSubmatch(annoBlock); w != nil {
+				wire = w[1]
+			}
+
+			// Per-property keys (value-asserted by tests).
+			setProps(&dtoEnt,
+				"prop."+pname+".type", ptype,
+				"prop."+pname+".nullable", strconv.FormatBool(nullable),
+				"prop."+pname+".wire_name", wire,
+			)
+			if pdefault != "" {
+				dtoEnt.Properties["prop."+pname+".default"] = pdefault
+			}
+			propList = append(propList, pname)
+		}
+		if len(propList) > 0 {
+			setProps(&dtoEnt, "properties", strings.Join(propList, ","))
+			setProps(&dtoEnt, "property_count", strconv.Itoa(len(propList)))
+		}
+		add(dtoEnt)
+	}
+}
+
+// emitKonform parses konform Validation<T> { T::field { constraint(bound) } }
+// DSL blocks, emitting one request_validation rule per field+constraint with
+// the parsed bound, plus the validated DTO schema.
+func emitKonform(add func(types.EntityRecord), src, filePath string) {
+	for _, hm := range reKonformHead.FindAllStringSubmatchIndex(src, -1) {
+		validated := src[hm[2]:hm[3]]
+		open := hm[1] - 1 // index of the head '{'
+		end := matchBraceKotlin(src, open)
+		if end < 0 {
+			end = len(src)
+		}
+		blockBody := src[open+1 : end]
+		blockBase := open + 1
+		line := lineOf(src, hm[0])
+
+		if !kotlinPrimitives[validated] {
+			dtoEnt := makeEntity(validated, "SCOPE.Schema", "dto", filePath, "kotlin", line)
+			setProps(&dtoEnt,
+				"validation_framework", "konform",
+				"provenance", "INFERRED_FROM_KONFORM",
+			)
+			add(dtoEnt)
+		}
+
+		// Each property block:  Foo::field { ... }.
+		for _, pm := range reKonformProperty.FindAllStringSubmatchIndex(blockBody, -1) {
+			field := blockBody[pm[4]:pm[5]]
+			pOpen := pm[1] - 1 // the property block '{'
+			pEnd := matchBraceKotlin(blockBody, pOpen)
+			if pEnd < 0 {
+				pEnd = len(blockBody)
+			}
+			propBody := blockBody[pOpen+1 : pEnd]
+			pLine := lineOf(src, blockBase+pm[0])
+
+			for _, cm := range reKonformConstraint.FindAllStringSubmatchIndex(propBody, -1) {
+				constraint := propBody[cm[2]:cm[3]]
+				bound := ""
+				if cm[4] >= 0 {
+					bound = strings.Trim(strings.TrimSpace(propBody[cm[4]:cm[5]]), `"`)
+				}
+				name := "validation:rule:" + validated + "." + field + ":" + constraint
+				ent := makeEntity(name, "SCOPE.Pattern", "request_validation", filePath, "kotlin", pLine)
+				setProps(&ent,
+					"validation_framework", "konform",
+					"validation_kind", "rule",
+					"dto", validated,
+					"field_name", field,
+					"constraint", constraint,
+					"provenance", "INFERRED_FROM_KONFORM",
+				)
+				if bound != "" {
+					ent.Properties["bound"] = bound
+				}
+				add(ent)
+			}
+		}
+	}
+}
+
+// matchBraceKotlin returns the index of the brace matching the one at open,
+// skipping over string literals. Returns -1 when unbalanced.
+func matchBraceKotlin(src string, open int) int {
+	depth := 0
+	var quote byte
+	for i := open; i < len(src); i++ {
+		c := src[i]
+		if quote != 0 {
+			if c == quote && (i == 0 || src[i-1] != '\\') {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			quote = c
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
 }

--- a/internal/custom/kotlin/validation_test.go
+++ b/internal/custom/kotlin/validation_test.go
@@ -140,11 +140,25 @@ func TestValidationWrongLanguage(t *testing.T) {
 	}
 }
 
-func TestValidationNoMatch(t *testing.T) {
+func TestValidationPlainDataClassEmitsDTOOnly(t *testing.T) {
+	// A plain data class (no validation annotations) is still a DTO: dto_extraction
+	// must emit the schema with its properties, but no request_validation rules.
 	src := `data class User(val name: String, val age: Int)`
 	ents := extract(t, "custom_kotlin_validation", fi("User.kt", "kotlin", src))
-	if len(ents) != 0 {
-		t.Errorf("expected no entities for plain data class, got %d", len(ents))
+	if !containsEntity(ents, "SCOPE.Schema", "User") {
+		t.Fatal("expected User DTO schema entity for plain data class")
+	}
+	for _, e := range ents {
+		if e.Subtype == "request_validation" {
+			t.Errorf("plain data class should not emit request_validation, got %q", e.Name)
+		}
+	}
+	dto := findEntity(ents, "SCOPE.Schema", "User")
+	if dto.Props["prop.name.type"] != "String" {
+		t.Errorf("expected name:String, got %q", dto.Props["prop.name.type"])
+	}
+	if dto.Props["prop.age.type"] != "Int" {
+		t.Errorf("expected age:Int, got %q", dto.Props["prop.age.type"])
 	}
 }
 
@@ -152,5 +166,154 @@ func TestValidationEmptyFile(t *testing.T) {
 	ents := extract(t, "custom_kotlin_validation", fi("Empty.kt", "kotlin", ""))
 	if len(ents) != 0 {
 		t.Errorf("empty file should return no entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Deep value-asserting tests (TS/JS bar): specific field + constraint + bound.
+// ---------------------------------------------------------------------------
+
+// request_validation: per-field rule with the SPECIFIC field name, constraint
+// kind and parsed bound — not mere annotation presence.
+func TestValidationBeanRulesFieldConstraintBounds(t *testing.T) {
+	src := `
+data class CreateUserRequest(
+    @field:NotBlank val name: String,
+    @field:Size(min = 1, max = 20) val username: String,
+    @field:Email val email: String,
+    @field:Min(18) val age: Int,
+    @field:Pattern(regexp = "\\d{10}") val phone: String
+)
+`
+	ents := extract(t, "custom_kotlin_validation", fi("CreateUserRequest.kt", "kotlin", src))
+
+	// email: @Email on the email field
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:CreateUserRequest.email:Email"); e == nil {
+		t.Error("expected email -> @Email rule")
+	} else if e.Props["field_name"] != "email" || e.Props["constraint"] != "Email" {
+		t.Errorf("email rule props wrong: %+v", e.Props)
+	}
+
+	// name: Size(min=1,max=20) bound capture on username
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:CreateUserRequest.username:Size"); e == nil {
+		t.Error("expected username -> Size rule")
+	} else if e.Props["min"] != "1" || e.Props["max"] != "20" {
+		t.Errorf("expected Size(min=1,max=20), got min=%q max=%q", e.Props["min"], e.Props["max"])
+	}
+
+	// Min(18) value bound on age
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:CreateUserRequest.age:Min"); e == nil {
+		t.Error("expected age -> Min rule")
+	} else if e.Props["value"] != "18" {
+		t.Errorf("expected Min value=18, got %q", e.Props["value"])
+	}
+
+	// Pattern(regexp=...) on phone
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:CreateUserRequest.phone:Pattern"); e == nil {
+		t.Error("expected phone -> Pattern rule")
+	} else if e.Props["regexp"] != `\\d{10}` {
+		// Kotlin source contains the escaped form `\\d{10}`; the extractor
+		// reports the literal token verbatim.
+		t.Errorf("expected Pattern regexp=\\\\d{10}, got %q", e.Props["regexp"])
+	}
+
+	// NotBlank on name
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:CreateUserRequest.name:NotBlank"); e == nil {
+		t.Error("expected name -> NotBlank rule")
+	}
+}
+
+// dto_extraction: property name + type + nullability + wire-name override.
+func TestValidationDTOPropertyShape(t *testing.T) {
+	src := `
+@Serializable
+data class AddressDto(
+    @SerialName("street_name") val streetName: String,
+    val unit: String? = null,
+    @JsonProperty("zip") val zipCode: String,
+    val country: String = "US"
+)
+`
+	ents := extract(t, "custom_kotlin_validation", fi("AddressDto.kt", "kotlin", src))
+	dto := findEntity(ents, "SCOPE.Schema", "AddressDto")
+	if dto == nil {
+		t.Fatal("expected AddressDto DTO schema")
+	}
+	// kotlinx-serialization @SerialName wire override
+	if dto.Props["prop.streetName.wire_name"] != "street_name" {
+		t.Errorf("expected streetName wire_name=street_name, got %q", dto.Props["prop.streetName.wire_name"])
+	}
+	// nullability: String?
+	if dto.Props["prop.unit.nullable"] != "true" {
+		t.Errorf("expected unit nullable=true, got %q", dto.Props["prop.unit.nullable"])
+	}
+	if dto.Props["prop.streetName.nullable"] != "false" {
+		t.Errorf("expected streetName nullable=false, got %q", dto.Props["prop.streetName.nullable"])
+	}
+	// Jackson @JsonProperty wire override
+	if dto.Props["prop.zipCode.wire_name"] != "zip" {
+		t.Errorf("expected zipCode wire_name=zip, got %q", dto.Props["prop.zipCode.wire_name"])
+	}
+	// default capture
+	if dto.Props["prop.country.default"] != `"US"` {
+		t.Errorf("expected country default=\"US\", got %q", dto.Props["prop.country.default"])
+	}
+	if dto.Props["prop.country.type"] != "String" {
+		t.Errorf("expected country type=String, got %q", dto.Props["prop.country.type"])
+	}
+}
+
+// konform DSL: Validation<Foo> { Foo::bar { minLength(1) } } — specific field +
+// constraint + bound, not len>0.
+func TestValidationKonformDSL(t *testing.T) {
+	src := `
+val userValidation = Validation<UserDto> {
+    UserDto::name {
+        minLength(1)
+        maxLength(20)
+    }
+    UserDto::email {
+        pattern(".+@.+")
+    }
+}
+`
+	ents := extract(t, "custom_kotlin_validation", fi("UserValidation.kt", "kotlin", src))
+
+	if !containsEntity(ents, "SCOPE.Schema", "UserDto") {
+		t.Error("expected UserDto DTO schema from konform Validation<UserDto>")
+	}
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:UserDto.name:minLength"); e == nil {
+		t.Error("expected name -> minLength rule")
+	} else if e.Props["bound"] != "1" || e.Props["field_name"] != "name" {
+		t.Errorf("expected minLength bound=1 field=name, got %+v", e.Props)
+	}
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:UserDto.name:maxLength"); e == nil {
+		t.Error("expected name -> maxLength rule")
+	} else if e.Props["bound"] != "20" {
+		t.Errorf("expected maxLength bound=20, got %q", e.Props["bound"])
+	}
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:UserDto.email:pattern"); e == nil {
+		t.Error("expected email -> pattern rule")
+	} else if e.Props["bound"] != ".+@.+" {
+		t.Errorf("expected pattern bound=.+@.+, got %q", e.Props["bound"])
+	}
+}
+
+// Bare (non-field:) bean annotations still attribute to the right field.
+func TestValidationBareBeanAnnotationField(t *testing.T) {
+	src := `
+data class LoginRequest(
+    @NotNull val username: String,
+    @Size(max = 64) val password: String
+)
+`
+	ents := extract(t, "custom_kotlin_validation", fi("LoginRequest.kt", "kotlin", src))
+	if e := findEntity(ents, "SCOPE.Pattern", "validation:rule:LoginRequest.password:Size"); e == nil {
+		t.Error("expected password -> Size rule")
+	} else if e.Props["max"] != "64" {
+		t.Errorf("expected Size max=64, got %q", e.Props["max"])
+	}
+	if findEntity(ents, "SCOPE.Pattern", "validation:rule:LoginRequest.username:NotNull") == nil {
+		t.Error("expected username -> NotNull rule")
 	}
 }


### PR DESCRIPTION
Closes #3434 (epic #3431).

Deepens the Kotlin validation extractor (`internal/custom/kotlin/validation.go`) from annotation-*presence* to **field-level, value-asserting** extraction matching the Go `huma` reference bar.

## dto_extraction (partial → full)
- Emit `SCOPE.Schema(dto)` for **every** Kotlin `data class` (not only annotated ones).
- Per-property capture: name, declared type, **nullability** (`String?`), **default** value, and **wire-name overrides** from kotlinx.serialization `@SerialName` and Jackson `@JsonProperty`. Recorded as `prop.<name>.{type,nullable,wire_name,default}`.

## request_validation (partial → full)
- **jakarta/javax bean validation**: one rule per field+constraint, entity named `validation:rule:<DTO>.<field>:<constraint>`, supporting `@field:`/`@get:`/`@param:`/`@property:` use-site targets and bare forms, with parsed bounds — `Size(min,max)`, `Min`/`Max` value, `Pattern(regexp=...)`, `Digits(integer,fraction)`.
- **konform DSL**: `Validation<Foo> { Foo::bar { minLength(1); pattern("...") } }` parsed via balanced-brace scan into per-field rules with bounds; emits the validated DTO schema.
- Valiktor/Arrow `validate<T>{}` contract blocks retained.

## Discipline / disposition
Flipped to **full** only with VALUE-ASSERTING tests (specific field + constraint + bound):
- `email: @Email`, `username: Size(min=1,max=20)`, `age: Min(18)`, `phone: Pattern(regexp)`
- DTO shape: `@SerialName("street_name")` wire override, `String?` nullability, `country = "US"` default
- konform: `name: minLength(1)`, `name: maxLength(20)`, `email: pattern(".+@.+")`

Records flipped to `full` (dto_extraction + request_validation): **http4k, javalin, ktor, micronaut, quarkus, spring-boot**. Non-web Kotlin records (arrow, coroutines, …) remain `not_applicable`.

`go test ./internal/custom/kotlin/ ./internal/types/ ./tools/coverage/` green; `gofmt -l` empty; `go vet` clean; coverage `gen` + `validate` (0 errors) + `fmt --check` (canonical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)