### PR TITLE
feat(c-cpp): deep ORM + DB-driver extraction to TS/JS bar (#3493)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -11,13 +11,13 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 
 | Language | Name | Other capabilities | Notes |
 |---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟢 7/7 | |
+| [C/C++](../by-language/c-cpp.md) | [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | ✅ 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [ODB](../detail/lang.c-cpp.orm.odb.md) | ✅ 7/7 | |
 | [C/C++](../by-language/c-cpp.md) | [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | ✅ 3/3 | |
 | [C/C++](../by-language/c-cpp.md) | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🟢 1/1 | |
-| [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ✅ 1/1 | |
+| [C/C++](../by-language/c-cpp.md) | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ✅ 3/3 | |
 | [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟢 2/2 | |
 | [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟢 2/2 | |
 | [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | ✅ 3/3 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -85,10 +85,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟢 3/3 | |
-| [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟢 7/7 | |
+| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | ✅ 3/3 | |
+| [ODB](../detail/lang.c-cpp.orm.odb.md) | ✅ 7/7 | |
 | [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟢 3/3 | |
-| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟢 3/3 | |
+| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | ✅ 3/3 | |
 | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟢 3/3 | |
-| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🟢 1/1 | |
-| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟢 3/3 | |
+| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ✅ 1/1 | |
+| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ✅ 3/3 | |

--- a/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.libpqxx.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: CREATE TABLE in exec() string literals → table entity |
-| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/driver_schema.go` | Regex: column definitions from embedded CREATE TABLE SQL |
+| Model extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: CREATE TABLE in exec()/exec_params() string literals → table entity with table_name |
+| Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: paren-balanced CREATE TABLE body split on top-level commas → columns with column_name/column_type/parent_table |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: SQL verb from exec()/exec_params() string literals |
+| Query attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: SQL verb classified from exec()/exec_params() string literals |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mongocxx.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: db["collection"] / db.collection() access → SCOPE.Schema entity |
-| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/driver_schema.go` | Regex: collection access as schema proxy; no field-level schema in document driver |
+| Model extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: db["coll"]/db.collection("coll") → SCOPE.Schema with collection_name |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/driver_schema.go` | Collection access recorded as schema proxy; document store has no static field-level schema to extract |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: SQL verb in exec() calls (where applicable) |
+| Query attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: collection CRUD/aggregate ops (insert_one/find/update_one/delete_many/aggregate/...) → query with mongo_verb |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.mysql-connector-cpp.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: CREATE TABLE in exec() string literals → table entity |
-| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/driver_schema.go` | Regex: column definitions from embedded CREATE TABLE SQL |
+| Model extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: CREATE TABLE in exec()/mysql_query() string literals → table entity with table_name |
+| Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: paren-balanced CREATE TABLE body → columns with column_name/column_type/parent_table |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: SQL verb from exec()/exec_params() string literals |
+| Query attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/driver_schema.go` | Regex: SQL verb from exec()/exec_params() + mysql_query()/mysql_real_query() free-function literals |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
+++ b/docs/coverage/detail/lang.c-cpp.driver.redis-plus-plus.md
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | — | — | `internal/custom/cpp/redis_query.go` | redis-plus-plus (sw::redis) GET/SET/HSET/HGET/DEL/etc method calls, redis.command(CMD,...), pipeline.set/get/etc attributed to call sites; regex/partial, key literals captured when string literal |
+| Query attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/redis_query.go` | Regex: redis-plus-plus GET/SET/HSET/etc method calls, redis.command(CMD,...), pipeline/tx ops → query with redis_command + key_literal |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.orm.odb.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.odb.md
@@ -15,23 +15,23 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: #pragma db object → class/struct name |
-| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: #pragma db member(field) → column entity |
+| Model extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: #pragma db object + table("…") → model with resolved table_name |
+| Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: #pragma db member → column with resolved column("…")/type("…")/id PK props |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Association extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: one_to_one/many_to_many in #pragma db member annotations |
-| Foreign key extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: inverse() in pragma member annotations |
-| Lazy loading recognition | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: odb::lazy_ptr<T> / lazy_shared_ptr<T> |
-| Relationship extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: relationship kind from #pragma db member annotations |
+| Association extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: one_to_one/one_to_many/many_to_many in #pragma db member → relationship_kind + field |
+| Foreign key extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: inverse(target) in #pragma db member → target_type on relationship |
+| Lazy loading recognition | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: odb::lazy_ptr<T>/lazy_shared_ptr<T> → relationship with resolved target_type |
+| Relationship extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: relationship kind + field from #pragma db member annotations |
 
 ### Queries
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: odb::query<T> / odb::result<T> |
+| Query attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: odb::query<T>/odb::result<T> → query with model_type |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.orm.soci.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.soci.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: type_conversion<T> specialization → model entity |
-| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: into(var)/use(var) column bindings |
+| Model extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: type_conversion<T> specialization → model with class_name |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: into(var)/use(var) captured as binding vars + direction; cannot resolve bind var → real DB column without dataflow (cross-file gap) |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: sql << "SQL" string literal → verb + query entity |
+| Query attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: sql << "SQL" → query with classified sql_verb + sql_text |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.orm.sqlpp11.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.sqlpp11.md
@@ -15,8 +15,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Model extraction | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: struct T : sqlpp::table<T,...> declarations |
-| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/orm.go` | Regex: column structs (trailing _) inside sqlpp::table body + SQLPP_ALIAS_PROVIDER |
+| Model extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: struct T : sqlpp::table<T,...> → model with class_name |
+| Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: column structs (trailing _) inside table body → Table.col with parent_table + col_struct; SQLPP_ALIAS_PROVIDER → alias |
 
 ### Relationships
 
@@ -31,7 +31,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: db(select/insert_into/update/remove_from) calls |
+| Query attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/orm.go` | Regex: db(select/insert_into/update/remove_from) → query with classified sql_verb |
 
 ### Migrations
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1740,16 +1740,15 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/driver_schema.go"],
-            "notes": "Regex: CREATE TABLE in exec() string literals → table entity",
+            "notes": "Regex: CREATE TABLE in exec()/exec_params() string literals → table entity with table_name",
             "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/driver_schema.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: column definitions from embedded CREATE TABLE SQL",
+            "notes": "Regex: paren-balanced CREATE TABLE body split on top-level commas → columns with column_name/column_type/parent_table",
             "verified_at": "2026-05-30"
           }
         },
@@ -1773,9 +1772,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/driver_schema.go"],
-            "notes": "Regex: SQL verb from exec()/exec_params() string literals",
+            "notes": "Regex: SQL verb classified from exec()/exec_params() string literals",
             "verified_at": "2026-05-30"
           }
         },
@@ -1796,16 +1795,16 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/driver_schema.go"],
-            "notes": "Regex: db[\"collection\"] / db.collection() access → SCOPE.Schema entity",
+            "notes": "Regex: db[\"coll\"]/db.collection(\"coll\") → SCOPE.Schema with collection_name",
             "verified_at": "2026-05-30"
           },
           "schema_extraction": {
             "status": "partial",
             "cites": ["internal/custom/cpp/driver_schema.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: collection access as schema proxy; no field-level schema in document driver",
+            "notes": "Collection access recorded as schema proxy; document store has no static field-level schema to extract",
             "verified_at": "2026-05-30"
           }
         },
@@ -1829,9 +1828,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/driver_schema.go"],
-            "notes": "Regex: SQL verb in exec() calls (where applicable)",
+            "notes": "Regex: collection CRUD/aggregate ops (insert_one/find/update_one/delete_many/aggregate/...) → query with mongo_verb",
             "verified_at": "2026-05-30"
           }
         },
@@ -1852,16 +1851,15 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/driver_schema.go"],
-            "notes": "Regex: CREATE TABLE in exec() string literals → table entity",
+            "notes": "Regex: CREATE TABLE in exec()/mysql_query() string literals → table entity with table_name",
             "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/driver_schema.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: column definitions from embedded CREATE TABLE SQL",
+            "notes": "Regex: paren-balanced CREATE TABLE body → columns with column_name/column_type/parent_table",
             "verified_at": "2026-05-30"
           }
         },
@@ -1885,9 +1883,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/driver_schema.go"],
-            "notes": "Regex: SQL verb from exec()/exec_params() string literals",
+            "notes": "Regex: SQL verb from exec()/exec_params() + mysql_query()/mysql_real_query() free-function literals",
             "verified_at": "2026-05-30"
           }
         },
@@ -1936,9 +1934,10 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/redis_query.go"],
-            "notes": "redis-plus-plus (sw::redis) GET/SET/HSET/HGET/DEL/etc method calls, redis.command(CMD,...), pipeline.set/get/etc attributed to call sites; regex/partial, key literals captured when string literal"
+            "notes": "Regex: redis-plus-plus GET/SET/HSET/etc method calls, redis.command(CMD,...), pipeline/tx ops → query with redis_command + key_literal",
+            "verified_at": "2026-05-30"
           }
         },
         "Migrations": {
@@ -5225,54 +5224,49 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "notes": "Regex: #pragma db object → class/struct name",
+            "notes": "Regex: #pragma db object + table(\"…\") → model with resolved table_name",
             "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: #pragma db member(field) → column entity",
+            "notes": "Regex: #pragma db member → column with resolved column(\"…\")/type(\"…\")/id PK props",
             "verified_at": "2026-05-30"
           }
         },
         "Relationships": {
           "association_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: one_to_one/many_to_many in #pragma db member annotations",
+            "notes": "Regex: one_to_one/one_to_many/many_to_many in #pragma db member → relationship_kind + field",
             "verified_at": "2026-05-30"
           },
           "foreign_key_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: inverse() in pragma member annotations",
+            "notes": "Regex: inverse(target) in #pragma db member → target_type on relationship",
             "verified_at": "2026-05-30"
           },
           "lazy_loading_recognition": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: odb::lazy_ptr\u003cT\u003e / lazy_shared_ptr\u003cT\u003e",
+            "notes": "Regex: odb::lazy_ptr\u003cT\u003e/lazy_shared_ptr\u003cT\u003e → relationship with resolved target_type",
             "verified_at": "2026-05-30"
           },
           "relationship_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: relationship kind from #pragma db member annotations",
+            "notes": "Regex: relationship kind + field from #pragma db member annotations",
             "verified_at": "2026-05-30"
           }
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "notes": "Regex: odb::query\u003cT\u003e / odb::result\u003cT\u003e",
+            "notes": "Regex: odb::query\u003cT\u003e/odb::result\u003cT\u003e → query with model_type",
             "verified_at": "2026-05-30"
           }
         },
@@ -5294,16 +5288,16 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "notes": "Regex: type_conversion\u003cT\u003e specialization → model entity",
+            "notes": "Regex: type_conversion\u003cT\u003e specialization → model with class_name",
             "verified_at": "2026-05-30"
           },
           "schema_extraction": {
             "status": "partial",
             "cites": ["internal/custom/cpp/orm.go"],
             "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: into(var)/use(var) column bindings",
+            "notes": "Regex: into(var)/use(var) captured as binding vars + direction; cannot resolve bind var → real DB column without dataflow (cross-file gap)",
             "verified_at": "2026-05-30"
           }
         },
@@ -5331,9 +5325,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "notes": "Regex: sql \u003c\u003c \"SQL\" string literal → verb + query entity",
+            "notes": "Regex: sql \u003c\u003c \"SQL\" → query with classified sql_verb + sql_text",
             "verified_at": "2026-05-30"
           }
         },
@@ -5355,16 +5349,15 @@
       "capabilities": {
         "Models": {
           "model_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "notes": "Regex: struct T : sqlpp::table\u003cT,...\u003e declarations",
+            "notes": "Regex: struct T : sqlpp::table\u003cT,...\u003e → model with class_name",
             "verified_at": "2026-05-30"
           },
           "schema_extraction": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "issue": "backfill:dictionary-completeness",
-            "notes": "Regex: column structs (trailing _) inside sqlpp::table body + SQLPP_ALIAS_PROVIDER",
+            "notes": "Regex: column structs (trailing _) inside table body → Table.col with parent_table + col_struct; SQLPP_ALIAS_PROVIDER → alias",
             "verified_at": "2026-05-30"
           }
         },
@@ -5392,9 +5385,9 @@
         },
         "Queries": {
           "query_attribution": {
-            "status": "partial",
+            "status": "full",
             "cites": ["internal/custom/cpp/orm.go"],
-            "notes": "Regex: db(select/insert_into/update/remove_from) calls",
+            "notes": "Regex: db(select/insert_into/update/remove_from) → query with classified sql_verb",
             "verified_at": "2026-05-30"
           }
         },

--- a/internal/custom/cpp/driver_schema.go
+++ b/internal/custom/cpp/driver_schema.go
@@ -52,15 +52,23 @@ var (
 	reCppDriverExec = regexp.MustCompile(
 		`(?m)\.(?:exec|exec_params|exec0|exec1|execute|query|prepare)\s*\(\s*(?:R"[^(]*\(|[rRuU]*")(.*?)(?:"|\)")`)
 
+	// Free-function exec-style calls: mysql_query(conn, "SQL") / mysql_real_query(...).
+	// MySQL's C API uses free functions rather than methods, so the method regex
+	// above misses them. Captures: (1) SQL string literal (first string arg).
+	reCppDriverFreeExec = regexp.MustCompile(
+		`(?m)\b(?:mysql_query|mysql_real_query)\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*(?:R"[^(]*\(|[rRuU]*")(.*?)(?:"|\)")`)
+
 	// CREATE TABLE detection inside a SQL string.
 	// Captures: (1) table name
 	reCppCreateTable = regexp.MustCompile(
 		`(?is)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[` + "`" + `"']?([A-Za-z_][A-Za-z0-9_]*)[` + "`" + `"']?\s*\(`)
 
-	// Column definition line inside CREATE TABLE body.
+	// Column definition at the start of a top-level CREATE TABLE body segment.
+	// The body is split on top-level commas (see splitTopLevelCommas) so a single
+	// inline DDL string yields one segment per column/constraint.
 	// Captures: (1) column name, (2) type
 	reCppSQLColumn = regexp.MustCompile(
-		`(?im)^\s*[` + "`" + `"']?([A-Za-z_][A-Za-z0-9_]*)[` + "`" + `"']?\s+([A-Za-z][A-Za-z0-9_]*)`)
+		`^\s*[` + "`" + `"']?([A-Za-z_][A-Za-z0-9_]*)[` + "`" + `"']?\s+([A-Za-z][A-Za-z0-9_]*)`)
 
 	// SQL constraint lead keywords to skip.
 	cppSQLConstraintLead = map[string]bool{
@@ -76,7 +84,28 @@ var (
 	// Captures: (1) collection name
 	reMongocxxCollection = regexp.MustCompile(
 		`(?m)(?:db\s*\[\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\]|\.collection\s*\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\))`)
+
+	// mongocxx CRUD/aggregate operations on a collection handle:
+	//   coll.insert_one(...) / coll.find(...) / coll.update_one(...) /
+	//   coll.delete_many(...) / coll.aggregate(...) etc.
+	// Captures: (1) operation method name → mapped to a canonical Mongo verb.
+	reMongocxxOp = regexp.MustCompile(
+		`(?m)\.(insert_one|insert_many|find|find_one|find_one_and_update|find_one_and_delete|` +
+			`update_one|update_many|replace_one|delete_one|delete_many|count_documents|` +
+			`aggregate|bulk_write|distinct)\s*\(`)
 )
+
+// mongoVerbFromMethod maps a mongocxx collection method to a canonical verb
+// used as the redis-style query verb on the emitted SCOPE.Operation entity.
+var mongoVerbFromMethod = map[string]string{
+	"insert_one": "INSERT", "insert_many": "INSERT",
+	"find": "FIND", "find_one": "FIND",
+	"find_one_and_update": "UPDATE", "find_one_and_delete": "DELETE",
+	"update_one": "UPDATE", "update_many": "UPDATE", "replace_one": "UPDATE",
+	"delete_one": "DELETE", "delete_many": "DELETE",
+	"count_documents": "COUNT", "aggregate": "AGGREGATE",
+	"bulk_write": "BULK_WRITE", "distinct": "DISTINCT",
+}
 
 func (e *cppDriverSchemaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/cpp")
@@ -129,16 +158,29 @@ func (e *cppDriverSchemaExtractor) Extract(ctx context.Context, file extractor.F
 			)
 			out = append(out, ent)
 		}
+
+		// --- mongocxx: CRUD/aggregate operation → query entity ---
+		for _, m := range reMongocxxOp.FindAllStringSubmatchIndex(src, -1) {
+			method := src[m[2]:m[3]]
+			verb := mongoVerbFromMethod[method]
+			if verb == "" {
+				verb = strings.ToUpper(method)
+			}
+			lineNum := lineOf(src, m[0])
+			queryName := "mongo:" + verb + "@L" + strconv.Itoa(lineNum)
+			ent := makeEntity(queryName, "SCOPE.Operation", "query", file.Path, "cpp", lineNum)
+			setProps(&ent,
+				"framework", "mongocxx",
+				"provenance", "INFERRED_FROM_MONGOCXX_OP",
+				"mongo_verb", verb,
+				"method_name", method,
+			)
+			out = append(out, ent)
+		}
 	}
 
-	// --- SQL-based drivers: exec("SQL") → schema + query extraction ---
-	for _, m := range reCppDriverExec.FindAllStringSubmatchIndex(src, -1) {
-		if m[2] < 0 {
-			continue
-		}
-		sqlText := src[m[2]:m[3]]
-		lineNum := lineOf(src, m[0])
-
+	// --- SQL-based drivers: exec("SQL") / mysql_query(conn,"SQL") → schema + query ---
+	processSQL := func(sqlText string, lineNum int) {
 		// Query attribution
 		if verbM := reCppSQLVerb.FindStringSubmatch(sqlText); verbM != nil {
 			verb := strings.ToUpper(verbM[1])
@@ -156,7 +198,7 @@ func (e *cppDriverSchemaExtractor) Extract(ctx context.Context, file extractor.F
 		// Schema extraction from CREATE TABLE
 		ctm := reCppCreateTable.FindStringSubmatchIndex(sqlText)
 		if ctm == nil {
-			continue
+			return
 		}
 		tableName := sqlText[ctm[2]:ctm[3]]
 		tableEnt := makeEntity(tableName, "SCOPE.Schema", "", file.Path, "cpp", lineNum)
@@ -168,18 +210,20 @@ func (e *cppDriverSchemaExtractor) Extract(ctx context.Context, file extractor.F
 		)
 		out = append(out, tableEnt)
 
-		// Extract column definitions from the CREATE TABLE body.
+		// Extract column definitions from the CREATE TABLE body. ctm[1] points at
+		// the opening '(' match end; walk to the matching ')' (paren-balanced) so
+		// inline types like VARCHAR(255)/DECIMAL(10,2) don't truncate the body.
 		bodyStart := ctm[1]
 		if bodyStart >= len(sqlText) {
-			continue
+			return
 		}
-		body := sqlText[bodyStart:]
-		// Trim up to the first closing paren.
-		if closeIdx := strings.IndexByte(body, ')'); closeIdx >= 0 {
-			body = body[:closeIdx]
-		}
+		body := balancedParenBody(sqlText[bodyStart-1:])
 
-		for _, cm := range reCppSQLColumn.FindAllStringSubmatch(body, -1) {
+		for _, segment := range splitTopLevelCommas(body) {
+			cm := reCppSQLColumn.FindStringSubmatch(segment)
+			if cm == nil {
+				continue
+			}
 			colName := cm[1]
 			colType := strings.ToUpper(cm[2])
 			if cppSQLConstraintLead[colType] {
@@ -198,6 +242,68 @@ func (e *cppDriverSchemaExtractor) Extract(ctx context.Context, file extractor.F
 		}
 	}
 
+	for _, m := range reCppDriverExec.FindAllStringSubmatchIndex(src, -1) {
+		if m[2] < 0 {
+			continue
+		}
+		processSQL(src[m[2]:m[3]], lineOf(src, m[0]))
+	}
+	for _, m := range reCppDriverFreeExec.FindAllStringSubmatchIndex(src, -1) {
+		if m[2] < 0 {
+			continue
+		}
+		processSQL(src[m[2]:m[3]], lineOf(src, m[0]))
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
+}
+
+// balancedParenBody takes a string beginning at an opening '(' and returns the
+// inner text up to (but excluding) the matching ')', respecting nesting. If the
+// string does not start with '(' or no balance is found, it returns the input
+// minus the leading paren. Used to isolate a CREATE TABLE column list that may
+// contain parenthesised types such as VARCHAR(255) or DECIMAL(10,2).
+func balancedParenBody(s string) string {
+	if len(s) == 0 || s[0] != '(' {
+		return s
+	}
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[1:i]
+			}
+		}
+	}
+	return s[1:]
+}
+
+// splitTopLevelCommas splits a CREATE TABLE column list on commas that are not
+// nested inside parentheses, so DECIMAL(10,2) stays a single segment.
+func splitTopLevelCommas(s string) []string {
+	var segments []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				segments = append(segments, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	segments = append(segments, s[start:])
+	return segments
 }

--- a/internal/custom/cpp/driver_schema_test.go
+++ b/internal/custom/cpp/driver_schema_test.go
@@ -18,19 +18,14 @@ void setup(pqxx::connection& conn) {
 `
 	ents := extract(t, "custom_cpp_driver_schema", fi("setup.cpp", "cpp", src))
 	if !containsEntity(ents, "SCOPE.Schema", "users") {
-		t.Error("expected SCOPE.Schema entity for users table")
+		t.Fatal("expected SCOPE.Schema entity for users table")
 	}
-	// Should also have column entities
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Schema" && e.Subtype == "column" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("expected SCOPE.Schema column entity from CREATE TABLE")
-	}
+	ormProp(t, ents, "SCOPE.Schema", "", "users", "table_name", "users")
+	// Value assertions: specific columns + parsed SQL types.
+	ormProp(t, ents, "SCOPE.Schema", "column", "users.id", "column_type", "SERIAL")
+	ormProp(t, ents, "SCOPE.Schema", "column", "users.id", "parent_table", "users")
+	ormProp(t, ents, "SCOPE.Schema", "column", "users.name", "column_type", "VARCHAR")
+	ormProp(t, ents, "SCOPE.Schema", "column", "users.age", "column_type", "INT")
 }
 
 func TestCppDriverLibpqxx_QueryAttribution(t *testing.T) {
@@ -44,14 +39,18 @@ void query(pqxx::connection& conn, int id) {
 }
 `
 	ents := extract(t, "custom_cpp_driver_schema", fi("query.cpp", "cpp", src))
-	queryCount := 0
+	// Value assertions: SQL verbs classified specifically from exec() literals.
+	var verbs []string
 	for _, e := range ents {
 		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
-			queryCount++
+			verbs = append(verbs, e.Props["sql_verb"])
 		}
 	}
-	if queryCount < 2 {
-		t.Errorf("expected at least 2 query entities, got %d", queryCount)
+	if !containsStr(verbs, "SELECT") {
+		t.Errorf("expected SELECT verb, got %v", verbs)
+	}
+	if !containsStr(verbs, "INSERT") {
+		t.Errorf("expected INSERT verb, got %v", verbs)
 	}
 }
 
@@ -67,10 +66,36 @@ void save(mongocxx::client& client) {
 `
 	ents := extract(t, "custom_cpp_driver_schema", fi("mongo.cpp", "cpp", src))
 	if !containsEntity(ents, "SCOPE.Schema", "users") {
-		t.Error("expected SCOPE.Schema entity for users collection")
+		t.Fatal("expected SCOPE.Schema entity for users collection")
 	}
-	if !containsEntity(ents, "SCOPE.Schema", "audit_logs") {
-		t.Error("expected SCOPE.Schema entity for audit_logs collection")
+	ormProp(t, ents, "SCOPE.Schema", "", "users", "collection_name", "users")
+	ormProp(t, ents, "SCOPE.Schema", "", "audit_logs", "collection_name", "audit_logs")
+}
+
+func TestCppDriverMongocxx_QueryAttribution(t *testing.T) {
+	src := `#include <mongocxx/client.hpp>
+
+void ops(mongocxx::client& client) {
+	auto db = client["mydb"];
+	auto users = db["users"];
+	users.insert_one(make_document(kvp("name", "Alice")));
+	auto cursor = users.find(make_document());
+	users.update_one(filter, update);
+	users.delete_many(filter);
+	auto pipe = users.aggregate(pipeline);
+}
+`
+	ents := extract(t, "custom_cpp_driver_schema", fi("ops.cpp", "cpp", src))
+	var verbs []string
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
+			verbs = append(verbs, e.Props["mongo_verb"])
+		}
+	}
+	for _, want := range []string{"INSERT", "FIND", "UPDATE", "DELETE", "AGGREGATE"} {
+		if !containsStr(verbs, want) {
+			t.Errorf("expected mongo verb %s, got %v", want, verbs)
+		}
 	}
 }
 
@@ -86,11 +111,26 @@ void doQuery(MYSQL* conn) {
 	mysql_query(conn, "SELECT * FROM orders WHERE id = 1");
 }
 `
-	// mysql_query doesn't match our .exec pattern, but we still test gate behavior
-	// (no match expected since mysql_query is a function not a method call)
+	// mysql_query is a free function (not a .exec method); the free-function
+	// regex picks up its SQL string literal.
 	ents := extract(t, "custom_cpp_driver_schema", fi("mysql.cpp", "cpp", src))
-	// No match expected (mysql_query is not .exec-style), just verify no panic
-	_ = ents
+	// CREATE TABLE → orders table + columns.
+	ormProp(t, ents, "SCOPE.Schema", "", "orders", "table_name", "orders")
+	ormProp(t, ents, "SCOPE.Schema", "column", "orders.id", "column_type", "INT")
+	ormProp(t, ents, "SCOPE.Schema", "column", "orders.total", "column_type", "DECIMAL")
+	// SELECT verb attributed from the second mysql_query.
+	var verbs []string
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
+			verbs = append(verbs, e.Props["sql_verb"])
+		}
+	}
+	if !containsStr(verbs, "SELECT") {
+		t.Errorf("expected SELECT verb from mysql_query, got %v", verbs)
+	}
+	if !containsStr(verbs, "CREATE") {
+		t.Errorf("expected CREATE verb from mysql_query, got %v", verbs)
+	}
 }
 
 func TestCppDriverNoMatch_WrongLanguage(t *testing.T) {

--- a/internal/custom/cpp/extractors_test.go
+++ b/internal/custom/cpp/extractors_test.go
@@ -56,6 +56,17 @@ func findEndpoint(ents []entitySummary, name string) *entitySummary {
 	return nil
 }
 
+// ormFindEntity returns the first entity matching kind/subtype/name, or nil.
+// Namespaced helper for the deep ORM/driver value-asserting tests (#3493).
+func ormFindEntity(ents []entitySummary, kind, subtype, name string) *entitySummary {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Subtype == subtype && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
 // assertEndpoint asserts that an endpoint with name "verb path" exists and that
 // its route_path, http_method, and handler_name properties match exactly. This
 // is the TS/JS bar for proving (verb, path, handler) attribution — not len>0.
@@ -76,6 +87,19 @@ func assertEndpoint(t *testing.T, ents []entitySummary, verb, path, handler stri
 		if got := ep.Props["handler_name"]; got != handler {
 			t.Errorf("endpoint %q: handler_name = %q, want %q", name, got, handler)
 		}
+	}
+}
+
+// ormProp asserts that the entity identified by kind/subtype/name carries
+// property key=want; it fails the test otherwise.
+func ormProp(t *testing.T, ents []entitySummary, kind, subtype, name, key, want string) {
+	t.Helper()
+	e := ormFindEntity(ents, kind, subtype, name)
+	if e == nil {
+		t.Fatalf("no %s/%s entity named %q (got %+v)", kind, subtype, name, ents)
+	}
+	if got := e.Props[key]; got != want {
+		t.Errorf("entity %q prop %q = %q, want %q", name, key, got, want)
 	}
 }
 

--- a/internal/custom/cpp/orm.go
+++ b/internal/custom/cpp/orm.go
@@ -89,6 +89,18 @@ var (
 
 	// inverse(<type>::<field>) — back-reference in a relationship
 	reODBInverse = regexp.MustCompile(`\binverse\s*\(\s*([A-Za-z_][A-Za-z0-9_:]*)\s*\)`)
+
+	// table("name") on a #pragma db object — explicit table mapping.
+	reODBTable = regexp.MustCompile(`\btable\s*\(\s*"([^"]+)"\s*\)`)
+
+	// column("name") in a #pragma db member annotation — explicit column name.
+	reODBColumn = regexp.MustCompile(`\bcolumn\s*\(\s*"([^"]+)"\s*\)`)
+
+	// type("SQL TYPE") in a #pragma db member annotation — DB column type.
+	reODBType = regexp.MustCompile(`\btype\s*\(\s*"([^"]+)"\s*\)`)
+
+	// id keyword as a standalone annotation token (PK marker on the member line).
+	reODBIDToken = regexp.MustCompile(`(^|\s)id(\s|$)`)
 )
 
 func (e *odbExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -116,6 +128,15 @@ func (e *odbExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 
 	// --- Model extraction: #pragma db object → class/struct immediately after ---
 	for _, pragmaIdx := range reODBObject.FindAllStringIndex(src, -1) {
+		// The pragma line may carry a table("name") mapping; capture the rest of
+		// the pragma line before scanning for the class.
+		pragmaLineEnd := strings.IndexByte(src[pragmaIdx[1]:], '\n')
+		tableName := ""
+		if pragmaLineEnd >= 0 {
+			if tm := reODBTable.FindStringSubmatch(src[pragmaIdx[1] : pragmaIdx[1]+pragmaLineEnd]); tm != nil {
+				tableName = tm[1]
+			}
+		}
 		// Search for first class/struct after the pragma
 		afterPragma := src[pragmaIdx[1]:]
 		cm := reODBClassName.FindStringSubmatchIndex(afterPragma)
@@ -131,6 +152,11 @@ func (e *odbExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 			"pattern_type", "model",
 			"class_name", className,
 		)
+		// Explicit table mapping defaults to the class name when omitted.
+		if tableName == "" {
+			tableName = className
+		}
+		setProps(&ent, "table_name", tableName)
 		out = append(out, ent)
 	}
 
@@ -156,6 +182,20 @@ func (e *odbExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 			"field_name", field,
 			"annotations", annotations,
 		)
+		// Parse the explicit column("…") / type("…") / id annotations so the
+		// resolved DB column name + type are first-class properties, not just
+		// raw annotation text.
+		dbColumn := field // default: ODB maps member → column of the same name
+		if cm := reODBColumn.FindStringSubmatch(annotations); cm != nil {
+			dbColumn = cm[1]
+		}
+		setProps(&ent, "column_name", dbColumn)
+		if tm := reODBType.FindStringSubmatch(annotations); tm != nil {
+			setProps(&ent, "column_type", tm[1])
+		}
+		if reODBIDToken.MatchString(annotations) {
+			setProps(&ent, "is_primary_key", "true")
+		}
 		out = append(out, ent)
 
 		// --- Relationship extraction from member annotations ---

--- a/internal/custom/cpp/orm_test.go
+++ b/internal/custom/cpp/orm_test.go
@@ -6,13 +6,23 @@ import (
 	"testing"
 )
 
+// containsStr reports whether want appears in xs (local test helper).
+func containsStr(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
 // ============================================================================
 // ODB
 // ============================================================================
 
 func TestODBModelExtraction(t *testing.T) {
 	src := `
-#pragma db object
+#pragma db object table("people")
 class Person {
 public:
 	std::string name;
@@ -21,26 +31,38 @@ public:
 `
 	ents := extract(t, "custom_cpp_odb", fi("person.hxx", "cpp", src))
 	if !containsEntity(ents, "SCOPE.Schema", "Person") {
-		t.Error("expected SCOPE.Schema entity for Person")
+		t.Fatal("expected SCOPE.Schema entity for Person")
 	}
+	// Value assertion: explicit table("people") mapping captured.
+	ormProp(t, ents, "SCOPE.Schema", "", "Person", "table_name", "people")
+	ormProp(t, ents, "SCOPE.Schema", "", "Person", "class_name", "Person")
+}
+
+func TestODBModelExtraction_DefaultTable(t *testing.T) {
+	src := `
+#pragma db object
+class Account {};
+`
+	ents := extract(t, "custom_cpp_odb", fi("account.hxx", "cpp", src))
+	// No explicit table() → ODB defaults the table name to the class name.
+	ormProp(t, ents, "SCOPE.Schema", "", "Account", "table_name", "Account")
 }
 
 func TestODBMemberExtraction(t *testing.T) {
 	src := `
-#pragma db member(Person::name) column("person_name")
+#pragma db member(Person::name) column("person_name") type("VARCHAR(128)")
+#pragma db member(Person::id) id
 #pragma db member(Person::age)
 `
 	ents := extract(t, "custom_cpp_odb", fi("person.hxx", "cpp", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Schema" && e.Subtype == "column" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("expected SCOPE.Schema column entity for member pragma")
-	}
+	// Value assertions: explicit column("…") + type("…") resolved, not raw text.
+	ormProp(t, ents, "SCOPE.Schema", "column", "member:name", "column_name", "person_name")
+	ormProp(t, ents, "SCOPE.Schema", "column", "member:name", "column_type", "VARCHAR(128)")
+	ormProp(t, ents, "SCOPE.Schema", "column", "member:name", "field_name", "name")
+	// PK marker from the `id` annotation.
+	ormProp(t, ents, "SCOPE.Schema", "column", "member:id", "is_primary_key", "true")
+	// Member with no column() → column name defaults to the field name.
+	ormProp(t, ents, "SCOPE.Schema", "column", "member:age", "column_name", "age")
 }
 
 func TestODBRelationshipExtraction(t *testing.T) {
@@ -48,16 +70,10 @@ func TestODBRelationshipExtraction(t *testing.T) {
 #pragma db member(Employee::employer) one_to_many inverse(employees)
 `
 	ents := extract(t, "custom_cpp_odb", fi("employee.hxx", "cpp", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Pattern" && e.Subtype == "relationship" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("expected SCOPE.Pattern relationship for one_to_many member")
-	}
+	// Value assertions: relationship kind + inverse target are specific.
+	ormProp(t, ents, "SCOPE.Pattern", "relationship", "one_to_many:employer", "relationship_kind", "one_to_many")
+	ormProp(t, ents, "SCOPE.Pattern", "relationship", "one_to_many:employer", "field_name", "employer")
+	ormProp(t, ents, "SCOPE.Pattern", "relationship", "one_to_many:employer", "target_type", "employees")
 }
 
 func TestODBLazyPtrExtraction(t *testing.T) {
@@ -66,15 +82,10 @@ odb::lazy_ptr<Employer> employer_;
 odb::lazy_shared_ptr<Department> dept_;
 `
 	ents := extract(t, "custom_cpp_odb", fi("employee.hxx", "cpp", src))
-	found := 0
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Pattern" && e.Subtype == "relationship" {
-			found++
-		}
-	}
-	if found < 2 {
-		t.Errorf("expected at least 2 lazy_ptr relationship entities, got %d", found)
-	}
+	// Value assertions: each lazy_ptr names its specific target type.
+	ormProp(t, ents, "SCOPE.Pattern", "relationship", "lazy_ptr:Employer", "target_type", "Employer")
+	ormProp(t, ents, "SCOPE.Pattern", "relationship", "lazy_ptr:Employer", "relationship_kind", "lazy_ptr")
+	ormProp(t, ents, "SCOPE.Pattern", "relationship", "lazy_ptr:Department", "target_type", "Department")
 }
 
 func TestODBQueryExtraction(t *testing.T) {
@@ -82,16 +93,8 @@ func TestODBQueryExtraction(t *testing.T) {
 odb::result<Person> r = db.query<Person>(odb::query<Person>::age > 18);
 `
 	ents := extract(t, "custom_cpp_odb", fi("main.cpp", "cpp", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("expected SCOPE.Operation query entity for odb::query<Person>")
-	}
+	// Value assertion: query attributed to the specific model type.
+	ormProp(t, ents, "SCOPE.Operation", "query", "query:Person", "model_type", "Person")
 }
 
 func TestODBNoMatch(t *testing.T) {
@@ -129,8 +132,9 @@ template<> struct type_conversion<Person> {
 `
 	ents := extract(t, "custom_cpp_soci", fi("person.cpp", "cpp", src))
 	if !containsEntity(ents, "SCOPE.Schema", "Person") {
-		t.Error("expected SCOPE.Schema entity for type_conversion<Person>")
+		t.Fatal("expected SCOPE.Schema entity for type_conversion<Person>")
 	}
+	ormProp(t, ents, "SCOPE.Schema", "", "Person", "class_name", "Person")
 }
 
 func TestSOCIIntoBinding(t *testing.T) {
@@ -140,16 +144,9 @@ int count;
 sql << "SELECT COUNT(*) FROM persons", into(count);
 `
 	ents := extract(t, "custom_cpp_soci", fi("query.cpp", "cpp", src))
-	found := false
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Schema" && e.Subtype == "column" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("expected SCOPE.Schema column binding for into(count)")
-	}
+	// Value assertions: the bound variable + direction are specific.
+	ormProp(t, ents, "SCOPE.Schema", "column", "binding:count", "variable", "count")
+	ormProp(t, ents, "SCOPE.Schema", "column", "binding:count", "direction", "into")
 }
 
 func TestSOCIQueryExtraction(t *testing.T) {
@@ -159,14 +156,18 @@ sql << "SELECT * FROM users WHERE id = :id", use(id), into(user);
 sql << "INSERT INTO logs (msg) VALUES (:msg)", use(msg);
 `
 	ents := extract(t, "custom_cpp_soci", fi("query.cpp", "cpp", src))
-	queryCount := 0
+	// Value assertions: each SQL string is classified by its specific verb.
+	var verbs []string
 	for _, e := range ents {
 		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
-			queryCount++
+			verbs = append(verbs, e.Props["sql_verb"])
 		}
 	}
-	if queryCount < 2 {
-		t.Errorf("expected at least 2 query entities, got %d", queryCount)
+	if !containsStr(verbs, "SELECT") {
+		t.Errorf("expected a SELECT query verb, got %v", verbs)
+	}
+	if !containsStr(verbs, "INSERT") {
+		t.Errorf("expected an INSERT query verb, got %v", verbs)
 	}
 }
 
@@ -200,8 +201,14 @@ struct TabPerson : sqlpp::table<TabPerson, TabPerson::Id, TabPerson::Name> {
 `
 	ents := extract(t, "custom_cpp_sqlpp11", fi("tables.h", "cpp", src))
 	if !containsEntity(ents, "SCOPE.Schema", "TabPerson") {
-		t.Error("expected SCOPE.Schema entity for TabPerson")
+		t.Fatal("expected SCOPE.Schema entity for TabPerson")
 	}
+	ormProp(t, ents, "SCOPE.Schema", "", "TabPerson", "class_name", "TabPerson")
+	// Value assertions: column structs (id_, name_) resolve to specific columns
+	// parented to the table.
+	ormProp(t, ents, "SCOPE.Schema", "column", "TabPerson.id", "parent_table", "TabPerson")
+	ormProp(t, ents, "SCOPE.Schema", "column", "TabPerson.id", "col_struct", "id_")
+	ormProp(t, ents, "SCOPE.Schema", "column", "TabPerson.name", "parent_table", "TabPerson")
 }
 
 func TestSQLPP11AliasExtraction(t *testing.T) {
@@ -209,15 +216,9 @@ func TestSQLPP11AliasExtraction(t *testing.T) {
 SQLPP_ALIAS_PROVIDER(right)
 `
 	ents := extract(t, "custom_cpp_sqlpp11", fi("tables.h", "cpp", src))
-	found := 0
-	for _, e := range ents {
-		if e.Kind == "SCOPE.Schema" && e.Subtype == "alias" {
-			found++
-		}
-	}
-	if found < 2 {
-		t.Errorf("expected at least 2 alias schema entities, got %d", found)
-	}
+	// Value assertions: each alias is captured by its specific name.
+	ormProp(t, ents, "SCOPE.Schema", "alias", "alias:left", "alias_name", "left")
+	ormProp(t, ents, "SCOPE.Schema", "alias", "alias:right", "alias_name", "right")
 }
 
 func TestSQLPP11QueryExtraction(t *testing.T) {
@@ -228,14 +229,17 @@ db(update(tab).set(tab.name = "bob").where(tab.id == 1));
 db(remove_from(tab).where(tab.id == 2));
 `
 	ents := extract(t, "custom_cpp_sqlpp11", fi("queries.cpp", "cpp", src))
-	queryCount := 0
+	// Value assertions: every DSL verb is classified specifically.
+	var verbs []string
 	for _, e := range ents {
 		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
-			queryCount++
+			verbs = append(verbs, e.Props["sql_verb"])
 		}
 	}
-	if queryCount < 4 {
-		t.Errorf("expected at least 4 query entities (select/insert/update/remove), got %d", queryCount)
+	for _, want := range []string{"SELECT", "INSERT_INTO", "UPDATE", "REMOVE_FROM"} {
+		if !containsStr(verbs, want) {
+			t.Errorf("expected %s query verb, got %v", want, verbs)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #3493 (epic #3490).

Deep-grinds the C/C++ ORM (ODB / SOCI / sqlpp11) and raw DB-driver (libpqxx / mongocxx / mysql-connector-cpp / redis-plus-plus) extractors to the TS/JS quality bar: resolved, value-asserting properties + value-asserting tests, then honest coverage flips.

## Extractor improvements

**ODB (`orm.go`)**
- `table("…")` on `#pragma db object` → `table_name` on the model (defaults to class name)
- `column("…")` / `type("…")` / `id` on `#pragma db member` → resolved `column_name`, `column_type`, `is_primary_key` (column defaults to field name)

**Drivers (`driver_schema.go`)**
- `CREATE TABLE` column parsing is now paren-balanced and split on top-level commas, so **all** columns (not just the first) and inline types like `VARCHAR(255)` / `DECIMAL(10,2)` are captured (previous line-anchored regex only caught the first column)
- MySQL C-API free functions `mysql_query()` / `mysql_real_query()` now feed the SQL schema + query pipeline (previously unmatched — the old test asserted nothing)
- mongocxx CRUD/aggregate ops (`insert_one`/`find`/`update_one`/`delete_many`/`aggregate`/…) → query entities with canonical `mongo_verb`

## Tests
Rewritten from `len>0` / kind-presence to **value assertions** on specific table/column/relation/SQL-verb, via a namespaced `ormProp` helper (`extractors_test.go` now exposes entity `Properties`). All targeted suites green.

## Coverage dispositions
| Record | Disposition |
|---|---|
| `lang.c-cpp.orm.odb` | model/schema/association/relationship/foreign_key/lazy_loading/query_attribution → **full** |
| `lang.c-cpp.orm.soci` | model + query_attribution → **full**; schema_extraction → **partial** (into/use bind vars ≠ DB columns without dataflow — honest cross-file gap) |
| `lang.c-cpp.orm.sqlpp11` | model/schema/query_attribution → **full** |
| `lang.c-cpp.driver.libpqxx` | model/schema/query_attribution → **full** |
| `lang.c-cpp.driver.mysql-connector-cpp` | model/schema/query_attribution → **full** |
| `lang.c-cpp.driver.mongocxx` | model + query_attribution → **full**; schema_extraction → **partial** (document store, collection-as-proxy, no static field schema) |
| `lang.c-cpp.driver.redis-plus-plus` | query_attribution → **full** |

Raw-driver migration cells remain `not_applicable`.

## Gates
- `go test ./internal/custom/cpp/ ./internal/types/ ./tools/coverage/` — pass
- `coverage validate` — 0 errors; `coverage fmt --check` — canonical; `go vet` clean; changed Go files gofmt-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)