### PR TITLE
feat(elixir): deep Ecto changeset validation + cast DTO extraction (#3470)

### DIFF
--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/elixir/ecto.go`<br>`internal/substrate/payload_shapes_elixir.go` | Ecto changesets (cast+validate_required) capture DTO field lists; payload shape sniffer collects cast allow-lists as request shapes |
-| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/elixir/ecto.go`<br>`internal/substrate/taint_sites_elixir.go` | Ecto.Changeset validate_required/validate_format/validate_length tracked as sanitisers in taint substrate; changeset extractor emits SCOPE.Operation |
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/elixir/ecto.go`<br>`internal/custom/elixir/ecto_validation.go`<br>`internal/custom/elixir/ecto_validation_test.go` | Deep Ecto cast (DTO) extraction: cast(attrs, [:name, :email, :age]) emits per-field ecto_cast_field:<field> entities (SCOPE.Pattern/dto_extraction) with field + cast_type props, enriched with declared schema field_type. Phoenix request params are validated via Ecto changesets. Value-asserting tests in ecto_validation_test.go assert exact field+type. Closes #3470. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/elixir/ecto.go`<br>`internal/custom/elixir/ecto_validation.go`<br>`internal/custom/elixir/ecto_validation_test.go` | Deep Ecto changeset request_validation: per-field validate_required/validate_format/validate_length/validate_number/validate_inclusion/exclusion/subset/validate_confirmation/validate_acceptance + unique/foreign_key/check_constraint emit ecto_val:<field>:<validator> entities (SCOPE.Pattern/request_validation) capturing exact field + validator + bound/regex (e.g. email format ~r/@/, name length min:1,max:20, age number greater_than:0). Value-asserting tests assert exact field+validation+bound. Closes #3470. |
 
 ### Middleware
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10778,16 +10778,16 @@
         },
         "Validation": {
           "dto_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/elixir/ecto.go","internal/substrate/payload_shapes_elixir.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Ecto changesets (cast+validate_required) capture DTO field lists; payload shape sniffer collects cast allow-lists as request shapes"
+            "status": "full",
+            "cites": ["internal/custom/elixir/ecto.go","internal/custom/elixir/ecto_validation.go","internal/custom/elixir/ecto_validation_test.go"],
+            "notes": "Deep Ecto cast (DTO) extraction: cast(attrs, [:name, :email, :age]) emits per-field ecto_cast_field:\u003cfield\u003e entities (SCOPE.Pattern/dto_extraction) with field + cast_type props, enriched with declared schema field_type. Phoenix request params are validated via Ecto changesets. Value-asserting tests in ecto_validation_test.go assert exact field+type. Closes #3470.",
+            "verified_at": "2026-05-30"
           },
           "request_validation": {
-            "status": "partial",
-            "cites": ["internal/custom/elixir/ecto.go","internal/substrate/taint_sites_elixir.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Ecto.Changeset validate_required/validate_format/validate_length tracked as sanitisers in taint substrate; changeset extractor emits SCOPE.Operation"
+            "status": "full",
+            "cites": ["internal/custom/elixir/ecto.go","internal/custom/elixir/ecto_validation.go","internal/custom/elixir/ecto_validation_test.go"],
+            "notes": "Deep Ecto changeset request_validation: per-field validate_required/validate_format/validate_length/validate_number/validate_inclusion/exclusion/subset/validate_confirmation/validate_acceptance + unique/foreign_key/check_constraint emit ecto_val:\u003cfield\u003e:\u003cvalidator\u003e entities (SCOPE.Pattern/request_validation) capturing exact field + validator + bound/regex (e.g. email format ~r/@/, name length min:1,max:20, age number greater_than:0). Value-asserting tests assert exact field+validation+bound. Closes #3470.",
+            "verified_at": "2026-05-30"
           }
         },
         "Middleware": {

--- a/internal/custom/elixir/ecto.go
+++ b/internal/custom/elixir/ecto.go
@@ -163,6 +163,9 @@ func (e *ectoExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 		add(ent)
 	}
 
+	// 9. Deep cast (DTO) + changeset validation extraction (issue #3470).
+	ectoValDeepExtract(src, file.Path, file.Language, add)
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
 }

--- a/internal/custom/elixir/ecto_validation.go
+++ b/internal/custom/elixir/ecto_validation.go
@@ -1,0 +1,241 @@
+// ecto_validation.go — deep Ecto changeset validation + cast (DTO) extraction.
+//
+// Raises lang.elixir.framework.phoenix Validation/dto_extraction and
+// Validation/request_validation from partial to full (TS/JS bar parity).
+//
+// Part of issue #3470 (epic #3467).
+//
+// In Elixir the request DTO IS the Ecto changeset-cast struct: the cast/3
+// field list enumerates the accepted (permitted) fields, and the chained
+// validate_* / *_constraint calls describe per-field validation rules.
+//
+// Two deep passes, mirroring the Rails deep model (internal/custom/ruby):
+//
+//  1. Per-field cast entities (dto_extraction):
+//     cast(attrs, [:name, :email, :age])
+//     → ecto_cast_field:name  (props: field=name, cast_type=scalar)
+//     → ecto_cast_field:email (props: field=email, cast_type=scalar)
+//     → ecto_cast_field:age   (props: field=age, cast_type=scalar)
+//     The schema `field :name, :string` declarations are used to enrich each
+//     cast field with its declared Ecto type when present (field_type prop).
+//
+//  2. Per-field validation entities (request_validation):
+//     validate_required([:name, :email]) → ecto_val:name:required,
+//     ecto_val:email:required
+//     validate_format(:email, ~r/@/)     → ecto_val:email:format (regex=~r/@/)
+//     validate_length(:name, min: 1, max: 20)
+//     → ecto_val:name:length (bound=min:1,max:20)
+//     validate_number(:age, greater_than: 0)
+//     → ecto_val:age:number (bound=greater_than:0)
+//     validate_inclusion(:role, ["admin","user"])
+//     → ecto_val:role:inclusion (bound=...)
+//     validate_exclusion / validate_subset / validate_confirmation likewise.
+//     unique_constraint(:email)          → ecto_val:email:unique_constraint
+//     foreign_key_constraint(:user_id)   → ecto_val:user_id:foreign_key_constraint
+//     check_constraint(:age, ...)        → ecto_val:age:check_constraint
+//
+// Collision safety: all package-level symbols added here are prefixed
+// ectoVal/reEctoVal to avoid clashing with names in ecto.go.
+package elixir
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+var (
+	// cast(<source>, [:a, :b, :c]) — capture the field-list argument.
+	// Source may be `attrs`, `params`, `%{...}` etc.; we only need the list.
+	reEctoValCast = regexp.MustCompile(
+		`(?ms)\bcast\s*\(\s*[^,]+,\s*\[([^\]]*)\]`,
+	)
+
+	// schema "x" do … field :name, :type … — capture field name + declared type.
+	reEctoValSchemaField = regexp.MustCompile(
+		`(?m)^\s*field\s+:([a-z_][a-zA-Z0-9_]*)\s*,\s*:([a-z_][a-zA-Z0-9_]*)`,
+	)
+
+	// validate_required([:a, :b]) or validate_required(:a) — capture arg blob.
+	reEctoValRequired = regexp.MustCompile(
+		`(?m)\bvalidate_required\s*\(\s*(\[[^\]]*\]|:[a-z_][a-zA-Z0-9_]*)`,
+	)
+
+	// validate_format(:field, ~r/regex/[flags]) — capture field + regex literal.
+	reEctoValFormat = regexp.MustCompile(
+		`(?m)\bvalidate_format\s*\(\s*:([a-z_][a-zA-Z0-9_]*)\s*,\s*(~r/[^/]*/[a-z]*|~r\{[^}]*\}[a-z]*)`,
+	)
+
+	// validate_length(:field, min: 1, max: 20) — capture field + option tail.
+	reEctoValLength = regexp.MustCompile(
+		`(?m)\bvalidate_length\s*\(\s*:([a-z_][a-zA-Z0-9_]*)\s*,\s*([^)]*)\)`,
+	)
+
+	// validate_number(:field, greater_than: 0) — capture field + option tail.
+	reEctoValNumber = regexp.MustCompile(
+		`(?m)\bvalidate_number\s*\(\s*:([a-z_][a-zA-Z0-9_]*)\s*,\s*([^)]*)\)`,
+	)
+
+	// validate_inclusion/exclusion/subset(:field, [...]) — capture kind + field + set.
+	reEctoValSetMember = regexp.MustCompile(
+		`(?m)\bvalidate_(inclusion|exclusion|subset)\s*\(\s*:([a-z_][a-zA-Z0-9_]*)\s*,\s*(\[[^\]]*\]|[A-Za-z_][\w.]*)`,
+	)
+
+	// validate_confirmation(:field) — capture field.
+	reEctoValConfirmation = regexp.MustCompile(
+		`(?m)\bvalidate_confirmation\s*\(\s*:([a-z_][a-zA-Z0-9_]*)`,
+	)
+
+	// validate_acceptance(:field) — capture field.
+	reEctoValAcceptance = regexp.MustCompile(
+		`(?m)\bvalidate_acceptance\s*\(\s*:([a-z_][a-zA-Z0-9_]*)`,
+	)
+
+	// *_constraint(:field[, ...]) — unique/foreign_key/check/exclusion constraints.
+	reEctoValConstraint = regexp.MustCompile(
+		`(?m)\b(unique|foreign_key|check|exclusion|no_assoc|assoc)_constraint\s*\(\s*:([a-z_][a-zA-Z0-9_]*)`,
+	)
+
+	// A bare :symbol (used to split a field list).
+	reEctoValSymbol = regexp.MustCompile(`:([a-z_][a-zA-Z0-9_]*)`)
+)
+
+// ectoValDeepExtract appends deep Ecto cast (DTO) and changeset validation
+// entities to the provided accumulator. It is called from ectoExtractor.Extract
+// after the structural passes so both entity sets coexist.
+func ectoValDeepExtract(src, filePath, language string, add func(types.EntityRecord)) {
+	fieldTypes := ectoValSchemaFieldTypes(src)
+	ectoValParseCast(src, filePath, language, fieldTypes, add)
+	ectoValParseValidations(src, filePath, language, add)
+}
+
+// ectoValSchemaFieldTypes maps schema field name → declared Ecto type, so cast
+// DTO fields can be enriched with their type when the schema is in the same file.
+func ectoValSchemaFieldTypes(src string) map[string]string {
+	out := map[string]string{}
+	for _, m := range reEctoValSchemaField.FindAllStringSubmatch(src, -1) {
+		out[m[1]] = m[2]
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// 1. cast(attrs, [:a, :b]) → per-field DTO entities
+// ---------------------------------------------------------------------------
+
+func ectoValParseCast(src, filePath, language string, fieldTypes map[string]string, add func(types.EntityRecord)) {
+	for _, idx := range reEctoValCast.FindAllStringSubmatchIndex(src, -1) {
+		listBlob := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		for _, fm := range reEctoValSymbol.FindAllStringSubmatch(listBlob, -1) {
+			field := fm[1]
+			name := "ecto_cast_field:" + field
+			ent := makeEntity(name, "SCOPE.Pattern", "dto_extraction", filePath, language, ln)
+			setProps(&ent,
+				"framework", "ecto",
+				"provenance", "DEEP_ECTO_CAST",
+				"signal", "dto",
+				"field", field,
+				"cast_type", "scalar",
+			)
+			if ft, ok := fieldTypes[field]; ok {
+				ent.Properties["field_type"] = ft
+			}
+			add(ent)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. validate_* / *_constraint → per-field validation entities
+// ---------------------------------------------------------------------------
+
+func ectoValParseValidations(src, filePath, language string, add func(types.EntityRecord)) {
+	emit := func(field, validator string, lineNum int, props ...string) {
+		name := "ecto_val:" + field + ":" + validator
+		ent := makeEntity(name, "SCOPE.Pattern", "request_validation", filePath, language, lineNum)
+		setProps(&ent,
+			"framework", "ecto",
+			"provenance", "DEEP_ECTO_VALIDATE",
+			"signal", "validation",
+			"field", field,
+			"validator", validator,
+		)
+		setProps(&ent, props...)
+		add(ent)
+	}
+
+	// validate_required([:a, :b]) / validate_required(:a)
+	for _, idx := range reEctoValRequired.FindAllStringSubmatchIndex(src, -1) {
+		blob := src[idx[2]:idx[3]]
+		lineNum := lineOf(src, idx[0])
+		for _, fm := range reEctoValSymbol.FindAllStringSubmatch(blob, -1) {
+			emit(fm[1], "required", lineNum)
+		}
+	}
+
+	// validate_format(:email, ~r/@/)
+	for _, idx := range reEctoValFormat.FindAllStringSubmatchIndex(src, -1) {
+		field := src[idx[2]:idx[3]]
+		regex := src[idx[4]:idx[5]]
+		emit(field, "format", lineOf(src, idx[0]), "regex", regex)
+	}
+
+	// validate_length(:name, min: 1, max: 20)
+	for _, idx := range reEctoValLength.FindAllStringSubmatchIndex(src, -1) {
+		field := src[idx[2]:idx[3]]
+		bound := ectoValNormalizeOpts(src[idx[4]:idx[5]])
+		emit(field, "length", lineOf(src, idx[0]), "bound", bound)
+	}
+
+	// validate_number(:age, greater_than: 0)
+	for _, idx := range reEctoValNumber.FindAllStringSubmatchIndex(src, -1) {
+		field := src[idx[2]:idx[3]]
+		bound := ectoValNormalizeOpts(src[idx[4]:idx[5]])
+		emit(field, "number", lineOf(src, idx[0]), "bound", bound)
+	}
+
+	// validate_inclusion/exclusion/subset(:role, [...])
+	for _, idx := range reEctoValSetMember.FindAllStringSubmatchIndex(src, -1) {
+		kind := src[idx[2]:idx[3]]
+		field := src[idx[4]:idx[5]]
+		set := strings.TrimSpace(src[idx[6]:idx[7]])
+		emit(field, kind, lineOf(src, idx[0]), "bound", set)
+	}
+
+	// validate_confirmation(:password)
+	for _, idx := range reEctoValConfirmation.FindAllStringSubmatchIndex(src, -1) {
+		emit(src[idx[2]:idx[3]], "confirmation", lineOf(src, idx[0]))
+	}
+
+	// validate_acceptance(:terms)
+	for _, idx := range reEctoValAcceptance.FindAllStringSubmatchIndex(src, -1) {
+		emit(src[idx[2]:idx[3]], "acceptance", lineOf(src, idx[0]))
+	}
+
+	// unique_constraint/foreign_key_constraint/check_constraint(:field)
+	for _, idx := range reEctoValConstraint.FindAllStringSubmatchIndex(src, -1) {
+		kind := src[idx[2]:idx[3]] + "_constraint"
+		field := src[idx[4]:idx[5]]
+		emit(field, kind, lineOf(src, idx[0]))
+	}
+}
+
+// ectoValNormalizeOpts collapses an option tail like " min: 1, max: 20 " into a
+// stable comma-joined "min:1,max:20" form for the bound property.
+func ectoValNormalizeOpts(tail string) string {
+	parts := strings.Split(tail, ",")
+	var out []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// "min: 1" → "min:1"
+		p = strings.ReplaceAll(p, ": ", ":")
+		p = strings.Join(strings.Fields(p), "")
+		out = append(out, p)
+	}
+	return strings.Join(out, ",")
+}

--- a/internal/custom/elixir/ecto_validation_test.go
+++ b/internal/custom/elixir/ecto_validation_test.go
@@ -1,0 +1,176 @@
+package elixir_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/elixir"
+)
+
+// extractFull returns the full EntityRecord set (with Properties) so tests can
+// assert exact field + validator + bound/regex values — the TS/JS bar.
+func extractFull(t *testing.T, name string, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+// findByName returns the first entity with the given Name, or nil.
+func findByName(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// assertProp fails unless entity `name` exists and has property key=want.
+func assertProp(t *testing.T, ents []types.EntityRecord, name, key, want string) {
+	t.Helper()
+	e := findByName(ents, name)
+	if e == nil {
+		t.Fatalf("expected entity %q, not found", name)
+	}
+	got := e.Properties[key]
+	if got != want {
+		t.Errorf("entity %q: prop %q = %q, want %q", name, key, got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ecto deep DTO extraction (cast field list)
+// ---------------------------------------------------------------------------
+
+func TestEctoCastDTOPerField(t *testing.T) {
+	src := `
+defmodule MyApp.Accounts.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "users" do
+    field :name, :string
+    field :email, :string
+    field :age, :integer
+  end
+
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:name, :email, :age])
+    |> validate_required([:name, :email])
+  end
+end
+`
+	ents := extractFull(t, "custom_elixir_ecto", fi("user.ex", "elixir", src))
+
+	// Each cast field becomes its own DTO entity with cast_type + field props.
+	assertProp(t, ents, "ecto_cast_field:name", "field", "name")
+	assertProp(t, ents, "ecto_cast_field:name", "cast_type", "scalar")
+	assertProp(t, ents, "ecto_cast_field:email", "field", "email")
+	assertProp(t, ents, "ecto_cast_field:age", "field", "age")
+
+	// DTO fields are enriched with their declared schema type.
+	assertProp(t, ents, "ecto_cast_field:name", "field_type", "string")
+	assertProp(t, ents, "ecto_cast_field:email", "field_type", "string")
+	assertProp(t, ents, "ecto_cast_field:age", "field_type", "integer")
+
+	// Subtype identifies the DTO capability.
+	if e := findByName(ents, "ecto_cast_field:name"); e == nil || e.Subtype != "dto_extraction" {
+		t.Errorf("ecto_cast_field:name subtype = %v, want dto_extraction", e)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ecto deep request_validation (per-field validate_* + constraints)
+// ---------------------------------------------------------------------------
+
+func TestEctoChangesetValidationsPerField(t *testing.T) {
+	src := `
+defmodule MyApp.Accounts.User do
+  import Ecto.Changeset
+
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:name, :email, :age, :role])
+    |> validate_required([:name, :email])
+    |> validate_format(:email, ~r/@/)
+    |> validate_length(:name, min: 1, max: 20)
+    |> validate_number(:age, greater_than: 0)
+    |> validate_inclusion(:role, ["admin", "user"])
+    |> unique_constraint(:email)
+    |> foreign_key_constraint(:org_id)
+  end
+end
+`
+	ents := extractFull(t, "custom_elixir_ecto", fi("user.ex", "elixir", src))
+
+	// validate_required → one entity per field, validator=required.
+	assertProp(t, ents, "ecto_val:name:required", "validator", "required")
+	assertProp(t, ents, "ecto_val:name:required", "field", "name")
+	assertProp(t, ents, "ecto_val:email:required", "field", "email")
+
+	// validate_format(:email, ~r/@/) — exact regex literal captured.
+	assertProp(t, ents, "ecto_val:email:format", "field", "email")
+	assertProp(t, ents, "ecto_val:email:format", "validator", "format")
+	assertProp(t, ents, "ecto_val:email:format", "regex", "~r/@/")
+
+	// validate_length(:name, min: 1, max: 20) — exact bounds, NOT len>0.
+	assertProp(t, ents, "ecto_val:name:length", "field", "name")
+	assertProp(t, ents, "ecto_val:name:length", "bound", "min:1,max:20")
+
+	// validate_number(:age, greater_than: 0) — exact bound.
+	assertProp(t, ents, "ecto_val:age:number", "field", "age")
+	assertProp(t, ents, "ecto_val:age:number", "bound", "greater_than:0")
+
+	// validate_inclusion(:role, [...]) — set captured.
+	assertProp(t, ents, "ecto_val:role:inclusion", "field", "role")
+	assertProp(t, ents, "ecto_val:role:inclusion", "validator", "inclusion")
+	assertProp(t, ents, "ecto_val:role:inclusion", "bound", `["admin", "user"]`)
+
+	// unique_constraint(:email) → ecto_val:email:unique_constraint.
+	assertProp(t, ents, "ecto_val:email:unique_constraint", "field", "email")
+	assertProp(t, ents, "ecto_val:email:unique_constraint", "validator", "unique_constraint")
+
+	// foreign_key_constraint(:org_id).
+	assertProp(t, ents, "ecto_val:org_id:foreign_key_constraint", "field", "org_id")
+	assertProp(t, ents, "ecto_val:org_id:foreign_key_constraint", "validator", "foreign_key_constraint")
+
+	// Subtype identifies the request_validation capability.
+	if e := findByName(ents, "ecto_val:email:format"); e == nil || e.Subtype != "request_validation" {
+		t.Errorf("ecto_val:email:format subtype = %v, want request_validation", e)
+	}
+}
+
+func TestEctoValidationConfirmationAndSingleArgRequired(t *testing.T) {
+	src := `
+defmodule MyApp.Accounts.User do
+  import Ecto.Changeset
+
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:password, :terms])
+    |> validate_required(:password)
+    |> validate_confirmation(:password)
+    |> validate_acceptance(:terms)
+  end
+end
+`
+	ents := extractFull(t, "custom_elixir_ecto", fi("user.ex", "elixir", src))
+
+	// validate_required with a single bare symbol (not a list).
+	assertProp(t, ents, "ecto_val:password:required", "field", "password")
+	// validate_confirmation(:password).
+	assertProp(t, ents, "ecto_val:password:confirmation", "validator", "confirmation")
+	// validate_acceptance(:terms).
+	assertProp(t, ents, "ecto_val:terms:acceptance", "validator", "acceptance")
+}


### PR DESCRIPTION
Closes #3470 (epic #3467).

## Disposition: full / full (1 record flipped)

Deep-grinds Elixir VALIDATION extraction (Ecto changesets) to the TS/JS bar. In Elixir the request DTO **is** the Ecto changeset-cast struct — the `cast/3` field list enumerates accepted fields, and chained `validate_*` / `*_constraint` calls describe per-field rules.

### Extractor (`internal/custom/elixir/ecto_validation.go`, wired into `ecto.go`)
- **dto_extraction** — `cast(attrs, [:name, :email, :age])` emits per-field `ecto_cast_field:<field>` entities (`SCOPE.Pattern`/`dto_extraction`) with `field` + `cast_type` props, enriched with the declared schema `field_type` when the schema is in-file.
- **request_validation** — per-field `validate_required` / `validate_format` / `validate_length` / `validate_number` / `validate_inclusion|exclusion|subset` / `validate_confirmation` / `validate_acceptance` plus `unique`/`foreign_key`/`check`/`exclusion`/`assoc` constraints emit `ecto_val:<field>:<validator>` entities (`SCOPE.Pattern`/`request_validation`) capturing the exact **field + validator + bound/regex** (e.g. `email` format `~r/@/`, `name` length `min:1,max:20`, `age` number `greater_than:0`, `role` inclusion `["admin", "user"]`).

New package symbols are namespaced `ectoVal`/`reEctoVal`.

### Tests (value-asserting — `ecto_validation_test.go`)
Property-aware helper asserts exact field + validator + bound/regex (NOT len>0): `email` → `format ~r/@/`; `name` → `length min:1,max:20`; `age` → `number greater_than:0`; `unique_constraint`/`foreign_key_constraint` per field; single-arg `validate_required(:password)`; `validate_confirmation`/`validate_acceptance`.

### Registry
`lang.elixir.framework.phoenix` **Validation/dto_extraction** and **Validation/request_validation** flipped `partial → full` (Phoenix request params are validated via Ecto changesets; record already cited `ecto.go`). Updated via `coverage update`, then `gen` + `validate` (0 errors) + `fmt --check` (canonical).

The other 4 Elixir Validation-partial records (absinthe/ash/oban/plug) use distinct mechanisms (`payload_shapes_elixir.go`), not Ecto changesets — left honest-**partial**.

### Verification
- `go test ./internal/custom/elixir/ ./internal/types/ ./tools/coverage/` — pass
- `go vet ./internal/custom/elixir/` clean; `gofmt -l` empty on changed files
- `coverage validate` — 0 errors (the two new `Validation/* full capability has no mapping entry` warnings match the existing rails/laravel `full` cells; the Validation group has no capability-map mappings repo-wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)