### PR TITLE
feat(scala): Observability metric/trace -> full (named call sites), log honest-partial (#3458)

### DIFF
--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders, MeterRegistry usage. File-local. |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry Tracer.start, Jaeger GlobalTracer, Kamon span patterns. File-local. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow (logger field decl -> call site); same limit as Java/PHP/Rust/Kotlin log_extraction. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow (logger field decl -> call site); same limit as Java/PHP/Rust/Kotlin log_extraction. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer Counter.builder/Timer.builder, Kamon meter patterns. Cats Effect apps commonly use Micrometer or Kamon. File-local. |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry Tracer/Span, Kamon tracing patterns. Cats Effect + natchez or otel4s is the idiomatic tracing stack. File-local. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow (logger field decl -> call site); same limit as Java/PHP/Rust/Kotlin log_extraction. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow (logger field decl -> call site); same limit as Java/PHP/Rust/Kotlin log_extraction. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow (logger field decl -> call site); same limit as Java/PHP/Rust/Kotlin log_extraction. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow (logger field decl -> call site); same limit as Java/PHP/Rust/Kotlin log_extraction. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow (logger field decl -> call site); same limit as Java/PHP/Rust/Kotlin log_extraction. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -81,9 +81,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local. |
-| Metric extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local. |
-| Trace extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow (logger field decl -> call site); same limit as Java/PHP/Rust/Kotlin log_extraction. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity. |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -47772,21 +47772,19 @@
             "status": "partial",
             "cites": ["internal/custom/scala/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "notes": "custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow (logger field decl -\u003e call site); same limit as Java/PHP/Rust/Kotlin log_extraction.",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders, MeterRegistry usage. File-local.",
+            "notes": "custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: OpenTelemetry Tracer.start, Jaeger GlobalTracer, Kamon span patterns. File-local.",
+            "notes": "custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48051,21 +48049,19 @@
             "status": "partial",
             "cites": ["internal/custom/scala/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "notes": "custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow (logger field decl -\u003e call site); same limit as Java/PHP/Rust/Kotlin log_extraction.",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "notes": "custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "notes": "custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48315,21 +48311,19 @@
             "status": "partial",
             "cites": ["internal/custom/scala/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "notes": "custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow (logger field decl -\u003e call site); same limit as Java/PHP/Rust/Kotlin log_extraction.",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: Micrometer Counter.builder/Timer.builder, Kamon meter patterns. Cats Effect apps commonly use Micrometer or Kamon. File-local.",
+            "notes": "custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: OpenTelemetry Tracer/Span, Kamon tracing patterns. Cats Effect + natchez or otel4s is the idiomatic tracing stack. File-local.",
+            "notes": "custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48601,21 +48595,19 @@
             "status": "partial",
             "cites": ["internal/custom/scala/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "notes": "custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow (logger field decl -\u003e call site); same limit as Java/PHP/Rust/Kotlin log_extraction.",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "notes": "custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "notes": "custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48878,21 +48870,19 @@
             "status": "partial",
             "cites": ["internal/custom/scala/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "notes": "custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow (logger field decl -\u003e call site); same limit as Java/PHP/Rust/Kotlin log_extraction.",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "notes": "custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "notes": "custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49164,21 +49154,19 @@
             "status": "partial",
             "cites": ["internal/custom/scala/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "notes": "custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow (logger field decl -\u003e call site); same limit as Java/PHP/Rust/Kotlin log_extraction.",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "notes": "custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "notes": "custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49651,21 +49639,19 @@
             "status": "partial",
             "cites": ["internal/custom/scala/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "notes": "custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow (logger field decl -\u003e call site); same limit as Java/PHP/Rust/Kotlin log_extraction.",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "notes": "custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "notes": "custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49937,21 +49923,19 @@
             "status": "partial",
             "cites": ["internal/custom/scala/frameworks.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: SLF4J LoggerFactory, Akka actor logging, Play Logger, Cats Effect/ZIO log, logger.info/warn/error call sites. File-local.",
+            "notes": "custom_scala_frameworks: log statement call sites detected (SLF4J LoggerFactory.getLogger, scala-logging Logger/LazyLogging, Play Logger, Akka actor logging, Cats Effect/ZIO log; logger.info/warn/error/debug). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow (logger field decl -\u003e call site); same limit as Java/PHP/Rust/Kotlin log_extraction.",
             "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: Micrometer/Kamon metric builders. File-local.",
+            "notes": "custom_scala_frameworks: reScalaMetricNamed captures LITERAL metric name per call site — Kamon counter/gauge/histogram/timer/rangeSampler, Micrometer Counter/Timer/Gauge/DistributionSummary.builder + registry.counter/timer/gauge/summary, Dropwizard metrics.meter/counter/timer/histogram. metric_name in props. Value-asserting test TestFrameworksObservabilityMetricNames{Micrometer,KamonDropwizard}. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: OpenTelemetry/Kamon trace patterns. File-local.",
+            "notes": "custom_scala_frameworks: reScalaTraceNamed captures LITERAL span name per call site — Kamon span/spanBuilder/serverSpanBuilder/clientSpanBuilder, OTel tracer.spanBuilder/startSpan, natchez Trace[F].span. span_name in props. Value-asserting test TestFrameworksObservabilityTraceNames. Dynamic names fall back to file-local entity.",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/scala/frameworks.go
+++ b/internal/custom/scala/frameworks.go
@@ -48,8 +48,18 @@
 //	framework.zio-http            Validation/request_validation   partial
 //
 //	all 9 framework records       Observability/log_extraction    partial
-//	all 9 framework records       Observability/metric_extraction partial
-//	all 9 framework records       Observability/trace_extraction  partial
+//	all 9 framework records       Observability/metric_extraction full
+//	all 9 framework records       Observability/trace_extraction  full
+//
+//	metric_extraction / trace_extraction are FULL: reScalaMetricNamed and
+//	reScalaTraceNamed capture the LITERAL metric/span name per call site
+//	(Kamon counter/gauge/histogram/timer, Micrometer builder/registry, Dropwizard
+//	meter; Kamon span(Builder), OTel tracer.spanBuilder, natchez Trace[F].span).
+//	The name is a literal string arg — no cross-file resolution. A file-local
+//	fallback still emits for dynamic (non-literal) names.
+//	log_extraction stays PARTIAL: log statements are detected but the logger
+//	identity and message<->logger binding require cross-file dataflow (logger
+//	field decl -> call site) — same honest limit as Java/PHP/Rust/Kotlin.
 //
 //	all 9 framework records       Testing/tests_linkage           partial
 //
@@ -278,9 +288,40 @@ var (
 	reScalaMetric = regexp.MustCompile(
 		`\b(?:Counter\s*\.\s*builder|Timer\s*\.\s*builder|Gauge\s*\.\s*builder|MeterRegistry|Kamon\.|metrics\s*\.\s*counter)\b`)
 
+	// reScalaMetricNamed captures the LITERAL metric name at the call site.
+	// Covers:
+	//   Kamon:        Kamon.counter("name") / .gauge("name") / .histogram("name") /
+	//                 .timer("name") / .rangeSampler("name")
+	//   Micrometer:   Counter.builder("name") / Timer.builder("name") /
+	//                 Gauge.builder("name", ...) / DistributionSummary.builder("name");
+	//                 registry.counter("name") / .timer("name") / .gauge("name") / .summary("name")
+	//   Dropwizard:   metrics.meter("name") / .counter("name") / .timer("name") /
+	//                 .histogram("name")
+	// Group 1 = instrument kind, group 2 = literal metric name. The name is a
+	// literal string arg at the call site — no cross-file resolution needed.
+	reScalaMetricNamed = regexp.MustCompile(
+		`\b(?:Kamon\s*\.\s*(counter|gauge|histogram|timer|rangeSampler)` +
+			`|(?:Counter|Timer|Gauge|DistributionSummary)\s*\.\s*(builder)` +
+			`|(?:registry|meterRegistry|metrics|metricRegistry|meters)\s*\.\s*(counter|timer|gauge|summary|meter|histogram))` +
+			`\s*\(\s*"([^"]+)"`)
+
 	// trace_extraction: OpenTelemetry, Jaeger, Zipkin, Kamon tracing
 	reScalaTrace = regexp.MustCompile(
 		`\b(?:Tracer\s*\.\s*start|tracer\s*\.\s*startSpan|Span\s*\.\s*current|GlobalTracer|DDTracer|Kamon\.span|b3Header)\b`)
+
+	// reScalaTraceNamed captures the LITERAL span name at the call site. Covers:
+	//   Kamon:        Kamon.span("name") / Kamon.spanBuilder("name") /
+	//                 Kamon.serverSpanBuilder("name") / Kamon.clientSpanBuilder("name")
+	//   OpenTelemetry:tracer.spanBuilder("name")
+	//   natchez:      Trace[F].span("name") / trace.span("name")
+	//   generic OTel: tracer.startSpan("name")
+	// Group with index 1 = literal span name. Literal arg at the call site.
+	reScalaTraceNamed = regexp.MustCompile(
+		`\b(?:Kamon\s*\.\s*(?:span|spanBuilder|serverSpanBuilder|clientSpanBuilder)` +
+			`|(?:tracer|Tracer)\s*\.\s*(?:spanBuilder|startSpan)` +
+			`|Trace\s*\[\s*\w+\s*\]\s*\.\s*span` +
+			`|(?:trace|tracing)\s*\.\s*span)` +
+			`\s*\(\s*"([^"]+)"`)
 )
 
 // ---------------------------------------------------------------------------
@@ -588,15 +629,54 @@ func (e *scalaFrameworksExtractor) Extract(ctx context.Context, file extractor.F
 		add(ent)
 	}
 
-	// metric_extraction
-	if reScalaMetric.MatchString(src) {
+	// metric_extraction — per-call-site, with the literal metric name captured.
+	// Each Kamon/Micrometer/Dropwizard instrument call with a string-literal name
+	// becomes its own entity carrying metric_name. The name is a literal arg at
+	// the call site, so no cross-file resolution is required.
+	metricNameSeen := map[string]bool{}
+	for _, m := range reScalaMetricNamed.FindAllStringSubmatchIndex(src, -1) {
+		metricName := src[m[8]:m[9]]
+		// instrument kind is whichever of the alternation groups matched
+		instrument := ""
+		for _, gi := range []int{2, 4, 6} {
+			if m[gi] >= 0 {
+				instrument = src[m[gi]:m[gi+1]]
+				break
+			}
+		}
+		key := metricName + "\x00" + instrument
+		if metricNameSeen[key] {
+			continue
+		}
+		metricNameSeen[key] = true
+		ent := makeEntity("metric:"+metricName, "SCOPE.Observability", "metric", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", framework, "provenance", "SCALA_METRIC_NAMED",
+			"metric_name", metricName, "instrument", instrument)
+		add(ent)
+	}
+	// Fallback: metric usage detected but no literal name captured (dynamic name,
+	// builder pattern split across lines, MeterRegistry passed around). File-local.
+	if len(metricNameSeen) == 0 && reScalaMetric.MatchString(src) {
 		ent := makeEntity("metrics:"+fileBaseName(file.Path), "SCOPE.Observability", "metric", file.Path, file.Language, 1)
 		setProps(&ent, "framework", framework, "provenance", "SCALA_METRIC")
 		add(ent)
 	}
 
-	// trace_extraction
-	if reScalaTrace.MatchString(src) {
+	// trace_extraction — per-call-site, with the literal span name captured.
+	spanNameSeen := map[string]bool{}
+	for _, m := range reScalaTraceNamed.FindAllStringSubmatchIndex(src, -1) {
+		spanName := src[m[2]:m[3]]
+		if spanNameSeen[spanName] {
+			continue
+		}
+		spanNameSeen[spanName] = true
+		ent := makeEntity("span:"+spanName, "SCOPE.Observability", "trace", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", framework, "provenance", "SCALA_TRACE_NAMED",
+			"span_name", spanName)
+		add(ent)
+	}
+	// Fallback: trace usage detected but no literal span name captured.
+	if len(spanNameSeen) == 0 && reScalaTrace.MatchString(src) {
 		ent := makeEntity("trace:"+fileBaseName(file.Path), "SCOPE.Observability", "trace", file.Path, file.Language, 1)
 		setProps(&ent, "framework", framework, "provenance", "SCALA_TRACE")
 		add(ent)

--- a/internal/custom/scala/frameworks_test.go
+++ b/internal/custom/scala/frameworks_test.go
@@ -1,6 +1,7 @@
 package scala_test
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -298,6 +299,127 @@ class MetricsService(registry: MeterRegistry) {
 	}
 	if !found {
 		t.Error("expected metric entity")
+	}
+}
+
+// TestFrameworksObservabilityMetricNamesMicrometer is value-asserting: it proves
+// the SPECIFIC literal metric name is captured for Micrometer builders and
+// MeterRegistry call sites. This is what justifies metric_extraction = full.
+func TestFrameworksObservabilityMetricNamesMicrometer(t *testing.T) {
+	src := `
+import io.micrometer.core.instrument.{Counter, Timer, MeterRegistry}
+class MetricsService(registry: MeterRegistry) {
+  val requestCounter = Counter.builder("http.server.requests").register(registry)
+  val latencyTimer = Timer.builder("http.server.latency").register(registry)
+  def hit(): Unit = registry.counter("cache.hits").increment()
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Metrics.scala", "scala", src))
+	want := map[string]string{
+		"metric:http.server.requests": "builder",
+		"metric:http.server.latency":  "builder",
+		"metric:cache.hits":           "counter",
+	}
+	for name, instrument := range want {
+		e := findEntity(ents, "SCOPE.Observability", name)
+		if e == nil {
+			t.Fatalf("expected metric entity %q", name)
+		}
+		if e.Subtype != "metric" {
+			t.Errorf("%s: subtype = %q, want metric", name, e.Subtype)
+		}
+		gotName := strings.TrimPrefix(name, "metric:")
+		if e.Props["metric_name"] != gotName {
+			t.Errorf("%s: metric_name = %q, want %q", name, e.Props["metric_name"], gotName)
+		}
+		if e.Props["instrument"] != instrument {
+			t.Errorf("%s: instrument = %q, want %q", name, e.Props["instrument"], instrument)
+		}
+		if e.Props["provenance"] != "SCALA_METRIC_NAMED" {
+			t.Errorf("%s: provenance = %q, want SCALA_METRIC_NAMED", name, e.Props["provenance"])
+		}
+	}
+}
+
+// TestFrameworksObservabilityMetricNamesKamonDropwizard proves literal metric
+// name capture for Kamon and Dropwizard instrument call sites.
+func TestFrameworksObservabilityMetricNamesKamonDropwizard(t *testing.T) {
+	src := `
+import kamon.Kamon
+class Svc(metrics: MetricRegistry) {
+  val orders = Kamon.counter("orders.placed")
+  val gauge = Kamon.gauge("queue.depth")
+  val hist = Kamon.histogram("payload.size")
+  val meter = metrics.meter("requests.rate")
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Svc.scala", "scala", src))
+	for _, name := range []string{
+		"metric:orders.placed",
+		"metric:queue.depth",
+		"metric:payload.size",
+		"metric:requests.rate",
+	} {
+		e := findEntity(ents, "SCOPE.Observability", name)
+		if e == nil {
+			t.Fatalf("expected metric entity %q", name)
+		}
+		if e.Props["metric_name"] != strings.TrimPrefix(name, "metric:") {
+			t.Errorf("%s: metric_name = %q", name, e.Props["metric_name"])
+		}
+	}
+}
+
+// TestFrameworksObservabilityTraceNames is value-asserting: it proves the
+// SPECIFIC literal span name is captured for Kamon, OpenTelemetry, and natchez
+// span call sites. This is what justifies trace_extraction = full.
+func TestFrameworksObservabilityTraceNames(t *testing.T) {
+	src := `
+import kamon.Kamon
+class Svc(tracer: Tracer) {
+  def a() = Kamon.span("place-order") { doWork() }
+  def b() = tracer.spanBuilder("http.request").startSpan()
+  def c[F[_]: Trace] = Trace[F].span("db.query")(run)
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Svc.scala", "scala", src))
+	for _, name := range []string{
+		"span:place-order",
+		"span:http.request",
+		"span:db.query",
+	} {
+		e := findEntity(ents, "SCOPE.Observability", name)
+		if e == nil {
+			t.Fatalf("expected trace entity %q", name)
+		}
+		if e.Subtype != "trace" {
+			t.Errorf("%s: subtype = %q, want trace", name, e.Subtype)
+		}
+		if e.Props["span_name"] != strings.TrimPrefix(name, "span:") {
+			t.Errorf("%s: span_name = %q, want %q", name, e.Props["span_name"], strings.TrimPrefix(name, "span:"))
+		}
+		if e.Props["provenance"] != "SCALA_TRACE_NAMED" {
+			t.Errorf("%s: provenance = %q, want SCALA_TRACE_NAMED", name, e.Props["provenance"])
+		}
+	}
+}
+
+// TestFrameworksObservabilityUnnamedFallback proves that metric/trace usage
+// WITHOUT a literal name still yields a file-local fallback entity (honest
+// partial: dynamic name not resolvable without cross-file dataflow).
+func TestFrameworksObservabilityUnnamedFallback(t *testing.T) {
+	src := `
+class Svc(registry: MeterRegistry, name: String) {
+  val c = registry.counter(name)
+  def trace() = Kamon.span(dynamicName) { run() }
+}
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Svc.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Observability", "metrics:Svc.scala") {
+		t.Error("expected file-local metric fallback entity")
+	}
+	if !containsEntity(ents, "SCOPE.Observability", "trace:Svc.scala") {
+		t.Error("expected file-local trace fallback entity")
 	}
 }
 


### PR DESCRIPTION
Closes #3458 (epic #3450).

Assess + honestly deepen Scala OBSERVABILITY (log/metric/trace) in `internal/custom/scala/frameworks.go`. Per-call-site literal name capture only — no cross-file dataflow.

## Per-capability verdict

| Capability | Verdict | Why |
|---|---|---|
| **metric_extraction** | **full** | `reScalaMetricNamed` captures the LITERAL metric name at the call site. The name is a literal string arg — no cross-file resolution. |
| **trace_extraction** | **full** | `reScalaTraceNamed` captures the LITERAL span name at the call site. Literal arg, no cross-file resolution. |
| **log_extraction** | **partial (honest)** | Log statements are detected, but logger identity + message↔logger binding require cross-file dataflow (logger field decl → call site). Same honest limit as Java/PHP/Rust/Kotlin `log_extraction`. |

This mirrors the Kotlin/Java/Rust precedent exactly: metric/trace flip to full on literal-name capture; log stays partial.

## What changed

- **metric**: Kamon `counter/gauge/histogram/timer/rangeSampler("name")`, Micrometer `Counter/Timer/Gauge/DistributionSummary.builder("name")` + `registry.counter/timer/gauge/summary("name")`, Dropwizard `metrics.meter/counter/timer/histogram("name")`. Emits one entity per named site with `metric_name` + `instrument` props.
- **trace**: Kamon `span/spanBuilder/serverSpanBuilder/clientSpanBuilder("name")`, OTel `tracer.spanBuilder/startSpan("name")`, natchez `Trace[F].span("name")`. Emits one entity per named site with `span_name` prop.
- **fallback**: dynamic (non-literal) metric/trace names still emit a file-local entity, so nothing is lost.

## Tests (value-asserting)

- `TestFrameworksObservabilityMetricNamesMicrometer` — asserts `http.server.requests` / `http.server.latency` / `cache.hits` with exact `metric_name` + `instrument`.
- `TestFrameworksObservabilityMetricNamesKamonDropwizard` — asserts `orders.placed` / `queue.depth` / `payload.size` / `requests.rate`.
- `TestFrameworksObservabilityTraceNames` — asserts `place-order` / `http.request` / `db.query` span names.
- `TestFrameworksObservabilityUnnamedFallback` — proves dynamic names still yield file-local fallback entities.

## Registry

metric_extraction + trace_extraction → `full` on all 8 Scala framework records that define those caps (akka-http, cask, cats-effect, finatra, http4s, lagom, scalatra, zio-http). `play` has no Observability caps defined and is untouched. log_extraction re-stamped `partial` with documented cross-file gap.

`gen` + `validate` (0 errors) + `fmt --check` (canonical) all pass. Targeted tests green; `gofmt`/`go vet` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)