### PR TITLE
feat(elixir): deep-grind HTTP routing to full (#3468)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -37,7 +37,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 2/2 | |
 | [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 1/1 | |
 | [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
 | [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -32,7 +32,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 2/2 | |
 | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 1/1 | |
 | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
 | [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
 
 

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml`<br>`internal/engine/rules/graphql/frameworks/absinthe_elixir.yaml` | — |
 | Handler attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/elixir/frameworks/absinthe.yaml` | — |
-| Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/elixir/frameworks/absinthe.yaml` | Absinthe GraphQL types/fields serve as route-equivalents; field resolvers extracted via engine YAML detection markers |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/elixir_routes.go`<br>`internal/engine/elixir_routes_test.go` | synthesizeAbsinthe maps each top-level 'field :name' under an Absinthe query/mutation/subscription block to http:GRAPHQL:/graphql/<Root>/<field> (Strawberry/Apollo convention, #3066), tracking do/end depth so nested object-type fields are excluded. Value-asserting test (TestAbsinthe_Schema proves Query/users, Query/user, Mutation/create_user and excludes nested object fields). |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | — | — | `internal/substrate/entry_points_elixir.go` | Cowboy handler init/handle callbacks recognised as framework_lifecycle entry-points |
 | Handler attribution | 🟢 `partial` | — | — | `internal/substrate/entry_points_elixir.go` | init/2 and handle/2 callbacks recognised as framework_lifecycle; cowboy_handler behaviour tracked via @behaviour |
-| Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/rules/elixir/frameworks/absinthe.yaml` | Cowboy dispatch routes specified as match patterns; detection via engine YAML markers |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/elixir_routes.go`<br>`internal/engine/elixir_routes_test.go` | synthesizeCowboy parses :cowboy_router.compile dispatch tables, emitting an ANY http_endpoint per {"/path", Handler, _} route (:id->{id}), attributed to the handler module; the :_ host wildcard rule is skipped and the gate requires a cowboy_router/cowboy_handler signal. Value-asserting test (TestCowboy_Dispatch proves ANY /, ANY /users/{id}, ANY /ws with handler attribution). |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -35,7 +35,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Route extraction | 🟢 `partial` | — | — | `internal/custom/elixir/phoenix.go`<br>`internal/engine/phoenix_routes.go` | live/1 macro routes extracted as SCOPE.Operation/endpoint with route_type=live; scope context preserved |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/elixir/phoenix.go`<br>`internal/engine/elixir_routes.go`<br>`internal/engine/elixir_routes_test.go`<br>`internal/engine/phoenix_routes.go` | synthesizePhoenixLive emits the initial-GET http_endpoint for each Phoenix LiveView 'live "/path", Module, :action' route, composing the active scope prefix and normalising :id->{id}; live-module :action attributed as handler (route_type=live). Value-asserting tests (TestPhoenixLive_Routes proves GET /dashboard + GET /users/{id} with handler attribution; TestPhoenixLive_NoAction covers the action-less form). |
 | Router pattern | 🟢 `partial` | — | — | `internal/custom/elixir/phoenix.go` | Phoenix scope blocks extracted as SCOPE.Pattern/scope; pipeline declarations as SCOPE.Pattern; live_session not yet separately tracked |
 
 ### Build

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | ✅ `full` | `2026-05-28` | — | `internal/engine/phoenix_routes.go`<br>`internal/engine/rules/elixir/frameworks/phoenix.yaml` | — |
 | Handler attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/phoenix_routes.go` | — |
-| Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/elixir/phoenix.go`<br>`internal/engine/phoenix_routes.go`<br>`internal/engine/rules/elixir/frameworks/phoenix.yaml` | phoenixExtractor extracts HTTP verbs (get/post/put/patch/delete), resources CRUD expansion (8 routes), live routes; scope blocks captured as SCOPE.Pattern |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/phoenix_routes.go`<br>`internal/engine/phoenix_routes_test.go` | synthesizePhoenix emits canonical http_endpoint per get/post/put/patch/delete/head/options verb + resources CRUD expansion (only:/except: filters) with nested scope-prefix composition and :id->{id} normalisation; controller#action attributed via handler_file hint. Value-asserting engine tests (TestPhoenix_VerbInScope/Resources/NestedScope/ControllerHandlerRef) prove exact (verb,path,controller#action). |
 
 ### Auth
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Endpoint synthesis | 🟢 `partial` | — | — | `internal/custom/elixir/plug.go` | use Plug.Router module extracted; match routes synthesised as SCOPE.Operation/endpoint per verb+path |
 | Handler attribution | 🟢 `partial` | — | — | `internal/custom/elixir/plug.go` | def call(conn, opts) implementation captured as SCOPE.Operation/plug_impl per module |
-| Route extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/elixir/plug.go` | plugExtractor extracts get/post/put/patch/delete/match routes from Plug.Router modules; forward/2 captured |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/elixir/plug.go`<br>`internal/custom/elixir/plug_test.go`<br>`internal/engine/elixir_routes.go`<br>`internal/engine/elixir_routes_test.go` | synthesizePlugRouter emits canonical http_endpoint per Plug.Router get/post/put/patch/delete/options/head verb route (:id->{id}) + forward/2 as ANY mount, attributed to the router module; catch-all 'match _' correctly excluded. plugExtractor additionally emits SCOPE.Operation route + middleware/call entities. Value-asserting tests (TestPlugRouter_Verbs proves GET /health, GET /users/{id}, POST /users, DELETE /users/{id}, ANY /admin; TestPlugRouter_NotPlug guards false positives). |
 
 ### Auth
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9497,10 +9497,10 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Absinthe GraphQL types/fields serve as route-equivalents; field resolvers extracted via engine YAML detection markers"
+            "status": "full",
+            "cites": ["internal/engine/elixir_routes.go","internal/engine/elixir_routes_test.go"],
+            "notes": "synthesizeAbsinthe maps each top-level 'field :name' under an Absinthe query/mutation/subscription block to http:GRAPHQL:/graphql/\u003cRoot\u003e/\u003cfield\u003e (Strawberry/Apollo convention, #3066), tracking do/end depth so nested object-type fields are excluded. Value-asserting test (TestAbsinthe_Schema proves Query/users, Query/user, Mutation/create_user and excludes nested object fields).",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -10140,10 +10140,10 @@
             "notes": "init/2 and handle/2 callbacks recognised as framework_lifecycle; cowboy_handler behaviour tracked via @behaviour"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/engine/rules/elixir/frameworks/absinthe.yaml"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Cowboy dispatch routes specified as match patterns; detection via engine YAML markers"
+            "status": "full",
+            "cites": ["internal/engine/elixir_routes.go","internal/engine/elixir_routes_test.go"],
+            "notes": "synthesizeCowboy parses :cowboy_router.compile dispatch tables, emitting an ANY http_endpoint per {\"/path\", Handler, _} route (:id-\u003e{id}), attributed to the handler module; the :_ host wildcard rule is skipped and the gate requires a cowboy_router/cowboy_handler signal. Value-asserting test (TestCowboy_Dispatch proves ANY /, ANY /users/{id}, ANY /ws with handler attribution).",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -10769,10 +10769,10 @@
             "verified_at": "2026-05-28"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/elixir/phoenix.go","internal/engine/phoenix_routes.go","internal/engine/rules/elixir/frameworks/phoenix.yaml"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "phoenixExtractor extracts HTTP verbs (get/post/put/patch/delete), resources CRUD expansion (8 routes), live routes; scope blocks captured as SCOPE.Pattern"
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_synthesis.go","internal/engine/phoenix_routes.go","internal/engine/phoenix_routes_test.go"],
+            "notes": "synthesizePhoenix emits canonical http_endpoint per get/post/put/patch/delete/head/options verb + resources CRUD expansion (only:/except: filters) with nested scope-prefix composition and :id-\u003e{id} normalisation; controller#action attributed via handler_file hint. Value-asserting engine tests (TestPhoenix_VerbInScope/Resources/NestedScope/ControllerHandlerRef) prove exact (verb,path,controller#action).",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {
@@ -11007,9 +11007,10 @@
         },
         "Routing": {
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/elixir/phoenix.go","internal/engine/phoenix_routes.go"],
-            "notes": "live/1 macro routes extracted as SCOPE.Operation/endpoint with route_type=live; scope context preserved"
+            "status": "full",
+            "cites": ["internal/custom/elixir/phoenix.go","internal/engine/elixir_routes.go","internal/engine/elixir_routes_test.go","internal/engine/phoenix_routes.go"],
+            "notes": "synthesizePhoenixLive emits the initial-GET http_endpoint for each Phoenix LiveView 'live \"/path\", Module, :action' route, composing the active scope prefix and normalising :id-\u003e{id}; live-module :action attributed as handler (route_type=live). Value-asserting tests (TestPhoenixLive_Routes proves GET /dashboard + GET /users/{id} with handler attribution; TestPhoenixLive_NoAction covers the action-less form).",
+            "verified_at": "2026-05-30"
           },
           "router_pattern": {
             "status": "partial",
@@ -11192,10 +11193,10 @@
             "notes": "def call(conn, opts) implementation captured as SCOPE.Operation/plug_impl per module"
           },
           "route_extraction": {
-            "status": "partial",
-            "cites": ["internal/custom/elixir/plug.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "plugExtractor extracts get/post/put/patch/delete/match routes from Plug.Router modules; forward/2 captured"
+            "status": "full",
+            "cites": ["internal/custom/elixir/plug.go","internal/custom/elixir/plug_test.go","internal/engine/elixir_routes.go","internal/engine/elixir_routes_test.go"],
+            "notes": "synthesizePlugRouter emits canonical http_endpoint per Plug.Router get/post/put/patch/delete/options/head verb route (:id-\u003e{id}) + forward/2 as ANY mount, attributed to the router module; catch-all 'match _' correctly excluded. plugExtractor additionally emits SCOPE.Operation route + middleware/call entities. Value-asserting tests (TestPlugRouter_Verbs proves GET /health, GET /users/{id}, POST /users, DELETE /users/{id}, ANY /admin; TestPlugRouter_NotPlug guards false positives).",
+            "verified_at": "2026-05-30"
           }
         },
         "Auth": {

--- a/internal/engine/elixir_routes.go
+++ b/internal/engine/elixir_routes.go
@@ -1,0 +1,328 @@
+// elixir_routes.go — deep Elixir HTTP routing synthesis (#3468).
+//
+// Phoenix verb/resources/scope synthesis lives in phoenix_routes.go
+// (synthesizePhoenix, #2692). This file extends Elixir endpoint synthesis to
+// the remaining first-class Elixir HTTP surfaces so they emit canonical
+// `http:<VERB>:<path>` (and `http:GRAPHQL:/...`) synthetics with handler
+// attribution, on par with the TS/JS bar:
+//
+//   - synthesizePhoenixLive  — Phoenix LiveView `live "/path", Module, :action`
+//   - synthesizePlugRouter   — Plug.Router `get|post|... "/path" do ... end`
+//   - synthesizeCowboy       — Cowboy dispatch `{"/path", Handler, []}`
+//   - synthesizeAbsinthe      — Absinthe GraphQL `field :name` under query/mutation/subscription
+//
+// Each is gated on a cheap file-level signal so it is a no-op on unrelated
+// Elixir files, and each asserts a specific (verb, canonical-path) — never a
+// bare length check.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// Phoenix LiveView — `live "/path", PageLive, :action`
+// ---------------------------------------------------------------------------
+//
+// LiveView routes are declared in the Phoenix router with the `live` macro:
+//
+//	scope "/", MyAppWeb do
+//	    live "/dashboard", DashboardLive, :index
+//	    live "/users/:id", UserLive.Show, :show
+//	end
+//
+// A `live` route is reachable over HTTP via an initial GET render (the
+// subsequent state lives over the LiveView WebSocket channel). We synthesise
+// the initial GET endpoint so the route shows up in the HTTP surface, stamping
+// `route_type=live` and attributing the live-module `:action` as the handler.
+//
+// The `:action` atom is optional in the `live` macro; when absent we still
+// emit the GET endpoint with the module basename as the handler hint.
+var exPhoenixLiveRe = regexp.MustCompile(
+	`(?m)^\s*live\s+"([^"\r\n]+)"\s*,\s*([A-Za-z_][\w.]*)` +
+		`(?:\s*,\s*:([A-Za-z_]\w*))?`,
+)
+
+// synthesizePhoenixLive emits the initial-GET endpoint for each `live` route
+// in a Phoenix router file, composing the active `scope` prefix (reusing the
+// Phoenix scope-stack walker).
+func synthesizePhoenixLive(content string, emit phoenixEmitFn) {
+	if !strings.Contains(content, "live ") && !strings.Contains(content, "live\t") {
+		return
+	}
+	for _, m := range exPhoenixLiveRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		raw := content[m[2]:m[3]]
+		modRef := content[m[4]:m[5]]
+		action := ""
+		if m[6] >= 0 {
+			action = content[m[6]:m[7]]
+		}
+		prefix := phoenixScopePrefixAt(content, m[0])
+		full := joinPathFragments(prefix, raw)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkPhoenix, full)
+		if canonical == "" {
+			continue
+		}
+		refName := action
+		if refName == "" {
+			refName = exModuleBasename(modRef)
+		}
+		emit("GET", canonical, "phoenix_live", "SCOPE.Operation", refName, phoenixControllerHint(modRef))
+	}
+}
+
+// exModuleBasename returns the final dotted segment of an Elixir module
+// reference, lower-cased nothing (kept as-is). `MyAppWeb.UserLive.Show` → `Show`.
+func exModuleBasename(modRef string) string {
+	if i := strings.LastIndexByte(modRef, '.'); i >= 0 {
+		return modRef[i+1:]
+	}
+	return modRef
+}
+
+// ---------------------------------------------------------------------------
+// Plug.Router — `get|post|put|patch|delete|options|head "/path" do ... end`
+// ---------------------------------------------------------------------------
+//
+// Plug.Router is the bare-metal routing DSL underneath Phoenix:
+//
+//	defmodule MyApp.Router do
+//	    use Plug.Router
+//	    plug :match
+//	    plug :dispatch
+//
+//	    get "/health", do: send_resp(conn, 200, "ok")
+//	    get "/users/:id" do
+//	        send_resp(conn, 200, ...)
+//	    end
+//	    post "/users", do: ...
+//	    forward "/admin", to: AdminRouter
+//	end
+//
+// Unlike Phoenix, the handler is the inline `do` block, not a controller
+// action, so there is no cross-file handler_file hint — the synthetic is
+// attributed to the router module + verb. Paths use `:name` colon params.
+var (
+	exPlugRouterUseRe = regexp.MustCompile(`(?m)use\s+Plug\.Router\b`)
+	exPlugVerbRe      = regexp.MustCompile(
+		`(?m)^\s*(get|post|put|patch|delete|options|head)\s+"([^"\r\n]+)"`,
+	)
+	exPlugForwardRe = regexp.MustCompile(
+		`(?m)^\s*forward\s+"([^"\r\n]+)"`,
+	)
+	exModuleDeclRe = regexp.MustCompile(`(?m)^\s*defmodule\s+([\w.]+)`)
+)
+
+// synthesizePlugRouter emits one endpoint per verb route in a Plug.Router
+// module. `forward "/prefix", to: Mod` is emitted as an ANY mount so the
+// downstream surface records the delegation point.
+func synthesizePlugRouter(content string, emit emitFn) {
+	if !exPlugRouterUseRe.MatchString(content) {
+		return
+	}
+	router := "PlugRouter"
+	if mm := exModuleDeclRe.FindStringSubmatch(content); len(mm) > 1 {
+		router = mm[1]
+	}
+	for _, m := range exPlugVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkPlug, raw)
+		if canonical == "" {
+			continue
+		}
+		emit(verb, canonical, "plug", "SCOPE.Component", router)
+	}
+	for _, m := range exPlugForwardRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		raw := content[m[2]:m[3]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkPlug, raw)
+		if canonical == "" {
+			continue
+		}
+		emit("ANY", canonical, "plug_forward", "SCOPE.Component", router)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cowboy dispatch — `{"/path", Handler, InitialState}`
+// ---------------------------------------------------------------------------
+//
+// Cowboy is the Erlang HTTP server. Routes are declared as a compiled dispatch
+// table of host/path rules:
+//
+//	dispatch = :cowboy_router.compile([
+//	    {:_, [
+//	        {"/", MyApp.IndexHandler, []},
+//	        {"/users/:id", MyApp.UserHandler, []},
+//	        {"/ws", MyApp.SocketHandler, []}
+//	    ]}
+//	])
+//
+// Each `{"/path", Handler, _}` triple is a route. Cowboy paths use the
+// Phoenix-style `:name` colon binding (and `[...]` optional segments, which we
+// pass through). The HTTP verb is not encoded in the dispatch table (the
+// handler's `init/2` dispatches on `:cowboy_req.method`), so we synthesise an
+// ANY endpoint attributed to the handler module.
+var exCowboyRouteRe = regexp.MustCompile(
+	`(?m)\{\s*"([^"\r\n]+)"\s*,\s*([A-Za-z_][\w.]*)\s*,`,
+)
+
+// synthesizeCowboy emits an ANY endpoint per dispatch-table route, attributed
+// to the handler module. Gated on a `:cowboy_router` / `cowboy_router` signal
+// so plain Elixir tuples elsewhere are not misread as routes.
+func synthesizeCowboy(content string, emit emitFn) {
+	if !strings.Contains(content, "cowboy_router") && !strings.Contains(content, "cowboy_handler") {
+		return
+	}
+	for _, m := range exCowboyRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		raw := content[m[2]:m[3]]
+		handler := content[m[4]:m[5]]
+		// Skip the host wildcard `:_` rule and obviously non-path strings.
+		if raw == "" || !strings.HasPrefix(raw, "/") {
+			continue
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkCowboy, raw)
+		if canonical == "" {
+			continue
+		}
+		emit("ANY", canonical, "cowboy", "SCOPE.Component", handler)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Absinthe GraphQL — `query/mutation/subscription do field :name ... end`
+// ---------------------------------------------------------------------------
+//
+// Absinthe is the Elixir GraphQL toolkit. Schemas are defined with a macro DSL:
+//
+//	defmodule MyAppWeb.Schema do
+//	    use Absinthe.Schema
+//
+//	    query do
+//	        field :users, list_of(:user) do
+//	            resolve &Resolvers.list_users/3
+//	        end
+//	        field :user, :user do
+//	            arg :id, non_null(:id)
+//	            resolve &Resolvers.get_user/3
+//	        end
+//	    end
+//
+//	    mutation do
+//	        field :create_user, :user do
+//	            resolve &Resolvers.create_user/3
+//	        end
+//	    end
+//	end
+//
+// We map each top-level `field :name` under a `query`/`mutation`/`subscription`
+// block to `http:GRAPHQL:/graphql/<Root>/<field>` (Query/Mutation/Subscription),
+// mirroring the Strawberry/Apollo convention (#3066). The resolver reference
+// (when present as `resolve &Mod.fun/3`) is recorded as the handler.
+var (
+	exAbsintheRootRe  = regexp.MustCompile(`^\s*(query|mutation|subscription)\s+do\b`)
+	exAbsintheFieldRe = regexp.MustCompile(`^\s*field\s+:([A-Za-z_]\w*)`)
+)
+
+// exLineOpensBlock reports whether an Elixir source line opens a new `do`
+// block (ends with `do` or `do:`-less trailing `do`). Inline `do:` keyword
+// forms (`field :x, do: ...`) do NOT open a multi-line block.
+func exLineOpensBlock(line string) bool {
+	t := strings.TrimRight(line, " \t\r")
+	if strings.HasSuffix(t, " do") || strings.HasSuffix(t, "\tdo") || t == "do" {
+		return true
+	}
+	return false
+}
+
+// exLineClosesBlock reports whether a line is a bare `end` (closing a block).
+func exLineClosesBlock(line string) bool {
+	t := strings.TrimSpace(line)
+	return t == "end" || strings.HasPrefix(t, "end ") || strings.HasPrefix(t, "end\t")
+}
+
+// absintheRootName maps the block keyword to the GraphQL root type name used
+// in the synthetic path.
+func absintheRootName(block string) string {
+	switch block {
+	case "query":
+		return "Query"
+	case "mutation":
+		return "Mutation"
+	case "subscription":
+		return "Subscription"
+	}
+	if block == "" {
+		return block
+	}
+	return strings.ToUpper(block[:1]) + block[1:]
+}
+
+// synthesizeAbsinthe emits a GraphQL field endpoint per `field :name` declared
+// directly inside a `query`/`mutation`/`subscription` block. Nested field
+// blocks (e.g. object types) are excluded by tracking block depth: only fields
+// at depth 1 (immediately inside the root block) are emitted.
+func synthesizeAbsinthe(content string, emit emitFn) {
+	if !strings.Contains(content, "Absinthe") && !strings.Contains(content, "absinthe") {
+		return
+	}
+	// Single line-oriented scan. We track the current root block (query /
+	// mutation / subscription) and the `do`/`end` nesting depth *inside* it.
+	// A `field :name` at depth 1 (directly in the root body) is an endpoint;
+	// deeper fields belong to nested object/field blocks and are skipped.
+	var curRoot string
+	depth := 0 // do-block depth relative to (and including) the open root block
+
+	for _, line := range strings.Split(content, "\n") {
+		// Root-block opener?
+		if rm := exAbsintheRootRe.FindStringSubmatch(line); rm != nil && curRoot == "" {
+			curRoot = rm[1]
+			depth = 1
+			continue
+		}
+		if curRoot == "" {
+			continue
+		}
+
+		// Field directly in the root body (depth 1) → endpoint. Check before
+		// adjusting depth so a `field :x do` line is attributed at its own
+		// depth, then opens a nested block.
+		if depth == 1 {
+			if fm := exAbsintheFieldRe.FindStringSubmatch(line); fm != nil {
+				fieldName := fm[1]
+				root := absintheRootName(curRoot)
+				path := "/graphql/" + root + "/" + fieldName
+				canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
+				emit("GRAPHQL", canonical, "absinthe", "SCOPE.Operation", root+"."+fieldName)
+			}
+		}
+
+		// Depth bookkeeping. A line can both close and (rarely) open; handle
+		// close first, then open.
+		if exLineClosesBlock(line) {
+			depth--
+			if depth == 0 {
+				curRoot = ""
+			}
+			continue
+		}
+		if exLineOpensBlock(line) {
+			depth++
+		}
+	}
+}

--- a/internal/engine/elixir_routes_test.go
+++ b/internal/engine/elixir_routes_test.go
@@ -1,0 +1,263 @@
+package engine
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Phoenix LiveView — `live "/path", Mod, :action`  (#3468)
+// ---------------------------------------------------------------------------
+
+// TestPhoenixLive_Routes asserts the initial-GET endpoint synthesised for each
+// LiveView route, including scope-prefix composition and :id normalisation.
+func TestPhoenixLive_Routes(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+
+  scope "/", MyAppWeb do
+    live "/dashboard", DashboardLive, :index
+    live "/users/:id", UserLive.Show, :show
+  end
+end
+`
+	ids, res := runDetect(t, "elixir", "router.ex", src)
+	want := []string{
+		"http:GET:/dashboard",
+		"http:GET:/users/{id}",
+	}
+	requireContains(t, ids, want, "phoenix-live-routes")
+
+	// Verify framework + handler attribution on the :id route.
+	var found bool
+	for _, e := range res.Entities {
+		if e.ID != "http:GET:/users/{id}" {
+			continue
+		}
+		found = true
+		if e.Properties["framework"] != "phoenix_live" {
+			t.Errorf("phoenix-live: framework=%q, want phoenix_live", e.Properties["framework"])
+		}
+		if e.Properties["source_handler"] != "SCOPE.Operation:show" {
+			t.Errorf("phoenix-live: source_handler=%q, want SCOPE.Operation:show", e.Properties["source_handler"])
+		}
+		if e.Properties["handler_file"] != "show" {
+			// phoenixControllerHint("UserLive.Show") → snake_case of "Show" = "show"
+			t.Errorf("phoenix-live: handler_file=%q, want show", e.Properties["handler_file"])
+		}
+	}
+	if !found {
+		t.Errorf("phoenix-live: missing http:GET:/users/{id}")
+	}
+}
+
+// TestPhoenixLive_NoAction covers the `live "/path", Mod` form (no :action atom).
+func TestPhoenixLive_NoAction(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use Phoenix.Router
+  scope "/admin", MyAppWeb do
+    live "/panel", AdminLive
+  end
+end
+`
+	ids, _ := runDetect(t, "elixir", "router.ex", src)
+	requireContains(t, ids, []string{"http:GET:/admin/panel"}, "phoenix-live-no-action")
+}
+
+// ---------------------------------------------------------------------------
+// Plug.Router — verb routes + forward  (#3468)
+// ---------------------------------------------------------------------------
+
+// TestPlugRouter_Verbs asserts each verb route from a Plug.Router module,
+// including the :id colon param and the inline `do:` / `do ... end` forms.
+func TestPlugRouter_Verbs(t *testing.T) {
+	src := `
+defmodule MyApp.Router do
+  use Plug.Router
+
+  plug :match
+  plug :dispatch
+
+  get "/health", do: send_resp(conn, 200, "ok")
+  get "/users/:id" do
+    send_resp(conn, 200, "user")
+  end
+  post "/users", do: send_resp(conn, 201, "created")
+  delete "/users/:id", do: send_resp(conn, 204, "")
+  forward "/admin", to: MyApp.Admin.Router
+
+  match _, do: send_resp(conn, 404, "nope")
+end
+`
+	ids, res := runDetect(t, "elixir", "router.ex", src)
+	want := []string{
+		"http:GET:/health",
+		"http:GET:/users/{id}",
+		"http:POST:/users",
+		"http:DELETE:/users/{id}",
+		"http:ANY:/admin",
+	}
+	requireContains(t, ids, want, "plug-router-verbs")
+
+	// `match _` is a catch-all, not a path route — must NOT be emitted.
+	for _, e := range res.Entities {
+		if e.ID == "http:ANY:/_" || e.ID == "http:GET:/_" {
+			t.Errorf("plug-router: catch-all match _ wrongly synthesised as %s", e.ID)
+		}
+	}
+
+	// Verify framework + router-module attribution on a verb route.
+	var found bool
+	for _, e := range res.Entities {
+		if e.ID != "http:POST:/users" {
+			continue
+		}
+		found = true
+		if e.Properties["framework"] != "plug" {
+			t.Errorf("plug-router: framework=%q, want plug", e.Properties["framework"])
+		}
+		if e.Properties["source_handler"] != "SCOPE.Component:MyApp.Router" {
+			t.Errorf("plug-router: source_handler=%q, want SCOPE.Component:MyApp.Router", e.Properties["source_handler"])
+		}
+	}
+	if !found {
+		t.Errorf("plug-router: missing http:POST:/users")
+	}
+}
+
+// TestPlugRouter_NotPhoenix ensures a non-Plug.Router Elixir file produces no
+// Plug endpoints (no false positives from bare verb-like identifiers).
+func TestPlugRouter_NotPlug(t *testing.T) {
+	src := `
+defmodule MyApp.Helper do
+  def get(key), do: Map.get(state(), key)
+  def post(data), do: data
+end
+`
+	ids, _ := runDetect(t, "elixir", "helper.ex", src)
+	for _, id := range ids {
+		if id == "http:GET:/key" || id == "http:POST:/data" {
+			t.Errorf("plug-router: false positive endpoint %s from plain module", id)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cowboy dispatch  (#3468)
+// ---------------------------------------------------------------------------
+
+// TestCowboy_Dispatch asserts an ANY endpoint per dispatch-table route, with
+// :id normalisation and handler attribution, skipping the `:_` host wildcard.
+func TestCowboy_Dispatch(t *testing.T) {
+	src := `
+defmodule MyApp.Server do
+  def dispatch do
+    :cowboy_router.compile([
+      {:_, [
+        {"/", MyApp.IndexHandler, []},
+        {"/users/:id", MyApp.UserHandler, []},
+        {"/ws", MyApp.SocketHandler, []}
+      ]}
+    ])
+  end
+end
+`
+	ids, res := runDetect(t, "elixir", "server.ex", src)
+	want := []string{
+		"http:ANY:/",
+		"http:ANY:/users/{id}",
+		"http:ANY:/ws",
+	}
+	requireContains(t, ids, want, "cowboy-dispatch")
+
+	var found bool
+	for _, e := range res.Entities {
+		if e.ID != "http:ANY:/users/{id}" {
+			continue
+		}
+		found = true
+		if e.Properties["framework"] != "cowboy" {
+			t.Errorf("cowboy: framework=%q, want cowboy", e.Properties["framework"])
+		}
+		if e.Properties["source_handler"] != "SCOPE.Component:MyApp.UserHandler" {
+			t.Errorf("cowboy: source_handler=%q, want SCOPE.Component:MyApp.UserHandler", e.Properties["source_handler"])
+		}
+	}
+	if !found {
+		t.Errorf("cowboy: missing http:ANY:/users/{id}")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Absinthe GraphQL  (#3468)
+// ---------------------------------------------------------------------------
+
+// TestAbsinthe_Schema asserts a GraphQL field endpoint per top-level field in
+// query/mutation blocks, excluding nested object-type fields.
+func TestAbsinthe_Schema(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Schema do
+  use Absinthe.Schema
+
+  object :user do
+    field :name, :string
+    field :email, :string
+  end
+
+  query do
+    field :users, list_of(:user) do
+      resolve &Resolvers.list_users/3
+    end
+
+    field :user, :user do
+      arg :id, non_null(:id)
+      resolve &Resolvers.get_user/3
+    end
+  end
+
+  mutation do
+    field :create_user, :user do
+      resolve &Resolvers.create_user/3
+    end
+  end
+end
+`
+	ids, res := runDetect(t, "elixir", "schema.ex", src)
+	want := []string{
+		"http:GRAPHQL:/graphql/Query/users",
+		"http:GRAPHQL:/graphql/Query/user",
+		"http:GRAPHQL:/graphql/Mutation/create_user",
+	}
+	requireContains(t, ids, want, "absinthe-schema")
+
+	// Nested object-type fields (:name, :email) must NOT become endpoints.
+	for _, bad := range []string{
+		"http:GRAPHQL:/graphql/Query/name",
+		"http:GRAPHQL:/graphql/Query/email",
+		"http:GRAPHQL:/graphql/Mutation/name",
+	} {
+		for _, id := range ids {
+			if id == bad {
+				t.Errorf("absinthe: object-type field wrongly emitted as %s", bad)
+			}
+		}
+	}
+
+	var found bool
+	for _, e := range res.Entities {
+		if e.ID != "http:GRAPHQL:/graphql/Mutation/create_user" {
+			continue
+		}
+		found = true
+		if e.Properties["framework"] != "absinthe" {
+			t.Errorf("absinthe: framework=%q, want absinthe", e.Properties["framework"])
+		}
+		if e.Properties["source_handler"] != "SCOPE.Operation:Mutation.create_user" {
+			t.Errorf("absinthe: source_handler=%q, want SCOPE.Operation:Mutation.create_user", e.Properties["source_handler"])
+		}
+	}
+	if !found {
+		t.Errorf("absinthe: missing http:GRAPHQL:/graphql/Mutation/create_user")
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -766,6 +766,26 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 			}
 			last.Properties["handler_file"] = fileHint
 		})
+		// Producer side (#3468): Phoenix LiveView `live "/path", Mod, :action`
+		// initial-GET endpoints (handler_file hint stamped like verb routes).
+		synthesizePhoenixLive(string(content), func(method, canonicalPath, framework, refKind, refName, fileHint string) {
+			before := len(entities)
+			emit(method, canonicalPath, framework, refKind, refName)
+			if fileHint == "" || len(entities) == before {
+				return
+			}
+			last := &entities[len(entities)-1]
+			if last.Properties == nil {
+				last.Properties = map[string]string{}
+			}
+			last.Properties["handler_file"] = fileHint
+		})
+		// Producer side (#3468): Plug.Router verb routes + forwards.
+		synthesizePlugRouter(string(content), emit)
+		// Producer side (#3468): Cowboy dispatch route tables.
+		synthesizeCowboy(string(content), emit)
+		// Producer side (#3468): Absinthe GraphQL query/mutation/subscription fields.
+		synthesizeAbsinthe(string(content), emit)
 		// Consumer side (#1483): Finch.build(:verb, url) + HTTPoison.<verb>(url).
 		synthesizeElixirHTTPClients(string(content), emitClient)
 	}

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -133,6 +133,16 @@ const (
 	// (dynamic segments come from Scala PathMatcher / segment() calls, not embedded `{name}`).
 	// Canonicalisation is identity + slash normalisation (default case).
 	FrameworkAkkaHTTP = "akka-http"
+	// FrameworkPlug (#3468) — Elixir Plug.Router `get "/users/:id" do ... end`
+	// uses the Express-style `:name` colon-prefixed path parameter convention,
+	// identical to Phoenix. Canonicalisation reuses canonicalizeColonParams.
+	FrameworkPlug = "plug"
+	// FrameworkCowboy (#3468) — Erlang/Elixir Cowboy dispatch route tables
+	// (`{"/users/:id", Handler, []}`) use the Phoenix-style `:name` colon
+	// convention; Cowboy's native `:name` / `[...]` bindings are normalised to
+	// the colon form by the synthesizer before canonicalisation. Reuses
+	// canonicalizeColonParams.
+	FrameworkCowboy = "cowboy"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -181,7 +191,7 @@ func Canonicalize(framework, raw string) string {
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkExpress, FrameworkGin, FrameworkEcho, FrameworkChi, FrameworkPhoenix,
 		FrameworkAdonis, FrameworkMarble, FrameworkPolka, FrameworkRestify, FrameworkSails,
-		FrameworkRobyn:
+		FrameworkRobyn, FrameworkPlug, FrameworkCowboy:
 		out = canonicalizeColonParams(raw)
 	default:
 		// Unknown framework: pass through but still normalise slashes.


### PR DESCRIPTION
Closes #3468 (epic #3467). Deep-grinds Elixir HTTP **route_extraction** to the TS/JS bar.

## What changed
New `internal/engine/elixir_routes.go` extends Elixir endpoint synthesis beyond the existing Phoenix verb/resources synth to every first-class Elixir routing surface. Each emits canonical `http:<VERB>:<path>` (or `http:GRAPHQL:/...`) synthetics with handler attribution and `:id`->`{id}` normalisation, wired into the `case "elixir"` synthesis dispatch:

- **synthesizePhoenixLive** — Phoenix LiveView `live "/path", Mod, :action` initial-GET endpoints, scope-prefix composed, `handler_file`-hinted.
- **synthesizePlugRouter** — Plug.Router `get|post|put|patch|delete|options|head "/path"` verb routes + `forward/2` (ANY mount), attributed to the router module; catch-all `match _` excluded.
- **synthesizeCowboy** — `:cowboy_router.compile` dispatch tables → ANY endpoint per `{"/path", Handler, _}`; `:_` host wildcard skipped; gated on a `cowboy_router`/`cowboy_handler` signal.
- **synthesizeAbsinthe** — Absinthe GraphQL `field :name` under `query`/`mutation`/`subscription` → `http:GRAPHQL:/graphql/<Root>/<field>`, do/end depth-tracked so nested object-type fields are excluded.

New `FrameworkPlug` / `FrameworkCowboy` canonicalisation constants reuse the Phoenix-style colon-param walker.

## Tests (value-asserting, not len>0)
`internal/engine/elixir_routes_test.go` proves exact `(verb, path)` + handler attribution for every surface, plus false-positive guards:
- Phoenix LiveView: `GET /dashboard`, `GET /users/{id}` (handler `:show`), action-less form.
- Plug.Router: `GET /health`, `GET /users/{id}`, `POST /users`, `DELETE /users/{id}`, `ANY /admin`; catch-all + plain-module guards.
- Cowboy: `ANY /`, `ANY /users/{id}`, `ANY /ws` (handler attribution); `:_` skipped.
- Absinthe: `GRAPHQL Query/users`, `Query/user`, `Mutation/create_user`; nested object fields excluded.

## Coverage disposition (route_extraction)
Flipped **partial → full**:
- `lang.elixir.framework.phoenix` (honest-flip; engine synth already value-asserted)
- `lang.elixir.framework.plug` (honest-flip + new engine synth)
- `lang.elixir.framework.phoenix-liveview` (deepened: new engine synth)
- `lang.elixir.framework.cowboy` (deepened: new dispatch-table synth)
- `lang.elixir.framework.absinthe` (deepened: new GraphQL field synth)

Unchanged: `lang.elixir.framework.bandit` stays **not_applicable** (transport adapter — routing belongs to the Plug/Phoenix layer above it).

Registry regenerated via `coverage gen`; `validate` exits 0, `fmt --check` canonical, `gofmt -l` clean on touched files, `go vet` clean. Targeted suites pass: `internal/custom/elixir/ internal/engine/ internal/types/ tools/coverage/ internal/engine/httproutes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)