### PR TITLE
feat(lua): deepen observability — resolve metric & span names (#3486)

### DIFF
--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/observability.go` | Regex extractor covering log_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow. |
-| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/observability.go` | Regex extractor covering metric_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow. |
-| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/observability.go` | Regex extractor covering trace_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow. |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/observability.go` | ngx.log(ngx.LEVEL, ...) captures the log LEVEL (prop level); print/io.write captured as Lapis log call-sites. PARTIAL by design: message text and logger->sink binding need cross-file dataflow not resolved here. |
+| Metric extraction | ✅ `full` | — | — | `internal/custom/lua/observability.go` | prometheus:counter/histogram/gauge("name") capture the metric name from the string literal in-call (prop metric_name); value-asserting tests prove requests_total/request_duration_ms. No cross-file resolution needed. Non-literal names flagged metric_name=<unresolved>. |
+| Trace extraction | ✅ `full` | — | — | `internal/custom/lua/observability.go` | tracer:start_span("name") captures the span name from the string literal in-call (prop span_name); value-asserting test proves the literal. No cross-file resolution needed. |
 
 ### Data
 

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -57,9 +57,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/observability.go` | Regex extractor covering log_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow. |
-| Metric extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/observability.go` | Regex extractor covering metric_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow. |
-| Trace extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/observability.go` | Regex extractor covering trace_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow. |
+| Log extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/observability.go` | ngx.log(ngx.LEVEL, ...) captures the log LEVEL (prop level: ERR/WARN/INFO/DEBUG etc.); resty.logger.socket / print / io.write captured as log call-sites. PARTIAL by design: the log message and the logger->sink binding require cross-file dataflow that this regex extractor does not resolve. |
+| Metric extraction | ✅ `full` | — | — | `internal/custom/lua/observability.go` | prometheus:counter/histogram/gauge("name") capture the metric name from the string literal in-call (prop metric_name); value-asserting tests prove requests_total/request_duration_ms. No cross-file resolution needed. Non-literal names flagged metric_name=<unresolved>. statsd op-types also captured. |
+| Trace extraction | ✅ `full` | — | — | `internal/custom/lua/observability.go` | tracer:start_span("name") and kong.tracing.start_span("name") capture the span name from the string literal in-call (prop span_name); value-asserting test proves handle_request/db.query. No cross-file resolution needed. Non-literal span names fall back to span_op (partial subset). |
 
 ### Data
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -32806,19 +32806,17 @@
             "status": "partial",
             "cites": ["internal/custom/lua/observability.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor covering log_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow."
+            "notes": "ngx.log(ngx.LEVEL, ...) captures the log LEVEL (prop level); print/io.write captured as Lapis log call-sites. PARTIAL by design: message text and logger-\u003esink binding need cross-file dataflow not resolved here."
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/lua/observability.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor covering metric_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow."
+            "notes": "prometheus:counter/histogram/gauge(\"name\") capture the metric name from the string literal in-call (prop metric_name); value-asserting tests prove requests_total/request_duration_ms. No cross-file resolution needed. Non-literal names flagged metric_name=\u003cunresolved\u003e."
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/lua/observability.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor covering trace_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow."
+            "notes": "tracer:start_span(\"name\") captures the span name from the string literal in-call (prop span_name); value-asserting test proves the literal. No cross-file resolution needed."
           }
         },
         "Substrate": {
@@ -33033,19 +33031,17 @@
             "status": "partial",
             "cites": ["internal/custom/lua/observability.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor covering log_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow."
+            "notes": "ngx.log(ngx.LEVEL, ...) captures the log LEVEL (prop level: ERR/WARN/INFO/DEBUG etc.); resty.logger.socket / print / io.write captured as log call-sites. PARTIAL by design: the log message and the logger-\u003esink binding require cross-file dataflow that this regex extractor does not resolve."
           },
           "metric_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/lua/observability.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor covering metric_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow."
+            "notes": "prometheus:counter/histogram/gauge(\"name\") capture the metric name from the string literal in-call (prop metric_name); value-asserting tests prove requests_total/request_duration_ms. No cross-file resolution needed. Non-literal names flagged metric_name=\u003cunresolved\u003e. statsd op-types also captured."
           },
           "trace_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/lua/observability.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor covering trace_extraction: ngx.log/resty.logger (log), resty.prometheus/resty.statsd (metric), opentelemetry/resty.zipkin/kong.tracing (trace). Partial: import+call-site heuristics without cross-file dataflow."
+            "notes": "tracer:start_span(\"name\") and kong.tracing.start_span(\"name\") capture the span name from the string literal in-call (prop span_name); value-asserting test proves handle_request/db.query. No cross-file resolution needed. Non-literal span names fall back to span_op (partial subset)."
           }
         },
         "Substrate": {

--- a/internal/custom/lua/extractors_test.go
+++ b/internal/custom/lua/extractors_test.go
@@ -267,6 +267,66 @@ local metric_latency = prometheus:histogram("request_duration_ms", "Request late
 	if !hasMetric {
 		t.Error("expected prometheus metric entity")
 	}
+
+	// Value-asserting: the specific metric names must be resolved from the literals.
+	names := map[string]string{}
+	for _, r := range got {
+		if n := r.Properties["metric_name"]; n != "" {
+			names[n] = r.Properties["kind"]
+		}
+	}
+	if names["requests_total"] != "counter" {
+		t.Errorf("expected counter metric_name=requests_total, got names=%v", names)
+	}
+	if names["request_duration_ms"] != "histogram" {
+		t.Errorf("expected histogram metric_name=request_duration_ms, got names=%v", names)
+	}
+}
+
+func TestLuaObservabilityMetricNameUnresolved(t *testing.T) {
+	// Non-literal name (variable) must NOT be falsely resolved.
+	src := `
+local prometheus = require("resty.prometheus")
+local name = "dynamic_metric"
+local m = prometheus:gauge(name)
+`
+	e := &luaObservabilityExtractor{}
+	got, err := e.Extract(context.Background(), makeFile("metrics.lua", src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range got {
+		if r.Properties["kind"] == "gauge" {
+			if r.Properties["metric_name"] != "<unresolved>" {
+				t.Errorf("expected unresolved gauge name, got %q", r.Properties["metric_name"])
+			}
+		}
+	}
+}
+
+func TestLuaObservabilityTraceSpanName(t *testing.T) {
+	src := `
+local span = tracer:start_span("handle_request")
+kong.tracing.start_span("db.query")
+span:set_attribute("http.status", 200)
+`
+	e := &luaObservabilityExtractor{}
+	got, err := e.Extract(context.Background(), makeFile("trace.lua", src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spanNames := map[string]bool{}
+	for _, r := range got {
+		if n := r.Properties["span_name"]; n != "" {
+			spanNames[n] = true
+		}
+	}
+	if !spanNames["handle_request"] {
+		t.Errorf("expected otel span_name=handle_request, got %v", spanNames)
+	}
+	if !spanNames["db.query"] {
+		t.Errorf("expected kong span_name=db.query, got %v", spanNames)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/custom/lua/observability.go
+++ b/internal/custom/lua/observability.go
@@ -18,7 +18,13 @@
 //	  - Jaeger: require("resty.jaeger")
 //	  - Kong tracing: kong.tracing.start_span / span:set_attribute
 //
-// All cells are partial: import + call-site heuristics, no cross-file dataflow.
+// Name resolution:
+//   - metric_extraction: prometheus:counter("name")/:histogram/:gauge capture the
+//     metric name when it is a string literal in the same call (prop "metric_name").
+//   - trace_extraction: tracer:start_span("name") and kong.tracing.start_span("name")
+//     capture the span name when it is a string literal (prop "span_name").
+//   - log_extraction stays heuristic: level is captured, but the log message and the
+//     logger↔sink binding require cross-file dataflow that this extractor does not do.
 package lua
 
 import (
@@ -64,8 +70,14 @@ var (
 	reLuaPrometheusRequire = regexp.MustCompile(
 		`(?m)\brequire\s*[("']resty\.prometheus["']?\)?`)
 
-	// prometheus:counter / prometheus:histogram / prometheus:gauge
+	// prometheus:counter("name") / prometheus:histogram("name") / prometheus:gauge("name")
+	// Capture group 1 = metric type, group 2 = quoted metric name (string literal).
 	reLuaPrometheusOp = regexp.MustCompile(
+		`(?m)\bprometheus\s*:\s*(counter|histogram|gauge|summary)\s*\(\s*["']([A-Za-z_][A-Za-z0-9_:]*)["']`)
+
+	// Fallback: prometheus:counter(...) where the name is not a plain string literal
+	// (variable / concatenation). Type captured, name unresolved → partial.
+	reLuaPrometheusOpNoName = regexp.MustCompile(
 		`(?m)\bprometheus\s*:\s*(counter|histogram|gauge|summary)\s*\(`)
 
 	// require("resty.statsd") or statsd-related patterns
@@ -82,11 +94,22 @@ var (
 	reLuaOTelRequire = regexp.MustCompile(
 		`(?m)\brequire\s*[("']opentelemetry(?:\.[a-z._]+)?["']?\)?`)
 
-	// OpenTelemetry span operations
+	// OpenTelemetry / generic span start with a quoted span name literal:
+	//   tracer:start_span("name")  /  tracer.start_span("name")
+	// Capture group 1 = span name (string literal).
+	reLuaSpanStartName = regexp.MustCompile(
+		`(?m)\b(?:tracer|span)\s*[.:]\s*start_span\s*\(\s*["']([^"']+)["']`)
+
+	// OpenTelemetry span operations (no resolvable name — set_attribute/end/etc., or
+	// start_span with a non-literal name argument).
 	reLuaOTelSpan = regexp.MustCompile(
 		`(?m)\b(?:tracer|span)\s*[.:]\s*(?:start_span|set_attribute|end_span|record_error|add_event)\s*\(`)
 
-	// Kong tracing: kong.tracing.start_span
+	// Kong tracing with a quoted span name: kong.tracing.start_span("name")
+	reLuaKongSpanName = regexp.MustCompile(
+		`(?m)\bkong\.tracing\s*\.\s*(?:start_span|new_span)\s*\(\s*["']([^"']+)["']`)
+
+	// Kong tracing: kong.tracing.start_span (no resolvable literal name)
 	reLuaKongTracing = regexp.MustCompile(
 		`(?m)\bkong\.tracing\s*\.\s*(?:start_span|new_span)\s*\(`)
 
@@ -147,11 +170,27 @@ func (e *luaObservabilityExtractor) Extract(_ context.Context, file extractor.Fi
 		out = append(out, entity)
 	}
 
+	// Named prometheus metrics: prometheus:counter("requests_total", ...) — name resolved.
+	namedPromOffsets := make(map[int]bool)
 	for _, idx := range reLuaPrometheusOp.FindAllStringSubmatchIndex(src, -1) {
+		metricType := src[idx[2]:idx[3]]
+		metricName := src[idx[4]:idx[5]]
+		namedPromOffsets[idx[0]] = true
+		ln := lineOf(src, idx[0])
+		entity := makeEntity("prometheus_"+metricType+":"+metricName, string(types.EntityKindPattern), "metric_call", file.Path, "lua", ln)
+		setProps(&entity, "signal", "observability", "library", "resty.prometheus", "kind", metricType, "metric_name", metricName)
+		out = append(out, entity)
+	}
+
+	// Unnamed prometheus metrics (variable / concatenated name) — type only, partial.
+	for _, idx := range reLuaPrometheusOpNoName.FindAllStringSubmatchIndex(src, -1) {
+		if namedPromOffsets[idx[0]] {
+			continue
+		}
 		metricType := src[idx[2]:idx[3]]
 		ln := lineOf(src, idx[0])
 		entity := makeEntity("prometheus_"+metricType, string(types.EntityKindPattern), "metric_call", file.Path, "lua", ln)
-		setProps(&entity, "signal", "observability", "library", "resty.prometheus", "kind", metricType)
+		setProps(&entity, "signal", "observability", "library", "resty.prometheus", "kind", metricType, "metric_name", "<unresolved>")
 		out = append(out, entity)
 	}
 
@@ -181,14 +220,39 @@ func (e *luaObservabilityExtractor) Extract(_ context.Context, file extractor.Fi
 		out = append(out, entity)
 	}
 
+	// Named span starts: tracer:start_span("operation") — span name resolved.
+	namedSpanOffsets := make(map[int]bool)
+	for _, idx := range reLuaSpanStartName.FindAllStringSubmatchIndex(src, -1) {
+		spanName := src[idx[2]:idx[3]]
+		namedSpanOffsets[idx[0]] = true
+		ln := lineOf(src, idx[0])
+		entity := makeEntity("otel_span:"+spanName, string(types.EntityKindPattern), "trace_call", file.Path, "lua", ln)
+		setProps(&entity, "signal", "observability", "library", "opentelemetry", "kind", "start_span", "span_name", spanName)
+		out = append(out, entity)
+	}
+
+	// Other span ops (set_attribute/end/etc.) or start_span with a non-literal name.
 	for _, idx := range reLuaOTelSpan.FindAllStringIndex(src, -1) {
+		if namedSpanOffsets[idx[0]] {
+			continue
+		}
 		ln := lineOf(src, idx[0])
 		entity := makeEntity("otel_span_op", string(types.EntityKindPattern), "trace_call", file.Path, "lua", ln)
 		setProps(&entity, "signal", "observability", "library", "opentelemetry", "kind", "span_op")
 		out = append(out, entity)
 	}
 
-	if reLuaKongTracing.MatchString(src) {
+	// Named Kong spans: kong.tracing.start_span("name") — name resolved.
+	for _, idx := range reLuaKongSpanName.FindAllStringSubmatchIndex(src, -1) {
+		spanName := src[idx[2]:idx[3]]
+		ln := lineOf(src, idx[0])
+		entity := makeEntity("kong_span:"+spanName, string(types.EntityKindPattern), "trace_call", file.Path, "lua", ln)
+		setProps(&entity, "signal", "observability", "framework", "kong", "kind", "kong_tracing", "span_name", spanName)
+		out = append(out, entity)
+	}
+
+	// Kong tracing without a resolvable literal span name.
+	if reLuaKongTracing.MatchString(src) && !reLuaKongSpanName.MatchString(src) {
 		idx := reLuaKongTracing.FindStringIndex(src)
 		ln := lineOf(src, idx[0])
 		entity := makeEntity("kong_tracing_span", string(types.EntityKindPattern), "trace_call", file.Path, "lua", ln)


### PR DESCRIPTION
Closes #3486 (epic #3483).

Deepens the Lua OpenResty/Lapis Observability lane in `internal/custom/lua/observability.go` by resolving **specific names** from string-literal call arguments, and re-grades the registry honestly.

## Per-capability verdict (lang.lua.framework.{openresty,lapis})

| Capability | Before | After | Why |
|---|---|---|---|
| `metric_extraction` | partial | **full** | `prometheus:counter/histogram/gauge("name")` captures the metric name from the in-call string literal (`metric_name` prop). Value-asserting test proves `requests_total` (counter) + `request_duration_ms` (histogram). No cross-file resolution needed. |
| `trace_extraction` | partial | **full** | `tracer:start_span("name")` + `kong.tracing.start_span("name")` capture the span name (`span_name` prop). Value-asserting test proves `handle_request` (otel) + `db.query` (kong). No cross-file resolution needed. |
| `log_extraction` | partial | **partial** (honest) | `ngx.log(ngx.LEVEL, …)` captures the **level**, but the message text and the logger→sink binding need cross-file dataflow this regex extractor does not do. Notes updated; kept partial by design. |

## Honest-partial discipline
- Non-literal metric names degrade to `metric_name=<unresolved>` (test `TestLuaObservabilityMetricNameUnresolved`) — no false-resolution.
- Non-literal span names fall back to the generic `span_op` cell.
- `log_extraction` deliberately not flipped.

## Validation
- `go test ./internal/custom/lua/ ./internal/types/ ./tools/coverage/` — pass (3 new value-asserting tests).
- `gofmt -l` on changed Go files: clean. `go vet ./internal/custom/lua/`: clean.
- `coverage gen` + `validate` (0 errors) + `fmt --check` (registry canonical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)