### PR TITLE
feat(lua): deep VALIDATION + TESTING linkage (busted/luaunit, assert_valid field+rule)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -66,8 +66,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 8/8 | |
-| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 18/18 | 🟢 6/6 | |
-| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟢 3/3 | 🟢 1/1 | — | 🟢 1/1 | 🟢 18/18 | 🟢 6/6 | |
+| [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | 🟢 3/3 | 🟢 1/1 | — | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |
+| [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟢 3/3 | 🟢 1/1 | — | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-language/lua.md
+++ b/docs/coverage/by-language/lua.md
@@ -26,5 +26,5 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [Lapis](../detail/lang.lua.framework.lapis.md) | 🟢 3/3 | 🟢 1/1 | 🟢 1/1 | 🟢 18/18 | 🟢 6/6 | |
-| [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟢 3/3 | 🟢 1/1 | 🟢 1/1 | 🟢 18/18 | 🟢 6/6 | |
+| [Lapis](../detail/lang.lua.framework.lapis.md) | 🟢 3/3 | 🟢 1/1 | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |
+| [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟢 3/3 | 🟢 1/1 | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |

--- a/docs/coverage/detail/lang.lua.framework.lapis.md
+++ b/docs/coverage/detail/lang.lua.framework.lapis.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/validation.go` | Regex extractor for ngx.req.get_post/uri_args, cjson.decode DTOs, lapis.validate/check_params/capture_errors, and resty.jsonschema schema validation. |
-| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/validation.go` | Regex extractor for ngx.req.get_post/uri_args, cjson.decode DTOs, lapis.validate/check_params/capture_errors, and resty.jsonschema schema validation. |
+| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/validation.go` | Captures Lapis params.<field> access and assert_valid field tuples (field name per tuple) plus cjson.decode DTO ingestion. Partial: no cross-file dataflow or type binding — the DTO's full shape/types are not resolved, only per-call-site field names. |
+| Request validation | ✅ `full` | — | — | `internal/custom/lua/validation.go` | Lapis assert_valid/validate.validate(self.params, { {"field", exists=true, min_length=3, matches_pattern=...} }) is walked per-tuple to emit one request_validation entity per (field, rule) pair capturing the SPECIFIC field name and validation rule; lapis.csrf / csrf.validate_token / @csrf emits a csrf_token entity. Also covers lapis.validate import + check_params/capture_errors signals. |
 
 ### Middleware
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/testing.go` | Regex extractor for busted describe/it/hooks/assertions/spies, luaunit testXxx methods, lapis.spec integration test patterns, and Kong spec.helpers. Partial: full TESTS-edge linkage requires multi-hop HTTP engine pass. |
+| Tests linkage | ✅ `full` | — | — | `internal/custom/lua/testing.go`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks_lua.go`<br>`internal/extractors/cross/testmap/resolver.go` | busted (describe/it) + luaunit (TestClass:testXxx) registered in the shared testmap extractor: each test case emits a TESTS edge to the production symbol via direct-call resolution (high), describe-subject / Test<Subject> class fallback (medium), and *_spec.lua/*_test.lua naming convention (low). Lua block-body extractor balances function/if/do...end (quote+long-bracket aware); busted/luaunit assertion DSL stop-worded. custom/lua/testing.go still surfaces standalone test-pattern nodes. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.lua.framework.openresty.md
+++ b/docs/coverage/detail/lang.lua.framework.openresty.md
@@ -29,8 +29,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/validation.go` | Regex extractor for ngx.req.get_post/uri_args, ngx.req.read_body, cjson.decode, ngx.exit(400) guards, and resty.jsonschema schema validation. |
-| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/validation.go` | Regex extractor for ngx.req.get_post/uri_args, ngx.req.read_body, cjson.decode, ngx.exit(400) guards, and resty.jsonschema schema validation. |
+| DTO extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/validation.go` | OpenResty DTO extraction via ngx.req.get_post/uri_args() + ngx.req.read_body()/get_body_data() and cjson.decode JSON ingestion. Partial: no cross-file dataflow or type binding; DTO field set is not resolved from the decoded body. |
+| Request validation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/validation.go` | OpenResty request validation via ngx.exit(400/401/422/HTTP_BAD_REQUEST) guards and resty.jsonschema schema-validation import. Partial: regex guard/import heuristics without the specific field+rule binding the Lapis assert_valid path captures. |
 
 ### Middleware
 
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/lua/testing.go` | Regex extractor for busted/luaunit test patterns and Kong spec.helpers. Partial: full TESTS-edge linkage requires multi-hop HTTP engine pass. |
+| Tests linkage | ✅ `full` | — | — | `internal/custom/lua/testing.go`<br>`internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks_lua.go`<br>`internal/extractors/cross/testmap/resolver.go` | busted (describe/it) + luaunit (TestClass:testXxx) registered in the shared testmap extractor: each test case emits a TESTS edge to the production symbol via direct-call resolution (high), describe-subject / Test<Subject> class fallback (medium), and *_spec.lua/*_test.lua naming convention (low). Lua block-body extractor balances function/if/do...end (quote+long-bracket aware); busted/luaunit assertion DSL stop-worded. custom/lua/testing.go still surfaces standalone test-pattern nodes. |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -32754,13 +32754,12 @@
             "status": "partial",
             "cites": ["internal/custom/lua/validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor for ngx.req.get_post/uri_args, cjson.decode DTOs, lapis.validate/check_params/capture_errors, and resty.jsonschema schema validation."
+            "notes": "Captures Lapis params.\u003cfield\u003e access and assert_valid field tuples (field name per tuple) plus cjson.decode DTO ingestion. Partial: no cross-file dataflow or type binding — the DTO's full shape/types are not resolved, only per-call-site field names."
           },
           "request_validation": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/lua/validation.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor for ngx.req.get_post/uri_args, cjson.decode DTOs, lapis.validate/check_params/capture_errors, and resty.jsonschema schema validation."
+            "notes": "Lapis assert_valid/validate.validate(self.params, { {\"field\", exists=true, min_length=3, matches_pattern=...} }) is walked per-tuple to emit one request_validation entity per (field, rule) pair capturing the SPECIFIC field name and validation rule; lapis.csrf / csrf.validate_token / @csrf emits a csrf_token entity. Also covers lapis.validate import + check_params/capture_errors signals."
           }
         },
         "Middleware": {
@@ -32795,10 +32794,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/lua/testing.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor for busted describe/it/hooks/assertions/spies, luaunit testXxx methods, lapis.spec integration test patterns, and Kong spec.helpers. Partial: full TESTS-edge linkage requires multi-hop HTTP engine pass."
+            "status": "full",
+            "cites": ["internal/custom/lua/testing.go","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks_lua.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "busted (describe/it) + luaunit (TestClass:testXxx) registered in the shared testmap extractor: each test case emits a TESTS edge to the production symbol via direct-call resolution (high), describe-subject / Test\u003cSubject\u003e class fallback (medium), and *_spec.lua/*_test.lua naming convention (low). Lua block-body extractor balances function/if/do...end (quote+long-bracket aware); busted/luaunit assertion DSL stop-worded. custom/lua/testing.go still surfaces standalone test-pattern nodes."
           }
         },
         "Observability": {
@@ -32981,13 +32979,13 @@
             "status": "partial",
             "cites": ["internal/custom/lua/validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor for ngx.req.get_post/uri_args, ngx.req.read_body, cjson.decode, ngx.exit(400) guards, and resty.jsonschema schema validation."
+            "notes": "OpenResty DTO extraction via ngx.req.get_post/uri_args() + ngx.req.read_body()/get_body_data() and cjson.decode JSON ingestion. Partial: no cross-file dataflow or type binding; DTO field set is not resolved from the decoded body."
           },
           "request_validation": {
             "status": "partial",
             "cites": ["internal/custom/lua/validation.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor for ngx.req.get_post/uri_args, ngx.req.read_body, cjson.decode, ngx.exit(400) guards, and resty.jsonschema schema validation."
+            "notes": "OpenResty request validation via ngx.exit(400/401/422/HTTP_BAD_REQUEST) guards and resty.jsonschema schema-validation import. Partial: regex guard/import heuristics without the specific field+rule binding the Lapis assert_valid path captures."
           }
         },
         "Middleware": {
@@ -33022,10 +33020,9 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/custom/lua/testing.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex extractor for busted/luaunit test patterns and Kong spec.helpers. Partial: full TESTS-edge linkage requires multi-hop HTTP engine pass."
+            "status": "full",
+            "cites": ["internal/custom/lua/testing.go","internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks_lua.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "busted (describe/it) + luaunit (TestClass:testXxx) registered in the shared testmap extractor: each test case emits a TESTS edge to the production symbol via direct-call resolution (high), describe-subject / Test\u003cSubject\u003e class fallback (medium), and *_spec.lua/*_test.lua naming convention (low). Lua block-body extractor balances function/if/do...end (quote+long-bracket aware); busted/luaunit assertion DSL stop-worded. custom/lua/testing.go still surfaces standalone test-pattern nodes."
           }
         },
         "Observability": {

--- a/internal/custom/lua/extractors_test.go
+++ b/internal/custom/lua/extractors_test.go
@@ -217,6 +217,69 @@ end))
 	}
 }
 
+func TestLuaValidationLapisFieldRules(t *testing.T) {
+	src := `
+local validate = require("lapis.validate")
+app:post("/users", capture_errors(function(self)
+    validate.assert_valid(self.params, {
+        { "username", exists = true, min_length = 3 },
+        { "email", exists = true, matches_pattern = "^.+@.+$" }
+    })
+    return { json = { ok = true } }
+end))
+`
+	e := &luaValidationExtractor{}
+	got, err := e.Extract(context.Background(), makeFile("app.lua", src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Value assertion: the specific (field, rule) pairs must be captured.
+	want := map[string]bool{
+		"username.exists":       false,
+		"username.min_length":   false,
+		"email.exists":          false,
+		"email.matches_pattern": false,
+	}
+	for _, r := range got {
+		if r.Properties["kind"] != "field_rule" {
+			continue
+		}
+		key := r.Properties["field"] + "." + r.Properties["rule"]
+		if _, ok := want[key]; ok {
+			want[key] = true
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("missing field+rule entity %q", k)
+		}
+	}
+}
+
+func TestLuaValidationLapisCSRF(t *testing.T) {
+	src := `
+local csrf = require("lapis.csrf")
+app:post("/form", capture_errors(function(self)
+    csrf.assert_token(self)
+    return { redirect_to = "/" }
+end))
+`
+	e := &luaValidationExtractor{}
+	got, err := e.Extract(context.Background(), makeFile("app.lua", src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasCSRF := false
+	for _, r := range got {
+		if r.Properties["kind"] == "csrf_token" {
+			hasCSRF = true
+		}
+	}
+	if !hasCSRF {
+		t.Error("expected csrf_token validation entity")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Observability
 // ---------------------------------------------------------------------------

--- a/internal/custom/lua/validation.go
+++ b/internal/custom/lua/validation.go
@@ -76,7 +76,81 @@ var (
 	// Lapis params shape: params.field_name access (DTO-like extraction)
 	reLapisParams = regexp.MustCompile(
 		`(?m)\bparams\s*\.\s*([a-z_]\w*)`)
+
+	// Lapis assert_valid / validate.validate field tuples. Captures the call so
+	// the per-field+rule scanner can walk the tuple table.
+	//   assert_valid(self.params, { {"name", exists=true}, {"email", ...} })
+	//   validate.assert_valid(self.params, { … })
+	//   validate.validate(self.params, { … })
+	reLapisAssertValidCall = regexp.MustCompile(
+		`(?m)\b(?:validate\s*\.\s*)?(?:assert_valid|validate)\s*\(`)
+
+	// A single field-spec tuple inside an assert_valid table:
+	//   { "name", exists = true, min_length = 3 }
+	//   { "email", matches_pattern = "..." }
+	// Group 1 = field name; group 2 = the remainder of the tuple (the rule list).
+	reLapisFieldTuple = regexp.MustCompile(
+		`\{\s*["']([a-zA-Z_]\w*)["']\s*,\s*([^}]*)\}`)
+
+	// A single validation rule key inside a field tuple: `exists = true`,
+	// `min_length = 3`, `matches_pattern = "..."`. Group 1 = rule name.
+	reLapisRuleKey = regexp.MustCompile(
+		`([a-zA-Z_]\w*)\s*=`)
+
+	// Lapis CSRF: lapis.csrf require, csrf.validate_token / @csrf annotations and
+	// the generate_token / assert_token helpers.
+	reLapisCSRF = regexp.MustCompile(
+		`(?m)\brequire\s*[("']lapis\.csrf["']?\)?|\bcsrf\s*\.\s*(?:validate_token|assert_token|generate_token)\s*\(|@csrf\b`)
 )
+
+// braceArg returns the first balanced `{ … }` table literal at or after startAt
+// in src, including the braces. It is quote-aware (single and double quotes with
+// backslash escapes) so a `}` inside a string literal does not close the table
+// prematurely. Returns "" when no balanced table is found.
+func braceArg(src string, startAt int) string {
+	n := len(src)
+	i := startAt
+	for i < n && src[i] != '{' {
+		// Stop if we hit a statement terminator before any table — the call has
+		// no table argument (e.g. assert_valid(self.params)).
+		if src[i] == ')' || src[i] == ';' || src[i] == '\n' {
+			// Allow newlines/whitespace before the table; only bail on ')'/';'.
+			if src[i] == ')' || src[i] == ';' {
+				return ""
+			}
+		}
+		i++
+	}
+	if i >= n {
+		return ""
+	}
+	depth := 0
+	start := i
+	for i < n {
+		c := src[i]
+		switch c {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start : i+1]
+			}
+		case '"', '\'':
+			q := c
+			i++
+			for i < n && src[i] != q {
+				if src[i] == '\\' {
+					i += 2
+					continue
+				}
+				i++
+			}
+		}
+		i++
+	}
+	return ""
+}
 
 // Extract implements extractor.Extractor.
 func (e *luaValidationExtractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -90,7 +164,8 @@ func (e *luaValidationExtractor) Extract(_ context.Context, file extractor.FileI
 		strings.Contains(src, "json.decode") || strings.Contains(src, "ngx.exit") ||
 		strings.Contains(src, "jsonschema") || strings.Contains(src, "check_params") ||
 		strings.Contains(src, "capture_errors") || strings.Contains(src, "lapis.validate") ||
-		strings.Contains(src, "assert_valid") || strings.Contains(src, "yield_error")
+		strings.Contains(src, "assert_valid") || strings.Contains(src, "yield_error") ||
+		strings.Contains(src, "csrf") || strings.Contains(src, "@csrf")
 	if !hasValidation {
 		return nil, nil
 	}
@@ -152,6 +227,65 @@ func (e *luaValidationExtractor) Extract(_ context.Context, file extractor.FileI
 		ln := lineOf(src, idx[0])
 		entity := makeEntity("lapis_capture_errors", string(types.EntityKindPattern), "request_validation", file.Path, "lua", ln)
 		setProps(&entity, "signal", "validation", "framework", "lapis", "kind", "capture_errors")
+		out = append(out, entity)
+	}
+
+	// Lapis: assert_valid / validate field+rule tuples. For each
+	// assert_valid(self.params, { {"field", rule=...}, ... }) call we walk the
+	// table argument and emit one request_validation entity per (field, rule)
+	// pair, capturing the SPECIFIC field name and validation rule (exists,
+	// min_length, matches_pattern, …) rather than a single opaque "capture_errors"
+	// signal. This is the value-asserting upgrade for request_validation.
+	for _, call := range reLapisAssertValidCall.FindAllStringIndex(src, -1) {
+		// The table argument follows the open paren — extract the balanced
+		// brace-delimited table that holds the field tuples.
+		table := braceArg(src, call[1])
+		if table == "" {
+			continue
+		}
+		tableOffset := strings.Index(src[call[1]:], table)
+		if tableOffset < 0 {
+			tableOffset = 0
+		}
+		base := call[1] + tableOffset
+		for _, ft := range reLapisFieldTuple.FindAllStringSubmatchIndex(table, -1) {
+			field := table[ft[2]:ft[3]]
+			rules := table[ft[4]:ft[5]]
+			ln := lineOf(src, base+ft[0])
+			seenRule := map[string]bool{}
+			emittedRule := false
+			for _, rk := range reLapisRuleKey.FindAllStringSubmatch(rules, -1) {
+				rule := rk[1]
+				if seenRule[rule] {
+					continue
+				}
+				seenRule[rule] = true
+				emittedRule = true
+				entity := makeEntity("assert_valid:"+field+"."+rule,
+					string(types.EntityKindPattern), "request_validation", file.Path, "lua", ln)
+				setProps(&entity, "signal", "validation", "framework", "lapis",
+					"kind", "field_rule", "field", field, "rule", rule)
+				out = append(out, entity)
+			}
+			if !emittedRule {
+				// Field tuple with no recognised rule key (e.g. just { "name" }):
+				// still record the field as a validated DTO field.
+				ln := lineOf(src, base+ft[0])
+				entity := makeEntity("assert_valid:"+field,
+					string(types.EntityKindPattern), "dto_field", file.Path, "lua", ln)
+				setProps(&entity, "signal", "validation", "framework", "lapis",
+					"kind", "field_rule", "field", field)
+				out = append(out, entity)
+			}
+		}
+	}
+
+	// Lapis: CSRF token validation (lapis.csrf, csrf.validate_token, @csrf).
+	if reLapisCSRF.MatchString(src) {
+		idx := reLapisCSRF.FindStringIndex(src)
+		ln := lineOf(src, idx[0])
+		entity := makeEntity("lapis_csrf", string(types.EntityKindPattern), "request_validation", file.Path, "lua", ln)
+		setProps(&entity, "signal", "validation", "framework", "lapis", "kind", "csrf_token")
 		out = append(out, entity)
 	}
 

--- a/internal/extractors/cross/testmap/extractor.go
+++ b/internal/extractors/cross/testmap/extractor.go
@@ -244,6 +244,21 @@ func productionFileFromTestPath(filePath string) (prodFile, prodSymbol string) {
 				return path.Join(dir, prodStem+".cs"), prodStem
 			}
 		}
+	case ".lua":
+		// busted: foo_spec.lua → foo.lua; luaunit: foo_test.lua → foo.lua.
+		// Specs commonly live under spec/ mirroring the source tree
+		// (spec/user_spec.lua → user.lua in the same relative dir); we keep the
+		// same directory, which is the safe default for the resolver's
+		// byLocation lookup. The symbol guess is the bare stem (Lua modules and
+		// functions are lowercase by convention).
+		switch {
+		case strings.HasSuffix(lowerStem, "_spec"):
+			prodStem := stem[:len(stem)-len("_spec")]
+			return path.Join(dir, prodStem+".lua"), prodStem
+		case strings.HasSuffix(lowerStem, "_test"):
+			prodStem := stem[:len(stem)-len("_test")]
+			return path.Join(dir, prodStem+".lua"), prodStem
+		}
 	case ".rs":
 		// no standard filename convention for Rust tests — leave empty
 	case ".php":

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -2060,6 +2060,35 @@ var frameworkOrder = []frameworkEntry{
 		},
 		detect: detectScalaTest,
 	},
+	// Lua — busted (BDD) and luaunit (xUnit). #3485. busted is listed FIRST so a
+	// file that uses both `describe`/`it` and a luaunit require is attributed to
+	// busted (the describe/it surface is the test cases). luaunit catches the
+	// xUnit TestClass:testXxx style. Both detect by import token OR the
+	// *_spec.lua / *_test.lua filename convention, plus a /spec/ or /tests?/ path
+	// fallback for suites that require their helpers indirectly.
+	{
+		name:        "busted",
+		importHints: []string{"busted", "luassert", "say"},
+		filenameHints: []*regexp.Regexp{
+			regexp.MustCompile(`_spec\.lua$`),
+		},
+		pathHints: []*regexp.Regexp{
+			regexp.MustCompile(`/spec/.*\.lua$`),
+		},
+		detect: detectBusted,
+	},
+	{
+		name:        "luaunit",
+		importHints: []string{"luaunit"},
+		filenameHints: []*regexp.Regexp{
+			regexp.MustCompile(`_test\.lua$`),
+			regexp.MustCompile(`[Tt]est.*\.lua$`),
+		},
+		pathHints: []*regexp.Regexp{
+			regexp.MustCompile(`/tests?/.*\.lua$`),
+		},
+		detect: detectLuaunit,
+	},
 }
 
 // selectFramework picks the first framework whose import hints OR filename

--- a/internal/extractors/cross/testmap/frameworks_lua.go
+++ b/internal/extractors/cross/testmap/frameworks_lua.go
@@ -1,0 +1,349 @@
+// Package testmap — Lua test-framework detection and call resolution.
+//
+// Deep linkage (#3485) for the two dominant Lua test runners:
+//
+//	busted (BDD): describe("X", function() it("does y", function() … end) end).
+//	  Each it()/pending() leaf is a test case; its body (the function() … end
+//	  block) is scanned for direct production calls. The enclosing describe()
+//	  subject is carried as a naming-convention fallback when the leaf body has
+//	  no resolvable production call.
+//
+//	luaunit (xUnit): TestFoo = {}; function TestFoo:testBar() … end. Each
+//	  TestClass:testXxx method is a test case; the receiver class name (minus a
+//	  leading "Test") is the subject-under-test fallback, mirroring the
+//	  C#/Java/Kotlin describeSubject path.
+//
+// Lua blocks are not brace-delimited, so this file carries a Lua-specific
+// keyword-balanced body extractor (extractLuaBlockBody) that pairs
+// function/if/for/while/do block openers with their matching `end` (and
+// repeat … until), quote- and comment-aware.
+package testmap
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Lua block-body extraction — keyword balanced (function/if/for/while/do … end)
+// ---------------------------------------------------------------------------
+
+// luaBlockOpeners is the set of Lua keywords that open a block closed by `end`.
+//
+// Crucially, `for` and `while` are NOT counted as openers: in Lua they are
+// always followed by a `do` that introduces the loop body (`for … do … end`,
+// `while … do … end`), and we count that `do` instead. Counting both `for` and
+// its `do` would double-increment the depth. Likewise `if … then` is balanced by
+// counting `if` (and `then` is not an opener). `repeat` opens a block closed by
+// `until`, handled separately in extractLuaBlockBody.
+//
+// Net effect — each `end` is matched by exactly one of: function | if | do.
+var luaBlockOpeners = []string{"function", "if", "do"}
+
+// luaIdentByteRE reports whether a byte can be part of a Lua identifier — used to
+// avoid treating `endpoint` / `function_name` substrings as block keywords.
+func luaIsIdentByte(c byte) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9')
+}
+
+// extractLuaBlockBody returns the source slice from the first block-opening
+// keyword at or after startAt up to (and including) its matching `end` /
+// `until`. It is keyword-balanced and skips string literals (single, double and
+// long-bracket [[ … ]]) and comments (-- line, --[[ … ]] block) so that the word
+// `end` inside a string or comment never closes a block.
+//
+// When balancing fails (truncated source) it returns the slice from the opener
+// to end-of-source, so the resolver still gets a body to scan rather than "".
+func extractLuaBlockBody(source string, startAt int) string {
+	n := len(source)
+	// Locate the first opener keyword at/after startAt.
+	openStart := -1
+	for i := startAt; i < n; {
+		c := source[i]
+		// Skip strings/comments while searching for the opener so a keyword inside
+		// them is not mistaken for the block start.
+		if skipped, next := luaSkipNonCode(source, i); skipped {
+			i = next
+			continue
+		}
+		if isLuaBlockOpenerAt(source, i) {
+			openStart = i
+			break
+		}
+		_ = c
+		i++
+	}
+	if openStart < 0 {
+		return ""
+	}
+
+	depth := 0
+	i := openStart
+	for i < n {
+		if skipped, next := luaSkipNonCode(source, i); skipped {
+			i = next
+			continue
+		}
+		// `repeat` blocks close with `until`, not `end`.
+		if matchLuaWord(source, i, "repeat") {
+			depth++
+			i += len("repeat")
+			continue
+		}
+		if matchLuaWord(source, i, "until") {
+			depth--
+			if depth == 0 {
+				end := i + len("until")
+				return source[openStart:end]
+			}
+			i += len("until")
+			continue
+		}
+		if isLuaBlockOpenerAt(source, i) {
+			// Determine which opener so we can advance past it.
+			for _, kw := range luaBlockOpeners {
+				if matchLuaWord(source, i, kw) {
+					depth++
+					i += len(kw)
+					break
+				}
+			}
+			continue
+		}
+		if matchLuaWord(source, i, "end") {
+			depth--
+			if depth == 0 {
+				return source[openStart : i+len("end")]
+			}
+			i += len("end")
+			continue
+		}
+		i++
+	}
+	// Unbalanced — return what we have.
+	return source[openStart:]
+}
+
+// luaSkipNonCode reports whether position i begins a Lua string literal or
+// comment and, if so, returns the index just past it. Handles: -- line comments,
+// --[[ … ]] block comments, [[ … ]] long-bracket strings, and '…' / "…" short
+// strings (with backslash escapes).
+func luaSkipNonCode(source string, i int) (bool, int) {
+	n := len(source)
+	c := source[i]
+	// Comments: -- … (line) or --[[ … ]] (block).
+	if c == '-' && i+1 < n && source[i+1] == '-' {
+		j := i + 2
+		// Block comment --[[ … ]] (also --[==[ … ]==]).
+		if j < n && source[j] == '[' {
+			if end, ok := luaLongBracketEnd(source, j); ok {
+				return true, end
+			}
+		}
+		// Line comment: to end of line.
+		for j < n && source[j] != '\n' {
+			j++
+		}
+		return true, j
+	}
+	// Long-bracket string [[ … ]] / [==[ … ]==].
+	if c == '[' && i+1 < n && (source[i+1] == '[' || source[i+1] == '=') {
+		if end, ok := luaLongBracketEnd(source, i); ok {
+			return true, end
+		}
+	}
+	// Short strings.
+	if c == '"' || c == '\'' {
+		j := i + 1
+		for j < n {
+			if source[j] == '\\' {
+				j += 2
+				continue
+			}
+			if source[j] == c {
+				j++
+				break
+			}
+			j++
+		}
+		return true, j
+	}
+	return false, i
+}
+
+// luaLongBracketEnd parses a Lua long bracket starting at index i (which must
+// point at '['). It returns the index just past the matching close bracket and
+// true on success, or (i, false) when i is not a valid long-bracket opener.
+func luaLongBracketEnd(source string, i int) (int, bool) {
+	n := len(source)
+	if i >= n || source[i] != '[' {
+		return i, false
+	}
+	j := i + 1
+	level := 0
+	for j < n && source[j] == '=' {
+		level++
+		j++
+	}
+	if j >= n || source[j] != '[' {
+		return i, false
+	}
+	j++ // past the second '['
+	closeSeq := "]" + strings.Repeat("=", level) + "]"
+	idx := strings.Index(source[j:], closeSeq)
+	if idx < 0 {
+		return n, true // unterminated — consume to EOF
+	}
+	return j + idx + len(closeSeq), true
+}
+
+// matchLuaWord reports whether the whole word `word` begins at index i in source
+// (i.e. preceded and followed by a non-identifier byte).
+func matchLuaWord(source string, i int, word string) bool {
+	if i+len(word) > len(source) {
+		return false
+	}
+	if source[i:i+len(word)] != word {
+		return false
+	}
+	if i > 0 && luaIsIdentByte(source[i-1]) {
+		return false
+	}
+	after := i + len(word)
+	if after < len(source) && luaIsIdentByte(source[after]) {
+		return false
+	}
+	return true
+}
+
+// isLuaBlockOpenerAt reports whether a whole-word `end`-closed block opener
+// (function | if | do) starts at index i. `repeat` is intentionally excluded —
+// it is closed by `until`, not `end`, and is handled directly in
+// extractLuaBlockBody.
+func isLuaBlockOpenerAt(source string, i int) bool {
+	for _, kw := range luaBlockOpeners {
+		if matchLuaWord(source, i, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// busted — describe / it / pending  (BDD)
+// ---------------------------------------------------------------------------
+
+// bustedItRE matches a busted leaf case: it("desc", …) / pending("desc", …).
+// Group 1 is the verb, group 2 the description. `spec` is an alias some suites
+// use; `it` and `pending` are the canonical leaves.
+var bustedItRE = regexp.MustCompile(
+	`(?m)\b(it|pending|spec)\s*\(\s*["']([^"']{1,200})["']\s*,`,
+)
+
+// bustedDescribeRE matches a busted container: describe("Subject", …) /
+// context("Subject", …). The first describe whose subject looks like a code
+// identifier (CamelCase / dotted / module-ish) is used as the subject-under-test
+// fallback. Group 1 = verb, group 2 = subject text.
+var bustedDescribeRE = regexp.MustCompile(
+	`(?m)\b(describe|context)\s*\(\s*["']([^"']{1,200})["']\s*,`,
+)
+
+// bustedSubjectIdentRE recognises a describe subject that names a code symbol
+// (e.g. "UserService", "users.handler", "Account.create") so it can seed a
+// naming-convention TESTS edge. Plain prose subjects ("returns 200 on GET") are
+// rejected — they have spaces and are not identifier-shaped.
+var bustedSubjectIdentRE = regexp.MustCompile(`^[A-Za-z_][\w]*(?:[.:][A-Za-z_][\w]*)*$`)
+
+// bustedDescribeSubject returns the first describe/context subject that is
+// identifier-shaped (no spaces), trimming a trailing "()" some authors append.
+// Returns "" when no describe block names a code symbol.
+func bustedDescribeSubject(source string) string {
+	for _, m := range bustedDescribeRE.FindAllStringSubmatch(source, -1) {
+		subj := strings.TrimSpace(m[2])
+		subj = strings.TrimSuffix(subj, "()")
+		if bustedSubjectIdentRE.MatchString(subj) {
+			// Use the tail of a dotted/colon subject ("users.handler" → "handler").
+			if idx := strings.IndexAny(subj, ".:"); idx >= 0 {
+				tail := subj[strings.LastIndexAny(subj, ".:")+1:]
+				if tail != "" {
+					return tail
+				}
+			}
+			return subj
+		}
+	}
+	return ""
+}
+
+func detectBusted(source string) []testFunction {
+	subject := bustedDescribeSubject(source)
+
+	var out []testFunction
+	seen := map[string]bool{}
+	for _, m := range bustedItRE.FindAllStringSubmatchIndex(source, -1) {
+		desc := source[m[4]:m[5]]
+		name := jestCaseQName(desc) // reuse JS normaliser: spaces → underscores
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		// Body is the function() … end block that follows the description arg.
+		body := extractLuaBlockBody(source, m[1])
+		out = append(out, testFunction{qname: name, body: body, describeSubject: subject})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// luaunit — TestClass:testXxx  (xUnit)
+// ---------------------------------------------------------------------------
+
+// luaunitMethodRE matches a luaunit test method definition:
+//
+//	function TestFoo:testBar() … end
+//	function TestFoo.testBar() … end
+//
+// Group 1 = test class name, group 2 = test method name (test-prefixed).
+var luaunitMethodRE = regexp.MustCompile(
+	`(?m)\bfunction\s+(\w+)\s*[.:]\s*(test\w*)\s*\(`,
+)
+
+// luaunitSubjectFromClass derives the subject-under-test from a luaunit test
+// class name by stripping a leading "Test" (the luaunit convention is
+// `Test<Subject>`):
+//
+//	TestUserService → UserService
+//	TestAccount     → Account
+//	(no Test prefix)→ ""
+func luaunitSubjectFromClass(className string) string {
+	if strings.HasPrefix(className, "Test") && len(className) > len("Test") {
+		return className[len("Test"):]
+	}
+	return ""
+}
+
+func detectLuaunit(source string) []testFunction {
+	var out []testFunction
+	seen := map[string]bool{}
+	for _, m := range luaunitMethodRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		method := source[m[4]:m[5]]
+		if seen[method] {
+			continue
+		}
+		seen[method] = true
+		// Scan from the `function` keyword (match start) so the method's own
+		// function … end block is the body — the body does not re-open a block
+		// after the parameter list.
+		body := extractLuaBlockBody(source, m[0])
+		out = append(out, testFunction{
+			qname:           method,
+			body:            body,
+			describeSubject: luaunitSubjectFromClass(className),
+		})
+	}
+	return out
+}

--- a/internal/extractors/cross/testmap/frameworks_lua_test.go
+++ b/internal/extractors/cross/testmap/frameworks_lua_test.go
@@ -1,0 +1,260 @@
+// Package testmap — value-asserting tests for the Lua busted/luaunit detectors
+// and the Lua-specific block-body extractor (#3485).
+package testmap
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// busted — direct production call inside it() body → high-confidence TESTS edge
+// ---------------------------------------------------------------------------
+
+func TestBusted_DirectCallHighConfidence(t *testing.T) {
+	src := `
+local user = require("user")
+
+describe("User", function()
+  it("creates a user", function()
+    local u = create_user({ name = "ada" })
+    assert.are.equal("ada", u.name)
+  end)
+end)
+`
+	recs := runExtract(t, "spec/user_spec.lua", "lua", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected >=1 testmap entity for busted spec")
+	}
+	rec := findByTested(t, recs, "it_creates_a_user", "create_user")
+	if rec.Properties["test_framework"] != "busted" {
+		t.Errorf("framework=%q, want busted", rec.Properties["test_framework"])
+	}
+	if rec.Properties["confidence"] != "high" {
+		t.Errorf("confidence=%q, want high", rec.Properties["confidence"])
+	}
+	if !hasEdge(recs, "it_creates_a_user", "create_user") {
+		t.Errorf("missing TESTS edge it_creates_a_user -> create_user")
+	}
+}
+
+// busted assertion helpers (assert.are.equal, assert.is_true, …) must never
+// surface as the tested production subject.
+func TestBusted_AssertionStopwordsExcluded(t *testing.T) {
+	src := `
+describe("Account", function()
+  it("validates balance", function()
+    assert.are.equal(100, balance_of(acct))
+    assert.is_true(is_active(acct))
+    assert.has_error(function() withdraw(acct, -1) end)
+  end)
+end)
+`
+	recs := runExtract(t, "spec/account_spec.lua", "lua", src)
+	for _, r := range recs {
+		tf := r.Properties["tested_function"]
+		if tf == "assert.are.equal" || tf == "assert.is_true" || tf == "assert.has_error" ||
+			tf == "assert" {
+			t.Errorf("assertion helper escaped stopword filter: %q", tf)
+		}
+		for _, rel := range r.Relationships {
+			if rel.Properties["tested"] == "assert.are.equal" || rel.Properties["tested"] == "assert.is_true" {
+				t.Errorf("assertion helper escaped into TESTS edge: %q", rel.Properties["tested"])
+			}
+		}
+	}
+	// At least one real production call must survive (balance_of / is_active / withdraw).
+	if !hasEdgeAny(recs, "it_validates_balance", "balance_of") &&
+		!hasEdgeAny(recs, "it_validates_balance", "is_active") &&
+		!hasEdgeAny(recs, "it_validates_balance", "withdraw") {
+		t.Errorf("expected a real production call to survive the stopword filter")
+	}
+}
+
+// A describe subject that names a code symbol seeds a naming-convention edge
+// when the it() body has no resolvable production call.
+func TestBusted_DescribeSubjectFallback(t *testing.T) {
+	src := `
+describe("UserService", function()
+  it("exists", function()
+    assert.is_not_nil(true)
+  end)
+end)
+`
+	recs := runExtract(t, "spec/userservice_spec.lua", "lua", src)
+	if !hasEdgeAny(recs, "it_exists", "UserService") {
+		t.Errorf("expected describe-subject fallback edge it_exists -> UserService; recs=%d", len(recs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// luaunit — TestClass:testXxx with a direct call → high-confidence TESTS edge
+// ---------------------------------------------------------------------------
+
+func TestLuaunit_DirectCallHighConfidence(t *testing.T) {
+	src := `
+local luaunit = require("luaunit")
+
+TestCalculator = {}
+
+function TestCalculator:testAdd()
+  local result = compute_sum(2, 3)
+  luaunit.assertEquals(result, 5)
+end
+
+os.exit(luaunit.run())
+`
+	recs := runExtract(t, "test_calculator.lua", "lua", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected >=1 testmap entity for luaunit test")
+	}
+	rec := findByTested(t, recs, "testAdd", "compute_sum")
+	if rec.Properties["test_framework"] != "luaunit" {
+		t.Errorf("framework=%q, want luaunit", rec.Properties["test_framework"])
+	}
+	if rec.Properties["confidence"] != "high" {
+		t.Errorf("confidence=%q, want high", rec.Properties["confidence"])
+	}
+	if !hasEdge(recs, "testAdd", "compute_sum") {
+		t.Errorf("missing TESTS edge testAdd -> compute_sum")
+	}
+}
+
+// luaunit.assertXxx helpers must be stop-worded.
+func TestLuaunit_AssertionStopwordsExcluded(t *testing.T) {
+	src := `
+local luaunit = require("luaunit")
+TestUser = {}
+function TestUser:testCreate()
+  luaunit.assertEquals(make_user("x").name, "x")
+  luaunit.assertTrue(make_user("x").active)
+end
+`
+	recs := runExtract(t, "test_user.lua", "lua", src)
+	for _, r := range recs {
+		tf := r.Properties["tested_function"]
+		if tf == "luaunit.assertEquals" || tf == "luaunit.assertTrue" {
+			t.Errorf("luaunit assertion escaped stopword filter: %q", tf)
+		}
+	}
+	if !hasEdgeAny(recs, "testCreate", "make_user") {
+		t.Errorf("expected make_user to survive the stopword filter")
+	}
+}
+
+// luaunit subject-from-class fallback: TestAccount with no resolvable body call
+// links to Account.
+func TestLuaunit_ClassSubjectFallback(t *testing.T) {
+	src := `
+TestAccount = {}
+function TestAccount:testNoop()
+  local x = 1
+end
+`
+	recs := runExtract(t, "test_account.lua", "lua", src)
+	if !hasEdgeAny(recs, "testNoop", "Account") {
+		t.Errorf("expected class-subject fallback edge testNoop -> Account; recs=%d", len(recs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lua block-body extractor — keyword balancing, string/comment awareness
+// ---------------------------------------------------------------------------
+
+func TestExtractLuaBlockBody_NestedAndStrings(t *testing.T) {
+	src := `it("x", function()
+  if cond then
+    do_work()
+  end
+  local s = "this end is in a string"
+  -- this end is in a comment
+  for i = 1, 3 do
+    step(i)
+  end
+end)
+trailing_should_not_appear()`
+	// Start scan just after the description arg (at the comma) — mimic detector.
+	idx := indexOfByte(src, ',')
+	body := extractLuaBlockBody(src, idx)
+	if body == "" {
+		t.Fatal("expected a non-empty body")
+	}
+	if containsStr(body, "trailing_should_not_appear") {
+		t.Errorf("body over-ran the matching end:\n%s", body)
+	}
+	if !containsStr(body, "do_work()") || !containsStr(body, "step(i)") {
+		t.Errorf("body missing inner calls:\n%s", body)
+	}
+}
+
+// Long-bracket strings/comments containing `end` must not close the block early.
+func TestExtractLuaBlockBody_LongBracketString(t *testing.T) {
+	src := `function()
+  local doc = [[ this end should be ignored ]]
+  real_call()
+end
+after()`
+	body := extractLuaBlockBody(src, 0)
+	if containsStr(body, "after()") {
+		t.Errorf("long-bracket string `end` prematurely closed the block:\n%s", body)
+	}
+	if !containsStr(body, "real_call()") {
+		t.Errorf("body missing real_call():\n%s", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// luaunitSubjectFromClass / bustedDescribeSubject unit checks
+// ---------------------------------------------------------------------------
+
+func TestLuaunitSubjectFromClass(t *testing.T) {
+	cases := map[string]string{
+		"TestUserService": "UserService",
+		"TestAccount":     "Account",
+		"Account":         "",
+		"Test":            "",
+	}
+	for in, want := range cases {
+		if got := luaunitSubjectFromClass(in); got != want {
+			t.Errorf("luaunitSubjectFromClass(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBustedDescribeSubject(t *testing.T) {
+	if got := bustedDescribeSubject(`describe("UserService", function() end)`); got != "UserService" {
+		t.Errorf("identifier subject: got %q", got)
+	}
+	if got := bustedDescribeSubject(`describe("users.handler", function() end)`); got != "handler" {
+		t.Errorf("dotted subject tail: got %q", got)
+	}
+	if got := bustedDescribeSubject(`describe("returns 200 on GET", function() end)`); got != "" {
+		t.Errorf("prose subject should be rejected: got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tiny local helpers (avoid importing strings into this _test file twice)
+// ---------------------------------------------------------------------------
+
+func indexOfByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+func containsStr(haystack, needle string) bool {
+	return len(needle) == 0 || indexOfSub(haystack, needle) >= 0
+}
+
+func indexOfSub(s, sub string) int {
+	n, m := len(s), len(sub)
+	for i := 0; i+m <= n; i++ {
+		if s[i:i+m] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -283,6 +283,39 @@ var stopwords = map[string]bool{
 	"one_of": true, "constant": true, "integer": true, "binary": true,
 	"list_of": true, "map_of": true, "fixed_list": true,
 	"bind": true, "filter": true, "frequency": true, "tuple": true,
+	// Lua — busted (luassert) and luaunit assertion / lifecycle / spy DSL (#3485).
+	// These are test-harness identifiers and must never surface as the tested
+	// production subject. directCallRE captures the dotted forms (assert.equal,
+	// assert.are.equal, luaunit.assertEquals); the bare `assert`/`spy`/`stub`/
+	// `mock` are added too. Lower-cased (resolver lowercases before lookup).
+	// (`assert`, `assert.equal`, `assert.nil`, `assert.true`, `assert.false`,
+	// `assert.same`, `assert.contains`, `mock`, `setup`, `describe`, `it` are
+	// already covered by the generic blocks above.)
+	"assert.are": true, "assert.are.equal": true, "assert.are.same": true,
+	"assert.are_not": true, "assert.are_not.equal": true,
+	"assert.is": true, "assert.is.truthy": true, "assert.is.falsy": true,
+	"assert.is_true": true, "assert.is_false": true, "assert.is_nil": true,
+	"assert.is_not_nil": true, "assert.is_not": true,
+	"assert.truthy": true, "assert.falsy": true, "assert.has_error": true,
+	"assert.has.errors": true, "assert.has_no.errors": true,
+	"assert.no_error": true, "assert.near": true,
+	"assert.not_equal": true, "assert.not_same": true, "assert.spy": true,
+	"assert.stub": true, "assert.unique": true, "assert.message": true,
+	// busted spy / stub / mock DSL constructors and lifecycle (setup/teardown
+	// covered above; before_each/after_each are busted-specific).
+	"spy": true, "spy.on": true, "spy.new": true, "stub": true, "stub.new": true,
+	"before_each": true, "after_each": true, "before_all": true, "after_all": true,
+	"insulate": true, "expose": true, "randomize": true, "finally": true,
+	// luaunit — luaunit.assertXxx assertion family and runner entry points.
+	"luaunit.assertequals": true, "luaunit.assertnotequals": true,
+	"luaunit.asserttrue": true, "luaunit.assertfalse": true,
+	"luaunit.assertnil": true, "luaunit.assertnotnil": true,
+	"luaunit.assertis": true, "luaunit.assertnotis": true,
+	"luaunit.asserterror": true, "luaunit.asserterrormsgcontains": true,
+	"luaunit.assertstrcontains": true, "luaunit.assertitemsequals": true,
+	"luaunit.run": true, "lu.assertequals": true, "lu.asserttrue": true,
+	"lu.assertfalse": true, "lu.assertnil": true, "lu.assertnotnil": true,
+	"lu.run": true, "luaunit.assertalmostequals": true,
 	// Common language keywords that end up in call-like positions
 	"if": true, "for": true, "while": true, "switch": true, "return": true,
 	"func": true, "def": true, "class": true, "struct": true, "new": true,
@@ -294,6 +327,17 @@ var stopwords = map[string]bool{
 	"make": true, "len": true, "cap": true, "append": true, "copy": true,
 	"string": true, "int": true, "bool": true, "map": true, "list": true,
 	"range": true,
+	// Lua keywords and ubiquitous standard-library globals that appear in
+	// call-like positions inside test bodies but are never the production subject.
+	"function": true, "local": true, "end": true, "then": true, "elseif": true,
+	"else": true, "until": true, "repeat": true, "nil": true, "and": true,
+	"or": true, "not": true, "require": true, "pcall": true, "xpcall": true,
+	"pairs": true, "ipairs": true, "tostring": true, "tonumber": true,
+	"type": true, "select": true, "rawget": true, "rawset": true, "rawequal": true,
+	"setmetatable": true, "getmetatable": true, "next": true, "unpack": true,
+	"error": true, "assert_": true, "table.insert": true, "table.remove": true,
+	"table.concat": true, "table.sort": true, "string.format": true,
+	"string.match": true, "string.gmatch": true, "string.gsub": true,
 }
 
 // isStopword reports whether id is a test-helper, assertion, mock library,


### PR DESCRIPTION
Closes #3485 (epic #3483). Deep-grinds Lua VALIDATION + TESTING (OpenResty/Lapis) to the TS/JS bar.

## Disposition

| Record | Capability | Before | After | Why |
|---|---|---|---|---|
| lapis | tests_linkage | partial | **full** | busted+luaunit emit real test→prod TESTS edges via testmap |
| openresty | tests_linkage | partial | **full** | same shared detectors |
| lapis | request_validation | partial | **full** | assert_valid walked per-tuple → specific (field, rule) pairs + @csrf |
| openresty | request_validation | partial | partial (honest) | regex ngx.exit guards / jsonschema import — no field+rule binding |
| lapis | dto_extraction | partial | partial (honest) | per-call-site field names only; no cross-file dataflow/type binding |
| openresty | dto_extraction | partial | partial (honest) | get_args/cjson.decode ingestion; DTO shape unresolved |

## Testing lane (full)
Registered `busted` (describe/it/pending) and `luaunit` (`TestClass:testXxx`) framework entries in the **shared** `internal/extractors/cross/testmap` extractor. Each Lua test case now emits a `TESTS` edge to the production symbol:
- **high** — direct production call in the test body
- **medium** — busted `describe("Subject", …)` subject / luaunit `Test<Subject>` class-name fallback
- **low** — `*_spec.lua` / `*_test.lua` naming convention (`foo_spec.lua → foo.lua`)

New `frameworks_lua.go` carries a Lua keyword-balanced block-body extractor (`function/if/do … end`, `repeat … until`), quote- and long-bracket/comment-aware. busted (luassert) + luaunit assertion/spy DSL and Lua keywords/stdlib globals are stop-worded in `resolver.go`. `custom/lua/testing.go` still surfaces standalone test-pattern nodes.

## Validation lane
`custom/lua/validation.go` now walks `assert_valid(self.params, { {"name", exists=true, min_length=3}, … })` per-tuple, emitting one `request_validation` entity per (field, rule) pair capturing the **specific** field name + rule (exists / min_length / matches_pattern / …), plus `lapis.csrf` / `csrf.validate_token` / `@csrf` → `csrf_token`.

## Tests / gates
- Value-asserting tests added for both lanes (specific field+rule assertions; test→target edge assertions — not `len>0`).
- **Full** `go test ./internal/extractors/cross/testmap/` suite green (shared extractor touched — cross-language regression clean).
- `go test` green for `internal/custom/lua/`, `internal/types/`, `tools/coverage/`.
- coverage `gen` + `validate` (0 errors) + `fmt --check` (canonical); `gofmt -l` empty; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)