### PR TITLE
fix(effects): classify MongoDB driver reads/writes as db sinks (#3440)

### DIFF
--- a/internal/substrate/effect_sinks_jsts.go
+++ b/internal/substrate/effect_sinks_jsts.go
@@ -5,11 +5,15 @@
 //
 //   - http_out  : fetch(...), axios.<method>(...), got/ky/superagent
 //   - db_read   : Sequelize/TypeORM/Prisma `.find*` / `.findOne` / `.query`,
-//                 Mongoose `.find()` / `.aggregate()`, knex `.select`
-//   - db_write  : `.save`/`.create`/`.update`/`.delete`/`.insert`/`.upsert`
+//     Mongoose/native-driver `.find()` / `.findById()` /
+//     `.aggregate()` / `.countDocuments()` / `.distinct()`,
+//     knex `.select`
+//   - db_write  : `.save`/`.create`/`.update`/`.delete`/`.insert`/`.upsert`,
+//     Mongoose/native-driver `.findOneAndUpdate` /
+//     `.findByIdAndDelete` / `.replaceOne` / `.bulkWrite`
 //   - fs_read   : `fs.readFile*`, `fs.readSync`, `fs.createReadStream`
 //   - fs_write  : `fs.writeFile*`, `fs.writeSync`, `fs.createWriteStream`,
-//                 `fs.appendFile*`, `fs.mkdir*`, `fs.unlink*`
+//     `fs.appendFile*`, `fs.mkdir*`, `fs.unlink*`
 //   - mutation  : `this.<field> = ...` assignment inside a method body
 //
 // Function attribution is line-based: each match is assigned to the
@@ -24,13 +28,13 @@ func init() { RegisterEffectSniffer("jsts", sniffEffectsJSTS) }
 
 // jstsFuncHeaderRe matches function-introducing syntax we attribute sinks to:
 //
-//   function foo(             // named function declaration
-//   async function foo(
-//   foo(args) {               // method shorthand in object/class
-//   foo = function(           // function-expression assignment
-//   foo = (args) => {         // arrow function assignment
-//   const foo = (args) =>     // const arrow
-//   async foo(args) {         // async class method shorthand
+//	function foo(             // named function declaration
+//	async function foo(
+//	foo(args) {               // method shorthand in object/class
+//	foo = function(           // function-expression assignment
+//	foo = (args) => {         // arrow function assignment
+//	const foo = (args) =>     // const arrow
+//	async foo(args) {         // async class method shorthand
 //
 // Capture group 1 is the declaring identifier name.
 var jstsFuncHeaderRe = regexp.MustCompile(
@@ -54,13 +58,23 @@ var jstsHTTPRe = regexp.MustCompile(
 )
 
 // jstsDBReadRe matches read-flavoured ORM / query-builder primitives.
+// Includes Mongoose / native MongoDB driver collection reads — `.findById`,
+// `.countDocuments`, `.estimatedDocumentCount`, `.distinct` (#3440 ask 4);
+// `.find`/`.findOne`/`.aggregate`/`.count` were already covered.
 var jstsDBReadRe = regexp.MustCompile(
-	`\.\s*(findOne|findAll|findMany|findUnique|findFirst|find|aggregate|count|exists|query|select|raw|exec)\s*\(`,
+	`\.\s*(findOne|findAll|findMany|findUnique|findFirst|findById|find|aggregate|countDocuments|estimatedDocumentCount|count|distinct|exists|query|select|raw|exec)\s*\(`,
 )
 
 // jstsDBWriteRe matches write-flavoured ORM / query-builder primitives.
+// Includes Mongoose / native MongoDB driver writes — the find-and-modify
+// family (`.findOneAndUpdate`, `.findByIdAndUpdate`, `.findOneAndDelete`,
+// `.findByIdAndDelete`, `.findOneAndReplace`, `.findByIdAndRemove`),
+// `.replaceOne`, `.bulkWrite`, `.remove` (#3440 ask 4); `.save`/`.create`/
+// `.insertOne`/`.deleteMany`/... were already covered.
 var jstsDBWriteRe = regexp.MustCompile(
-	`\.\s*(save|create|createMany|update(?:Many|One)?|upsert|delete(?:Many|One)?|destroy|insert(?:Many|One)?|bulkCreate|bulkUpdate|bulkDelete)\s*\(`,
+	`\.\s*(save|create|createMany|update(?:Many|One)?|upsert|delete(?:Many|One)?|destroy|` +
+		`insert(?:Many|One)?|bulkCreate|bulkUpdate|bulkDelete|bulkWrite|replaceOne|remove|` +
+		`findOneAndUpdate|findByIdAndUpdate|findOneAndDelete|findByIdAndDelete|findOneAndReplace|findByIdAndRemove)\s*\(`,
 )
 
 // jstsFSReadRe matches Node fs / fs/promises read primitives.
@@ -170,4 +184,3 @@ func nearestHeader(headers []funcHeader, line int) string {
 	}
 	return name
 }
-

--- a/internal/substrate/effect_sinks_python.go
+++ b/internal/substrate/effect_sinks_python.go
@@ -3,23 +3,27 @@
 // Recognises Python sink primitives:
 //
 //   - http_out  : requests.<verb>(), httpx.<verb>(), urllib.request.urlopen,
-//                 aiohttp.ClientSession (.<verb>), urllib3.request,
-//                 boto3.client/resource(...) + AWS client ops (S3 upload/
-//                 download/put/get/copy, SQS send/receive, SNS publish,
-//                 Lambda invoke) — every boto3 call crosses the network
+//     aiohttp.ClientSession (.<verb>), urllib3.request,
+//     boto3.client/resource(...) + AWS client ops (S3 upload/
+//     download/put/get/copy, SQS send/receive, SNS publish,
+//     Lambda invoke) — every boto3 call crosses the network
 //   - db_read   : Django ORM Model.objects.<filter|get|all|...>,
-//                 SQLAlchemy session.query / .execute (SELECT),
-//                 raw cursor.execute("SELECT ..."), cursor.fetchall/fetchone,
-//                 DB-API driver connect/cursor (mysql.connector, psycopg2,
-//                 sqlite3, pymysql, MySQLdb, cx_Oracle, pyodbc, asyncpg)
+//     SQLAlchemy session.query / .execute (SELECT),
+//     raw cursor.execute("SELECT ..."), cursor.fetchall/fetchone,
+//     DB-API driver connect/cursor (mysql.connector, psycopg2,
+//     sqlite3, pymysql, MySQLdb, cx_Oracle, pyodbc, asyncpg),
+//     MongoDB pymongo/motor reads (.aggregate, .find, .find_one,
+//     .count_documents, .distinct, ...)
 //   - db_write  : Django .save() / .create() / .update() / .delete() /
-//                 .bulk_create / .bulk_update,
-//                 SQLAlchemy session.add / .commit / .delete,
-//                 cursor.execute("INSERT|UPDATE|DELETE ...")
+//     .bulk_create / .bulk_update,
+//     SQLAlchemy session.add / .commit / .delete,
+//     cursor.execute("INSERT|UPDATE|DELETE ..."),
+//     MongoDB pymongo/motor writes (.insert_one/.update_many/
+//     .delete_one/.bulk_write/.find_one_and_update/...)
 //   - fs_read   : open(...), pathlib.Path.read_*, os.listdir, os.scandir,
-//                 io.open
+//     io.open
 //   - fs_write  : open(..., "w"|"a"|"x"|"wb"|...), pathlib.Path.write_*,
-//                 os.mkdir, os.remove, os.rename, shutil.copy*
+//     os.mkdir, os.remove, os.rename, shutil.copy*
 //   - mutation  : self.<attr> = ... (assignment to a method receiver)
 //   - env_read  : os.getenv(...), os.environ[...] / os.environ.get(...)
 //
@@ -100,6 +104,29 @@ var pyCursorWriteRe = regexp.MustCompile(
 	`\.\s*execute\s*\(\s*['"](?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b)`,
 )
 
+// pyMongoReadRe matches MongoDB collection read primitives for the pymongo
+// (sync) and motor (async) drivers (#3440 ask 4). These call-shapes — e.g.
+// `collection.aggregate(pipeline)`, `coll.find_one({...})` — are NOT covered
+// by pyDBReadRe because they lack the Django `.objects.` prefix and the
+// receiver is a plain collection handle. The snake_case `_one`/`_documents`
+// and `aggregate`/`distinct` names are Mongo-specific enough to be safe;
+// bare `.find(` is the canonical Mongo cursor read. find_one_and_* are
+// excluded here (they mutate) and handled by pyMongoWriteRe.
+var pyMongoReadRe = regexp.MustCompile(
+	`\.\s*(?:aggregate|aggregate_raw_batches|find_raw_batches|count_documents|estimated_document_count|distinct|list_indexes|index_information)\s*\(` +
+		`|\.\s*find_one\s*\(` +
+		`|\.\s*find\s*\(`,
+)
+
+// pyMongoWriteRe matches MongoDB collection write primitives for pymongo /
+// motor (#3440 ask 4). Covers the document mutators plus the find-and-modify
+// family (which both read and mutate — classified write, the stronger
+// signal). `insert_one`/`update_many`/`bulk_write`/`find_one_and_update` are
+// distinctive Mongo names with no common false-positive collisions.
+var pyMongoWriteRe = regexp.MustCompile(
+	`\.\s*(?:insert_one|insert_many|update_one|update_many|replace_one|delete_one|delete_many|bulk_write|find_one_and_update|find_one_and_replace|find_one_and_delete|create_index|create_indexes|drop_index|drop_indexes)\s*\(`,
+)
+
 // pyFSReadRe matches read-only filesystem primitives.
 var pyFSReadRe = regexp.MustCompile(
 	`\bopen\s*\(\s*[^,)]+\s*(?:,\s*['"](?:r|rb|rt)['"][\s,)])` +
@@ -148,6 +175,8 @@ func sniffEffectsPython(content string) []EffectMatch {
 	out = appendPyMatches(out, content, headers, pyDBConnectRe, EffectDBRead, "db.connect/cursor", 0.8)
 	out = appendPyMatches(out, content, headers, pyDBWriteRe, EffectDBWrite, "orm.write", 0.85)
 	out = appendPyMatches(out, content, headers, pyCursorWriteRe, EffectDBWrite, "cursor.execute(WRITE)", 1.0)
+	out = appendPyMatches(out, content, headers, pyMongoReadRe, EffectDBRead, "mongo.read", 0.8)
+	out = appendPyMatches(out, content, headers, pyMongoWriteRe, EffectDBWrite, "mongo.write", 0.85)
 	out = appendPyMatches(out, content, headers, pyFSReadRe, EffectFSRead, "open/pathlib", 0.9)
 	out = appendPyMatches(out, content, headers, pyFSWriteRe, EffectFSWrite, "open(w)/shutil", 1.0)
 	out = appendPyMatches(out, content, headers, pyMutationRe, EffectMutation, "self.field=", 0.7)

--- a/internal/substrate/effects_test.go
+++ b/internal/substrate/effects_test.go
@@ -193,6 +193,111 @@ class Pipeline:
 	mustHave(t, by, EffectDBRead, "read_with_psycopg")
 }
 
+// TestSniffEffectsPython_MongoSinks is the #3440 (ask 4) regression:
+// the rewrite-agent reported core.tasks._get_me_inspections as
+// {effect_source: "pure", 0.3} despite calling inspections_cls.aggregate(
+// pipeline) — a Mongo read. pymongo/motor collection methods lack the
+// Django `.objects.` prefix so they bypassed pyDBReadRe. They must now
+// register db_read (reads) / db_write (mutators), and a genuinely pure
+// helper must stay pure (negative assertion).
+func TestSniffEffectsPython_MongoSinks(t *testing.T) {
+	const src = `
+class InspectionRepo:
+    def _get_me_inspections(self, building_id):
+        pipeline = [{"$match": {"building": building_id}}]
+        return list(inspections_cls.aggregate(pipeline))
+
+    def fetch_one(self, oid):
+        return self.coll.find_one({"_id": oid})
+
+    def fetch_many(self, q):
+        return self.coll.find(q)
+
+    def how_many(self, q):
+        return self.coll.count_documents(q)
+
+    def insert(self, doc):
+        self.coll.insert_one(doc)
+
+    def patch(self, oid, doc):
+        self.coll.update_one({"_id": oid}, {"$set": doc})
+
+    def upsert(self, oid, doc):
+        self.coll.find_one_and_update({"_id": oid}, {"$set": doc}, upsert=True)
+
+    def bulk(self, ops):
+        self.coll.bulk_write(ops)
+
+    def pure_add(self, a, b):
+        total = a + b
+        return total
+`
+	got := sniffEffectsPython(src)
+	if len(got) == 0 {
+		t.Fatal("expected python matches; got none")
+	}
+	by := groupByEffect(got)
+	// The exact bug: .aggregate(pipeline) on a plain collection handle.
+	mustHave(t, by, EffectDBRead, "_get_me_inspections")
+	mustHave(t, by, EffectDBRead, "fetch_one")
+	mustHave(t, by, EffectDBRead, "fetch_many")
+	mustHave(t, by, EffectDBRead, "how_many")
+	// Mutators classify as db_write.
+	mustHave(t, by, EffectDBWrite, "insert")
+	mustHave(t, by, EffectDBWrite, "patch")
+	mustHave(t, by, EffectDBWrite, "upsert")
+	mustHave(t, by, EffectDBWrite, "bulk")
+	// A pure helper stays pure: no db effect of either kind.
+	mustNotHave(t, by, EffectDBRead, "pure_add")
+	mustNotHave(t, by, EffectDBWrite, "pure_add")
+}
+
+// TestSniffEffectsJSTS_MongoSinks covers the Mongoose / native-driver
+// extras added in #3440 ask 4: .findById/.countDocuments/.distinct reads
+// and the find-and-modify / .bulkWrite / .replaceOne write family. A pure
+// helper must stay pure.
+func TestSniffEffectsJSTS_MongoSinks(t *testing.T) {
+	const src = `
+class Repo {
+  async byId(id) {
+    return await this.model.findById(id);
+  }
+  async total() {
+    return await this.model.countDocuments({});
+  }
+  async kinds() {
+    return await this.model.distinct("kind");
+  }
+  async patch(id, doc) {
+    return await this.model.findByIdAndUpdate(id, doc);
+  }
+  async swap(filter, doc) {
+    return await this.model.replaceOne(filter, doc);
+  }
+  async batch(ops) {
+    return await this.model.bulkWrite(ops);
+  }
+  pureAdd(a, b) {
+    const total = a + b;
+    return total;
+  }
+}
+`
+	got := sniffEffectsJSTS(src)
+	if len(got) == 0 {
+		t.Fatal("expected matches; got none")
+	}
+	by := groupByEffect(got)
+	mustHave(t, by, EffectDBRead, "byId")
+	mustHave(t, by, EffectDBRead, "total")
+	mustHave(t, by, EffectDBRead, "kinds")
+	mustHave(t, by, EffectDBWrite, "patch")
+	mustHave(t, by, EffectDBWrite, "swap")
+	mustHave(t, by, EffectDBWrite, "batch")
+	mustNotHave(t, by, EffectDBRead, "pureAdd")
+	mustNotHave(t, by, EffectDBWrite, "pureAdd")
+}
+
 func TestSniffEffectsJava_PrimitiveCoverage(t *testing.T) {
 	const src = `
 package x;
@@ -711,5 +816,15 @@ func mustHave(t *testing.T, by map[Effect]map[string]bool, eff Effect, fn string
 		}
 		sort.Strings(fns)
 		t.Errorf("expected effect %q on function %q; got functions %v", eff, fn, fns)
+	}
+}
+
+// mustNotHave asserts that function fn does NOT carry effect eff — the
+// negative guard for pure-function regressions (a genuinely pure helper
+// must not pick up a spurious db effect from the Mongo sniffers).
+func mustNotHave(t *testing.T, by map[Effect]map[string]bool, eff Effect, fn string) {
+	t.Helper()
+	if by[eff] != nil && by[eff][fn] {
+		t.Errorf("expected function %q to NOT carry effect %q, but it did", fn, eff)
 	}
 }


### PR DESCRIPTION
Part of #3440 (ask 4).

## Problem
`archigraph_effects` reported functions whose only effect is a MongoDB
collection call (e.g. `inspections_cls.aggregate(pipeline)`) as
`effect_source: "pure", confidence 0.3, "No sink primitives detected"`.
The `.aggregate` callee was already in the graph, but the effect-sink
classifier had no entry for pymongo/motor (Python) or mongoose/native
driver (JS/TS) collection methods — only Django `.objects.<m>` reads,
which require an `.objects.` prefix the plain collection handle lacks.

## Fix
Extends the existing per-language regex-sniffer catalog (no parallel system).

**Python (pymongo / motor)** — new `pyMongoReadRe` / `pyMongoWriteRe`:
- db_read: `.aggregate`, `.aggregate_raw_batches`, `.find`, `.find_one`, `.find_raw_batches`, `.count_documents`, `.estimated_document_count`, `.distinct`, `.list_indexes`, `.index_information`
- db_write: `.insert_one`, `.insert_many`, `.update_one`, `.update_many`, `.replace_one`, `.delete_one`, `.delete_many`, `.bulk_write`, `.find_one_and_update`, `.find_one_and_replace`, `.find_one_and_delete`, `.create_index(es)`, `.drop_index(es)`
- `.drop` deliberately excluded (collides with pandas `DataFrame.drop`)

**JS/TS (mongoose / native driver)** — extends existing `jstsDBReadRe` / `jstsDBWriteRe`:
- db_read: + `.findById`, `.countDocuments`, `.estimatedDocumentCount`, `.distinct` (`.find`/`.findOne`/`.aggregate`/`.count` already covered)
- db_write: + `.bulkWrite`, `.replaceOne`, `.remove`, `.findOneAndUpdate`, `.findByIdAndUpdate`, `.findOneAndDelete`, `.findByIdAndDelete`, `.findOneAndReplace`, `.findByIdAndRemove`

Conservative: only well-known Mongo collection method names, to avoid
false positives on same-named methods.

## Tests (value-asserting)
- `TestSniffEffectsPython_MongoSinks` — reproduces the exact `.aggregate(pipeline)` bug, asserts **db_read (not pure)**, db_write for mutators (`insert_one`/`update_one`/`find_one_and_update`/`bulk_write`), and a **negative** assertion that a pure helper stays pure.
- `TestSniffEffectsJSTS_MongoSinks` — covers the JS/TS extras + pure negative.
- Adds `mustNotHave` negative-assertion helper.

`go test ./internal/substrate/ ./internal/engine/ ./internal/types/` green; touched files gofmt-clean; `go vet ./internal/substrate/` clean.

**DEPLOY-DEFERRED**: takes effect after a daemon rebuild + reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)