### PR TITLE
feat(python): pymongo aggregation-pipeline extraction + variable-bound resolution

### DIFF
--- a/internal/engine/orm_queries.go
+++ b/internal/engine/orm_queries.go
@@ -138,6 +138,13 @@ func applyORMQueries(args DetectorPassArgs) DetectorPassResult {
 	switch lang {
 	case "python":
 		scanPythonORM(src, funcs, emit)
+		// Sibling pass: parse the pymongo `.aggregate(<pipeline>)` pipeline
+		// (inline list literal OR a same-function variable binding) into
+		// per-stage entities + $lookup/$graphLookup join edges (#3440).
+		scanPythonMongoAggregation(src, funcs, path, lang,
+			func(ent types.EntityRecord) { entities = append(entities, ent) },
+			func(rel types.RelationshipRecord) { relationships = append(relationships, rel) },
+		)
 	case "javascript", "typescript":
 		scanJSORM(src, funcs, emit)
 		scanJSDrivers(src, funcs, emit)

--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -1,0 +1,370 @@
+// MongoDB aggregation-pipeline internal extraction for Python pymongo / motor
+// (#3440, asks 1+2).
+//
+// This is the Python sibling of orm_queries_jsts_mongo_agg.go (#3430). The
+// existing Python ORM scanner (orm_queries_python.go) only recognises the
+// Django `Model.objects.aggregate(...)` verb; it does NOT understand the
+// pymongo driver idiom `<collection>.aggregate(<pipeline>)`, and it treats the
+// pipeline argument as an opaque blob. The pipeline is where the data-flow
+// lives: a `$lookup` stage is an implicit cross-collection JOIN the migration
+// must reason about (the legacy Django backend is the parity oracle — 151
+// `$lookup` stages), and each stage is a distinct transformation worth a node.
+//
+// This pass mirrors the JS emission shape exactly:
+//
+//  1. JOINS_COLLECTION relationship — for every `$lookup` / `$graphLookup`
+//     stage, an edge from the aggregating collection → the `from` collection.
+//     Properties: local_field, foreign_field, as, stage. This is the
+//     highest-value output: the application-side join Mongo has no FK for.
+//
+//  2. SCOPE.DataAccess pipeline-stage entities — one per stage, anchored at the
+//     aggregate call site, subtype = the stage operator, stage order preserved
+//     as stage_index. $group captures `_id` + accumulators; $facet its keys.
+//
+// SCOPE — two pipeline forms are resolved:
+//
+//   - INLINE list literal: `coll.aggregate([ {"$lookup": {...}}, ... ])`.
+//   - VARIABLE-BOUND (the important case — ~100% of real legacy usage):
+//     `pipeline = [ {"$lookup": {...}}, ... ]` one statement up, then
+//     `coll.aggregate(pipeline)`. We follow the identifier to its
+//     same-function assignment whose RHS is a list literal (single-binding
+//     follow). If the binding isn't a literal list in the same scope, we leave
+//     it unresolved — honest.
+//
+// The aggregating collection is recovered from pymongo idioms: `db.coll`,
+// `db["coll"]`, `client.db.coll`, `get_collection("coll")`, or a bare
+// `*_cls` / Collection variable name.
+//
+// HONEST LIMIT: builder/`.build()`-produced pipelines and cross-function
+// pipelines stay unresolved (that is ask 3, a separate PR). We never fabricate
+// stages or joins we cannot statically see.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// mongoAggPyGate signals whether a pymongo/motor surface is plausible in the
+// file, so we don't scan arbitrary `.aggregate(` chains (e.g. pandas).
+var mongoAggPyGateRe = regexp.MustCompile(
+	`\b(?:pymongo|motor|MongoClient|AsyncIOMotorClient|get_collection|get_database)\b`,
+)
+
+// mongoAggPyCallRe locates `.aggregate(` call sites. The receiver and the
+// first argument are recovered by scanning, as in the JS pass.
+var mongoAggPyCallRe = regexp.MustCompile(`\.aggregate\s*\(`)
+
+// mongoAggPyReceiverRe recovers the aggregating collection token immediately
+// preceding `.aggregate`. Captures the LAST dotted segment or a bracket key:
+//
+//	db.orders.aggregate(...)         → "orders"
+//	client.db.m_devices.aggregate(.) → "m_devices"
+//	orders_cls.aggregate(...)        → "orders_cls"
+//
+// `db["coll"]` and `get_collection("coll")` are handled separately because the
+// collection name is a quoted argument, not an identifier segment.
+var mongoAggPyReceiverRe = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\s*$`)
+
+// mongoAggPyBracketRecvRe recovers a `db["coll"]` / `db['coll']` subscript
+// receiver: the quoted key is the collection name.
+var mongoAggPyBracketRecvRe = regexp.MustCompile(
+	`\[\s*['"]([a-zA-Z_][\w$.]*)['"]\s*\]\s*$`,
+)
+
+// mongoAggPyGetCollRe recovers a `get_collection("coll")` / `db.get_collection('coll')`
+// receiver: the quoted first argument is the collection name.
+var mongoAggPyGetCollRe = regexp.MustCompile(
+	`get_collection\(\s*['"]([a-zA-Z_][\w$.]*)['"]`,
+)
+
+// scanPythonMongoAggregation walks `src`, finds pymongo `.aggregate(...)` call
+// sites, resolves the pipeline (inline list literal OR a single same-function
+// variable binding), parses each stage, and emits stage entities + join edges.
+func scanPythonMongoAggregation(
+	src string,
+	funcs []funcSpan,
+	path string,
+	lang string,
+	emitStage func(ent types.EntityRecord),
+	emitJoin func(rel types.RelationshipRecord),
+) {
+	if !mongoAggPyGateRe.MatchString(src) {
+		return
+	}
+
+	for _, loc := range mongoAggPyCallRe.FindAllStringIndex(src, -1) {
+		openParen := loc[1] - 1 // index of '('
+		coll := mongoAggPyResolveReceiver(src, loc[0])
+		if coll == "" {
+			continue
+		}
+
+		// Resolve the pipeline list literal (the full `[ ... ]`, brackets
+		// included, so mongoAggSplitStages can scan it) for either form.
+		listLiteral := mongoAggPyResolvePipeline(src, openParen, loc[0])
+		if listLiteral == "" {
+			continue // dynamic / builder pipeline — honest skip.
+		}
+		stages := mongoAggSplitStages(listLiteral, 0)
+		if len(stages) == 0 {
+			continue
+		}
+		caller := enclosingFuncAt(funcs, loc[0])
+		callLine := lineOfOffset(src, loc[0])
+
+		for idx, st := range stages {
+			op := mongoAggFirstKey(st)
+			if op == "" {
+				continue
+			}
+			props := map[string]string{
+				"pattern_type": mongoAggPatternType,
+				"collection":   coll,
+				"stage_index":  itoa(idx),
+				"stage":        op,
+			}
+			if caller != "" {
+				props["caller"] = caller
+			}
+
+			switch op {
+			case "$lookup":
+				lk := mongoAggParseLookup(st)
+				if lk.from != "" {
+					props["from"] = lk.from
+					if lk.localField != "" {
+						props["local_field"] = lk.localField
+					}
+					if lk.foreignField != "" {
+						props["foreign_field"] = lk.foreignField
+					}
+					if lk.as != "" {
+						props["as"] = lk.as
+					}
+					emitJoin(mongoAggJoinEdge(coll, lk, "lookup"))
+				}
+			case "$graphLookup":
+				lk := mongoAggParseLookup(st)
+				if lk.from != "" {
+					props["from"] = lk.from
+					if lk.as != "" {
+						props["as"] = lk.as
+					}
+					emitJoin(mongoAggJoinEdge(coll, lk, "graphLookup"))
+				}
+			case "$group":
+				id, accs := mongoAggParseGroup(st)
+				if id != "" {
+					props["group_id"] = id
+				}
+				if accs != "" {
+					props["accumulators"] = accs
+				}
+			case "$facet":
+				if keys := mongoAggParseFacetKeys(st); keys != "" {
+					props["facets"] = keys
+				}
+			}
+
+			name := fmt.Sprintf("%s.aggregate#%d %s", coll, idx, op)
+			emitStage(types.EntityRecord{
+				Name:       name,
+				Kind:       mongoAggStageEntityKind,
+				Subtype:    op,
+				SourceFile: path,
+				StartLine:  callLine,
+				EndLine:    callLine,
+				Language:   lang,
+				Properties: props,
+
+				EnrichmentRequired: false,
+				EnrichmentStatus:   types.StatusPending,
+				QualityScore:       0.8,
+			})
+		}
+	}
+}
+
+// mongoAggPyResolveReceiver recovers the aggregating collection name from the
+// text immediately preceding the `.aggregate` token at `dotPos`. It tries, in
+// order: a `db["coll"]` subscript, a `get_collection("coll")` call, then the
+// last dotted/bare identifier segment (`db.orders` → "orders", `orders_cls` →
+// "orders_cls"). Returns "" when nothing recognisable precedes the call.
+func mongoAggPyResolveReceiver(src string, dotPos int) string {
+	winStart := dotPos - 200
+	if winStart < 0 {
+		winStart = 0
+	}
+	window := src[winStart:dotPos]
+
+	// `db["coll"].aggregate(...)` / `db['coll'].aggregate(...)`.
+	if m := mongoAggPyBracketRecvRe.FindStringSubmatch(window); m != nil {
+		return m[1]
+	}
+	// `...get_collection("coll").aggregate(...)` — must end at dotPos.
+	if m := mongoAggPyGetCollRe.FindStringSubmatchIndex(window); m != nil {
+		// Ensure this get_collection(...) is the immediate receiver: the only
+		// thing between its close-paren and dotPos is whitespace.
+		tail := strings.TrimSpace(window[m[1]:])
+		if tail == "" || strings.HasPrefix(tail, ")") {
+			return window[m[2]:m[3]]
+		}
+	}
+	// `db.orders.aggregate(...)` / `orders_cls.aggregate(...)` — last segment.
+	if m := mongoAggPyReceiverRe.FindStringSubmatch(window); m != nil {
+		seg := m[1]
+		// Skip obvious non-collection keywords.
+		if seg == "self" || seg == "cls" {
+			return ""
+		}
+		return seg
+	}
+	return ""
+}
+
+// mongoAggPyResolvePipeline returns the full pipeline list literal `[ ... ]`
+// (brackets included) for the aggregate call whose `(` is at `openParen`. Two
+// forms:
+//
+//	coll.aggregate([ ... ])        — inline literal, parsed in place.
+//	coll.aggregate(pipeline)       — single identifier; follow it to its
+//	                                 nearest preceding same-function assignment
+//	                                 `pipeline = [ ... ]` and return that body.
+//
+// Returns "" for any other first-argument shape (builder var, call expr,
+// kwargs, non-literal binding) — honest unresolved.
+func mongoAggPyResolvePipeline(src string, openParen, dotPos int) string {
+	// Skip whitespace after '('.
+	i := openParen + 1
+	for i < len(src) && (src[i] == ' ' || src[i] == '\t' || src[i] == '\n' || src[i] == '\r') {
+		i++
+	}
+	if i >= len(src) {
+		return ""
+	}
+
+	// Form 1: inline list literal.
+	if src[i] == '[' {
+		return mongoAggPyBracketBody(src, i)
+	}
+
+	// Form 2: a bare identifier argument (`pipeline`) → follow the binding.
+	if isPyIdentStart(src[i]) {
+		idStart := i
+		for i < len(src) && isPyIdentChar(src[i]) {
+			i++
+		}
+		ident := src[idStart:i]
+		// The arg must be JUST the identifier: next non-space char is `)`.
+		j := i
+		for j < len(src) && (src[j] == ' ' || src[j] == '\t' || src[j] == '\n' || src[j] == '\r') {
+			j++
+		}
+		if j >= len(src) || src[j] != ')' {
+			return "" // e.g. `pipeline + extra`, `build()`, kwargs — unresolved.
+		}
+		return mongoAggPyFollowBinding(src, ident, dotPos, funcStartBefore(src, dotPos))
+	}
+	return ""
+}
+
+// mongoAggPyBracketBody returns the full balanced `[...]` literal (brackets
+// included) whose opening `[` is at `open`, string- and depth-aware. Returns ""
+// if the bracket is unbalanced. The result is suitable for mongoAggSplitStages.
+func mongoAggPyBracketBody(src string, open int) string {
+	if open >= len(src) || src[open] != '[' {
+		return ""
+	}
+	depth := 0
+	inStr := byte(0)
+	for i := open; i < len(src); i++ {
+		c := src[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inStr = c
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return src[open : i+1]
+			}
+		}
+	}
+	return ""
+}
+
+// mongoAggPyAssignRe matches a Python assignment `<ident> = [` at the start of
+// a (possibly indented) line. Used to locate a variable-bound pipeline's
+// definition. The `[` that follows confirms the RHS opens a list literal.
+var mongoAggPyAssignReCache = map[string]*regexp.Regexp{}
+
+func mongoAggPyAssignRe(ident string) *regexp.Regexp {
+	if re, ok := mongoAggPyAssignReCache[ident]; ok {
+		return re
+	}
+	re := regexp.MustCompile(`(?m)^[ \t]*` + regexp.QuoteMeta(ident) + `\s*=\s*\[`)
+	mongoAggPyAssignReCache[ident] = re
+	return re
+}
+
+// mongoAggPyFollowBinding finds the nearest assignment `ident = [ ... ]` that
+// precedes the aggregate call (at `usePos`) and lies within the enclosing
+// function (at or after `funcStart`), and returns its full list literal
+// `[ ... ]`. Single-binding follow: the LAST such assignment before the use
+// wins. Returns "" if no literal-list binding is found in scope.
+func mongoAggPyFollowBinding(src, ident string, usePos, funcStart int) string {
+	re := mongoAggPyAssignRe(ident)
+	best := -1
+	for _, m := range re.FindAllStringIndex(src, -1) {
+		// m[1]-1 is the index of the `[` that opens the RHS list.
+		if m[0] >= usePos {
+			break // assignment is at/after the use — not a preceding binding.
+		}
+		if m[0] < funcStart {
+			continue // belongs to an earlier function — out of scope.
+		}
+		best = m[1] - 1 // index of '['
+	}
+	if best < 0 {
+		return ""
+	}
+	return mongoAggPyBracketBody(src, best)
+}
+
+// funcStartBefore returns the offset of the nearest `def`/`async def` line
+// header that precedes `pos`, i.e. the start of the enclosing function body
+// scope used to bound variable-binding resolution. Returns 0 (file scope) if
+// none precedes `pos`.
+func funcStartBefore(src string, pos int) int {
+	start := 0
+	for _, m := range pyOrmFuncRe.FindAllStringIndex(src, -1) {
+		if m[0] >= pos {
+			break
+		}
+		start = m[0]
+	}
+	return start
+}
+
+func isPyIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isPyIdentChar(c byte) bool {
+	return isPyIdentStart(c) || (c >= '0' && c <= '9')
+}

--- a/internal/engine/orm_queries_python_mongo_agg_test.go
+++ b/internal/engine/orm_queries_python_mongo_agg_test.go
@@ -1,0 +1,277 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runMongoAggPy drives scanPythonMongoAggregation over `src` and collects the
+// emitted stage entities + join edges.
+func runMongoAggPy(t *testing.T, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	funcs := indexEnclosingFunctions("python", src)
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	scanPythonMongoAggregation(src, funcs, "svc/agg.py", "python",
+		func(e types.EntityRecord) { ents = append(ents, e) },
+		func(r types.RelationshipRecord) { rels = append(rels, r) },
+	)
+	return ents, rels
+}
+
+func pyStageSubtypesInOrder(ents []types.EntityRecord) []string {
+	var out []string
+	for _, e := range ents {
+		out = append(out, e.Subtype)
+	}
+	return out
+}
+
+func pyFindStage(ents []types.EntityRecord, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func pyFindJoinTo(rels []types.RelationshipRecord, toClass string) *types.RelationshipRecord {
+	for i := range rels {
+		if rels[i].Kind == string(types.RelationshipKindJoinsCollection) &&
+			rels[i].ToID == "Class:"+toClass {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+// THE important case — variable-bound pipeline, the legacy-Django/pymongo
+// shape: three $lookups to specific `from` collections then a $match. Asserts
+// the three JOINS_COLLECTION edges to the SPECIFIC collections, the stage
+// entities and their order.
+func TestMongoAggPy_VariableBound_ThreeLookups(t *testing.T) {
+	src := `
+import pymongo
+from pymongo import MongoClient
+
+def inspection_report(db):
+    pipeline = [
+        {"$lookup": {"from": "inspection_groups", "localField": "group_id", "foreignField": "_id", "as": "groups"}},
+        {"$lookup": {"from": "m_devices", "localField": "device_id", "foreignField": "_id", "as": "devices"}},
+        {"$lookup": {"from": "m_buildings", "localField": "building_id", "foreignField": "_id", "as": "buildings"}},
+        {"$match": {"status": "active"}},
+    ]
+    return db.inspections.aggregate(pipeline)
+`
+	ents, rels := runMongoAggPy(t, src)
+
+	// 3 join edges to the SPECIFIC from-collections.
+	wantTo := []string{"inspection_groups", "m_devices", "m_buildings"}
+	for _, coll := range wantTo {
+		j := pyFindJoinTo(rels, capitalisedSingular(coll))
+		if j == nil {
+			t.Fatalf("expected JOINS_COLLECTION edge to %s; rels=%+v", coll, rels)
+		}
+		if j.FromID != "Class:"+capitalisedSingular("inspections") {
+			t.Errorf("join from %s = %q, want aggregating collection inspections", coll, j.FromID)
+		}
+		if j.Properties["stage"] != "lookup" {
+			t.Errorf("join to %s stage = %q, want lookup", coll, j.Properties["stage"])
+		}
+	}
+	if n := len(rels); n != 3 {
+		t.Fatalf("expected exactly 3 join edges, got %d: %+v", n, rels)
+	}
+
+	// Local/foreign field props captured on the first lookup edge.
+	jg := pyFindJoinTo(rels, capitalisedSingular("inspection_groups"))
+	if jg.Properties["local_field"] != "group_id" || jg.Properties["foreign_field"] != "_id" || jg.Properties["as"] != "groups" {
+		t.Errorf("inspection_groups join props = %+v", jg.Properties)
+	}
+
+	// Stage entities + order.
+	got := pyStageSubtypesInOrder(ents)
+	want := []string{"$lookup", "$lookup", "$lookup", "$match"}
+	if len(got) != len(want) {
+		t.Fatalf("stage subtypes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stage[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
+	}
+	// stage_index preserved on each entity.
+	for i, e := range ents {
+		if e.Properties["stage_index"] != itoa(i) {
+			t.Errorf("stage[%d] stage_index = %q, want %d", i, e.Properties["stage_index"], i)
+		}
+		if e.Properties["collection"] != "inspections" {
+			t.Errorf("stage[%d] collection = %q, want inspections", i, e.Properties["collection"])
+		}
+		if e.Kind != string(types.EntityKindDataAccess) {
+			t.Errorf("stage[%d] kind = %q, want SCOPE.DataAccess", i, e.Kind)
+		}
+	}
+	if c := pyFindStage(ents, "$lookup").Properties["from"]; c != "inspection_groups" {
+		t.Errorf("first $lookup from = %q, want inspection_groups", c)
+	}
+}
+
+// Inline list-literal pipeline with $lookup + $graphLookup + $group + $facet,
+// receiver via db["collname"] subscript. Asserts both join kinds, the $group
+// _id/accumulators, and the $facet keys.
+func TestMongoAggPy_InlineLiteral_LookupGraphGroupFacet(t *testing.T) {
+	src := `
+from motor.motor_asyncio import AsyncIOMotorClient
+
+async def stats(db):
+    return await db["orders"].aggregate([
+        {"$lookup": {"from": "customers", "localField": "cust_id", "foreignField": "_id", "as": "cust"}},
+        {"$graphLookup": {"from": "categories", "startWith": "$cat", "connectFromField": "parent", "connectToField": "_id", "as": "tree"}},
+        {"$group": {"_id": "$status", "total": {"$sum": "$amount"}, "count": {"$sum": 1}}},
+        {"$facet": {"byStatus": [{"$match": {}}], "byMonth": [{"$match": {}}]}},
+    ])
+`
+	ents, rels := runMongoAggPy(t, src)
+
+	if j := pyFindJoinTo(rels, capitalisedSingular("customers")); j == nil {
+		t.Fatalf("expected $lookup join to customers; rels=%+v", rels)
+	} else if j.Properties["stage"] != "lookup" {
+		t.Errorf("customers join stage = %q, want lookup", j.Properties["stage"])
+	}
+	if j := pyFindJoinTo(rels, capitalisedSingular("categories")); j == nil {
+		t.Fatalf("expected $graphLookup join to categories; rels=%+v", rels)
+	} else if j.Properties["stage"] != "graphLookup" {
+		t.Errorf("categories join stage = %q, want graphLookup", j.Properties["stage"])
+	}
+	if len(rels) != 2 {
+		t.Fatalf("expected 2 join edges, got %d: %+v", len(rels), rels)
+	}
+
+	if got := pyStageSubtypesInOrder(ents); len(got) != 4 ||
+		got[0] != "$lookup" || got[1] != "$graphLookup" || got[2] != "$group" || got[3] != "$facet" {
+		t.Fatalf("stage subtypes = %v, want [$lookup $graphLookup $group $facet]", got)
+	}
+
+	g := pyFindStage(ents, "$group")
+	// _id value is captured as raw text; Python string literals keep quotes.
+	if g.Properties["group_id"] != `"$status"` {
+		t.Errorf("$group group_id = %q, want \"$status\"", g.Properties["group_id"])
+	}
+	if g.Properties["accumulators"] != "total,count" {
+		t.Errorf("$group accumulators = %q, want total,count", g.Properties["accumulators"])
+	}
+
+	f := pyFindStage(ents, "$facet")
+	if f.Properties["facets"] != "byStatus,byMonth" {
+		t.Errorf("$facet facets = %q, want byStatus,byMonth", f.Properties["facets"])
+	}
+
+	// Receiver resolved from db["orders"] subscript.
+	if ents[0].Properties["collection"] != "orders" {
+		t.Errorf("collection = %q, want orders", ents[0].Properties["collection"])
+	}
+}
+
+// get_collection("coll") receiver idiom.
+func TestMongoAggPy_GetCollectionReceiver(t *testing.T) {
+	src := `
+import pymongo
+
+def run(db):
+    coll = db.get_collection("events")
+    return db.get_collection("events").aggregate([
+        {"$lookup": {"from": "users", "localField": "uid", "foreignField": "_id", "as": "u"}},
+    ])
+`
+	ents, rels := runMongoAggPy(t, src)
+	if j := pyFindJoinTo(rels, capitalisedSingular("users")); j == nil {
+		t.Fatalf("expected join to users; rels=%+v", rels)
+	} else if j.FromID != "Class:"+capitalisedSingular("events") {
+		t.Errorf("join from = %q, want aggregating collection events", j.FromID)
+	}
+	if len(ents) != 1 || ents[0].Properties["collection"] != "events" {
+		t.Errorf("collection = %q, want events", ents[0].Properties["collection"])
+	}
+}
+
+// NEGATIVE: variable bound to a NON-literal (a builder call) must NOT fabricate
+// any join or stage. Honest unresolved.
+func TestMongoAggPy_NegativeBuilderBinding_NoFabrication(t *testing.T) {
+	src := `
+import pymongo
+
+def run(db):
+    pipeline = build_pipeline(db, status="active")
+    return db.inspections.aggregate(pipeline)
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("builder-bound pipeline must emit NO join edges, got %d: %+v", len(rels), rels)
+	}
+	if len(ents) != 0 {
+		t.Fatalf("builder-bound pipeline must emit NO stage entities, got %d: %+v", len(ents), ents)
+	}
+}
+
+// NEGATIVE: identifier argument that is an EXPRESSION (`pipeline + extra`) is
+// not a single-binding follow → unresolved, no fabrication.
+func TestMongoAggPy_NegativeExpressionArg_NoFabrication(t *testing.T) {
+	src := `
+import pymongo
+
+def run(db):
+    pipeline = [{"$lookup": {"from": "users", "localField": "u", "foreignField": "_id", "as": "x"}}]
+    extra = []
+    return db.inspections.aggregate(pipeline + extra)
+`
+	_, rels := runMongoAggPy(t, src)
+	if len(rels) != 0 {
+		t.Fatalf("expression-arg pipeline must emit NO join edges, got %d: %+v", len(rels), rels)
+	}
+}
+
+// NEGATIVE: no pymongo/motor surface in the file → gate skips entirely even if
+// some `.aggregate([...])` is present (e.g. pandas).
+func TestMongoAggPy_NegativeGate_NoMongoSurface(t *testing.T) {
+	src := `
+import pandas as pd
+
+def run(frame):
+    return frame.aggregate([
+        {"$lookup": {"from": "users", "localField": "u", "foreignField": "_id", "as": "x"}},
+    ])
+`
+	ents, rels := runMongoAggPy(t, src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("non-mongo file must be skipped by gate, got ents=%d rels=%d", len(ents), len(rels))
+	}
+}
+
+// Single-binding follow picks the NEAREST preceding assignment in the same
+// function; an earlier same-name binding in a different function is out of scope.
+func TestMongoAggPy_BindingScopedToFunction(t *testing.T) {
+	src := `
+import pymongo
+
+def other(db):
+    pipeline = [{"$lookup": {"from": "WRONG", "localField": "a", "foreignField": "_id", "as": "x"}}]
+    return db.x.aggregate(pipeline)
+
+def run(db):
+    pipeline = [{"$lookup": {"from": "right_coll", "localField": "b", "foreignField": "_id", "as": "y"}}]
+    return db.inspections.aggregate(pipeline)
+`
+	_, rels := runMongoAggPy(t, src)
+	if pyFindJoinTo(rels, capitalisedSingular("right_coll")) == nil {
+		t.Fatalf("expected join to right_coll (in-scope binding); rels=%+v", rels)
+	}
+	// The WRONG binding belongs to other(); run()'s aggregate must not use it.
+	for _, r := range rels {
+		if r.ToID == "Class:"+capitalisedSingular("WRONG") && r.FromID == "Class:"+capitalisedSingular("inspections") {
+			t.Fatalf("run() aggregate wrongly resolved to other()'s binding: %+v", r)
+		}
+	}
+}


### PR DESCRIPTION
Part of #3440 (asks 1+2).

Python sibling of the JS mongo-aggregation pass (#3430). The legacy Django/pymongo backend is the migration's parity oracle (151 `$lookup` stages), and these implicit application-side joins have no Mongo FK — this pass surfaces them in the graph.

## What's covered
Parses pymongo/motor `<collection>.aggregate(<pipeline>)` and, mirroring the JS emission shape exactly, emits:
- **JOINS_COLLECTION** edge per `$lookup`/`$graphLookup` — aggregating collection -> `from` collection, stamping `local_field`/`foreign_field`/`as`/`stage`.
- **SCOPE.DataAccess** entity per pipeline stage — `subtype`=operator, `stage_index` (order preserved), `$group._id`+accumulators, `$facet` keys.

Two pipeline forms resolved:
1. **Inline list literal** — `coll.aggregate([ {"$lookup": {...}}, ... ])`.
2. **Variable-bound** (~100% of real legacy usage) — `pipeline = [ ... ]` one statement up, then `coll.aggregate(pipeline)`. Single-binding follow to the nearest preceding **same-function** assignment whose RHS is a list literal.

Receiver idioms: `db.coll`, `db["coll"]`, `client.db.coll`, `get_collection("coll")`, `*_cls`/Collection vars. Gated on a pymongo/motor surface signal so non-mongo `.aggregate(...)` (e.g. pandas) is skipped.

## Honest limit
Builder/`.build()`-produced and cross-function pipelines stay unresolved — that's ask 3, a separate PR. No fabricated joins/stages for anything we cannot statically see (covered by negative tests: builder binding, expression arg `pipeline + extra`, non-mongo gate).

## Notes
- Reuses `JOINS_COLLECTION` + `SCOPE.DataAccess` (no new Kinds). `go test ./internal/types/` green.
- New helpers namespaced `mongoAggPy*`; reuses the JS pass's shared stage scanner/parsers.
- `go test ./internal/engine/ ./internal/types/` green, `go vet ./internal/engine/` clean, `gofmt -l` empty.

## DEPLOY-DEFERRED
Needs a daemon rebuild + reindex of the `upvate`/legacy group to materialise the new edges/entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)