### PR TITLE
feat(elixir): observability extraction — Logger + :telemetry/Telemetry.Metrics (#3474)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -31,14 +31,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 4/4 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟢 3/3 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 1/1 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 2/2 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 1/1 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 4/4 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 1/1 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
@@ -173,7 +173,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
 | [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟢 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -31,14 +31,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [FastEndpoints](../detail/lang.csharp.framework.fastendpoints.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [NancyFX](../detail/lang.csharp.framework.nancyfx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [ServiceStack](../detail/lang.csharp.framework.servicestack.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
-| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
-| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 1/1 | |
-| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
-| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [elixir](../by-language/elixir.md) | [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [elixir](../by-language/elixir.md) | [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟢 3/3 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [elixir](../by-language/elixir.md) | [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [elixir](../by-language/elixir.md) | [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [elixir](../by-language/elixir.md) | [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 1/1 | |
+| [elixir](../by-language/elixir.md) | [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [elixir](../by-language/elixir.md) | [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [elixir](../by-language/elixir.md) | [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [go](../by-language/go.md) | [Beego](../detail/lang.go.framework.beego.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Buffalo](../detail/lang.go.framework.buffalo.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [go](../by-language/go.md) | [Echo](../detail/lang.go.framework.echo.md) | 🟢 3/3 | ✅ 1/1 | 🟢 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
@@ -173,7 +173,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
 | [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟢 2/2 | 🟢 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 8/8 | |

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 4/4 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟢 3/3 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 1/1 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 2/2 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 1/1 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 4/4 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 1/1 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
 
 
 ## Tools
@@ -50,7 +50,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [ExUnit](../detail/test.exunit.md) | ✅ | — | — | ✅ | |
 | [Hex](../detail/build.hex.md) | 🟢 | — | — | 🟢 | |
 | [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | ✅ | |
-| [StreamData (property tests)](../detail/test.streamdata.md) | ✅ | — | — | ✅ | |
+| [StreamData (property tests)](../detail/test.streamdata.md) | 🔴 | — | — | 🔴 | |
 | [mix.exs](../detail/pkg.mix.md) | — | — | 🔴 | — | |
 
 ## ORMs

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -26,21 +26,21 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
-| [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 4/4 | |
-| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 1/1 | |
-| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
-| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Absinthe (GraphQL)](../detail/lang.elixir.framework.absinthe.md) | 🟢 3/3 | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Ash Framework](../detail/lang.elixir.framework.ash.md) | 🟢 3/3 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [Bandit](../detail/lang.elixir.framework.bandit.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Cowboy](../detail/lang.elixir.framework.cowboy.md) | 🟢 3/3 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 4/4 | |
+| [Nerves (embedded)](../detail/lang.elixir.framework.nerves.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 1/1 | |
+| [Oban (job queue)](../detail/lang.elixir.framework.oban.md) | 🟢 1/1 | — | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [Phoenix](../detail/lang.elixir.framework.phoenix.md) | ✅ 3/3 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Plug](../detail/lang.elixir.framework.plug.md) | 🟢 3/3 | ✅ 1/1 | 🟢 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
 ### Meta Framework
 
 | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 5/5 | |
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 5/5 | |
 
 
 ## Tools
@@ -50,7 +50,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [ExUnit](../detail/test.exunit.md) | ✅ | — | — | ✅ | |
 | [Hex](../detail/build.hex.md) | 🟢 | — | — | 🟢 | |
 | [Mix (mix.exs)](../detail/build.mix.md) | ✅ | — | — | ✅ | |
-| [StreamData (property tests)](../detail/test.streamdata.md) | 🔴 | — | — | 🔴 | |
+| [StreamData (property tests)](../detail/test.streamdata.md) | ✅ | — | — | ✅ | |
 | [mix.exs](../detail/pkg.mix.md) | — | — | 🔴 | — | |
 
 ## ORMs

--- a/docs/coverage/detail/lang.elixir.framework.absinthe.md
+++ b/docs/coverage/detail/lang.elixir.framework.absinthe.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_elixir.go` | Logger.* calls captured via elixir template-pattern sniffer |
-| Metric extraction | — `not_applicable` | — | — | — | :telemetry.execute convention-based; no dedicated Absinthe metric extractor |
-| Trace extraction | — `not_applicable` | — | — | — | OpenTelemetry spans not statically extractable in Absinthe |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.ash.md
+++ b/docs/coverage/detail/lang.elixir.framework.ash.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_elixir.go` | Logger.* literal calls captured |
-| Metric extraction | — `not_applicable` | — | — | — | :telemetry convention; no dedicated extractor |
-| Trace extraction | — `not_applicable` | — | — | — | OpenTelemetry spans not statically extractable |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.bandit.md
+++ b/docs/coverage/detail/lang.elixir.framework.bandit.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_elixir.go` | Logger.* calls captured |
-| Metric extraction | — `not_applicable` | — | — | — | :telemetry convention; no dedicated extractor |
-| Trace extraction | — `not_applicable` | — | — | — | OpenTelemetry spans not statically extractable |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.cowboy.md
+++ b/docs/coverage/detail/lang.elixir.framework.cowboy.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_elixir.go` | Logger.* calls captured |
-| Metric extraction | — `not_applicable` | — | — | — | :telemetry convention; no dedicated extractor |
-| Trace extraction | — `not_applicable` | — | — | — | OpenTelemetry spans not statically extractable |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.nerves.md
+++ b/docs/coverage/detail/lang.elixir.framework.nerves.md
@@ -57,7 +57,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_elixir.go` | Logger.* calls captured |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. |
 | Metric extraction | — `not_applicable` | — | — | — | Nerves metrics are hardware/system telemetry; not statically extractable |
 | Trace extraction | — `not_applicable` | — | — | — | No distributed tracing in Nerves embedded firmware context |
 

--- a/docs/coverage/detail/lang.elixir.framework.oban.md
+++ b/docs/coverage/detail/lang.elixir.framework.oban.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_elixir.go` | Logger.* calls captured |
-| Metric extraction | — `not_applicable` | — | — | — | Oban emits :telemetry events; no dedicated extractor |
-| Trace extraction | — `not_applicable` | — | — | — | OpenTelemetry spans not statically extractable |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.phoenix.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_elixir.go` | Logger.debug/info/warn/error with string literals captured as log_format template patterns via elixir template sniffer |
-| Metric extraction | — `not_applicable` | — | — | — | Telemetry event calls are convention-based (:telemetry.execute/3); no dedicated extractor. Covered at framework level by Phoenix.Telemetry integration. |
-| Trace extraction | — `not_applicable` | — | — | — | OpenTelemetry / :telemetry spans not statically extractable without runtime context. No dedicated elixir trace extractor. |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). |
 
 ### Data
 

--- a/docs/coverage/detail/lang.elixir.framework.plug.md
+++ b/docs/coverage/detail/lang.elixir.framework.plug.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/template_pattern_elixir.go` | Logger.* calls with string literals captured via elixir template-pattern sniffer |
-| Metric extraction | — `not_applicable` | — | — | — | :telemetry.execute convention-based; no dedicated extractor |
-| Trace extraction | — `not_applicable` | — | — | — | OpenTelemetry spans not statically extractable |
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved. |
+| Metric extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum("name") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -> :telemetry.attach handler -> reporter/exporter wiring spans multiple files and is not resolved. |
+| Trace extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3474) | `internal/custom/elixir/observability.go`<br>`internal/custom/elixir/observability_test.go` | :telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file). |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9567,17 +9567,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_elixir.go"],
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Logger.* calls captured via elixir template-pattern sniffer"
+            "notes": "Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "not_applicable",
-            "notes": ":telemetry.execute convention-based; no dedicated Absinthe metric extractor"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "not_applicable",
-            "notes": "OpenTelemetry spans not statically extractable in Absinthe"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -9783,17 +9790,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_elixir.go"],
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Logger.* literal calls captured"
+            "notes": "Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "not_applicable",
-            "notes": ":telemetry convention; no dedicated extractor"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "not_applicable",
-            "notes": "OpenTelemetry spans not statically extractable"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -9992,17 +10006,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_elixir.go"],
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Logger.* calls captured"
+            "notes": "Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "not_applicable",
-            "notes": ":telemetry convention; no dedicated extractor"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "not_applicable",
-            "notes": "OpenTelemetry spans not statically extractable"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -10205,17 +10226,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_elixir.go"],
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Logger.* calls captured"
+            "notes": "Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "not_applicable",
-            "notes": ":telemetry convention; no dedicated extractor"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "not_applicable",
-            "notes": "OpenTelemetry spans not statically extractable"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -10411,9 +10439,10 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_elixir.go"],
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Logger.* calls captured"
+            "notes": "Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
             "status": "not_applicable",
@@ -10621,17 +10650,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_elixir.go"],
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Logger.* calls captured"
+            "notes": "Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "not_applicable",
-            "notes": "Oban emits :telemetry events; no dedicated extractor"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "not_applicable",
-            "notes": "OpenTelemetry spans not statically extractable"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -10839,17 +10875,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_elixir.go"],
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Logger.debug/info/warn/error with string literals captured as log_format template patterns via elixir template sniffer"
+            "notes": "Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "not_applicable",
-            "notes": "Telemetry event calls are convention-based (:telemetry.execute/3); no dedicated extractor. Covered at framework level by Phoenix.Telemetry integration."
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "not_applicable",
-            "notes": "OpenTelemetry / :telemetry spans not statically extractable without runtime context. No dedicated elixir trace extractor."
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -11264,17 +11307,24 @@
         "Observability": {
           "log_extraction": {
             "status": "partial",
-            "cites": ["internal/substrate/template_pattern_elixir.go"],
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Logger.* calls with string literals captured via elixir template-pattern sniffer"
+            "notes": "Logger.debug/info/warning/error(...) statements captured by dedicated observabilityExtractor as SCOPE.Pattern/log_statement with log_level + leading string-literal message; Logger.metadata(...) captured. PARTIAL: logger require/import and message binding not correlated cross-file; interpolated/concatenated message tails not resolved.",
+            "verified_at": "2026-05-30"
           },
           "metric_extraction": {
-            "status": "not_applicable",
-            "notes": ":telemetry.execute convention-based; no dedicated extractor"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.execute([:a,:b],...) event names and Telemetry.Metrics counter/summary/last_value/distribution/sum(\"name\") captured by observabilityExtractor as SCOPE.Pattern/metric (metric_name + telemetry_event) when literal at call site. Value-asserting tests prove exact names. PARTIAL: metric/event name -\u003e :telemetry.attach handler -\u003e reporter/exporter wiring spans multiple files and is not resolved.",
+            "verified_at": "2026-05-30"
           },
           "trace_extraction": {
-            "status": "not_applicable",
-            "notes": "OpenTelemetry spans not statically extractable"
+            "status": "partial",
+            "cites": ["internal/custom/elixir/observability.go","internal/custom/elixir/observability_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3474",
+            "notes": ":telemetry.span([:a,:b],...) event-prefix captured by observabilityExtractor as SCOPE.Pattern/trace_span (span_name + telemetry_event) when literal at call site. Value-asserting test proves exact name. PARTIAL: idiomatic Elixir has no static OTel span/exporter binding; spans are bridged from :telemetry events by a handler attached at runtime (cross-file).",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {

--- a/internal/custom/elixir/ecto_validation_test.go
+++ b/internal/custom/elixir/ecto_validation_test.go
@@ -4,12 +4,10 @@ import (
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/types"
-
-	_ "github.com/cajasmota/archigraph/internal/custom/elixir"
 )
 
-// extractFull returns the full EntityRecord set (with Properties) so tests can
-// assert exact field + validator + bound/regex values — the TS/JS bar.
+// extractFull and assertProp are shared with ecto_test.go (same package);
+// findByName / assertNamedProp below are the name-keyed variants this file uses.
 
 // findByName returns the first entity with the given Name, or nil.
 func findByName(ents []types.EntityRecord, name string) *types.EntityRecord {
@@ -21,8 +19,8 @@ func findByName(ents []types.EntityRecord, name string) *types.EntityRecord {
 	return nil
 }
 
-// assertValProp fails unless entity `name` exists and has property key=want.
-func assertValProp(t *testing.T, ents []types.EntityRecord, name, key, want string) {
+// assertNamedProp fails unless entity `name` exists and has property key=want.
+func assertNamedProp(t *testing.T, ents []types.EntityRecord, name, key, want string) {
 	t.Helper()
 	e := findByName(ents, name)
 	if e == nil {
@@ -60,15 +58,15 @@ end
 	ents := extractFull(t, "custom_elixir_ecto", fi("user.ex", "elixir", src))
 
 	// Each cast field becomes its own DTO entity with cast_type + field props.
-	assertValProp(t, ents, "ecto_cast_field:name", "field", "name")
-	assertValProp(t, ents, "ecto_cast_field:name", "cast_type", "scalar")
-	assertValProp(t, ents, "ecto_cast_field:email", "field", "email")
-	assertValProp(t, ents, "ecto_cast_field:age", "field", "age")
+	assertNamedProp(t, ents, "ecto_cast_field:name", "field", "name")
+	assertNamedProp(t, ents, "ecto_cast_field:name", "cast_type", "scalar")
+	assertNamedProp(t, ents, "ecto_cast_field:email", "field", "email")
+	assertNamedProp(t, ents, "ecto_cast_field:age", "field", "age")
 
 	// DTO fields are enriched with their declared schema type.
-	assertValProp(t, ents, "ecto_cast_field:name", "field_type", "string")
-	assertValProp(t, ents, "ecto_cast_field:email", "field_type", "string")
-	assertValProp(t, ents, "ecto_cast_field:age", "field_type", "integer")
+	assertNamedProp(t, ents, "ecto_cast_field:name", "field_type", "string")
+	assertNamedProp(t, ents, "ecto_cast_field:email", "field_type", "string")
+	assertNamedProp(t, ents, "ecto_cast_field:age", "field_type", "integer")
 
 	// Subtype identifies the DTO capability.
 	if e := findByName(ents, "ecto_cast_field:name"); e == nil || e.Subtype != "dto_extraction" {
@@ -101,35 +99,35 @@ end
 	ents := extractFull(t, "custom_elixir_ecto", fi("user.ex", "elixir", src))
 
 	// validate_required → one entity per field, validator=required.
-	assertValProp(t, ents, "ecto_val:name:required", "validator", "required")
-	assertValProp(t, ents, "ecto_val:name:required", "field", "name")
-	assertValProp(t, ents, "ecto_val:email:required", "field", "email")
+	assertNamedProp(t, ents, "ecto_val:name:required", "validator", "required")
+	assertNamedProp(t, ents, "ecto_val:name:required", "field", "name")
+	assertNamedProp(t, ents, "ecto_val:email:required", "field", "email")
 
 	// validate_format(:email, ~r/@/) — exact regex literal captured.
-	assertValProp(t, ents, "ecto_val:email:format", "field", "email")
-	assertValProp(t, ents, "ecto_val:email:format", "validator", "format")
-	assertValProp(t, ents, "ecto_val:email:format", "regex", "~r/@/")
+	assertNamedProp(t, ents, "ecto_val:email:format", "field", "email")
+	assertNamedProp(t, ents, "ecto_val:email:format", "validator", "format")
+	assertNamedProp(t, ents, "ecto_val:email:format", "regex", "~r/@/")
 
 	// validate_length(:name, min: 1, max: 20) — exact bounds, NOT len>0.
-	assertValProp(t, ents, "ecto_val:name:length", "field", "name")
-	assertValProp(t, ents, "ecto_val:name:length", "bound", "min:1,max:20")
+	assertNamedProp(t, ents, "ecto_val:name:length", "field", "name")
+	assertNamedProp(t, ents, "ecto_val:name:length", "bound", "min:1,max:20")
 
 	// validate_number(:age, greater_than: 0) — exact bound.
-	assertValProp(t, ents, "ecto_val:age:number", "field", "age")
-	assertValProp(t, ents, "ecto_val:age:number", "bound", "greater_than:0")
+	assertNamedProp(t, ents, "ecto_val:age:number", "field", "age")
+	assertNamedProp(t, ents, "ecto_val:age:number", "bound", "greater_than:0")
 
 	// validate_inclusion(:role, [...]) — set captured.
-	assertValProp(t, ents, "ecto_val:role:inclusion", "field", "role")
-	assertValProp(t, ents, "ecto_val:role:inclusion", "validator", "inclusion")
-	assertValProp(t, ents, "ecto_val:role:inclusion", "bound", `["admin", "user"]`)
+	assertNamedProp(t, ents, "ecto_val:role:inclusion", "field", "role")
+	assertNamedProp(t, ents, "ecto_val:role:inclusion", "validator", "inclusion")
+	assertNamedProp(t, ents, "ecto_val:role:inclusion", "bound", `["admin", "user"]`)
 
 	// unique_constraint(:email) → ecto_val:email:unique_constraint.
-	assertValProp(t, ents, "ecto_val:email:unique_constraint", "field", "email")
-	assertValProp(t, ents, "ecto_val:email:unique_constraint", "validator", "unique_constraint")
+	assertNamedProp(t, ents, "ecto_val:email:unique_constraint", "field", "email")
+	assertNamedProp(t, ents, "ecto_val:email:unique_constraint", "validator", "unique_constraint")
 
 	// foreign_key_constraint(:org_id).
-	assertValProp(t, ents, "ecto_val:org_id:foreign_key_constraint", "field", "org_id")
-	assertValProp(t, ents, "ecto_val:org_id:foreign_key_constraint", "validator", "foreign_key_constraint")
+	assertNamedProp(t, ents, "ecto_val:org_id:foreign_key_constraint", "field", "org_id")
+	assertNamedProp(t, ents, "ecto_val:org_id:foreign_key_constraint", "validator", "foreign_key_constraint")
 
 	// Subtype identifies the request_validation capability.
 	if e := findByName(ents, "ecto_val:email:format"); e == nil || e.Subtype != "request_validation" {
@@ -154,9 +152,9 @@ end
 	ents := extractFull(t, "custom_elixir_ecto", fi("user.ex", "elixir", src))
 
 	// validate_required with a single bare symbol (not a list).
-	assertValProp(t, ents, "ecto_val:password:required", "field", "password")
+	assertNamedProp(t, ents, "ecto_val:password:required", "field", "password")
 	// validate_confirmation(:password).
-	assertValProp(t, ents, "ecto_val:password:confirmation", "validator", "confirmation")
+	assertNamedProp(t, ents, "ecto_val:password:confirmation", "validator", "confirmation")
 	// validate_acceptance(:terms).
-	assertValProp(t, ents, "ecto_val:terms:acceptance", "validator", "acceptance")
+	assertNamedProp(t, ents, "ecto_val:terms:acceptance", "validator", "acceptance")
 }

--- a/internal/custom/elixir/observability.go
+++ b/internal/custom/elixir/observability.go
@@ -1,0 +1,246 @@
+package elixir
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Elixir observability custom extractor: structured logging (Logger),
+// metrics + traces via :telemetry and Telemetry.Metrics (#3474, epic #3467).
+//
+// Covers the Observability lane, file-local and regex-based:
+//   - log_extraction: `Logger.debug/info/warn/warning/error(...)` statements
+//     and `Logger.metadata(...)` calls. Emits a SCOPE.Pattern(subtype=
+//     log_statement) per Logger call carrying log_level (+ the message string
+//     literal when present), and a SCOPE.Pattern(subtype=log_metadata) per
+//     Logger.metadata call. Stays PARTIAL: the logger require/import and the
+//     message binding are not correlated across files, and interpolated /
+//     non-literal messages are not resolved.
+//   - metric_extraction: `:telemetry.execute([:a, :b], ...)` event emission and
+//     Telemetry.Metrics reporter definitions —
+//     counter/summary/last_value/distribution/sum("event.name"). Emits a
+//     SCOPE.Pattern(subtype=metric) carrying metric_name + telemetry_event when
+//     the name is a literal at the call site. Stays PARTIAL: the metric/event
+//     name → handler-attach (`:telemetry.attach`) → reporter wiring spans
+//     multiple files and is NOT resolved here.
+//   - trace_extraction: `:telemetry.span([:a, :b], ...)` span emission. Emits a
+//     SCOPE.Pattern(subtype=trace_span) carrying telemetry_event. Stays
+//     PARTIAL: there is no statically-resolvable OpenTelemetry span/exporter
+//     binding in idiomatic Elixir — spans are bridged from :telemetry events by
+//     a separate handler (e.g. OpentelemetryPhoenix) attached at runtime.
+//
+// Reuses the SCOPE.Pattern entity Kind (matching the Java observability
+// extractor and the Plug/Phoenix elixir extractors) so no new entity Kind is
+// registered, per the #2839 "prefer decorating over inventing Kinds"
+// discipline. The observability role is recorded in the entity Subtype.
+
+func init() {
+	extractor.Register("custom_elixir_observability", &observabilityExtractor{})
+}
+
+type observabilityExtractor struct{}
+
+func (e *observabilityExtractor) Language() string { return "custom_elixir_observability" }
+
+var (
+	// obsLoggerStmtRE matches a Logger statement call:
+	//   Logger.info("msg") / Logger.warning("msg") / Logger.error(...) etc.
+	// Group 1 = level. The level set matches the Elixir Logger API
+	// (warn is the legacy alias of warning).
+	obsLoggerStmtRE = regexp.MustCompile(
+		`\bLogger\s*\.\s*(emergency|alert|critical|error|warning|warn|notice|info|debug)\s*\(`)
+
+	// obsLoggerMetadataRE matches `Logger.metadata(...)` calls that attach
+	// structured fields to the logging context.
+	obsLoggerMetadataRE = regexp.MustCompile(
+		`\bLogger\s*\.\s*metadata\s*\(`)
+
+	// obsTelemetryExecuteRE matches a :telemetry.execute call and captures the
+	// event-name atom list literal, e.g.
+	//   :telemetry.execute([:my_app, :request, :stop], measurements, metadata)
+	// Group 1 = the raw bracketed atom list (`:my_app, :request, :stop`).
+	obsTelemetryExecuteRE = regexp.MustCompile(
+		`:telemetry\s*\.\s*execute\s*\(\s*\[([^\]]*)\]`)
+
+	// obsTelemetrySpanRE matches a :telemetry.span call and captures the
+	// event-prefix atom list literal, e.g.
+	//   :telemetry.span([:my_app, :worker], metadata, fn -> ... end)
+	// Group 1 = the raw bracketed atom list.
+	obsTelemetrySpanRE = regexp.MustCompile(
+		`:telemetry\s*\.\s*span\s*\(\s*\[([^\]]*)\]`)
+
+	// obsTelemetryMetricRE matches a Telemetry.Metrics reporter definition:
+	//   counter("phoenix.endpoint.stop.duration")
+	//   summary("my_app.repo.query.total_time", unit: ...)
+	//   last_value("vm.memory.total")
+	//   distribution("http.request.duration")
+	//   sum("my_app.events.count")
+	// Group 1 = metric kind, group 2 = the metric name string literal.
+	obsTelemetryMetricRE = regexp.MustCompile(
+		`\b(counter|summary|last_value|distribution|sum)\s*\(\s*"([^"]*)"`)
+
+	// obsLeadingStringRE pulls a leading double-quoted string argument off the
+	// remainder of a Logger.<level>( call so the message literal can be
+	// recorded when present (interpolated/non-literal messages yield "").
+	obsLeadingStringRE = regexp.MustCompile(`^\s*"((?:[^"\\]|\\.)*)"`)
+)
+
+// obsAtomList normalises a raw bracketed atom list (`:my_app, :request, :stop`)
+// into a dotted event name (`my_app.request.stop`). Non-atom / interpolated
+// entries (e.g. a bare variable) are kept verbatim so the name is honest about
+// what was at the call site. Returns "" when no segment is recoverable.
+func obsAtomList(raw string) string {
+	parts := strings.Split(raw, ",")
+	segs := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		p = strings.TrimPrefix(p, ":")
+		segs = append(segs, p)
+	}
+	return strings.Join(segs, ".")
+}
+
+func (e *observabilityExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/elixir")
+	_, span := tracer.Start(ctx, "indexer.observability_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "observability"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "elixir" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name + ":" +
+			ent.Properties["telemetry_event"] + ":" + ent.Properties["log_level"]
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// --- log_extraction -----------------------------------------------------
+
+	// Logger.<level>(...) statements.
+	for _, m := range obsLoggerStmtRE.FindAllStringSubmatchIndex(src, -1) {
+		level := src[m[2]:m[3]]
+		if level == "warn" {
+			level = "warning" // canonicalise the legacy alias
+		}
+		// Recover a leading string-literal message argument when present.
+		message := ""
+		if sm := obsLeadingStringRE.FindStringSubmatch(src[m[1]:]); sm != nil {
+			message = sm[1]
+		}
+		name := "Logger." + level
+		ent := makeEntity(name, "SCOPE.Pattern", "log_statement", file.Path, file.Language, lineOf(src, m[0]))
+		props := []string{
+			"signal", "log",
+			"provenance", "INFERRED_FROM_OBSERVABILITY_LOG",
+			"library", "elixir_logger",
+			"log_level", level,
+		}
+		if message != "" {
+			props = append(props, "message", message)
+		}
+		setProps(&ent, props...)
+		add(ent)
+	}
+
+	// Logger.metadata(...) calls.
+	for _, m := range obsLoggerMetadataRE.FindAllStringIndex(src, -1) {
+		ent := makeEntity("Logger.metadata", "SCOPE.Pattern", "log_metadata", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"signal", "log",
+			"provenance", "INFERRED_FROM_OBSERVABILITY_LOG",
+			"library", "elixir_logger",
+		)
+		add(ent)
+	}
+
+	// --- metric_extraction --------------------------------------------------
+
+	// :telemetry.execute([:a, :b], ...) event emission.
+	for _, m := range obsTelemetryExecuteRE.FindAllStringSubmatchIndex(src, -1) {
+		event := obsAtomList(src[m[2]:m[3]])
+		if event == "" {
+			continue
+		}
+		ent := makeEntity(event, "SCOPE.Pattern", "metric", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"signal", "metric",
+			"provenance", "INFERRED_FROM_OBSERVABILITY_METRIC",
+			"library", "telemetry",
+			"metric_type", "telemetry_event",
+			"metric_name", event,
+			"telemetry_event", event,
+		)
+		add(ent)
+	}
+
+	// Telemetry.Metrics reporter definitions: counter/summary/last_value/...
+	for _, m := range obsTelemetryMetricRE.FindAllStringSubmatchIndex(src, -1) {
+		metricType := src[m[2]:m[3]]
+		metricName := src[m[4]:m[5]]
+		if metricName == "" {
+			continue
+		}
+		ent := makeEntity(metricName, "SCOPE.Pattern", "metric", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"signal", "metric",
+			"provenance", "INFERRED_FROM_OBSERVABILITY_METRIC",
+			"library", "telemetry_metrics",
+			"metric_type", metricType,
+			"metric_name", metricName,
+			"telemetry_event", metricName,
+		)
+		add(ent)
+	}
+
+	// --- trace_extraction ---------------------------------------------------
+
+	// :telemetry.span([:a, :b], ...) span emission.
+	for _, m := range obsTelemetrySpanRE.FindAllStringSubmatchIndex(src, -1) {
+		event := obsAtomList(src[m[2]:m[3]])
+		if event == "" {
+			continue
+		}
+		ent := makeEntity(event, "SCOPE.Pattern", "trace_span", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"signal", "trace",
+			"provenance", "INFERRED_FROM_OBSERVABILITY_TRACE",
+			"library", "telemetry",
+			"span_kind", "telemetry_span",
+			"span_name", event,
+			"telemetry_event", event,
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/elixir/observability_test.go
+++ b/internal/custom/elixir/observability_test.go
@@ -1,0 +1,192 @@
+package elixir_test
+
+// ---------------------------------------------------------------------------
+// Observability extractor tests (#3474)
+//
+// Value-asserting: the telemetry event/metric names and log levels/messages
+// are checked against the exact literal at the call site. These prove the
+// per-call-site name capture that justifies flipping metric_extraction and
+// trace_extraction from not_applicable -> partial. The cells stay PARTIAL
+// (not full) because handler-attach / reporter / exporter binding spans
+// multiple files and is NOT resolved here.
+// ---------------------------------------------------------------------------
+
+import "testing"
+
+func TestObservabilityLoggerStatements(t *testing.T) {
+	src := `
+defmodule MyApp.Worker do
+  require Logger
+
+  def run do
+    Logger.info("starting worker")
+    Logger.debug("debug detail")
+    Logger.warn("legacy warn alias")
+    Logger.error("boom: " <> reason)
+  end
+end
+`
+	ents := extract(t, "custom_elixir_observability", fi("worker.ex", "elixir", src))
+
+	info := findEntity(ents, "SCOPE.Pattern", "Logger.info")
+	if info == nil {
+		t.Fatal("expected Logger.info log_statement")
+	}
+	if info.Subtype != "log_statement" {
+		t.Errorf("expected subtype log_statement, got %q", info.Subtype)
+	}
+	if got := info.Props["log_level"]; got != "info" {
+		t.Errorf("expected log_level info, got %q", got)
+	}
+	if got := info.Props["message"]; got != "starting worker" {
+		t.Errorf("expected message 'starting worker', got %q", got)
+	}
+	if got := info.Props["signal"]; got != "log" {
+		t.Errorf("expected signal log, got %q", got)
+	}
+
+	// `Logger.warn` is the legacy alias of warning -> canonicalised to warning.
+	if findEntity(ents, "SCOPE.Pattern", "Logger.warning") == nil {
+		t.Error("expected Logger.warn to canonicalise to Logger.warning")
+	}
+
+	// A concatenated message records the leading string-literal segment; the
+	// dynamic tail (<> reason) is not resolved (file-local, no dataflow).
+	err := findEntity(ents, "SCOPE.Pattern", "Logger.error")
+	if err == nil {
+		t.Fatal("expected Logger.error log_statement")
+	}
+	if got := err.Props["message"]; got != "boom: " {
+		t.Errorf("expected leading literal message 'boom: ', got %q", got)
+	}
+	if got := err.Props["log_level"]; got != "error" {
+		t.Errorf("expected log_level error, got %q", got)
+	}
+}
+
+func TestObservabilityLoggerMetadata(t *testing.T) {
+	src := `
+defmodule MyApp.Ctx do
+  require Logger
+  def tag, do: Logger.metadata(request_id: "abc")
+end
+`
+	ents := extract(t, "custom_elixir_observability", fi("ctx.ex", "elixir", src))
+	md := findEntity(ents, "SCOPE.Pattern", "Logger.metadata")
+	if md == nil {
+		t.Fatal("expected Logger.metadata pattern")
+	}
+	if md.Subtype != "log_metadata" {
+		t.Errorf("expected subtype log_metadata, got %q", md.Subtype)
+	}
+}
+
+// TestObservabilityTelemetryExecute proves the exact event-name atom list of a
+// :telemetry.execute call is captured as a dotted metric name at the call site.
+func TestObservabilityTelemetryExecute(t *testing.T) {
+	src := `
+defmodule MyApp.Requests do
+  def stop(measurements, metadata) do
+    :telemetry.execute([:my_app, :request, :stop], measurements, metadata)
+  end
+end
+`
+	ents := extract(t, "custom_elixir_observability", fi("requests.ex", "elixir", src))
+	ev := findEntity(ents, "SCOPE.Pattern", "my_app.request.stop")
+	if ev == nil {
+		t.Fatal("expected my_app.request.stop telemetry metric")
+	}
+	if ev.Subtype != "metric" {
+		t.Errorf("expected subtype metric, got %q", ev.Subtype)
+	}
+	if got := ev.Props["telemetry_event"]; got != "my_app.request.stop" {
+		t.Errorf("expected telemetry_event my_app.request.stop, got %q", got)
+	}
+	if got := ev.Props["metric_type"]; got != "telemetry_event" {
+		t.Errorf("expected metric_type telemetry_event, got %q", got)
+	}
+	if got := ev.Props["library"]; got != "telemetry" {
+		t.Errorf("expected library telemetry, got %q", got)
+	}
+}
+
+// TestObservabilityTelemetryMetrics proves the metric-name string literal of a
+// Telemetry.Metrics reporter definition is captured along with its kind.
+func TestObservabilityTelemetryMetrics(t *testing.T) {
+	src := `
+defmodule MyApp.Telemetry do
+  def metrics do
+    [
+      counter("phoenix.endpoint.stop.duration"),
+      summary("my_app.repo.query.total_time", unit: {:native, :millisecond}),
+      last_value("vm.memory.total")
+    ]
+  end
+end
+`
+	ents := extract(t, "custom_elixir_observability", fi("telemetry.ex", "elixir", src))
+
+	c := findEntity(ents, "SCOPE.Pattern", "phoenix.endpoint.stop.duration")
+	if c == nil {
+		t.Fatal("expected counter metric phoenix.endpoint.stop.duration")
+	}
+	if got := c.Props["metric_type"]; got != "counter" {
+		t.Errorf("expected metric_type counter, got %q", got)
+	}
+	if got := c.Props["library"]; got != "telemetry_metrics" {
+		t.Errorf("expected library telemetry_metrics, got %q", got)
+	}
+
+	s := findEntity(ents, "SCOPE.Pattern", "my_app.repo.query.total_time")
+	if s == nil {
+		t.Fatal("expected summary metric my_app.repo.query.total_time")
+	}
+	if got := s.Props["metric_type"]; got != "summary" {
+		t.Errorf("expected metric_type summary, got %q", got)
+	}
+
+	if lv := findEntity(ents, "SCOPE.Pattern", "vm.memory.total"); lv == nil {
+		t.Error("expected last_value metric vm.memory.total")
+	}
+}
+
+// TestObservabilityTelemetrySpan proves the event-prefix atom list of a
+// :telemetry.span call is captured as a trace_span name at the call site.
+func TestObservabilityTelemetrySpan(t *testing.T) {
+	src := `
+defmodule MyApp.Job do
+  def perform(metadata) do
+    :telemetry.span([:my_app, :worker, :job], metadata, fn ->
+      {do_work(), %{}}
+    end)
+  end
+end
+`
+	ents := extract(t, "custom_elixir_observability", fi("job.ex", "elixir", src))
+	sp := findEntity(ents, "SCOPE.Pattern", "my_app.worker.job")
+	if sp == nil {
+		t.Fatal("expected my_app.worker.job trace_span")
+	}
+	if sp.Subtype != "trace_span" {
+		t.Errorf("expected subtype trace_span, got %q", sp.Subtype)
+	}
+	if got := sp.Props["span_kind"]; got != "telemetry_span" {
+		t.Errorf("expected span_kind telemetry_span, got %q", got)
+	}
+	if got := sp.Props["telemetry_event"]; got != "my_app.worker.job" {
+		t.Errorf("expected telemetry_event my_app.worker.job, got %q", got)
+	}
+	if got := sp.Props["signal"]; got != "trace" {
+		t.Errorf("expected signal trace, got %q", got)
+	}
+}
+
+func TestObservabilityNoMatch(t *testing.T) {
+	src := `defmodule MyApp.Plain do
+  def add(a, b), do: a + b
+end`
+	ents := extract(t, "custom_elixir_observability", fi("plain.ex", "elixir", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
Closes #3474 (epic #3467).

## What
Adds a dedicated Elixir observability extractor (`internal/custom/elixir/observability.go`), registered as `custom_elixir_observability` and auto-dispatched via the `custom_elixir_` prefix. Per-call-site, file-local, regex-based. All entities are `SCOPE.Pattern` (no new entity Kind, per #2839).

Captures:
- **log**: `Logger.debug/info/warning/error(...)` statements (with `log_level` + leading string-literal `message`) and `Logger.metadata(...)`. `warn` canonicalised to `warning`.
- **metric**: `:telemetry.execute([:a, :b], ...)` event-name atom lists (→ dotted `metric_name`/`telemetry_event`) and `Telemetry.Metrics` `counter/summary/last_value/distribution/sum("name")` reporter definitions.
- **trace**: `:telemetry.span([:a, :b], ...)` event prefixes.

Value-asserting tests (`observability_test.go`) prove the **exact** telemetry event names (`my_app.request.stop`, `my_app.worker.job`), metric names (`phoenix.endpoint.stop.duration`, `my_app.repo.query.total_time`), and log levels/messages.

## Honest per-capability verdict
| capability | before | after | rationale |
|---|---|---|---|
| `log_extraction` | partial | **partial** (refreshed) | Logger statements + message literal captured by a dedicated extractor now; logger require/import + message binding still not correlated cross-file; interpolated/concatenated tails unresolved. |
| `metric_extraction` | not_applicable | **partial** | event/metric **name** captured at call site (literal); the name → `:telemetry.attach` handler → reporter/exporter wiring spans multiple files and is NOT resolved. |
| `trace_extraction` | not_applicable | **partial** | `:telemetry.span` event captured at call site; idiomatic Elixir has no static OTel span/exporter binding — spans are bridged from `:telemetry` events by a runtime-attached handler (cross-file). |

Applied to the 7 server-side framework records (phoenix, plug, absinthe, ash, bandit, cowboy, oban). **Nerves** metric/trace kept `not_applicable` (embedded-firmware rationale preserved). No cell flipped to `full` — cross-file dataflow binding stays partial, per the Java/PHP/Rust/Kotlin/Scala precedent.

## Checks
- `go test ./internal/custom/elixir/ ./internal/types/ ./tools/coverage/` — all pass
- `coverage gen` + `validate` (0 errors) + `fmt --check` (canonical) — clean
- `gofmt -l` clean on touched files, `go vet ./internal/custom/elixir/` clean

Rebased onto current `main` (sibling elixir PRs #3470/#3476/#3478/#3481 landed concurrently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)