### PR TITLE
feat(scala): deep-grind testmap TESTING linkage to full (#3457)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -143,14 +143,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ## UI Frontend
@@ -181,7 +181,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | ✅ 2/2 | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | — | |
 
 
 ## Mobile

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -143,14 +143,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ## UI Frontend
@@ -181,7 +181,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
 | [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | — | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 2/2 | |
 
 
 ## Mobile

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ### Meta Framework
 
-| Name | Routing | Type System | Testing | Substrate | Notes |
-|---|---|---|---|---|---|
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | |
+| Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 2/2 | |
 
 
 ## Tools

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 9/9 | |
-| [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [Lagom](../detail/lang.scala.framework.lagom.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
+| [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ### Meta Framework
 
-| Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|---|
-| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | ✅ 2/2 | |
+| Name | Routing | Type System | Testing | Substrate | Notes |
+|---|---|---|---|---|---|
+| [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.scala.framework.akka-http.md
+++ b/docs/coverage/detail/lang.scala.framework.akka-http.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.scala.framework.cask.md
+++ b/docs/coverage/detail/lang.scala.framework.cask.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.scala.framework.cats-effect.md
+++ b/docs/coverage/detail/lang.scala.framework.cats-effect.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.scala.framework.finatra.md
+++ b/docs/coverage/detail/lang.scala.framework.finatra.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.scala.framework.http4s.md
+++ b/docs/coverage/detail/lang.scala.framework.http4s.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.scala.framework.lagom.md
+++ b/docs/coverage/detail/lang.scala.framework.lagom.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -62,7 +62,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.scala.framework.scalatra.md
+++ b/docs/coverage/detail/lang.scala.framework.scalatra.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.scala.framework.zio-http.md
+++ b/docs/coverage/detail/lang.scala.framework.zio-http.md
@@ -42,7 +42,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local. |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/frameworks.go` | Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec->UserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test->target edges per framework. Closes #3457. |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -47690,10 +47690,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },
@@ -47966,10 +47965,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48228,10 +48226,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48502,10 +48499,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },
@@ -48784,10 +48780,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49058,10 +49053,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49364,9 +49358,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49563,10 +49557,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },
@@ -49836,10 +49829,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/scala/frameworks.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "custom_scala_frameworks extractor: ScalaTest (AnyFlatSpec/WordSpec/FunSuite), Specs2 (Specification), MUnit (CatsEffectSuite), Akka TestKit, http4s test suite, ZIO Test, Finatra EmbeddedTwitterServer detection. File-local.",
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/frameworks.go"],
+            "notes": "Deep testmap Scala TESTS linkage: scalatest (AnyFunSuite/AnyFlatSpec/AnyWordSpec/AnyFunSpec), specs2, MUnit, ZIO Test leaf cases with subject-from-spec-name (UserServiceSpec-\u003eUserService) + body call resolution; Scala assertion/matcher stopwords (assert/assertResult/assertTrue/shouldBe/mustBe/must_==/specs2 matchers). Value-asserting tests in extractor_test.go assert specific test-\u003etarget edges per framework. Closes #3457.",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -2707,6 +2707,155 @@ class FooSpec extends AnyFunSuite {
 	}
 }
 
+// TestScala_FunSuite_DirectCall asserts a ScalaTest AnyFunSuite leaf whose body
+// directly calls a production method emits a high-confidence TESTS edge to that
+// specific symbol (the `assert(...)` wrapper is stop-worded).
+func TestScala_FunSuite_DirectCall(t *testing.T) {
+	src := `import org.scalatest.funsuite.AnyFunSuite
+class UserServiceSpec extends AnyFunSuite {
+    test("registers a new user") {
+        val svc = new UserService
+        assert(svc.register("alice") == true)
+    }
+}`
+	recs := runExtract(t, "UserServiceSpec.scala", "scala", src)
+	if recs[0].Properties["test_framework"] != "scalatest" {
+		t.Errorf("framework=%q, want scalatest", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_registers_a_new_user", "svc.register") {
+		t.Fatalf("expected TESTS edge to svc.register; recs=%+v", recs)
+	}
+	// The assert(...) wrapper must NOT be a tested target.
+	if hasEdgeAny(recs, "it_registers_a_new_user", "assert") {
+		t.Errorf("assert() must be stop-worded, not a tested target")
+	}
+}
+
+// TestScala_FlatSpec_DirectCall asserts an AnyFlatSpec `"X" should "y" in { … }`
+// leaf links to the production call in its body.
+func TestScala_FlatSpec_DirectCall(t *testing.T) {
+	src := `import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+class StackSpec extends AnyFlatSpec with Matchers {
+    "A Stack" should "pop values in LIFO order" in {
+        val s = new Stack
+        s.pop() shouldBe 5
+    }
+}`
+	recs := runExtract(t, "StackSpec.scala", "scala", src)
+	if !hasEdgeAny(recs, "it_A_Stack_pop_values_in_LIFO_order", "s.pop") {
+		t.Fatalf("expected TESTS edge to s.pop; recs=%+v", recs)
+	}
+	if hasEdgeAny(recs, "it_A_Stack_pop_values_in_LIFO_order", "shouldBe") {
+		t.Errorf("shouldBe matcher must be stop-worded")
+	}
+}
+
+// TestScala_FunSpec_DirectCall asserts an AnyFunSpec `it("…") { … }` leaf links
+// to its production call.
+func TestScala_FunSpec_DirectCall(t *testing.T) {
+	src := `import org.scalatest.funspec.AnyFunSpec
+class CalculatorSpec extends AnyFunSpec {
+    describe("Calculator") {
+        it("adds two numbers") {
+            val c = new Calculator
+            assertResult(3)(c.add(1, 2))
+        }
+    }
+}`
+	recs := runExtract(t, "CalculatorSpec.scala", "scala", src)
+	if !hasEdgeAny(recs, "it_adds_two_numbers", "c.add") {
+		t.Fatalf("expected TESTS edge to c.add; recs=%+v", recs)
+	}
+	if hasEdgeAny(recs, "it_adds_two_numbers", "assertResult") {
+		t.Errorf("assertResult must be stop-worded")
+	}
+}
+
+// TestScala_Specs2_NamingConvention asserts a specs2 spec whose leaf has no
+// direct production call still emits a subject-derived TESTS edge from the
+// spec type name (OrderServiceSpec → OrderService), at medium confidence.
+func TestScala_Specs2_NamingConvention(t *testing.T) {
+	src := `import org.specs2.mutable.Specification
+class OrderServiceSpec extends Specification {
+    "OrderService" should {
+        "be defined" in {
+            ok
+        }
+    }
+}`
+	recs := runExtract(t, "OrderServiceSpec.scala", "scala", src)
+	if recs[0].Properties["test_framework"] != "specs2" {
+		t.Errorf("framework=%q, want specs2", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_be_defined", "OrderService") {
+		t.Fatalf("expected naming-convention TESTS edge to OrderService; recs=%+v", recs)
+	}
+}
+
+// TestScala_MUnit_DirectCall asserts a MUnit FunSuite leaf links to its
+// production call and is attributed to the munit framework.
+func TestScala_MUnit_DirectCall(t *testing.T) {
+	src := `import munit.FunSuite
+class ParserSuite extends FunSuite {
+    test("parses input") {
+        val p = new Parser
+        assertEquals(p.parse("x"), 1)
+    }
+}`
+	recs := runExtract(t, "ParserSuite.scala", "scala", src)
+	if recs[0].Properties["test_framework"] != "munit" {
+		t.Errorf("framework=%q, want munit", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_parses_input", "p.parse") {
+		t.Fatalf("expected TESTS edge to p.parse; recs=%+v", recs)
+	}
+	if hasEdgeAny(recs, "it_parses_input", "assertEquals") {
+		t.Errorf("assertEquals must be stop-worded")
+	}
+}
+
+// TestScala_ZioTest_DirectCall asserts a ZIO Test object spec leaf (paren-thunk
+// and brace forms) links to its production call and is attributed to zio_test.
+func TestScala_ZioTest_DirectCall(t *testing.T) {
+	src := `import zio.test._
+import zio.test.Assertion._
+object GreeterSpec extends ZIOSpecDefault {
+    def spec = suite("Greeter")(
+        test("greets the user") {
+            val g = new Greeter
+            assertTrue(g.greet("ann") == "hi ann")
+        }
+    )
+}`
+	recs := runExtract(t, "GreeterSpec.scala", "scala", src)
+	if recs[0].Properties["test_framework"] != "zio_test" {
+		t.Errorf("framework=%q, want zio_test", recs[0].Properties["test_framework"])
+	}
+	if !hasEdgeAny(recs, "it_greets_the_user", "g.greet") {
+		t.Fatalf("expected TESTS edge to g.greet; recs=%+v", recs)
+	}
+	if hasEdgeAny(recs, "it_greets_the_user", "assertTrue") {
+		t.Errorf("assertTrue must be stop-worded")
+	}
+}
+
+func TestScalaSubjectFromSpecName(t *testing.T) {
+	cases := map[string]string{
+		"UserServiceSpec":  "UserService",
+		"UserServiceTest":  "UserService",
+		"UserServiceSuite": "UserService",
+		"OrderSpecs":       "Order",
+		"Spec":             "",
+		"Plain":            "",
+	}
+	for in, want := range cases {
+		if got := scalaSubjectFromSpecName(in); got != want {
+			t.Errorf("scalaSubjectFromSpecName(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Path normalisation / test-type inference
 // ---------------------------------------------------------------------------

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -1411,22 +1411,203 @@ func detectXCTest(source string) []testFunction {
 }
 
 // ---------------------------------------------------------------------------
-// Scala — Spock / ScalaTest
+// Scala — ScalaTest / specs2 / MUnit / ZIO Test  (deep linkage, #3457)
+//
+// Deep linkage covers four families, all subject-aware: the class/object under
+// test is derived from the spec's own type name (UserServiceSpec → UserService),
+// mirroring the C#/Kotlin/Java describeSubject path, so a naming-convention
+// TESTS edge is emitted even when a leaf case contains no direct production
+// call. Where a leaf case body DOES contain a production call, the resolver
+// promotes it to a high-confidence edge (the Scala assertion helpers — assert,
+// assertResult, mustBe, shouldBe, assertTrue, … — are stop-worded in
+// resolver.go so they never masquerade as the tested subject).
+//
+//	scalatest — AnyFunSuite     test("desc") { … }
+//	            AnyFlatSpec     "X" should "do y" in { … }
+//	            AnyWordSpec     "X" should { "do y" in { … } }
+//	            AnyFunSpec      describe("X") { it("does y") { … } }
+//	specs2    — class XSpec extends Specification { "x" should { "y" in { … } } }
+//	            (the `>>` and `in` leaf forms are both accepted)
+//	munit     — class XSuite extends FunSuite { test("y") { … } }
+//	zio-test  — object XSpec extends ZIOSpecDefault {
+//	                def spec = suite("x")(test("y")(assertTrue(…)))
+//	            }
 // ---------------------------------------------------------------------------
 
-// ScalaTest FunSuite: test("name") { ... }
-var scalaTestRE = regexp.MustCompile(
+// scalaSpecTypeRE captures the first class/object name in a Scala test source so
+// the subject under test can be derived from it (FooSpec → Foo). Both `class`
+// and `object` (zio-test specs are objects) are accepted, as are the optional
+// `final`/`abstract`/`sealed`/`case` modifiers.
+var scalaSpecTypeRE = regexp.MustCompile(
+	`(?m)^\s*(?:(?:final|abstract|sealed|case|private|protected)\s+)*(?:class|object)\s+(\w+)`,
+)
+
+// scalaFunSuiteCaseRE matches a ScalaTest AnyFunSuite / MUnit FunSuite leaf:
+//
+//	test("computes the total") { … }
+//
+// Group 1 is the description. Shared by scalatest-funsuite and munit (both use
+// the identical `test("…") { … }` surface).
+var scalaFunSuiteCaseRE = regexp.MustCompile(
 	`(?m)\btest\s*\(\s*"([^"]{1,200})"\s*\)\s*{`,
 )
 
-func detectScalaTest(source string) []testFunction {
-	var out []testFunction
-	for _, m := range scalaTestRE.FindAllStringSubmatchIndex(source, -1) {
-		name := source[m[2]:m[3]]
-		body := extractBraceBody(source, m[1]-1)
-		out = append(out, testFunction{qname: jestCaseQName(name), body: body})
+// scalaFlatSpecCaseRE matches a ScalaTest AnyFlatSpec leaf:
+//
+//	"A Stack" should "pop values in LIFO order" in { … }
+//	"it"      must    "do something"           in { … }
+//
+// Group 1 is the subject phrase, group 2 the verb phrase. The leaf description
+// is the concatenation; the body follows `in {`.
+var scalaFlatSpecCaseRE = regexp.MustCompile(
+	`(?m)"([^"]{1,200})"\s+(?:should|must|can|may)\s+"([^"]{1,200})"\s+in\s*{`,
+)
+
+// scalaWordSpecLeafRE matches a ScalaTest AnyWordSpec / specs2 leaf case:
+//
+//	"return the user" in { … }
+//	"return the user" >> { … }     (specs2 acceptance/unit style)
+//
+// Group 1 is the leaf description. The enclosing `"subject" should { … }` block
+// is handled by the type-name subject; we only need the leaf bodies.
+var scalaWordSpecLeafRE = regexp.MustCompile(
+	`(?m)"([^"]{1,200})"\s+(?:in|>>)\s*{`,
+)
+
+// scalaFunSpecCaseRE matches a ScalaTest AnyFunSpec leaf:
+//
+//	it("does the thing") { … }
+//
+// Group 1 is the description. `describe("…")` containers are intentionally not
+// emitted as leaves — `it` is the finest-grained case.
+var scalaFunSpecCaseRE = regexp.MustCompile(
+	`(?m)\bit\s*\(\s*"([^"]{1,200})"\s*\)\s*{`,
+)
+
+// scalaZioTestCaseRE matches a ZIO Test leaf inside a suite(...) tree:
+//
+//	test("returns the user") { … }
+//	test("returns the user")(assertTrue(…))
+//
+// ZIO uses both the brace-lambda and the paren-thunk forms. Group 1 is the
+// description; the brace-lambda form is captured by scalaFunSuiteCaseRE, so this
+// RE only needs to add the paren-thunk form. Group 1 = description.
+var scalaZioTestParenCaseRE = regexp.MustCompile(
+	`(?m)\btest\s*\(\s*"([^"]{1,200})"\s*\)\s*\(`,
+)
+
+// scalaSubjectFromSpecName derives the class/object under test from a Scala
+// spec/suite type name by stripping the conventional trailing suffixes.
+//
+//	UserServiceSpec  → UserService
+//	UserServiceTest  → UserService
+//	UserServiceSuite → UserService
+//	UserServiceSpecs → UserService   (specs2 plural convention)
+//	(no suffix)      → ""
+func scalaSubjectFromSpecName(typeName string) string {
+	for _, suf := range []string{"Specs", "Spec", "Suite", "Tests", "Test"} {
+		if strings.HasSuffix(typeName, suf) && len(typeName) > len(suf) {
+			return typeName[:len(typeName)-len(suf)]
+		}
 	}
+	return ""
+}
+
+// scalaFirstSpecType returns the first class/object name declared in source.
+func scalaFirstSpecType(source string) string {
+	if m := scalaSpecTypeRE.FindStringSubmatch(source); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// detectScalaTest detects ScalaTest (FunSuite/FlatSpec/WordSpec/FunSpec),
+// specs2, MUnit and ZIO Test leaf cases. Every leaf is annotated with the
+// subject derived from the spec type name, so a TESTS edge is emitted even for
+// pure-naming-convention cases; leaves whose body contains a production call are
+// promoted by the resolver to high confidence.
+func detectScalaTest(source string) []testFunction {
+	subject := scalaSubjectFromSpecName(scalaFirstSpecType(source))
+
+	var out []testFunction
+	seen := map[string]bool{}
+	add := func(rawName, body string) {
+		name := jestCaseQName(rawName)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, testFunction{qname: name, body: body, describeSubject: subject})
+	}
+
+	// FunSuite / MUnit / ZIO brace form: test("…") { … }
+	for _, m := range scalaFunSuiteCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		add(source[m[2]:m[3]], extractBraceBody(source, m[1]-1))
+	}
+	// ZIO paren-thunk form: test("…")( … ) — body is the paren group. We reuse
+	// extractBraceBody is brace-only, so capture from the opening paren to its
+	// matching close via extractParenBody.
+	for _, m := range scalaZioTestParenCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		add(source[m[2]:m[3]], scalaParenBody(source, m[1]-1))
+	}
+	// FlatSpec: "subject" should "verb" in { … }
+	for _, m := range scalaFlatSpecCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		desc := source[m[2]:m[3]] + "_" + source[m[4]:m[5]]
+		add(desc, extractBraceBody(source, m[1]-1))
+	}
+	// FunSpec: it("…") { … }
+	for _, m := range scalaFunSpecCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		add(source[m[2]:m[3]], extractBraceBody(source, m[1]-1))
+	}
+	// WordSpec / specs2 leaf: "…" in { … } / "…" >> { … }. Scanned last so that
+	// the more specific FlatSpec/FunSpec forms claim their descriptions first
+	// (jestCaseQName de-dupes identical leaf names via `seen`).
+	for _, m := range scalaWordSpecLeafRE.FindAllStringSubmatchIndex(source, -1) {
+		add(source[m[2]:m[3]], extractBraceBody(source, m[1]-1))
+	}
+
 	return out
+}
+
+// scalaParenBody returns the substring of source from the first `(` at or after
+// startAt to its balanced `)`. Used for the ZIO `test("…")( … )` paren-thunk
+// form. Mirrors extractBraceBody for parentheses; quote-aware so a `)` inside a
+// string literal does not close the group prematurely.
+func scalaParenBody(source string, startAt int) string {
+	n := len(source)
+	i := startAt
+	for i < n && source[i] != '(' {
+		i++
+	}
+	if i >= n {
+		return ""
+	}
+	depth := 0
+	start := i
+	for i < n {
+		c := source[i]
+		switch c {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return source[start : i+1]
+			}
+		case '"', '\'', '`':
+			quote := c
+			i++
+			for i < n && source[i] != quote {
+				if source[i] == '\\' {
+					i += 2
+					continue
+				}
+				i++
+			}
+		}
+		i++
+	}
+	return ""
 }
 
 // ---------------------------------------------------------------------------
@@ -1619,6 +1800,26 @@ var frameworkOrder = []frameworkEntry{
 			regexp.MustCompile(`Tests?\.swift$`),
 		},
 		detect: detectXCTest,
+	},
+	// Scala — specs2 / MUnit / ZIO Test: import-hints only, listed BEFORE the
+	// scalatest filename-fallback entry so a file carrying an explicit framework
+	// import is attributed to the right framework even though all four share the
+	// detectScalaTest detector (the leaf-case surfaces overlap). Files with no
+	// recognised import fall through to the scalatest entry's filename hints.
+	{
+		name:        "specs2",
+		importHints: []string{"org.specs2", "specs2"},
+		detect:      detectScalaTest,
+	},
+	{
+		name:        "munit",
+		importHints: []string{"munit"},
+		detect:      detectScalaTest,
+	},
+	{
+		name:        "zio_test",
+		importHints: []string{"zio.test", "zio.Test", "ziospec"},
+		detect:      detectScalaTest,
 	},
 	{
 		name:        "scalatest",

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -227,6 +227,37 @@ var stopwords = map[string]bool{
 	// Laravel RefreshDatabase / HTTP test lifecycle helpers
 	"refreshdatabase": true, "seeddatabase": true, "withoutexceptionhandling": true,
 	"withheaders": true, "actingas": true, "withtoken": true, "be": true,
+	// Scala — ScalaTest / specs2 / MUnit / ZIO Test assertion & matcher helpers
+	// (#3457). These are test-harness identifiers and must never surface as the
+	// tested production subject. directCallRE captures the paren-call forms
+	// (assert(…), assertResult(…), assertTrue(…)); the infix matcher forms
+	// (`x shouldBe y`, `x must_== y`) are included defensively for the dotted
+	// `x.shouldBe(y)` style. Lower-cased (resolver lowercases before lookup).
+	"assertresult": true, "assertthrows_scala": true,
+	"assertcompiles": true, "assertdoesnotcompile": true, "asserttypeerror": true,
+	// ScalaTest matchers (Matchers / MustMatchers): infix + dotted forms.
+	// (shouldbe/shouldmatch/shouldcontain/shouldnotbe already covered by the
+	// Kotlin kotest matcher block above.)
+	"shouldequal": true, "should_be": true,
+	"mustbe": true, "mustequal": true, "must_==": true, "must_be": true,
+	"mustmatch": true, "mustcontain": true,
+	"mustnotbe": true, "shouldreturn": true,
+	"shouldhave": true, "musthave": true,
+	// specs2 matchers (`x must beEqualTo(y)`, `x mustEqual y`, `x === y`).
+	"mustequalto": true, "beequalto": true, "beequalto_": true,
+	"mustbeequaltoignoringcase": true, "bnull": true, "benull": true,
+	"besome": true, "benone": true, "beleft": true, "beright": true,
+	"betrue": true, "befalse": true, "throwa": true, "throwan": true,
+	"contain_": true, "haveclass": true, "havesize": true,
+	// MUnit assertion helpers (assertEquals/assertNotEquals already covered by
+	// the generic assert* / assertequals entries; add the MUnit-specific ones).
+	"assertnoexception": true, "interceptmessage": true, "intercept": true,
+	"assertequalsdouble": true, "assertequalsfloat": true,
+	// ZIO Test assertions (assertTrue covered above; add the operator forms).
+	"assertz": true, "assertcompletes": true, "assertcompleteszio": true,
+	"equalto": true, "isleft": true, "isright": true, "issome": true, "isnone": true,
+	"issubtype": true, "haskey": true, "hasfield": true, "isgreaterthan": true,
+	"islessthan": true,
 	// Common language keywords that end up in call-like positions
 	"if": true, "for": true, "while": true, "switch": true, "return": true,
 	"func": true, "def": true, "class": true, "struct": true, "new": true,


### PR DESCRIPTION
Closes #3457 (epic #3450).

## Disposition
Deepens the Scala path in the shared `internal/extractors/cross/testmap` extractor from a single ScalaTest `AnyFunSuite test("…")` pattern to full, subject-aware multi-framework leaf detection, bringing Scala TESTING linkage to the TS/JS bar.

### Frameworks covered
- **scalatest** — `AnyFunSuite` (`test("d"){}`), `AnyFlatSpec` (`"X" should "y" in {}`), `AnyWordSpec` / `AnyFunSpec` (`it("d"){}`).
- **specs2** — `class XSpec extends Specification { "x" should { "y" in {} } }` (both `in` and `>>` leaf forms).
- **munit** — `class XSuite extends FunSuite { test("y"){} }`.
- **zio-test** — `object XSpec extends ZIOSpecDefault { def spec = suite("x")(test("y"){…}) }` (brace + paren-thunk forms via `scalaParenBody`).

### Linkage model
- Subject under test derived from spec type name (`UserServiceSpec` → `UserService`) → naming-convention TESTS edge even when a leaf has no direct call (medium confidence).
- Leaf bodies containing a production call are promoted to high confidence.
- New import-hint registry entries (`specs2`, `munit`, `zio_test`) attribute files to the right framework; all share `detectScalaTest`.
- Scala assertion/matcher **stopwords** added to `resolver.go` (`assert`, `assertResult`, `assertTrue`, `shouldBe`, `mustBe`, `shouldEqual`, `must_==`, `assertEquals`, specs2 matchers) so harness identifiers never surface as the tested subject. Duplicates already covered by the Kotlin/Python blocks were omitted.

### Tests (value-asserting)
`extractor_test.go` adds per-framework tests each asserting a **specific** test→target edge and confirming the assertion wrapper is stop-worded:
- FunSuite → `svc.register` | FlatSpec → `s.pop` | FunSpec → `c.add` | specs2 (naming-only) → `OrderService` | MUnit → `p.parse` | ZIO Test → `g.greet` | plus `scalaSubjectFromSpecName` unit table.

### Coverage
Flipped the 9 Scala framework `tests_linkage` cells partial→full, citing `internal/extractors/cross/testmap/frameworks.go`. `gen` + `validate` (exit 0, 0 errors) + `fmt --check` (canonical) all clean.

## Verification
- Full **shared** testmap suite passes — no cross-language regression: `go test ./internal/extractors/cross/testmap/` → `ok`.
- `go test ./internal/types/ ./tools/coverage/` → `ok`.
- `gofmt -l` empty, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)