### PR TITLE
feat(scala): deep-grind VALIDATION extraction to field level (#3454)

### DIFF
--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level request validation: refined predicate types (String Refined NonEmpty, Int Refined Positive, MatchesRegex[...], Refined[T,P]) captured as field+constraint; cats Validated/ValidatedNel validators (validator fn + inferred field); accord (validator[T]{ p.field is notEmpty }) per-clause field+predicate; octopus .rule(_.field,...). Each request_validation entity records the specific field + constraint. Refined constraints are field-co-located. Coarse framework directive signal (entity(as[T])/jsonOf[T]/decode[T]) retained. File-local: validators in a separate file from the DTO are not linked. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level constraints captured when present: refined types, cats Validated, accord (field+predicate), octopus. Coarse framework directive signal (params()/request.params/@NotEmpty/MessageSerializer) retained. Partial: this stack commonly validates via separate validator objects or JSR-303-style annotations resolved cross-file/at-runtime, which the file-local extractor cannot link to the originating DTO/endpoint. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level constraints captured when present: refined types, cats Validated, accord (field+predicate), octopus. Coarse framework directive signal (params()/request.params/@NotEmpty/MessageSerializer) retained. Partial: this stack commonly validates via separate validator objects or JSR-303-style annotations resolved cross-file/at-runtime, which the file-local extractor cannot link to the originating DTO/endpoint. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level request validation: refined predicate types (String Refined NonEmpty, Int Refined Positive, MatchesRegex[...], Refined[T,P]) captured as field+constraint; cats Validated/ValidatedNel validators (validator fn + inferred field); accord (validator[T]{ p.field is notEmpty }) per-clause field+predicate; octopus .rule(_.field,...). Each request_validation entity records the specific field + constraint. Refined constraints are field-co-located. Coarse framework directive signal (entity(as[T])/jsonOf[T]/decode[T]) retained. File-local: validators in a separate file from the DTO are not linked. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level constraints captured when present: refined types, cats Validated, accord (field+predicate), octopus. Coarse framework directive signal (params()/request.params/@NotEmpty/MessageSerializer) retained. Partial: this stack commonly validates via separate validator objects or JSR-303-style annotations resolved cross-file/at-runtime, which the file-local extractor cannot link to the originating DTO/endpoint. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level constraints captured when present: refined types, cats Validated, accord (field+predicate), octopus. Coarse framework directive signal (params()/request.params/@NotEmpty/MessageSerializer) retained. Partial: this stack commonly validates via separate validator objects or JSR-303-style annotations resolved cross-file/at-runtime, which the file-local extractor cannot link to the originating DTO/endpoint. |
 
 ### Middleware
 

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically. |
-| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local. |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | Field-level request validation: refined predicate types (String Refined NonEmpty, Int Refined Positive, MatchesRegex[...], Refined[T,P]) captured as field+constraint; cats Validated/ValidatedNel validators (validator fn + inferred field); accord (validator[T]{ p.field is notEmpty }) per-clause field+predicate; octopus .rule(_.field,...). Each request_validation entity records the specific field + constraint. Refined constraints are field-co-located. Coarse framework directive signal (entity(as[T])/jsonOf[T]/decode[T]) retained. File-local: validators in a separate file from the DTO are not linked. |
 
 ### Middleware
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -47668,17 +47668,15 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level request validation: refined predicate types (String Refined NonEmpty, Int Refined Positive, MatchesRegex[...], Refined[T,P]) captured as field+constraint; cats Validated/ValidatedNel validators (validator fn + inferred field); accord (validator[T]{ p.field is notEmpty }) per-clause field+predicate; octopus .rule(_.field,...). Each request_validation entity records the specific field + constraint. Refined constraints are field-co-located. Coarse framework directive signal (entity(as[T])/jsonOf[T]/decode[T]) retained. File-local: validators in a separate file from the DTO are not linked.",
             "verified_at": "2026-05-30"
           }
         },
@@ -47951,17 +47949,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "notes": "Field-level constraints captured when present: refined types, cats Validated, accord (field+predicate), octopus. Coarse framework directive signal (params()/request.params/@NotEmpty/MessageSerializer) retained. Partial: this stack commonly validates via separate validator objects or JSR-303-style annotations resolved cross-file/at-runtime, which the file-local extractor cannot link to the originating DTO/endpoint.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48500,17 +48497,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "notes": "Field-level constraints captured when present: refined types, cats Validated, accord (field+predicate), octopus. Coarse framework directive signal (params()/request.params/@NotEmpty/MessageSerializer) retained. Partial: this stack commonly validates via separate validator objects or JSR-303-style annotations resolved cross-file/at-runtime, which the file-local extractor cannot link to the originating DTO/endpoint.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48790,17 +48786,15 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level request validation: refined predicate types (String Refined NonEmpty, Int Refined Positive, MatchesRegex[...], Refined[T,P]) captured as field+constraint; cats Validated/ValidatedNel validators (validator fn + inferred field); accord (validator[T]{ p.field is notEmpty }) per-clause field+predicate; octopus .rule(_.field,...). Each request_validation entity records the specific field + constraint. Refined constraints are field-co-located. Coarse framework directive signal (entity(as[T])/jsonOf[T]/decode[T]) retained. File-local: validators in a separate file from the DTO are not linked.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49071,17 +49065,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "notes": "Field-level constraints captured when present: refined types, cats Validated, accord (field+predicate), octopus. Coarse framework directive signal (params()/request.params/@NotEmpty/MessageSerializer) retained. Partial: this stack commonly validates via separate validator objects or JSR-303-style annotations resolved cross-file/at-runtime, which the file-local extractor cannot link to the originating DTO/endpoint.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49571,17 +49564,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
             "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "notes": "Field-level constraints captured when present: refined types, cats Validated, accord (field+predicate), octopus. Coarse framework directive signal (params()/request.params/@NotEmpty/MessageSerializer) retained. Partial: this stack commonly validates via separate validator objects or JSR-303-style annotations resolved cross-file/at-runtime, which the file-local extractor cannot link to the originating DTO/endpoint.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49852,17 +49844,15 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: case class with parameters detected as DTO (SCOPE.Type/dto). Scala uses case classes as request/response bodies idiomatically.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level DTO extraction: case class primary-constructor fields (name+declared type), Option[T] nullability, circe (@JsonCodec/deriveDecoder)/play-json (Json.format[T])/zio-json codec attribution, and @JsonKey/@jsonField/@key wire-name overrides. Emits one SCOPE.Type/dto (fields summary + nullable_fields + wire_overrides + codec) plus one SCOPE.Type/dto_field per field. File-local.",
             "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: framework-specific validation patterns (entity(as[T]), jsonOf[T], params(), decode[T], @NotEmpty, MessageSerializer). File-local.",
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "Field-level request validation: refined predicate types (String Refined NonEmpty, Int Refined Positive, MatchesRegex[...], Refined[T,P]) captured as field+constraint; cats Validated/ValidatedNel validators (validator fn + inferred field); accord (validator[T]{ p.field is notEmpty }) per-clause field+predicate; octopus .rule(_.field,...). Each request_validation entity records the specific field + constraint. Refined constraints are field-co-located. Coarse framework directive signal (entity(as[T])/jsonOf[T]/decode[T]) retained. File-local: validators in a separate file from the DTO are not linked.",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/scala/extractors_test.go
+++ b/internal/custom/scala/extractors_test.go
@@ -37,6 +37,17 @@ type entitySummary struct {
 	Props               map[string]string
 }
 
+// findBySubtype returns the first entity matching subtype+name (and its props),
+// or (entitySummary{}, false) when none match. Used by value-asserting tests.
+func findBySubtype(ents []entitySummary, subtype, name string) (entitySummary, bool) {
+	for _, e := range ents {
+		if e.Subtype == subtype && e.Name == name {
+			return e, true
+		}
+	}
+	return entitySummary{}, false
+}
+
 func containsEntity(ents []entitySummary, kind, name string) bool {
 	for _, e := range ents {
 		if e.Kind == kind && e.Name == name {

--- a/internal/custom/scala/frameworks.go
+++ b/internal/custom/scala/frameworks.go
@@ -223,10 +223,6 @@ var (
 // ---------------------------------------------------------------------------
 
 var (
-	// case class fields with type annotations (DTO pattern)
-	reDTOCaseClass = regexp.MustCompile(
-		`(?m)^\s*case\s+class\s+(\w+)\s*\(([^)]+)\)`)
-
 	// request body extraction patterns
 	reAkkaValidation = regexp.MustCompile(
 		`\b(?:entity\s*\(\s*as\[|validate\s*\(|Validator\.)\b`)
@@ -560,13 +556,24 @@ func (e *scalaFrameworksExtractor) Extract(ctx context.Context, file extractor.F
 
 	// ---------------------------------------------------------------------------
 	// Validation / DTO extraction
+	//
+	// Field-level DTO modeling (fields + types + Option nullability + codec +
+	// wire-name overrides) and field-level request validation (refined / cats
+	// Validated / accord / octopus — specific field + constraint). See
+	// validation.go. Issue #3454.
 	// ---------------------------------------------------------------------------
-	for _, m := range reDTOCaseClass.FindAllStringSubmatchIndex(src, -1) {
-		name := src[m[2]:m[3]]
-		ent := makeEntity(name, "SCOPE.Type", "dto", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", framework, "provenance", "CASE_CLASS_DTO")
+	fm := fileMeta{Path: file.Path, Language: file.Language}
+	for _, ent := range extractScalaDTOFields(src, framework, fm) {
 		add(ent)
 	}
+	for _, ent := range extractScalaValidation(src, framework, fm) {
+		add(ent)
+	}
+
+	// Framework-specific request-body extraction directives (entity(as[T]),
+	// jsonOf[T], params(), decode[T], ...) remain a coarse file-local signal
+	// that a handler reads a request body, complementing the field-level
+	// constraint entities above.
 	valRe := validationReForFramework(framework)
 	if valRe != nil {
 		if valRe.MatchString(src) {

--- a/internal/custom/scala/frameworks_test.go
+++ b/internal/custom/scala/frameworks_test.go
@@ -1,6 +1,7 @@
 package scala_test
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -526,6 +527,195 @@ case class UserResponse(id: Long, name: String)
 	}
 	if !found {
 		t.Error("expected dto entity from case class")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// dto_extraction — VALUE-ASSERTING: fields, types, Option nullability, circe
+// codec attribution, and @JsonKey wire-name overrides (issue #3454).
+// ---------------------------------------------------------------------------
+
+func TestFrameworksDTOFieldsAndNullability(t *testing.T) {
+	src := `
+import io.circe.generic.semiauto._
+case class CreateUserRequest(
+  name: String,
+  email: String,
+  age: Int,
+  nickname: Option[String]
+)
+object CreateUserRequest {
+  implicit val dec = deriveDecoder[CreateUserRequest]
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Dto.scala", "scala", src))
+	got := dumpEntities(ents)
+
+	// Parent DTO carries the full field shape, nullability, and codec.
+	dto, ok := findBySubtype(ents, "dto", "CreateUserRequest")
+	if !ok {
+		t.Fatalf("expected dto CreateUserRequest; got:%s", got)
+	}
+	if dto.Props["field_count"] != "4" {
+		t.Errorf("expected field_count=4, got %q", dto.Props["field_count"])
+	}
+	if dto.Props["nullable_fields"] != "nickname" {
+		t.Errorf("expected nullable_fields=nickname, got %q", dto.Props["nullable_fields"])
+	}
+	if dto.Props["codec"] != "circe" {
+		t.Errorf("expected codec=circe (deriveDecoder), got %q", dto.Props["codec"])
+	}
+
+	// A specific field entity records its exact type + nullability.
+	nick, ok := findBySubtype(ents, "dto_field", "dto_field:CreateUserRequest.nickname")
+	if !ok {
+		t.Fatalf("expected dto_field for nickname; got:%s", got)
+	}
+	if nick.Props["field_type"] != "Option[String]" {
+		t.Errorf("expected nickname field_type=Option[String], got %q", nick.Props["field_type"])
+	}
+	if nick.Props["nullable"] != "true" {
+		t.Errorf("expected nickname nullable=true, got %q", nick.Props["nullable"])
+	}
+
+	age, ok := findBySubtype(ents, "dto_field", "dto_field:CreateUserRequest.age")
+	if !ok {
+		t.Fatalf("expected dto_field for age; got:%s", got)
+	}
+	if age.Props["field_type"] != "Int" {
+		t.Errorf("expected age field_type=Int, got %q", age.Props["field_type"])
+	}
+	if age.Props["nullable"] != "false" {
+		t.Errorf("expected age nullable=false, got %q", age.Props["nullable"])
+	}
+}
+
+func TestFrameworksDTOWireNameAndPlayCodec(t *testing.T) {
+	src := `
+import play.api.libs.json._
+case class Account(
+  @JsonKey("user_name") userName: String,
+  balance: Long
+)
+object Account { implicit val fmt = Json.format[Account] }
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Account.scala", "scala", src))
+	got := dumpEntities(ents)
+
+	dto, ok := findBySubtype(ents, "dto", "Account")
+	if !ok {
+		t.Fatalf("expected dto Account; got:%s", got)
+	}
+	if dto.Props["codec"] != "play-json" {
+		t.Errorf("expected codec=play-json (Json.format[Account]), got %q", dto.Props["codec"])
+	}
+	if dto.Props["wire_overrides"] != "userName=user_name" {
+		t.Errorf("expected wire_overrides=userName=user_name, got %q", dto.Props["wire_overrides"])
+	}
+
+	field, ok := findBySubtype(ents, "dto_field", "dto_field:Account.userName")
+	if !ok {
+		t.Fatalf("expected dto_field for userName; got:%s", got)
+	}
+	if field.Props["wire_name"] != "user_name" {
+		t.Errorf("expected userName wire_name=user_name, got %q", field.Props["wire_name"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// request_validation — VALUE-ASSERTING: refined, cats Validated, accord,
+// octopus. Each asserts the SPECIFIC field + constraint (issue #3454).
+// ---------------------------------------------------------------------------
+
+func TestFrameworksValidationRefined(t *testing.T) {
+	src := `
+import eu.timepit.refined._
+import eu.timepit.refined.string.MatchesRegex
+case class SignupRequest(
+  email: String Refined MatchesRegex["^.+@.+$"],
+  age: Int Refined Positive,
+  bio: Refined[String, NonEmpty]
+)
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Signup.scala", "scala", src))
+	got := dumpEntities(ents)
+
+	email, ok := findBySubtype(ents, "request_validation", "validate:refined:email")
+	if !ok {
+		t.Fatalf("expected refined validation for email; got:%s", got)
+	}
+	if !strings.HasPrefix(email.Props["constraint"], "MatchesRegex") {
+		t.Errorf("expected email constraint MatchesRegex..., got %q", email.Props["constraint"])
+	}
+
+	age, ok := findBySubtype(ents, "request_validation", "validate:refined:age")
+	if !ok {
+		t.Fatalf("expected refined validation for age; got:%s", got)
+	}
+	if age.Props["constraint"] != "Positive" {
+		t.Errorf("expected age constraint Positive, got %q", age.Props["constraint"])
+	}
+
+	bio, ok := findBySubtype(ents, "request_validation", "validate:refined:bio")
+	if !ok {
+		t.Fatalf("expected refined validation for bio; got:%s", got)
+	}
+	if bio.Props["constraint"] != "NonEmpty" {
+		t.Errorf("expected bio constraint NonEmpty, got %q", bio.Props["constraint"])
+	}
+}
+
+func TestFrameworksValidationAccord(t *testing.T) {
+	src := `
+import com.wix.accord._
+import com.wix.accord.dsl._
+implicit val userValidator = validator[User] { user =>
+  user.name is notEmpty
+  user.age should be >= 18
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserValidator.scala", "scala", src))
+	got := dumpEntities(ents)
+
+	name, ok := findBySubtype(ents, "request_validation", "validate:accord:name")
+	if !ok {
+		t.Fatalf("expected accord validation for name; got:%s", got)
+	}
+	if name.Props["constraint"] != "notEmpty" {
+		t.Errorf("expected name constraint notEmpty, got %q", name.Props["constraint"])
+	}
+	if name.Props["dto"] != "User" {
+		t.Errorf("expected accord dto=User, got %q", name.Props["dto"])
+	}
+
+	age, ok := findBySubtype(ents, "request_validation", "validate:accord:age")
+	if !ok {
+		t.Fatalf("expected accord validation for age; got:%s", got)
+	}
+	if !strings.Contains(age.Props["constraint"], ">= 18") {
+		t.Errorf("expected age constraint to contain '>= 18', got %q", age.Props["constraint"])
+	}
+}
+
+func TestFrameworksValidationCatsValidated(t *testing.T) {
+	src := `
+import cats.data.ValidatedNel
+import cats.syntax.validated._
+def validateEmail(s: String): ValidatedNel[String, String] = ???
+def validateAge(a: Int): Validated[String, Int] = ???
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Validators.scala", "scala", src))
+	got := dumpEntities(ents)
+
+	email, ok := findBySubtype(ents, "request_validation", "validate:cats-validated:email")
+	if !ok {
+		t.Fatalf("expected cats-validated validation for email; got:%s", got)
+	}
+	if email.Props["validator_fn"] != "validateEmail" {
+		t.Errorf("expected validator_fn=validateEmail, got %q", email.Props["validator_fn"])
+	}
+	if _, ok := findBySubtype(ents, "request_validation", "validate:cats-validated:age"); !ok {
+		t.Errorf("expected cats-validated validation for age; got:%s", got)
 	}
 }
 

--- a/internal/custom/scala/validation.go
+++ b/internal/custom/scala/validation.go
@@ -1,0 +1,443 @@
+// Package scala — field-level DTO and request-validation extraction.
+//
+// This file deepens the Scala Validation capability from "name-only" DTO
+// detection to full field-level modeling, matching the TS/JS bar:
+//
+//   - dto_extraction:     case class request/response DTOs broken into their
+//     individual fields (name + type), Option[T] nullability, circe
+//     (@JsonCodec / deriveDecoder) and play-json (Json.format[T]) codec
+//     attribution, and @key / @jsonField wire-name overrides.
+//   - request_validation: refined types (Refined[String, NonEmpty],
+//     Int Refined Positive, MatchesRegex[...]), cats Validated / ValidatedNel
+//     validators, accord (validator[T] { p.field is notEmpty }), and octopus.
+//     Each emitted entity records the SPECIFIC field + the constraint /
+//     refinement applied to it.
+//
+// Every entity carries a synthetic, non-colliding name and a SCOPE.Pattern /
+// SCOPE.Type kind so it never shadows a real class/function node. Issue #3454.
+package scala
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// DTO field extraction
+// ---------------------------------------------------------------------------
+
+var (
+	// case class Name ( ... — match the header + opening paren only; the
+	// parameter blob is extracted with a balanced-paren scan (balancedParens)
+	// so that parens inside field annotations (e.g. @JsonKey("x")) or default
+	// values do not prematurely terminate the constructor.
+	valDTOCaseClassRe = regexp.MustCompile(
+		`(?ms)\bcase\s+class\s+(\w+)\s*(?:\[[^\]]*\]\s*)?\(`)
+
+	// A single constructor field:  [@anno ...] name : Type [= default]
+	// We capture leading annotations (for wire-name overrides), the field name,
+	// and the declared type up to a comma / default / end.
+	valDTOFieldRe = regexp.MustCompile(
+		`(?s)((?:@\w+(?:\([^)]*\))?\s*)*)\b(\w+)\s*:\s*([^,=]+?)\s*(?:=\s*[^,]+)?$`)
+
+	// @key("wire")  (upickle)  /  @JsonKey("wire")  (circe)  /
+	// @jsonField("wire") (zio-json)  — wire-name override annotations.
+	valWireNameRe = regexp.MustCompile(
+		`@(?:key|JsonKey|jsonField|JsonProperty)\s*\(\s*"([^"]+)"\s*\)`)
+
+	// circe codec derivation attached to / near a DTO.
+	valCirceJsonCodecRe = regexp.MustCompile(`@JsonCodec\b`)
+	valCirceDeriveRe    = regexp.MustCompile(`\bderive(?:Codec|Decoder|Encoder)\s*\[\s*(\w+)\s*\]`)
+	valPlayJsonFormatRe = regexp.MustCompile(`\bJson\s*\.\s*(?:format|reads|writes|using)\s*\[\s*(\w+)\s*\]`)
+	valZioJsonDeriveRe  = regexp.MustCompile(`\bDeriveJson(?:Codec|Decoder|Encoder)\s*\.\s*gen\s*\[\s*(\w+)\s*\]`)
+)
+
+// scalaDTOField is a parsed primary-constructor field.
+type scalaDTOField struct {
+	Name     string
+	Type     string // declared type, with Option[...] preserved
+	Nullable bool   // true when declared Option[T] (or Maybe[T])
+	WireName string // @key/@JsonKey override, empty if none
+}
+
+// extractScalaDTOFields parses every case class in src into field-level entities.
+// It returns one SCOPE.Type/dto entity per case class (carrying a fields summary)
+// plus one SCOPE.Type/dto_field entity per field so consumers can navigate to a
+// specific field + its type + nullability + wire name.
+func extractScalaDTOFields(src, framework string, file fileMeta) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// File-level codec attribution maps DTO name -> codec library.
+	codecByDTO := scalaCodecAttribution(src)
+
+	for _, m := range valDTOCaseClassRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		// m[1] is the byte just past the opening "(" of the constructor.
+		paramBlob := balancedParens(src, m[1])
+		line := lineOf(src, m[0])
+
+		fields := parseScalaDTOFields(paramBlob)
+		if len(fields) == 0 {
+			// Parameterless case class (rare for a DTO) — still record the type
+			// so name-only detection is preserved, matching prior behavior.
+			ent := makeEntity(name, "SCOPE.Type", "dto", file.Path, file.Language, line)
+			setProps(&ent, "framework", framework, "provenance", "CASE_CLASS_DTO")
+			if codec := codecByDTO[name]; codec != "" {
+				setProps(&ent, "codec", codec)
+			}
+			out = append(out, ent)
+			continue
+		}
+
+		// Parent DTO entity with a fields summary + codec attribution.
+		ent := makeEntity(name, "SCOPE.Type", "dto", file.Path, file.Language, line)
+		setProps(&ent, "framework", framework, "provenance", "CASE_CLASS_DTO",
+			"field_count", itoa(len(fields)),
+			"fields", scalaFieldSummary(fields))
+		if codec := codecByDTO[name]; codec != "" {
+			setProps(&ent, "codec", codec)
+		}
+		var nullable, wired []string
+		for _, f := range fields {
+			if f.Nullable {
+				nullable = append(nullable, f.Name)
+			}
+			if f.WireName != "" {
+				wired = append(wired, f.Name+"="+f.WireName)
+			}
+		}
+		if len(nullable) > 0 {
+			setProps(&ent, "nullable_fields", strings.Join(nullable, ","))
+		}
+		if len(wired) > 0 {
+			setProps(&ent, "wire_overrides", strings.Join(wired, ","))
+		}
+		out = append(out, ent)
+
+		// One entity per field, name-spaced under the DTO.
+		for _, f := range fields {
+			fe := makeEntity("dto_field:"+name+"."+f.Name, "SCOPE.Type", "dto_field",
+				file.Path, file.Language, line)
+			setProps(&fe, "framework", framework, "provenance", "CASE_CLASS_DTO_FIELD",
+				"dto", name, "field", f.Name, "field_type", f.Type,
+				"nullable", boolStr(f.Nullable))
+			if f.WireName != "" {
+				setProps(&fe, "wire_name", f.WireName)
+			}
+			if codec := codecByDTO[name]; codec != "" {
+				setProps(&fe, "codec", codec)
+			}
+			out = append(out, fe)
+		}
+	}
+	return out
+}
+
+// parseScalaDTOFields splits a primary-constructor parameter blob into fields,
+// respecting bracket depth so commas inside Type params (Map[String, Int]) do
+// not split a field.
+func parseScalaDTOFields(blob string) []scalaDTOField {
+	var fields []scalaDTOField
+	for _, part := range splitTopLevelCommas(blob) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		// Strip leading val/var modifiers, but keep annotations for wire names.
+		wire := ""
+		if wm := valWireNameRe.FindStringSubmatch(part); wm != nil {
+			wire = wm[1]
+		}
+		m := valDTOFieldRe.FindStringSubmatch(part)
+		if m == nil {
+			continue
+		}
+		fname := stripValVar(m[2])
+		ftype := strings.TrimSpace(m[3])
+		fields = append(fields, scalaDTOField{
+			Name:     fname,
+			Type:     ftype,
+			Nullable: isScalaOptional(ftype),
+			WireName: wire,
+		})
+	}
+	return fields
+}
+
+// stripValVar removes a leading "val"/"var" keyword that the field regex may
+// have captured as the name when present (e.g. `val name: String`).
+func stripValVar(name string) string {
+	switch name {
+	case "val", "var":
+		return ""
+	}
+	return name
+}
+
+// isScalaOptional reports whether a declared type denotes an optional/nullable
+// field — Option[T], Maybe[T], or scala.Option[T].
+func isScalaOptional(t string) bool {
+	t = strings.TrimSpace(t)
+	return strings.HasPrefix(t, "Option[") ||
+		strings.HasPrefix(t, "scala.Option[") ||
+		strings.HasPrefix(t, "Maybe[")
+}
+
+// scalaFieldSummary renders "name:Type" pairs (comma-separated) for the parent
+// DTO entity, so a single property captures the full shape.
+func scalaFieldSummary(fields []scalaDTOField) string {
+	parts := make([]string, 0, len(fields))
+	for _, f := range fields {
+		parts = append(parts, f.Name+":"+f.Type)
+	}
+	return strings.Join(parts, ",")
+}
+
+// scalaCodecAttribution maps each DTO type name to the JSON codec library that
+// derives a codec for it (circe / play-json / zio-json / upickle). @JsonCodec
+// is class-attached so it is resolved separately at field-parse time; the
+// derive-by-type forms (deriveDecoder[Foo], Json.format[Foo]) name the DTO
+// explicitly and are mapped here.
+func scalaCodecAttribution(src string) map[string]string {
+	out := map[string]string{}
+	for _, m := range valCirceDeriveRe.FindAllStringSubmatch(src, -1) {
+		out[m[1]] = "circe"
+	}
+	for _, m := range valPlayJsonFormatRe.FindAllStringSubmatch(src, -1) {
+		out[m[1]] = "play-json"
+	}
+	for _, m := range valZioJsonDeriveRe.FindAllStringSubmatch(src, -1) {
+		out[m[1]] = "zio-json"
+	}
+	// @JsonCodec annotates the immediately-following case class. Attribute it to
+	// the next case class name appearing after each annotation site.
+	if valCirceJsonCodecRe.MatchString(src) {
+		for _, loc := range valCirceJsonCodecRe.FindAllStringIndex(src, -1) {
+			rest := src[loc[1]:]
+			if cm := valDTOCaseClassRe.FindStringSubmatchIndex(rest); cm != nil {
+				dto := rest[cm[2]:cm[3]]
+				if _, ok := out[dto]; !ok {
+					out[dto] = "circe"
+				}
+			}
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Request validation: refined / cats / accord / octopus
+// ---------------------------------------------------------------------------
+
+var (
+	// refined predicate types attached to a field, e.g.
+	//   name: String Refined NonEmpty
+	//   age: Int Refined Positive
+	//   email: String Refined MatchesRegex[...]
+	//   port: Refined[Int, Interval.Closed[1024, 65535]]
+	valRefinedInfixRe = regexp.MustCompile(
+		`(?m)\b(\w+)\s*:\s*\w+\s+Refined\s+([A-Za-z][\w.]*(?:\s*\[[^\]]*\])?)`)
+	valRefinedAppliedRe = regexp.MustCompile(
+		`(?m)\b(\w+)\s*:\s*Refined\s*\[\s*[^,]+,\s*([^\]]+?)\s*\]`)
+
+	// cats Validated / ValidatedNel field validators:
+	//   def validateName(n: String): ValidatedNel[Error, String] = ...
+	//   (validateName, validateAge).mapN(...)
+	valCatsValidatedRe = regexp.MustCompile(
+		`(?m)\bdef\s+(\w+)\s*\([^)]*\)\s*:\s*Validated(?:Nel|Nec)?\s*\[`)
+	valCatsImportRe = regexp.MustCompile(`cats\.data\.Validated|cats\.syntax\.validated`)
+
+	// accord:  validator[User] { user => user.name is notEmpty; user.age should be >= 18 }
+	// We capture each `subject.field <constraint> <predicate>` clause.
+	valAccordBlockRe  = regexp.MustCompile(`\bvalidator\s*\[\s*(\w+)\s*\]\s*\{`)
+	valAccordClauseRe = regexp.MustCompile(
+		`\b\w+\.(\w+)\s+(?:is|should|must)\s+(?:be\s+)?([A-Za-z][\w]*(?:\s*\([^)]*\))?(?:\s*[<>=!]+\s*[^;\n}]+)?)`)
+	valAccordImportRe = regexp.MustCompile(`com\.wix\.accord`)
+
+	// octopus:  implicit val v: Validator[User] = Validator[User].rule(_.email, ...)
+	valOctopusRuleRe = regexp.MustCompile(
+		`\.rule(?:Field)?\s*\(\s*[^,]*?\.(\w+)\s*,`)
+	valOctopusImportRe = regexp.MustCompile(`octopus\b|import\s+octopus`)
+)
+
+// extractScalaValidation emits field-level request_validation entities for
+// refined types, cats Validated validators, accord, and octopus. Each entity
+// records the SPECIFIC field and the constraint/refinement applied.
+func extractScalaValidation(src, framework string, file fileMeta) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// --- refined ---------------------------------------------------------
+	for _, m := range valRefinedInfixRe.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		pred := strings.TrimSpace(src[m[4]:m[5]])
+		out = append(out, validationEntity(field, "refined", pred, framework, file, lineOf(src, m[0])))
+	}
+	for _, m := range valRefinedAppliedRe.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		pred := strings.TrimSpace(src[m[4]:m[5]])
+		out = append(out, validationEntity(field, "refined", pred, framework, file, lineOf(src, m[0])))
+	}
+
+	// --- cats Validated --------------------------------------------------
+	if valCatsImportRe.MatchString(src) || valCatsValidatedRe.MatchString(src) {
+		for _, m := range valCatsValidatedRe.FindAllStringSubmatchIndex(src, -1) {
+			fn := src[m[2]:m[3]]
+			// Field name = validator fn with a "validate" prefix stripped.
+			field := strings.TrimPrefix(strings.TrimPrefix(fn, "validate"), "Validate")
+			if field == "" {
+				field = fn
+			}
+			field = lowerFirst(field)
+			ent := validationEntity(field, "cats-validated", fn, framework, file, lineOf(src, m[0]))
+			setProps(&ent, "validator_fn", fn)
+			out = append(out, ent)
+		}
+	}
+
+	// --- accord ----------------------------------------------------------
+	if valAccordImportRe.MatchString(src) || valAccordBlockRe.MatchString(src) {
+		for _, b := range valAccordBlockRe.FindAllStringSubmatchIndex(src, -1) {
+			subject := src[b[2]:b[3]]
+			body := accordBlockBody(src, b[1])
+			for _, cm := range valAccordClauseRe.FindAllStringSubmatch(body, -1) {
+				field := cm[1]
+				constraint := strings.TrimSpace(collapseSpaces(cm[2]))
+				ent := validationEntity(field, "accord", constraint, framework, file, lineOf(src, b[0]))
+				setProps(&ent, "dto", subject)
+				out = append(out, ent)
+			}
+		}
+	}
+
+	// --- octopus ---------------------------------------------------------
+	if valOctopusImportRe.MatchString(src) {
+		for _, m := range valOctopusRuleRe.FindAllStringSubmatchIndex(src, -1) {
+			field := src[m[2]:m[3]]
+			out = append(out, validationEntity(field, "octopus", "rule", framework, file, lineOf(src, m[0])))
+		}
+	}
+
+	return out
+}
+
+// validationEntity builds a request_validation pattern entity carrying the
+// specific field and the constraint/refinement applied to it.
+func validationEntity(field, library, constraint, framework string, file fileMeta, line int) types.EntityRecord {
+	ent := makeEntity("validate:"+library+":"+field, "SCOPE.Operation", "request_validation",
+		file.Path, file.Language, line)
+	setProps(&ent, "framework", framework, "provenance", "FIELD_VALIDATION",
+		"library", library, "field", field, "constraint", constraint)
+	return ent
+}
+
+// balancedParens returns the substring from open (the byte just past an opening
+// "(") up to its matching ")", respecting nested parens. Used to capture a case
+// class primary-constructor parameter list that may contain parens in field
+// annotations or default values.
+func balancedParens(src string, open int) string {
+	depth := 1
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[open:i]
+			}
+		}
+	}
+	return src[open:]
+}
+
+// accordBlockBody returns the brace-balanced body of an accord validator block
+// starting at byte offset open (just past the opening "{").
+func accordBlockBody(src string, open int) string {
+	depth := 1
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[open:i]
+			}
+		}
+	}
+	return src[open:]
+}
+
+// ---------------------------------------------------------------------------
+// small local helpers (namespaced — no collisions with frameworks.go)
+// ---------------------------------------------------------------------------
+
+// fileMeta carries the path/language fields the validation extractors need,
+// decoupling them from the extractor.FileInput type.
+type fileMeta struct {
+	Path     string
+	Language string
+}
+
+// splitTopLevelCommas splits on commas that are not nested inside [] or ().
+func splitTopLevelCommas(s string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '[', '(':
+			depth++
+		case ']', ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	if r[0] >= 'A' && r[0] <= 'Z' {
+		r[0] = r[0] - 'A' + 'a'
+	}
+	return string(r)
+}
+
+func collapseSpaces(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}


### PR DESCRIPTION
## Summary

Deepens the Scala **Validation** capability from name-only DTO detection to full field-level modeling, matching the TS/JS bar. New extractor logic is isolated in `internal/custom/scala/validation.go`.

### dto_extraction — `partial` → **`full`** (all flagship web frameworks)
- case class primary-constructor **fields** (name + declared type)
- `Option[T]` **nullability** (per-field + `nullable_fields` summary)
- **codec attribution**: circe (`@JsonCodec` / `deriveDecoder`), play-json (`Json.format[T]`), zio-json (`DeriveJsonCodec.gen`)
- **wire-name overrides**: `@JsonKey` / `@jsonField` / `@key` (`wire_overrides`)
- emits `SCOPE.Type/dto` (fields summary) + one `SCOPE.Type/dto_field` per field
- balanced-paren constructor scan tolerates parens inside field annotations

### request_validation — `partial` → **`full`** (refined/FP trio), honest **`partial`** elsewhere
- **refined** predicate types: `String Refined NonEmpty`, `Int Refined Positive`, `MatchesRegex[...]`, `Refined[T, P]` — captured as **field + constraint**
- **cats** `Validated` / `ValidatedNel` validators (validator fn + inferred field)
- **accord** `validator[T] { p.field is notEmpty }` — per-clause **field + predicate**
- **octopus** `.rule(_.field, ...)`
- each `request_validation` entity records the **SPECIFIC field + constraint**

## Disposition

| Record | dto_extraction | request_validation |
|---|---|---|
| akka-http, http4s, zio-http | **full** | **full** (refined is field-co-located) |
| finatra, scalatra, cask, lagom | **full** | **partial** (validators commonly live in separate objects / JSR-303-style annotations resolved cross-file — the file-local extractor cannot link them to the originating DTO) |

`dto_extraction` is full across all flagship frameworks (case-class shape is file-local). `request_validation` stays honest-`partial` where validator→DTO linkage is cross-file.

## Tests (value-asserting)
- DTO fields/types/`Option` nullability + circe `deriveDecoder` attribution
- `@JsonKey` wire name + play-json `Json.format` attribution
- refined: `Positive`, `NonEmpty`, `MatchesRegex`
- accord: `notEmpty`, `>= 18` (+ subject DTO)
- cats `ValidatedNel` / `Validated`

`go test ./internal/custom/scala/ ./internal/types/ ./tools/coverage/` green. `gofmt -l` empty, `go vet` clean. `coverage gen` + `validate` (0 errors) + `fmt --check` canonical.

Closes #3454 (epic #3450).

🤖 Generated with [Claude Code](https://claude.com/claude-code)