### PR TITLE
feat(kotlin): deep-grind TESTING linkage (kotest/junit5/mockk/spek) to full (#3437)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -135,14 +135,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Spring Boot / Spring MVC](../detail/lang.java.framework.spring-boot.md) | 🟢 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 18/18 | |
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
-| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 12/12 | |
-| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 12/12 | |
+| [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
@@ -197,8 +197,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Ionic](../detail/lang.jsts.framework.ionic.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [NativeScript](../detail/lang.jsts.framework.nativescript.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 10/10 | |
 | [JS/TS](../by-language/jsts.md) | [React Native](../detail/lang.jsts.framework.react-native.md) | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | ✅ 19/19 | |
-| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟢 18/18 | 🟢 9/9 | |
-| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [kotlin](../by-language/kotlin.md) | [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | ✅ 1/1 | 🟢 18/18 | 🟢 9/9 | |
+| [kotlin](../by-language/kotlin.md) | [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
 
 
 ## Desktop

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -26,22 +26,22 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 12/12 | |
-| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 12/12 | |
+| [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 
 
 ### Mobile
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | 🟢 1/1 | 🟢 18/18 | 🟢 9/9 | |
-| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [Jetpack Compose (Android UI)](../detail/lang.kotlin.framework.compose.md) | ✅ 3/3 | ✅ 1/1 | 🟢 18/18 | 🟢 9/9 | |
+| [Kotlin Multiplatform (KMP / KMM)](../detail/lang.kotlin.framework.kmp.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/lang.kotlin.framework.arrow.md
+++ b/docs/coverage/detail/lang.kotlin.framework.arrow.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.kotlin.framework.compose.md
+++ b/docs/coverage/detail/lang.kotlin.framework.compose.md
@@ -62,7 +62,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.kotlin.framework.coroutines.md
+++ b/docs/coverage/detail/lang.kotlin.framework.coroutines.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.kotlin.framework.http4k.md
+++ b/docs/coverage/detail/lang.kotlin.framework.http4k.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.kotlin.framework.javalin.md
+++ b/docs/coverage/detail/lang.kotlin.framework.javalin.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.kotlin.framework.kmp.md
+++ b/docs/coverage/detail/lang.kotlin.framework.kmp.md
@@ -62,7 +62,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.kotlin.framework.ktor.md
+++ b/docs/coverage/detail/lang.kotlin.framework.ktor.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.kotlin.framework.micronaut.md
+++ b/docs/coverage/detail/lang.kotlin.framework.micronaut.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.kotlin.framework.quarkus.md
+++ b/docs/coverage/detail/lang.kotlin.framework.quarkus.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
+++ b/docs/coverage/detail/lang.kotlin.framework.spring-boot.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/substrate/entry_points_kotlin.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/engine/rules/kotlin/test_patterns.yaml`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk<T>() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*). |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -29623,9 +29623,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -29907,8 +29908,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"]
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -30215,9 +30218,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -30468,9 +30472,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -30726,9 +30731,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -31009,8 +31015,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"]
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -31177,9 +31185,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -31442,9 +31451,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -31722,9 +31732,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {
@@ -32002,9 +32013,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/substrate/entry_points_kotlin.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/engine/rules/kotlin/test_patterns.yaml","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "Deep Kotlin TESTING linkage (#3437): junit5 @Test/@ParameterizedTest/@RepeatedTest + class-name subject; kotest StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/Spek DSL leaf cases with body call-scan; MockK mockk\u003cT\u003e() subject association with every{}/verify{} blocks blanked so the mocked call never leaks; Kotlin assertion/mockk stopwords (shouldBe/assertThrows/every/verify/any). Value-asserted in extractor_test.go (TestKotlin_JUnit5_*/Kotest_*/Mockk_*/Spek_*).",
+            "verified_at": "2026-05-30"
           }
         },
         "Type System": {

--- a/internal/extractors/cross/testmap/extractor.go
+++ b/internal/extractors/cross/testmap/extractor.go
@@ -222,7 +222,8 @@ func productionFileFromTestPath(filePath string) (prodFile, prodSymbol string) {
 			}
 		}
 	case ".kt":
-		for _, suf := range []string{"Tests", "Test"} {
+		// XxxTest.kt / XxxTests.kt → Xxx.kt; kotest specs XxxSpec.kt → Xxx.kt.
+		for _, suf := range []string{"Tests", "Test", "Spec"} {
 			if strings.HasSuffix(stem, suf) && len(stem) > len(suf) {
 				prodStem := stem[:len(stem)-len(suf)]
 				return path.Join(dir, prodStem+".kt"), prodStem

--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -1342,6 +1342,234 @@ func TestKotlin_BacktickName(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Kotlin — deep TESTING linkage (#3437): junit5 / kotest / mockk / spek
+// ---------------------------------------------------------------------------
+
+// TestKotlin_JUnit5_DirectCallHighConfidence — a JUnit5 @Test that directly
+// calls a production method emits a high-confidence TESTS edge to that symbol.
+// Value-asserts the specific target (register), not len>0.
+func TestKotlin_JUnit5_DirectCall(t *testing.T) {
+	src := `import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class UserServiceTest {
+    @Test
+    fun registersAUser() {
+        val svc = UserService()
+        val result = svc.register("ada")
+        assertEquals("ada", result.name)
+    }
+}`
+	recs := runExtract(t, "UserServiceTest.kt", "kotlin", src)
+	if recs[0].Properties["test_framework"] != "kotlin_test" {
+		t.Fatalf("framework=%q, want kotlin_test", recs[0].Properties["test_framework"])
+	}
+	// The direct call `svc.register("ada")` is captured at high confidence with
+	// its receiver preserved (the resolver does not strip the receiver).
+	if !hasEdgeAny(recs, "registersAUser", "svc.register") {
+		t.Fatalf("expected high-confidence TESTS edge registersAUser->svc.register; recs=%d", len(recs))
+	}
+	// Confidence must be high (direct call), and assertEquals must NOT leak.
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Properties["tested"] == "svc.register" && rel.Properties["confidence"] != "high" {
+				t.Errorf("register edge confidence=%q, want high", rel.Properties["confidence"])
+			}
+			if strings.Contains(rel.Properties["tested"], "assertEquals") {
+				t.Errorf("assertEquals leaked as a tested subject: %q", rel.Properties["tested"])
+			}
+		}
+	}
+}
+
+// TestKotlin_JUnit5_ParameterizedAndRepeated verifies @ParameterizedTest and
+// @RepeatedTest functions are detected and linked to a direct production call.
+func TestKotlin_JUnit5_ParameterizedAndRepeated(t *testing.T) {
+	src := `import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class CalculatorTest {
+    @ParameterizedTest
+    @ValueSource(ints = [1, 2, 3])
+    fun addsNumbers(n: Int) {
+        val calc = Calculator()
+        calc.add(n, n)
+    }
+
+    @RepeatedTest(5)
+    fun resetsState() {
+        Calculator().reset()
+    }
+}`
+	recs := runExtract(t, "CalculatorTest.kt", "kotlin", src)
+	if !hasEdgeAny(recs, "addsNumbers", "calc.add") {
+		t.Errorf("expected @ParameterizedTest addsNumbers->calc.add edge")
+	}
+	if !hasEdgeAny(recs, "resetsState", "reset") {
+		t.Errorf("expected @RepeatedTest resetsState->reset edge")
+	}
+}
+
+// TestKotlin_JUnit5_ClassSubjectFallback — when a @Test body has no resolvable
+// production call, the test-class name convention (UserServiceTest →
+// UserService) yields a medium-confidence TESTS edge.
+func TestKotlin_JUnit5_ClassSubjectFallback(t *testing.T) {
+	src := `import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class UserServiceTest {
+    @Test
+    fun isReady() {
+        assertTrue(true)
+    }
+}`
+	recs := runExtract(t, "UserServiceTest.kt", "kotlin", src)
+	found := false
+	for _, r := range recs {
+		if r.Properties["tested_function"] == "UserService" && r.Properties["confidence"] == "medium" {
+			for _, rel := range r.Relationships {
+				if rel.Kind == "TESTS" && rel.Properties["tested"] == "UserService" {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected medium-confidence class-subject TESTS edge isReady->UserService; recs=%d", len(recs))
+	}
+}
+
+// TestKotlin_Kotest_StringSpec — a kotest StringSpec leaf case `"desc" { … }`
+// is detected and linked to the production call inside its lambda.
+func TestKotlin_Kotest_StringSpec(t *testing.T) {
+	src := `import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class UserServiceSpec : StringSpec({
+    "registers a user" {
+        val svc = UserService()
+        svc.register("ada").name shouldBe "ada"
+    }
+})`
+	recs := runExtract(t, "UserServiceSpec.kt", "kotlin", src)
+	if recs[0].Properties["test_framework"] != "kotlin_test" {
+		t.Fatalf("framework=%q, want kotlin_test", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_registers_a_user", "svc.register") {
+		t.Fatalf("expected kotest StringSpec edge ->svc.register; recs=%d", len(recs))
+	}
+	// shouldBe matcher must never leak as a tested subject.
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if strings.Contains(rel.Properties["tested"], "shouldBe") {
+				t.Errorf("kotest matcher shouldBe leaked as tested subject: %q", rel.Properties["tested"])
+			}
+		}
+	}
+}
+
+// TestKotlin_Kotest_FunSpec — FunSpec `test("x") { … }` verb-style cases.
+func TestKotlin_Kotest_FunSpec(t *testing.T) {
+	src := `import io.kotest.core.spec.style.FunSpec
+
+class OrderServiceTest : FunSpec({
+    test("places an order") {
+        val svc = OrderService()
+        svc.place(order)
+    }
+})`
+	recs := runExtract(t, "OrderServiceTest.kt", "kotlin", src)
+	if !hasEdgeAny(recs, "it_places_an_order", "svc.place") {
+		t.Fatalf("expected kotest FunSpec edge ->svc.place; recs=%d", len(recs))
+	}
+}
+
+// TestKotlin_Kotest_DescribeSpec — DescribeSpec describe/it nesting.
+func TestKotlin_Kotest_DescribeSpec(t *testing.T) {
+	src := `import io.kotest.core.spec.style.DescribeSpec
+
+class BillingSpec : DescribeSpec({
+    describe("billing") {
+        it("charges the card") {
+            val svc = BillingService()
+            svc.charge(100)
+        }
+    }
+})`
+	recs := runExtract(t, "BillingSpec.kt", "kotlin", src)
+	if !hasEdgeAny(recs, "it_charges_the_card", "svc.charge") {
+		t.Fatalf("expected kotest DescribeSpec edge ->svc.charge; recs=%d", len(recs))
+	}
+	// The container describe("billing") must not emit a redundant case.
+	for _, r := range recs {
+		if r.Properties["test_function"] == "it_billing" {
+			t.Errorf("container describe leaked as a case (it_billing); leaf should win")
+		}
+	}
+}
+
+// TestKotlin_Mockk_AssociatesMockedType — mockk<T>() records T as the subject;
+// the every{}/verify{} mocked call is NOT treated as the tested production
+// symbol. We assert the mocked type (PaymentGateway) is the subject and the
+// MockK verbs (every/verify) never leak.
+func TestKotlin_Mockk_AssociatesMockedType(t *testing.T) {
+	src := `import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class CheckoutTest {
+    @Test
+    fun completesCheckout() {
+        val gateway = mockk<PaymentGateway>()
+        every { gateway.charge(any()) } returns true
+        val svc = CheckoutService(gateway)
+        svc.checkout()
+        verify { gateway.charge(any()) }
+    }
+}`
+	recs := runExtract(t, "CheckoutTest.kt", "kotlin", src)
+	// The real production subject is the direct call CheckoutService.checkout.
+	if !hasEdgeAny(recs, "completesCheckout", "svc.checkout") {
+		t.Errorf("expected direct-call edge completesCheckout->svc.checkout")
+	}
+	// MockK DSL verbs/matchers AND the mocked call inside every{}/verify{}
+	// (gateway.charge) must never appear as tested subjects.
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			tested := rel.Properties["tested"]
+			switch tested {
+			case "every", "verify", "mockk", "any", "gateway.charge":
+				t.Errorf("MockK helper/mocked-call %q leaked as tested subject", tested)
+			}
+		}
+	}
+}
+
+// TestKotlin_Spek_Group — Spek2 describe/it DSL.
+func TestKotlin_Spek_Group(t *testing.T) {
+	src := `import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object ParserSpec : Spek({
+    describe("parser") {
+        it("parses input") {
+            val p = Parser()
+            p.parse("x")
+        }
+    }
+})`
+	recs := runExtract(t, "ParserSpec.kt", "kotlin", src)
+	if recs[0].Properties["test_framework"] != "kotlin_test" {
+		t.Fatalf("framework=%q, want kotlin_test", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_parses_input", "p.parse") {
+		t.Fatalf("expected spek edge it_parses_input->p.parse; recs=%d", len(recs))
+	}
+}
+
+// ---------------------------------------------------------------------------
 // C# — xUnit / NUnit / MSTest deep linkage (#3383)
 // ---------------------------------------------------------------------------
 

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -1146,22 +1146,249 @@ func detectPhpPest(source string) []testFunction {
 }
 
 // ---------------------------------------------------------------------------
-// Kotlin — JUnit on Kotlin / kotlin.test
+// Kotlin — JUnit5 / kotlin.test / kotest / spek / mockk  (deep linkage, #3437)
+//
+// Deep linkage covers four families:
+//
+//	junit5  — @Test / @ParameterizedTest / @RepeatedTest fun (incl. backtick
+//	          names) and @Nested inner classes. Subject derived from the
+//	          enclosing class name (UserServiceTest → UserService) so a class-
+//	          level naming-convention edge is emitted when no direct call is
+//	          found, mirroring the C#/Java describeSubject path.
+//	kotest   — spec-style DSL test cases: StringSpec `"desc" { … }`,
+//	          FunSpec `test("x") { … }`, DescribeSpec/BehaviorSpec
+//	          (describe/context/given/when/then/it), ShouldSpec `should("x")`.
+//	          The case body is scanned for the production call.
+//	spek     — describe/context/group/it DSL (Spek2). Same body-scan approach.
+//	mockk    — `mockk<T>()` records the mocked type T as a describeSubject hint;
+//	          the mocked call (`every { svc.foo() }` / `verify { svc.foo() }`)
+//	          is NOT treated as the tested subject (its receiver is a mock) —
+//	          the mockk DSL verbs are stop-worded in resolver.go.
 // ---------------------------------------------------------------------------
 
-var kotlinTestRE = regexp.MustCompile(
-	`(?m)@Test(?:\s*\([^)]*\))?\s*(?:public\s+|private\s+|internal\s+)?fun\s+(` + "`" + `[^` + "`" + `]+` + "`" + `|\w+)\s*\([^)]*\)\s*(?::\s*\w+\s*)?{`,
+// kotlinJUnitTestRE matches a JUnit5/kotlin.test annotated function. It accepts
+// @Test, @ParameterizedTest and @RepeatedTest (each optionally carrying an
+// argument list), optional additional annotation lines (e.g. @DisplayName(…),
+// @ValueSource(…)) between the test annotation and the `fun`, and backtick fun
+// names containing spaces. Group 1 captures the function name (with backticks).
+var kotlinJUnitTestRE = regexp.MustCompile(
+	`(?m)@(?:Test|ParameterizedTest|RepeatedTest)(?:\s*\([^)]*\))?` +
+		`(?:\s*@\w+(?:\s*\([^)]*\))?)*` +
+		`\s*(?:public\s+|private\s+|internal\s+|protected\s+|override\s+|suspend\s+)*` +
+		`fun\s+(` + "`" + `[^` + "`" + `]+` + "`" + `|\w+)\s*\([^)]*\)\s*(?::\s*[\w<>.,? ]+\s*)?{`,
 )
 
+// kotlinClassRE captures the first declared class name in a Kotlin source file.
+// Used to derive the JUnit subject under test from the test-class name.
+var kotlinClassRE = regexp.MustCompile(
+	`(?m)^\s*(?:(?:public|private|internal|abstract|open|final|sealed|data)\s+)*class\s+(\w+)`,
+)
+
+// kotlinSpecClassRE captures a kotest/spek spec class or object and its spec
+// style. Group 1 is the class/object name, group 2 the spec base. Kotest specs
+// declare `class FooTest : StringSpec({ … })`; Spek2 declares
+// `object FooSpec : Spek({ … })`. Both `class` and `object` are accepted.
+var kotlinSpecClassRE = regexp.MustCompile(
+	`(?m)\b(?:class|object)\s+(\w+)\s*:\s*(StringSpec|FunSpec|DescribeSpec|BehaviorSpec|ShouldSpec|FreeSpec|WordSpec|AnnotationSpec|ExpectSpec|FeatureSpec|Spek)\b`,
+)
+
+// kotestStringCaseRE matches a StringSpec / FreeSpec leaf case: a string literal
+// immediately followed by a `{` lambda — `"adds two numbers" { … }`. Group 1 is
+// the description.
+var kotestStringCaseRE = regexp.MustCompile(
+	`(?m)"([^"]{1,200})"\s*{`,
+)
+
+// kotestFnCaseRE matches a kotest DSL case introduced by a verb taking a string
+// description: test("x"){}, describe("x"){}, context("x"){}, given("x"){},
+// `when`("x"){}, then("x"){}, it("x"){}, should("x"){}, feature/scenario/expect.
+// Group 1 = verb, group 2 = description.
+var kotestFnCaseRE = regexp.MustCompile(
+	"(?m)\\b(test|describe|context|given|`when`|when|then|it|should|feature|scenario|expect|xtest|xdescribe|xcontext|xit)\\s*\\(\\s*\"([^\"]{1,200})\"\\s*\\)\\s*{",
+)
+
+// kotlinMockkTypeRE captures the mocked type T in `mockk<T>()` / `spyk<T>()` /
+// `mockkClass(T::class)`. Group 1 or group 2 carries the type name. The mocked
+// type is the subject the test exercises through the mock.
+var kotlinMockkTypeRE = regexp.MustCompile(
+	`(?m)\b(?:mockk|spyk)\s*<\s*([A-Z]\w*)\s*>|\bmockkClass\s*\(\s*([A-Z]\w*)::class`,
+)
+
+// kotlinMockkBlockRE locates the start of a MockK stubbing/verification block —
+// `every {`, `coEvery {`, `verify {`, `coVerify {`, `verifyOrder {`,
+// `verifySequence {`, `verifyAll {`, `excludeRecords {`. The mocked call inside
+// these blocks is on a mock receiver, NOT the production subject, so the block
+// body is blanked before the resolver scans for production calls. The mocked
+// type is still recorded separately as the describeSubject (mockk<T>()).
+var kotlinMockkBlockRE = regexp.MustCompile(
+	`\b(?:every|coEvery|verify|coVerify|verifyOrder|verifySequence|verifyAll|excludeRecords)\s*(?:\([^)]*\))?\s*{`,
+)
+
+// blankKotlinMockkBlocks blanks out every MockK every/verify lambda body in body
+// (replacing characters with spaces, preserving offsets and newlines) so the
+// resolver never treats the mocked call (e.g. `gateway.charge(...)` inside
+// `every { … }`) as a tested production subject.
+func blankKotlinMockkBlocks(body string) string {
+	if !kotlinMockkBlockRE.MatchString(body) {
+		return body
+	}
+	out := body
+	for {
+		loc := kotlinMockkBlockRE.FindStringIndex(out)
+		if loc == nil {
+			break
+		}
+		// The lambda body starts at the trailing `{` of the match.
+		block := extractBraceBody(out, loc[1]-1)
+		if block == "" {
+			// Unbalanced — blank from the match start to end of the keyword to
+			// avoid an infinite loop, then stop.
+			out = out[:loc[0]] + strings.Repeat(" ", loc[1]-loc[0]) + out[loc[1]:]
+			continue
+		}
+		blockStart := strings.Index(out[loc[0]:], block) + loc[0]
+		blanked := subtractRanges(out, [][2]int{{loc[0], blockStart + len(block)}})
+		out = blanked
+	}
+	return out
+}
+
+// kotlinSubjectFromClassName derives the class under test from a Kotlin test
+// class name by stripping trailing "Tests"/"Test"/"Spec" suffixes.
+//
+//	UserServiceTest  → UserService
+//	UserServiceTests → UserService
+//	UserServiceSpec  → UserService
+//	(no suffix)      → ""
+func kotlinSubjectFromClassName(className string) string {
+	for _, suf := range []string{"Tests", "Test", "Spec"} {
+		if strings.HasSuffix(className, suf) && len(className) > len(suf) {
+			return className[:len(className)-len(suf)]
+		}
+	}
+	return ""
+}
+
+// kotlinFirstClassName returns the first class name declared in source.
+func kotlinFirstClassName(source string) string {
+	if m := kotlinClassRE.FindStringSubmatch(source); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// kotlinMockkSubject returns the first mocked type found via mockk<T>()/spyk<T>()
+// /mockkClass(T::class), or "".
+func kotlinMockkSubject(source string) string {
+	if m := kotlinMockkTypeRE.FindStringSubmatch(source); m != nil {
+		if m[1] != "" {
+			return m[1]
+		}
+		return m[2]
+	}
+	return ""
+}
+
+// detectKotlinTest detects Kotlin test cases across junit5, kotest, spek and
+// mockk. kotest/spek spec files are handled first (they declare a recognised
+// spec base class); plain annotated junit5 files fall through to the @Test path.
 func detectKotlinTest(source string) []testFunction {
+	// kotest / spek spec-class files: scan DSL cases inside the spec lambda.
+	if specClass := kotlinSpecClassRE.FindStringSubmatch(source); specClass != nil {
+		className := specClass[1]
+		subject := kotlinSubjectFromClassName(className)
+		// A mockk subject (mockk<UserService>()) is more specific than the class
+		// name when the spec name does not encode the subject.
+		if mockSub := kotlinMockkSubject(source); mockSub != "" {
+			subject = mockSub
+		}
+		return detectKotlinSpecCases(source, subject)
+	}
+
+	// junit5 / kotlin.test annotated functions.
+	className := kotlinFirstClassName(source)
+	subject := kotlinSubjectFromClassName(className)
+	if mockSub := kotlinMockkSubject(source); mockSub != "" && subject == "" {
+		subject = mockSub
+	}
+
 	var out []testFunction
-	for _, m := range kotlinTestRE.FindAllStringSubmatchIndex(source, -1) {
+	seen := map[string]bool{}
+	for _, m := range kotlinJUnitTestRE.FindAllStringSubmatchIndex(source, -1) {
 		name := strings.Trim(source[m[2]:m[3]], "`")
 		// Backtick names can contain spaces — normalise.
 		name = strings.ReplaceAll(name, " ", "_")
-		body := extractBraceBody(source, m[1]-1)
-		out = append(out, testFunction{qname: name, body: body})
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		body := blankKotlinMockkBlocks(extractBraceBody(source, m[1]-1))
+		out = append(out, testFunction{qname: name, body: body, describeSubject: subject})
 	}
+	return out
+}
+
+// detectKotlinSpecCases scans a kotest/spek spec file for leaf DSL cases and
+// returns one testFunction per case. Each case carries its body (scanned for
+// production calls) and the spec-level describeSubject (mockk type or class-name
+// convention) as a medium-confidence fallback.
+func detectKotlinSpecCases(source, subject string) []testFunction {
+	var out []testFunction
+	seen := map[string]bool{}
+	add := func(name, body string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, testFunction{
+			qname:           name,
+			body:            blankKotlinMockkBlocks(body),
+			describeSubject: subject,
+		})
+	}
+
+	// Leaf verbs introduce an actual test case; container verbs only group cases.
+	// We collect leaf-verb cases first; when at least one leaf exists, container
+	// cases (describe/context/given/feature/scenario/when) are skipped so the
+	// finest-grained leaf wins and we don't emit a redundant container case whose
+	// body merely re-scans the same nested production calls.
+	leafVerb := map[string]bool{
+		"test": true, "it": true, "should": true, "then": true,
+		"expect": true, "xtest": true, "xit": true, "scenario": true,
+	}
+
+	type caseHit struct {
+		verb, name, body string
+	}
+	var hits []caseHit
+	haveLeaf := false
+	for _, m := range kotestFnCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		verb := strings.Trim(source[m[2]:m[3]], "`")
+		desc := source[m[4]:m[5]]
+		body := extractBraceBody(source, m[1]-1)
+		if leafVerb[verb] {
+			haveLeaf = true
+		}
+		hits = append(hits, caseHit{verb: verb, name: jestCaseQName(desc), body: body})
+	}
+	for _, h := range hits {
+		if haveLeaf && !leafVerb[h.verb] {
+			continue
+		}
+		add(h.name, h.body)
+	}
+
+	// StringSpec/FreeSpec leaf cases: "desc" { … }. Only scanned when no verb-
+	// style cases were found, to avoid double-counting the string argument of a
+	// verb-style case and to keep the finest-grained leaf as the case.
+	if len(hits) == 0 {
+		for _, m := range kotestStringCaseRE.FindAllStringSubmatchIndex(source, -1) {
+			desc := source[m[2]:m[3]]
+			body := extractBraceBody(source, m[1]-1)
+			add(jestCaseQName(desc), body)
+		}
+	}
+
 	return out
 }
 
@@ -1336,11 +1563,17 @@ var frameworkOrder = []frameworkEntry{
 		detect: detectJUnit,
 	},
 	{
-		name:        "kotlin_test",
-		importHints: []string{"kotlin.test", "org.junit", "junit.jupiter"},
+		name: "kotlin_test",
+		importHints: []string{
+			"kotlin.test", "org.junit", "junit.jupiter",
+			// kotest spec DSL + assertions, Spek2 DSL, and MockK.
+			"io.kotest", "kotest", "org.spekframework", "spek", "io.mockk", "mockk",
+		},
 		filenameHints: []*regexp.Regexp{
 			regexp.MustCompile(`Test\.kt$`),
 			regexp.MustCompile(`Tests\.kt$`),
+			// kotest specs conventionally end in Spec.kt.
+			regexp.MustCompile(`Spec\.kt$`),
 		},
 		detect: detectKotlinTest,
 	},
@@ -1412,6 +1645,18 @@ func selectFramework(tokens map[string]bool, filePath string) *frameworkEntry {
 		pathMatch := len(fe.pathHints) > 0 && matchesAnyPath(filePath, fe.pathHints)
 
 		switch fe.name {
+		case "junit":
+			// The Java JUnit entry shares import hints (org.junit / junit.jupiter)
+			// with Kotlin tests, and is listed before kotlin_test. A Kotlin test
+			// using org.junit.jupiter.* would otherwise be routed to detectJUnit
+			// (which scans for `void` Java methods) and yield zero results. Skip
+			// the Java entry for .kt files so the kotlin_test entry wins.
+			if strings.HasSuffix(strings.ToLower(filePath), ".kt") {
+				continue
+			}
+			if importMatch || fileMatch || pathMatch {
+				return fe
+			}
 		case "rust_test":
 			// Filename alone is not a signal — require the detector to
 			// actually yield at least one match, which is checked at the

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -87,6 +87,38 @@ var stopwords = map[string]bool{
 	// JUnit
 	"assertions.assertequals": true, "assertequals": true,
 	"assertnull": true, "assertnotnull": true,
+	// Kotlin — kotest matchers (infix + paren forms), kotlin.test / JUnit5
+	// assertions, and MockK DSL verbs. These are test-harness identifiers and
+	// must never surface as the tested production subject. Lower-cased.
+	"shouldbe": true, "shouldnotbe": true, "shouldthrow": true,
+	"shouldthrowany": true, "shouldthrowexactly": true, "shouldnotthrow": true,
+	"shouldcontain": true, "shouldnotcontain": true, "shouldcontainall": true,
+	"shouldcontainexactly": true, "shouldstartwith": true, "shouldendwith": true,
+	"shouldbeempty": true, "shouldnotbeempty": true, "shouldbenull": true,
+	"shouldnotbenull": true, "shouldbetrue": true, "shouldbefalse": true,
+	"shouldhavesize": true, "shouldbegreaterthan": true, "shouldbelessthan": true,
+	"shouldhavekey": true, "shouldbeinstanceof": true, "shouldmatch": true,
+	"shouldbeequal": true, "shouldbesameinstanceas": true, "shouldcontainkey": true,
+	"assertthrows": true, "assertdoesnotthrow": true, "assertall": true,
+	"assertnotsame": true, "assertcontentequals": true,
+	"assertfailswith": true, "assertfails": true, "fail": true,
+	// MockK DSL — mock construction, stubbing and verification verbs. The mocked
+	// CALL inside every/verify is on a mock receiver, not the production subject,
+	// so the whole MockK surface is stop-worded (the real subject is recorded as
+	// the describeSubject from mockk<T>()).
+	"every": true, "coevery": true, "verify": true, "coverify": true,
+	"verifyall": true, "verifyorder": true, "verifysequence": true,
+	"confirmverified": true, "clearmocks": true, "clearallmocks": true,
+	"unmockkall": true, "unmockkstatic": true, "mockkstatic": true,
+	"mockkobject": true, "justrun": true, "answers": true, "returnsmany": true,
+	"mockk": true, "spyk": true, "mockkclass": true, "slot": true, "capture": true,
+	// kotest lifecycle / property-test DSL
+	"beforetest": true, "aftertest": true, "beforespec": true, "afterspec": true,
+	"forall": true, "checkall": true,
+	// MockK argument matchers (any()/eq()/match()/capture(slot)) — these are
+	// stubbing helpers, never the production subject under test.
+	"any": true, "anynullable": true, "neq": true, "less": true,
+	"more": true, "oftype": true, "allany": true,
 	// RSpec matchers and DSL helpers
 	"allow": true, "receive": true, "expect.to": true,
 	"be_valid": true, "be_nil": true, "be_present": true, "be_empty": true,

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -12203,13 +12203,50 @@ records:
           verified_at: "2026-05-28"
       Testing:
         tests_linkage:
-          status: partial
+          # Deep Kotlin TESTING linkage (#3437). Kotlin test files (*Test.kt /
+          # *Tests.kt / *Spec.kt) are routed to the cross-language testmap
+          # extractor's kotlin_test framework. detectKotlinTest covers four
+          # families:
+          #   junit5     — @Test / @ParameterizedTest / @RepeatedTest fun
+          #                (incl. backtick names) + @Nested; class-name subject
+          #                (UserServiceTest → UserService) as a medium-confidence
+          #                fallback when no direct call is found.
+          #   kotest     — StringSpec "desc"{…}, FunSpec test("x"){…},
+          #                DescribeSpec/BehaviorSpec/ShouldSpec describe/context/
+          #                given/when/then/it/should DSL leaf cases; case body
+          #                scanned for the production call (high confidence).
+          #                Container verbs are skipped when a leaf exists.
+          #   spek       — Spek2 object X : Spek({ describe/it … }) DSL.
+          #   mockk      — mockk<T>()/spyk<T>()/mockkClass(T::class) record the
+          #                mocked type T as the subject; every{}/verify{} blocks
+          #                are blanked so the mocked call never leaks as the
+          #                tested subject.
+          # resolver.go carries Kotlin assertion/harness stopwords (kotest
+          # matchers shouldBe/shouldThrow/…, kotlin.test/JUnit5 assertThrows/
+          # assertEquals/…, MockK every/verify/confirmVerified/coEvery + matchers
+          # any/eq). Value-asserted by the TestKotlin_* tests below.
+          status: full
           symbols:
-            - file: internal/substrate/entry_points_kotlin.go
-              functions: [sniffKotlinEntryPoints]
+            - file: internal/extractors/cross/testmap/frameworks.go
+              functions: [detectKotlinTest, detectKotlinSpecCases, blankKotlinMockkBlocks, kotlinSubjectFromClassName, kotlinMockkSubject]
+            - file: internal/extractors/cross/testmap/resolver.go
+              functions: [resolveCalls, isStopword]
+            - file: internal/extractors/cross/testmap/extractor.go
+              functions: [Extract, buildCollapsedEntity, productionFileFromTestPath]
             - file: internal/engine/rules/kotlin/test_patterns.yaml
-          issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
+          tests:
+            - file: internal/extractors/cross/testmap/extractor_test.go
+              functions:
+                - TestKotlin_JUnit5_DirectCall
+                - TestKotlin_JUnit5_ParameterizedAndRepeated
+                - TestKotlin_JUnit5_ClassSubjectFallback
+                - TestKotlin_Kotest_StringSpec
+                - TestKotlin_Kotest_FunSpec
+                - TestKotlin_Kotest_DescribeSpec
+                - TestKotlin_Mockk_AssociatesMockedType
+                - TestKotlin_Spek_Group
+          issues_implemented: ["3437"]
+          verified_at: "2026-05-31"
 
   lang.elixir.framework.phoenix:
     capabilities:


### PR DESCRIPTION
Closes #3437 (epic #3431).

## Disposition: tests_linkage partial → full for Kotlin

Deepens the Kotlin path in the cross-language testmap extractor to the TS/JS bar across four test families.

### Detection (frameworks.go)
- **junit5** — `@Test` / `@ParameterizedTest` / `@RepeatedTest` fun (incl. backtick names) + `@Nested`; class-name subject (`UserServiceTest` → `UserService`) as a medium-confidence fallback when no direct call is found.
- **kotest** — `StringSpec "desc"{…}`, `FunSpec test("x"){…}`, `DescribeSpec`/`BehaviorSpec`/`ShouldSpec` (`describe`/`context`/`given`/`when`/`then`/`it`/`should`) DSL leaf cases; case body scanned for the production call at high confidence. Container verbs are skipped when a leaf exists so the finest-grained case wins.
- **spek** — Spek2 `object X : Spek({ describe/it … })` DSL.
- **mockk** — `mockk<T>()`/`spyk<T>()`/`mockkClass(T::class)` record the mocked type `T` as the subject; `every{}`/`verify{}`/`coEvery{}`/… blocks are blanked before call resolution so the mocked call never leaks as the tested subject.

### Stopwords (resolver.go)
Kotlin assertion/harness identifiers added so they never surface as tested subjects: kotest matchers (`shouldBe`/`shouldNotBe`/`shouldThrow`/`shouldContain`/…), kotlin.test & JUnit5 asserts (`assertThrows`/`assertEquals`/`assertSame`/…), and the MockK DSL surface (`every`/`verify`/`confirmVerified`/`coEvery` + matchers `any`/`eq`).

### Routing
- `selectFramework` skips the Java JUnit entry for `.kt` files so Kotlin tests importing `org.junit.jupiter.*` route to `detectKotlinTest` rather than the Java (`void`-method) detector.
- `productionFileFromTestPath` strips a trailing `Spec` suffix for `.kt` (kotest specs).

### Tests (value-asserting, specific test→target edges — not `len>0`)
`TestKotlin_JUnit5_DirectCall` / `_ParameterizedAndRepeated` / `_ClassSubjectFallback`, `TestKotlin_Kotest_StringSpec` / `_FunSpec` / `_DescribeSpec`, `TestKotlin_Mockk_AssociatesMockedType` (asserts the mocked call + MockK verbs do NOT leak), `TestKotlin_Spek_Group`.

### Coverage
`tests_linkage` flipped partial → full for all 10 `lang.kotlin.framework.*` records (cites repointed at the testmap deep-linkage files). `capability-map.yaml` spring-boot `Testing` entry repointed at the testmap symbols + the new tests. Registry + regenerated docs included.

## Verification
- **Full shared testmap suite passes** (`go test ./internal/extractors/cross/testmap/`) — no cross-language regression — plus `./internal/types/` and `./tools/coverage/`.
- `go run ./tools/coverage validate` → **0 errors**; `fmt --check` → canonical.
- `gofmt -l` clean on all changed `.go` files; `go vet ./internal/extractors/cross/testmap/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)