### PR TITLE
feat(elixir): deep-grind AUTH + MIDDLEWARE extraction to full (#3472)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -37,8 +37,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 2/2 | |
 | [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 1/1 | |
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -32,8 +32,8 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 2/2 | |
 | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 1/1 | |
 | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
 
 
 ### Meta Framework

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | — | — | `internal/engine/rules/elixir/frameworks/phoenix.yaml`<br>`internal/substrate/taint_sites_elixir.go` | Phoenix.Token.verify and Plug.Crypto.MessageVerifier tracked as sanitisers; conn.params sources tracked; Guardian-style pattern in taint sinks |
+| Auth coverage | ✅ `full` | — | — | `internal/custom/elixir/phoenix.go` | Guardian/Pow/custom auth plugs classified by provider+method (jwt/session/token) within pipelines; pipe_through propagates auth classification to bound scopes. Tests assert Guardian.Plug.VerifyHeader -> EnsureAuthenticated chain => provider=guardian method=jwt and pipe_through inheritance. |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/elixir/phoenix.go`<br>`internal/substrate/taint_sites_elixir.go` | Phoenix pipeline/plug declarations extracted by phoenixExtractor; Plug.Conn flow tracked via taint substrate |
+| Middleware coverage | ✅ `full` | — | — | `internal/custom/elixir/phoenix.go` | phoenixExtractor parses pipeline :name do...end blocks into ordered plug chains (plug_chain, plug_order per step) and binds scopes to pipelines via pipe_through [:a,:b]; module + function plugs captured. Tests assert exact :browser chain order + protect_from_forgery index + pipe_through 'api -> auth' binding. |
 
 ### Type System
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -23,7 +23,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | 🟢 `partial` | — | — | `internal/custom/elixir/plug.go`<br>`internal/substrate/taint_sites_elixir.go` | Plug.Crypto.MessageVerifier.verify + Phoenix.Token.verify tracked as sanitisers; conn.params taint sources; plug :authenticate patterns extracted |
+| Auth coverage | ✅ `full` | — | — | `internal/custom/elixir/plug.go` | Guardian/Pow/custom auth plugs in Plug.Builder chains classified by provider+method; test asserts Guardian.Plug.EnsureAuthenticated => provider=guardian method=jwt at order 2. |
 
 ### Validation
 
@@ -36,7 +36,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Middleware coverage | 🟢 `partial` | — | — | `internal/custom/elixir/plug.go` | plug :name / plug Module steps extracted as SCOPE.Pattern/middleware from Plug.Router and Plug.Builder modules |
+| Middleware coverage | ✅ `full` | — | — | `internal/custom/elixir/plug.go` | plugExtractor captures the ordered Plug.Builder/Plug.Router plug chain with plug_order per step (plug :name and plug Module). Test asserts Plug.Logger order 0 within builder chain. |
 
 ### Type System
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10771,9 +10771,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/phoenix.yaml","internal/substrate/taint_sites_elixir.go"],
-            "notes": "Phoenix.Token.verify and Plug.Crypto.MessageVerifier tracked as sanitisers; conn.params sources tracked; Guardian-style pattern in taint sinks"
+            "status": "full",
+            "cites": ["internal/custom/elixir/phoenix.go"],
+            "notes": "Guardian/Pow/custom auth plugs classified by provider+method (jwt/session/token) within pipelines; pipe_through propagates auth classification to bound scopes. Tests assert Guardian.Plug.VerifyHeader -\u003e EnsureAuthenticated chain =\u003e provider=guardian method=jwt and pipe_through inheritance."
           }
         },
         "Validation": {
@@ -10792,9 +10792,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/elixir/phoenix.go","internal/substrate/taint_sites_elixir.go"],
-            "notes": "Phoenix pipeline/plug declarations extracted by phoenixExtractor; Plug.Conn flow tracked via taint substrate"
+            "status": "full",
+            "cites": ["internal/custom/elixir/phoenix.go"],
+            "notes": "phoenixExtractor parses pipeline :name do...end blocks into ordered plug chains (plug_chain, plug_order per step) and binds scopes to pipelines via pipe_through [:a,:b]; module + function plugs captured. Tests assert exact :browser chain order + protect_from_forgery index + pipe_through 'api -\u003e auth' binding."
           }
         },
         "Type System": {
@@ -11189,9 +11189,9 @@
         },
         "Auth": {
           "auth_coverage": {
-            "status": "partial",
-            "cites": ["internal/custom/elixir/plug.go","internal/substrate/taint_sites_elixir.go"],
-            "notes": "Plug.Crypto.MessageVerifier.verify + Phoenix.Token.verify tracked as sanitisers; conn.params taint sources; plug :authenticate patterns extracted"
+            "status": "full",
+            "cites": ["internal/custom/elixir/plug.go"],
+            "notes": "Guardian/Pow/custom auth plugs in Plug.Builder chains classified by provider+method; test asserts Guardian.Plug.EnsureAuthenticated =\u003e provider=guardian method=jwt at order 2."
           }
         },
         "Validation": {
@@ -11210,9 +11210,9 @@
         },
         "Middleware": {
           "middleware_coverage": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/elixir/plug.go"],
-            "notes": "plug :name / plug Module steps extracted as SCOPE.Pattern/middleware from Plug.Router and Plug.Builder modules"
+            "notes": "plugExtractor captures the ordered Plug.Builder/Plug.Router plug chain with plug_order per step (plug :name and plug Module). Test asserts Plug.Logger order 0 within builder chain."
           }
         },
         "Type System": {

--- a/internal/custom/elixir/extractors_test.go
+++ b/internal/custom/elixir/extractors_test.go
@@ -25,12 +25,15 @@ func extract(t *testing.T, name string, file extreg.FileInput) []entitySummary {
 	}
 	var out []entitySummary
 	for _, ent := range ents {
-		out = append(out, entitySummary{Kind: ent.Kind, Subtype: ent.Subtype, Name: ent.Name})
+		out = append(out, entitySummary{Kind: ent.Kind, Subtype: ent.Subtype, Name: ent.Name, Props: ent.Properties})
 	}
 	return out
 }
 
-type entitySummary struct{ Kind, Subtype, Name string }
+type entitySummary struct {
+	Kind, Subtype, Name string
+	Props               map[string]string
+}
 
 func containsEntity(ents []entitySummary, kind, name string) bool {
 	for _, e := range ents {
@@ -39,6 +42,16 @@ func containsEntity(ents []entitySummary, kind, name string) bool {
 		}
 	}
 	return false
+}
+
+// findEntity returns the first entity matching kind+name, or nil.
+func findEntity(ents []entitySummary, kind, name string) *entitySummary {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -106,6 +119,100 @@ end
 	ents := extract(t, "custom_elixir_phoenix", fi("router.ex", "elixir", src))
 	if !containsEntity(ents, "SCOPE.Pattern", "pipeline:api") {
 		t.Error("expected api pipeline pattern")
+	}
+}
+
+// TestPhoenixPipelineOrderedPlugs asserts the exact ordered plug chain is
+// captured on the pipeline entity (not just the pipeline name).
+func TestPhoenixPipelineOrderedPlugs(t *testing.T) {
+	src := `
+pipeline :browser do
+  plug :accepts, ["html"]
+  plug :fetch_session
+  plug :fetch_live_flash
+  plug :protect_from_forgery
+  plug :put_secure_browser_headers
+end
+`
+	ents := extract(t, "custom_elixir_phoenix", fi("router.ex", "elixir", src))
+	pl := findEntity(ents, "SCOPE.Pattern", "pipeline:browser")
+	if pl == nil {
+		t.Fatal("expected pipeline:browser pattern")
+	}
+	if pl.Subtype != "pipeline" {
+		t.Errorf("expected subtype pipeline, got %q", pl.Subtype)
+	}
+	wantChain := ":accepts -> :fetch_session -> :fetch_live_flash -> :protect_from_forgery -> :put_secure_browser_headers"
+	if got := pl.Props["plug_chain"]; got != wantChain {
+		t.Errorf("plug_chain mismatch:\n got  %q\n want %q", got, wantChain)
+	}
+	if got := pl.Props["plug_count"]; got != "5" {
+		t.Errorf("expected plug_count 5, got %q", got)
+	}
+	if pl.Props["auth"] == "true" {
+		t.Error("browser pipeline (no auth plug) must not be flagged auth=true")
+	}
+	// Individual middleware entities carry their order index within the pipeline.
+	psf := findEntity(ents, "SCOPE.Pattern", "plug::protect_from_forgery")
+	if psf == nil {
+		t.Fatal("expected plug::protect_from_forgery middleware")
+	}
+	if got := psf.Props["plug_order"]; got != "3" {
+		t.Errorf("expected protect_from_forgery plug_order 3, got %q", got)
+	}
+	if got := psf.Props["pipeline_name"]; got != "browser" {
+		t.Errorf("expected pipeline_name browser, got %q", got)
+	}
+}
+
+// TestPhoenixGuardianAuthPipeline asserts a Guardian JWT pipeline is detected
+// with the correct provider + auth method, and that pipe_through binding
+// propagates the auth classification.
+func TestPhoenixGuardianAuthPipeline(t *testing.T) {
+	src := `
+pipeline :auth do
+  plug Guardian.Plug.VerifyHeader
+  plug Guardian.Plug.EnsureAuthenticated
+  plug Guardian.Plug.LoadResource
+end
+
+scope "/api", MyAppWeb do
+  pipe_through [:api, :auth]
+  get "/me", UserController, :show
+end
+`
+	ents := extract(t, "custom_elixir_phoenix", fi("router.ex", "elixir", src))
+	pl := findEntity(ents, "SCOPE.Pattern", "pipeline:auth")
+	if pl == nil {
+		t.Fatal("expected pipeline:auth pattern")
+	}
+	if pl.Props["auth"] != "true" {
+		t.Error("expected auth=true on :auth pipeline")
+	}
+	if got := pl.Props["auth_provider"]; got != "guardian" {
+		t.Errorf("expected auth_provider guardian, got %q", got)
+	}
+	if got := pl.Props["auth_method"]; got != "jwt" {
+		t.Errorf("expected auth_method jwt, got %q", got)
+	}
+	if got := pl.Props["auth_plug"]; got != "Guardian.Plug.VerifyHeader" {
+		t.Errorf("expected auth_plug Guardian.Plug.VerifyHeader, got %q", got)
+	}
+	wantChain := "Guardian.Plug.VerifyHeader -> Guardian.Plug.EnsureAuthenticated -> Guardian.Plug.LoadResource"
+	if got := pl.Props["plug_chain"]; got != wantChain {
+		t.Errorf("plug_chain mismatch:\n got  %q\n want %q", got, wantChain)
+	}
+	// pipe_through binding records ordered pipelines + propagates auth.
+	pt := findEntity(ents, "SCOPE.Pattern", "pipe_through:api,auth")
+	if pt == nil {
+		t.Fatal("expected pipe_through:api,auth pattern")
+	}
+	if got := pt.Props["pipelines"]; got != "api -> auth" {
+		t.Errorf("expected pipelines 'api -> auth', got %q", got)
+	}
+	if pt.Props["auth"] != "true" || pt.Props["auth_method"] != "jwt" {
+		t.Errorf("expected pipe_through to inherit jwt auth, got auth=%q method=%q",
+			pt.Props["auth"], pt.Props["auth_method"])
 	}
 }
 

--- a/internal/custom/elixir/phoenix.go
+++ b/internal/custom/elixir/phoenix.go
@@ -3,6 +3,7 @@ package elixir
 import (
 	"context"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -55,7 +56,53 @@ var (
 	rePhoenixControllerAction = regexp.MustCompile(
 		`(?m)def\s+(index|show|new|create|edit|update|delete|action)\s*\(`,
 	)
+	// pipe_through [:browser, :auth] / pipe_through :api
+	rePhoenixPipeThrough = regexp.MustCompile(
+		`(?m)^\s*pipe_through\s+(\[[^\]]*\]|:[a-z_]+)`,
+	)
+	// A plug line inside a pipeline body: plug :name / plug Module / plug Module, opts
+	rePhoenixPlugLine = regexp.MustCompile(
+		`(?m)^\s*plug\s+(:?[\w.]+)`,
+	)
 )
+
+// elixirPipeline holds an ordered list of plug invocations parsed from a
+// Phoenix `pipeline :name do ... end` block.
+type elixirPipeline struct {
+	name  string
+	plugs []string
+	line  int
+}
+
+// authPlugMethod classifies a plug name/module into an auth method.
+// Returns ("", "") when the plug is not auth-related.
+func authPlugMethod(plug string) (provider, method string) {
+	p := strings.TrimPrefix(plug, ":")
+	lower := strings.ToLower(p)
+	switch {
+	case strings.HasPrefix(p, "Guardian.Plug.") || strings.HasPrefix(lower, "guardian"):
+		// Guardian verifies JWTs (header) or session-stored tokens.
+		if strings.Contains(lower, "verifysession") || strings.Contains(lower, "loadsession") {
+			return "guardian", "session"
+		}
+		return "guardian", "jwt"
+	case strings.HasPrefix(p, "Pow.Plug.") || strings.HasPrefix(lower, "pow"):
+		return "pow", "session"
+	case strings.Contains(lower, "ensureauthenticated") || strings.Contains(lower, "verifyheader") || strings.Contains(lower, "verifyissuer"):
+		return "guardian", "jwt"
+	case lower == "authenticate" || lower == "authenticated" || lower == "require_auth" ||
+		lower == "require_authenticated_user" || lower == "ensure_authenticated" ||
+		strings.Contains(lower, "auth"):
+		// Generic custom auth plug; default to session unless name hints at token/jwt.
+		switch {
+		case strings.Contains(lower, "jwt") || strings.Contains(lower, "token") || strings.Contains(lower, "bearer"):
+			return "custom", "token"
+		default:
+			return "custom", "session"
+		}
+	}
+	return "", ""
+}
 
 // phoenixCRUDRoutes are the 8 REST routes for resources.
 var phoenixCRUDRoutes = []struct{ method, suffix string }{
@@ -143,21 +190,93 @@ func (e *phoenixExtractor) Extract(ctx context.Context, file extractor.FileInput
 		add(ent)
 	}
 
-	// 5. pipeline declarations -> SCOPE.Pattern
-	for _, m := range rePhoenixPipeline.FindAllStringSubmatchIndex(src, -1) {
-		name := src[m[2]:m[3]]
-		ent := makeEntity("pipeline:"+name, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "phoenix", "provenance", "INFERRED_FROM_PHOENIX_PIPELINE",
-			"pipeline_name", name)
+	// 5. pipeline declarations -> SCOPE.Pattern (with ordered plug list + auth)
+	pipelines := parsePhoenixPipelines(src)
+	for _, pl := range pipelines {
+		ent := makeEntity("pipeline:"+pl.name, "SCOPE.Pattern", "pipeline", file.Path, file.Language, pl.line)
+		props := []string{
+			"framework", "phoenix",
+			"provenance", "INFERRED_FROM_PHOENIX_PIPELINE",
+			"pipeline_name", pl.name,
+			"plug_chain", strings.Join(pl.plugs, " -> "),
+			"plug_count", itoa(len(pl.plugs)),
+		}
+		// Classify auth: scan the ordered plug list for an auth plug.
+		for _, pg := range pl.plugs {
+			if prov, meth := authPlugMethod(pg); prov != "" {
+				props = append(props,
+					"auth", "true",
+					"auth_plug", pg,
+					"auth_provider", prov,
+					"auth_method", meth)
+				break
+			}
+		}
+		setProps(&ent, props...)
 		add(ent)
 	}
 
-	// 6. plug declarations -> SCOPE.Pattern
+	// 6. plug declarations -> SCOPE.Pattern/middleware (with order within pipeline)
+	for _, pl := range pipelines {
+		for idx, plugName := range pl.plugs {
+			ent := makeEntity("plug:"+plugName, "SCOPE.Pattern", "middleware", file.Path, file.Language, pl.line)
+			props := []string{
+				"framework", "phoenix",
+				"provenance", "INFERRED_FROM_PHOENIX_PLUG",
+				"plug_name", plugName,
+				"pipeline_name", pl.name,
+				"plug_order", itoa(idx),
+			}
+			if prov, meth := authPlugMethod(plugName); prov != "" {
+				props = append(props, "auth", "true", "auth_provider", prov, "auth_method", meth)
+			}
+			setProps(&ent, props...)
+			add(ent)
+		}
+	}
+
+	// 6b. top-level plug declarations (endpoint plugs, not inside a pipeline)
+	//     captured as flat middleware for backward compatibility.
 	for _, m := range rePhoenixPlug.FindAllStringSubmatchIndex(src, -1) {
 		plugName := src[m[2]:m[3]]
-		ent := makeEntity("plug:"+plugName, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "phoenix", "provenance", "INFERRED_FROM_PHOENIX_PLUG",
-			"plug_name", plugName)
+		ent := makeEntity("plug:"+plugName, "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
+		props := []string{
+			"framework", "phoenix",
+			"provenance", "INFERRED_FROM_PHOENIX_PLUG",
+			"plug_name", plugName,
+		}
+		if prov, meth := authPlugMethod(plugName); prov != "" {
+			props = append(props, "auth", "true", "auth_provider", prov, "auth_method", meth)
+		}
+		setProps(&ent, props...)
+		add(ent)
+	}
+
+	// 6c. pipe_through bindings -> record which pipelines a scope applies.
+	for _, m := range rePhoenixPipeThrough.FindAllStringSubmatchIndex(src, -1) {
+		raw := src[m[2]:m[3]]
+		names := parsePipeThroughList(raw)
+		ent := makeEntity("pipe_through:"+strings.Join(names, ","), "SCOPE.Pattern", "pipe_through", file.Path, file.Language, lineOf(src, m[0]))
+		props := []string{
+			"framework", "phoenix",
+			"provenance", "INFERRED_FROM_PHOENIX_PIPE_THROUGH",
+			"pipelines", strings.Join(names, " -> "),
+		}
+		// Cross-reference: does any bound pipeline carry auth?
+		for _, n := range names {
+			for _, pl := range pipelines {
+				if pl.name != n {
+					continue
+				}
+				for _, pg := range pl.plugs {
+					if prov, meth := authPlugMethod(pg); prov != "" {
+						props = append(props, "auth", "true", "auth_provider", prov, "auth_method", meth)
+						break
+					}
+				}
+			}
+		}
+		setProps(&ent, props...)
 		add(ent)
 	}
 
@@ -207,4 +326,70 @@ func (e *phoenixExtractor) Extract(ctx context.Context, file extractor.FileInput
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// parsePhoenixPipelines walks `pipeline :name do ... end` blocks and returns
+// each pipeline with its ordered list of plug invocations. Nesting is shallow
+// in idiomatic router files, so we match `do`/`end` by line scanning from the
+// pipeline header until the matching `end` at the header's indentation.
+func parsePhoenixPipelines(src string) []elixirPipeline {
+	var out []elixirPipeline
+	lines := strings.Split(src, "\n")
+	for i := 0; i < len(lines); i++ {
+		mm := rePhoenixPipeline.FindStringSubmatch(lines[i])
+		if mm == nil {
+			continue
+		}
+		name := mm[1]
+		headerIndent := indentWidth(lines[i])
+		pl := elixirPipeline{name: name, line: i + 1}
+		for j := i + 1; j < len(lines); j++ {
+			ln := lines[j]
+			trimmed := strings.TrimSpace(ln)
+			// Matching `end` at (or below) the header indentation closes the block.
+			if trimmed == "end" && indentWidth(ln) <= headerIndent {
+				break
+			}
+			if pm := rePhoenixPlugLine.FindStringSubmatch(ln); pm != nil {
+				pl.plugs = append(pl.plugs, pm[1])
+			}
+		}
+		out = append(out, pl)
+	}
+	return out
+}
+
+// parsePipeThroughList normalises `pipe_through :api` or
+// `pipe_through [:browser, :auth]` into a slice of bare pipeline names.
+func parsePipeThroughList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "[")
+	raw = strings.TrimSuffix(raw, "]")
+	var names []string
+	for _, part := range strings.Split(raw, ",") {
+		p := strings.TrimSpace(part)
+		p = strings.TrimPrefix(p, ":")
+		if p != "" {
+			names = append(names, p)
+		}
+	}
+	return names
+}
+
+func indentWidth(line string) int {
+	n := 0
+	for _, r := range line {
+		if r == ' ' {
+			n++
+		} else if r == '\t' {
+			n += 4
+		} else {
+			break
+		}
+	}
+	return n
+}
+
+func itoa(n int) string {
+	return strconv.Itoa(n)
 }

--- a/internal/custom/elixir/plug.go
+++ b/internal/custom/elixir/plug.go
@@ -3,6 +3,7 @@ package elixir
 import (
 	"context"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/otel"
@@ -111,11 +112,21 @@ func (e *plugExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 	}
 
 	// 3. plug :name / plug Module  → SCOPE.Pattern/middleware
-	for _, m := range rePlugStep.FindAllStringSubmatchIndex(src, -1) {
+	//    Capture chain order (the Plug.Builder / Plug.Router plug pipeline is
+	//    an ordered list) and classify auth plugs (Guardian / Pow / custom).
+	for order, m := range rePlugStep.FindAllStringSubmatchIndex(src, -1) {
 		plugName := strings.TrimSpace(src[m[2]:m[3]])
 		ent := makeEntity("plug:"+plugName, "SCOPE.Pattern", "middleware", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "plug", "provenance", "INFERRED_FROM_PLUG_STEP",
-			"plug_name", plugName)
+		props := []string{
+			"framework", "plug",
+			"provenance", "INFERRED_FROM_PLUG_STEP",
+			"plug_name", plugName,
+			"plug_order", strconv.Itoa(order),
+		}
+		if prov, meth := authPlugMethod(plugName); prov != "" {
+			props = append(props, "auth", "true", "auth_provider", prov, "auth_method", meth)
+		}
+		setProps(&ent, props...)
 		add(ent)
 	}
 

--- a/internal/custom/elixir/plug_test.go
+++ b/internal/custom/elixir/plug_test.go
@@ -50,6 +50,51 @@ end
 	}
 }
 
+// TestPlugBuilderAuthChain asserts the ordered Plug.Builder plug chain is
+// captured with per-plug order indices and that the Guardian auth plug is
+// classified with the right provider + method.
+func TestPlugBuilderAuthChain(t *testing.T) {
+	src := `
+defmodule MyApp.AuthPipeline do
+  use Plug.Builder
+
+  plug Plug.Logger
+  plug Guardian.Plug.VerifyHeader
+  plug Guardian.Plug.EnsureAuthenticated
+  plug MyApp.LoadCurrentUser
+end
+`
+	ents := extract(t, "custom_elixir_plug", fi("auth_pipeline.ex", "elixir", src))
+
+	logger := findEntity(ents, "SCOPE.Pattern", "plug:Plug.Logger")
+	if logger == nil {
+		t.Fatal("expected plug:Plug.Logger middleware")
+	}
+	if got := logger.Props["plug_order"]; got != "0" {
+		t.Errorf("expected Plug.Logger order 0, got %q", got)
+	}
+	if logger.Props["auth"] == "true" {
+		t.Error("Plug.Logger must not be classified as auth")
+	}
+
+	guard := findEntity(ents, "SCOPE.Pattern", "plug:Guardian.Plug.EnsureAuthenticated")
+	if guard == nil {
+		t.Fatal("expected Guardian.Plug.EnsureAuthenticated middleware")
+	}
+	if got := guard.Props["plug_order"]; got != "2" {
+		t.Errorf("expected EnsureAuthenticated order 2, got %q", got)
+	}
+	if guard.Props["auth"] != "true" {
+		t.Error("expected auth=true on Guardian.Plug.EnsureAuthenticated")
+	}
+	if got := guard.Props["auth_provider"]; got != "guardian" {
+		t.Errorf("expected auth_provider guardian, got %q", got)
+	}
+	if got := guard.Props["auth_method"]; got != "jwt" {
+		t.Errorf("expected auth_method jwt, got %q", got)
+	}
+}
+
 func TestPlugCallImpl(t *testing.T) {
 	src := `
 defmodule MyApp.AuthPlug do


### PR DESCRIPTION
Closes #3472 (epic #3467).

## Disposition: FULL (4 records flipped)

Deep-grinds Elixir **auth_coverage** and **middleware_coverage** for the two flagship frameworks (Phoenix + Plug) to the TS/JS bar.

### Middleware
- `phoenixExtractor` now parses `pipeline :name do ... end` blocks into **ordered plug chains**: the pipeline entity carries `plug_chain` (ordered, joined) + `plug_count`; each middleware step carries `plug_order` + `pipeline_name`.
- `pipe_through [:a, :b]` / `pipe_through :api` bindings captured as `SCOPE.Pattern/pipe_through` with the ordered pipeline list — closes the route→pipeline binding gap.
- `plugExtractor` records `plug_order` per step across `Plug.Builder` / `Plug.Router` plug chains (module + function plugs).

### Auth
- New `authPlugMethod` classifier maps `Guardian.Plug.*` / `Pow.Plug.*` / custom auth plugs to `(provider, method)` where method ∈ `jwt | session | token`.
- Pipeline, middleware and `pipe_through` entities carry `auth` / `auth_provider` / `auth_method` / `auth_plug`; `pipe_through` **inherits** the bound pipeline's auth classification.

### Value-asserting tests (not len>0)
- `TestPhoenixPipelineOrderedPlugs` — exact `:browser` chain order + `protect_from_forgery` index 3 + `plug_count` 5.
- `TestPhoenixGuardianAuthPipeline` — `Guardian.Plug.VerifyHeader -> EnsureAuthenticated -> LoadResource` ⇒ provider=guardian, method=jwt; `pipe_through:api,auth` inherits jwt.
- `TestPlugBuilderAuthChain` — `Plug.Logger` order 0 (not auth), `Guardian.Plug.EnsureAuthenticated` order 2 ⇒ provider=guardian/method=jwt.

### Verification
- `go test ./internal/custom/elixir/ ./internal/types/ ./tools/coverage/` green.
- `gofmt -l` empty, `go vet` clean.
- `coverage validate` 0 errors, `coverage fmt --check` canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)