### PR TITLE
feat(kotlin): deepen HTTP routing extraction to full on flagship frameworks

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -140,7 +140,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 12/12 | |
 | [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -31,7 +31,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 12/12 | |
 | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/http4k.yaml` | — |
-| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; Kotlin trailing-lambda route DSL proven by TestKotlinJavalin_Routes_Issue3274 |
 | Handler attribution | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; handler attribution proven by TestKotlinJavalin_Routes_Issue3274 |
-| Route extraction | 🟢 `partial` | `2026-05-30` | 3274 | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; GET/POST/DELETE routes extracted by TestKotlinJavalin_Routes_Issue3274 |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/java/javalin_routes.go`<br>`internal/custom/java/kotlin_port_test.go` | java extractor language-gated to kotlin; GET/POST/DELETE routes extracted by TestKotlinJavalin_Routes_Issue3274 |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/micronaut_kotlin.yaml` | — |
-| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/quarkus_kotlin.yaml` | — |
-| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kotlin/frameworks/spring_boot_kotlin.yaml`<br>`internal/engine/spring_routes_kotlin.go` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/spring_routes_kotlin.go` | — |
-| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/kotlin/routing.go`<br>`internal/custom/kotlin/routing_test.go` | — |
 
 ### Auth
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -30435,9 +30435,8 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/routing.go","internal/custom/kotlin/routing_test.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },
@@ -30695,9 +30694,8 @@
             "verified_at": "2026-05-30"
           },
           "route_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/java/javalin_routes.go","internal/custom/java/kotlin_port_test.go"],
-            "issue": "3274",
             "notes": "java extractor language-gated to kotlin; GET/POST/DELETE routes extracted by TestKotlinJavalin_Routes_Issue3274",
             "verified_at": "2026-05-30"
           }
@@ -31417,9 +31415,8 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/routing.go","internal/custom/kotlin/routing_test.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },
@@ -31700,9 +31697,8 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/routing.go","internal/custom/kotlin/routing_test.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },
@@ -31983,9 +31979,8 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/kotlin/routing.go","internal/custom/kotlin/routing_test.go"],
-            "issue": "backfill:dictionary-completeness",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/kotlin/routing.go
+++ b/internal/custom/kotlin/routing.go
@@ -453,23 +453,28 @@ func (e *kotlinHttp4kRoutesExtractor) Extract(ctx context.Context, file extracto
 		entities = append(entities, ent)
 	}
 
-	// Flat bindings: "path" bind METHOD to handler.
-	for _, m := range reHttp4kBind.FindAllStringSubmatchIndex(src, -1) {
-		path := src[m[2]:m[3]]
-		verb := src[m[4]:m[5]]
-		name := verb + " " + path
-		line := lineOf(src, m[0])
-		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, "kotlin", line)
+	// Composed bindings: walk the source tracking a prefix stack from
+	// "prefix" bind routes( … ) blocks so that inner verb bindings inherit
+	// the enclosing prefix, e.g.:
+	//
+	//	"/api" bind routes(
+	//	    "/users" bind GET to ::listUsers,   → GET /api/users
+	//	)
+	for _, b := range http4kComposedBinds(src) {
+		fullPath := b.path
+		name := b.verb + " " + fullPath
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, "kotlin", lineOf(src, b.offset))
 		setProps(&ent,
 			"framework", "http4k",
-			"http_method", verb,
-			"path", path,
+			"http_method", b.verb,
+			"path", fullPath,
 			"provenance", "INFERRED_FROM_HTTP4K_BIND",
 		)
 		add(ent)
 	}
 
-	// Nested prefix blocks: extract the prefix as a route scope entity.
+	// Nested prefix blocks: also emit the prefix as a route scope entity so the
+	// scope node is discoverable independently of its leaf verbs.
 	for _, m := range reHttp4kNestedBind.FindAllStringSubmatchIndex(src, -1) {
 		prefix := src[m[2]:m[3]]
 		line := lineOf(src, m[0])
@@ -490,6 +495,99 @@ func (e *kotlinHttp4kRoutesExtractor) Extract(ctx context.Context, file extracto
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+// http4kBind is a resolved http4k leaf route with its enclosing prefix already
+// composed into path.
+type http4kBind struct {
+	verb   string
+	path   string
+	offset int
+}
+
+// http4kComposedBinds scans http4k routing DSL and returns leaf bindings with
+// nested "prefix" bind routes( … ) prefixes composed into the full path.
+//
+// It performs a single left-to-right pass over the source, maintaining a stack
+// of (prefix, closeParenDepth) frames. When it encounters `"p" bind routes(`
+// it pushes a frame whose prefix is p, tracking the paren depth so the frame is
+// popped when its routes( … ) closes. Leaf `"path" bind VERB` matches compose
+// every active prefix onto path.
+//
+// The scanner only tracks the prefix stack via http4k-specific tokens, so it is
+// robust against unrelated parentheses in handler bodies (handlers are normally
+// method references like ::handler, not inline parenthesised blocks). When in
+// doubt it favours under-composition over cross-contamination.
+func http4kComposedBinds(src string) []http4kBind {
+	type frame struct {
+		prefix   string
+		closeOff int // offset of the matching ')' that ends this routes( … )
+	}
+
+	var (
+		out   []http4kBind
+		stack []frame
+	)
+
+	nested := reHttp4kNestedBind.FindAllStringSubmatchIndex(src, -1)
+	leaf := reHttp4kBind.FindAllStringSubmatchIndex(src, -1)
+
+	ni, li := 0, 0
+	for pos := 0; pos < len(src); pos++ {
+		// Pop frames whose routes( … ) has closed before this position.
+		for len(stack) > 0 && pos > stack[len(stack)-1].closeOff {
+			stack = stack[:len(stack)-1]
+		}
+
+		// A nested prefix opener `"prefix" bind routes(` starts at pos. The '('
+		// it opens is the final char of the match (nested[ni][1]-1); find its
+		// matching ')' so we know exactly where this prefix scope ends.
+		if ni < len(nested) && nested[ni][0] == pos {
+			prefix := src[nested[ni][2]:nested[ni][3]]
+			openParen := nested[ni][1] - 1
+			if close := matchCloseParen(src, openParen); close >= 0 {
+				stack = append(stack, frame{prefix: prefix, closeOff: close})
+			}
+			ni++
+		}
+
+		// A leaf "path" bind VERB starts at pos: compose every active prefix.
+		if li < len(leaf) && leaf[li][0] == pos {
+			composed := src[leaf[li][2]:leaf[li][3]]
+			// Wrap innermost-first so the outermost prefix ends up leftmost.
+			for i := len(stack) - 1; i >= 0; i-- {
+				composed = joinKtRoutePaths(stack[i].prefix, composed)
+			}
+			out = append(out, http4kBind{
+				verb:   src[leaf[li][4]:leaf[li][5]],
+				path:   composed,
+				offset: leaf[li][0],
+			})
+			li++
+		}
+	}
+	return out
+}
+
+// matchCloseParen returns the offset of the ')' that matches the '(' at
+// openParen, or -1 if unbalanced. src[openParen] must be '('.
+func matchCloseParen(src string, openParen int) int {
+	if openParen < 0 || openParen >= len(src) || src[openParen] != '(' {
+		return -1
+	}
+	depth := 0
+	for i := openParen; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
 
 // joinKtRoutePaths composes a base path and a sub-path, normalising double
 // slashes. Both parts may be empty.

--- a/internal/custom/kotlin/routing_test.go
+++ b/internal/custom/kotlin/routing_test.go
@@ -248,13 +248,39 @@ val app = routes(
 )
 `
 	ents := extract(t, "custom_kotlin_http4k_routes", fi("Nested.kt", "kotlin", src))
-	// Flat bindings inside nested should still be captured.
+	// Nested "/api" bind routes( … ) must compose onto the leaf paths.
 	names := routeNames(ents)
-	if !names["GET /users"] {
-		t.Errorf("http4k: expected GET /users in nested; got %v", names)
+	if !names["GET /api/users"] {
+		t.Errorf("http4k: expected composed GET /api/users in nested; got %v", names)
 	}
-	if !names["POST /users"] {
-		t.Errorf("http4k: expected POST /users in nested; got %v", names)
+	if !names["POST /api/users"] {
+		t.Errorf("http4k: expected composed POST /api/users in nested; got %v", names)
+	}
+}
+
+func TestHttp4kRoutes_NestedTwoLevels(t *testing.T) {
+	src := `
+val app = routes(
+    "/api" bind routes(
+        "/v1" bind routes(
+            "/users" bind GET to ::listUsers,
+            "/users/{id}" bind DELETE to ::deleteUser,
+        ),
+    ),
+    "/ping" bind GET to ::ping,
+)
+`
+	ents := extract(t, "custom_kotlin_http4k_routes", fi("DeepNested.kt", "kotlin", src))
+	names := routeNames(ents)
+	want := []string{
+		"GET /api/v1/users",
+		"DELETE /api/v1/users/{id}",
+		"GET /ping",
+	}
+	for _, w := range want {
+		if !names[w] {
+			t.Errorf("http4k: expected composed route %q; got %v", w, names)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #3432 (epic #3431).

Deep-grinds Kotlin HTTP `route_extraction` to the TS/JS bar across the flagship web frameworks. Every flip is backed by a **value-asserting** test proving the exact `(verb, path)` (including prefix composition and `{id}` path-param normalization), not `len > 0`.

## Records: partial → full

| Framework | Idiom proven | Citations |
|---|---|---|
| **http4k** | `routes(...)` flat + **nested** `"/api" bind routes( "/v1" bind routes( "/users" bind GET to ::h ) )` → `GET /api/v1/users` | `internal/custom/kotlin/routing.go`, `routing_test.go` |
| **spring-boot** | `@RestController` + `@RequestMapping("/api")` class prefix composed with `@GetMapping("/orders/{id}")` etc. → `GET /api/orders/{id}` | `internal/custom/kotlin/routing.go`, `routing_test.go` |
| **micronaut** | `@Controller("/products")` + `@Get("/{id}")` → `GET /products/{id}` | `internal/custom/kotlin/routing.go`, `routing_test.go` |
| **quarkus** | JAX-RS `@Path` class + method `@Path`/`@VERB` (both orders) → `GET /orders/{id}` | `internal/custom/kotlin/routing.go`, `routing_test.go` |
| **javalin** | `app.get("/users/{id}") { ctx -> }` trailing-lambda DSL (kotlin-gated java extractor) → `DELETE /users/{id}` | `internal/custom/java/javalin_routes.go`, `kotlin_port_test.go` |

`ktor` was already `full` (CST nested-prefix composition) and is unchanged.

## Genuine code deepening (http4k)

Previously http4k only emitted flat `"path" bind VERB` leaves plus a bare scope node for `"prefix" bind routes(...)` — nested prefixes were **not** composed onto leaves. Added `http4kComposedBinds`: a paren-matched prefix-stack scanner (`matchCloseParen` finds each `routes(` block's matching close, frames pop by offset, prefixes wrap innermost-first) so nested prefixes compose correctly. New tests assert one- and two-level nesting plus a sibling flat route.

The other four frameworks already had composition-proving tests in the repo and only needed the honest flip.

## Honest partials

None remaining for `route_extraction` on these six. The spring-boot functional `routerFunction { GET("/x") {...} }` DSL and ktor typed `@Resource` routes are secondary idioms not relied on for the flip — the dominant annotation/DSL idioms are fully composed and asserted.

## Verification
- `go test ./internal/custom/kotlin/ ./internal/custom/java/ ./internal/engine/ ./internal/types/ ./tools/coverage/` — all pass
- `coverage gen` + `validate` (0 errors) + `fmt --check` (canonical)
- `gofmt -l` empty, `go vet` clean on touched package

🤖 Generated with [Claude Code](https://claude.com/claude-code)