### PR TITLE
feat(c-cpp): deep TESTING linkage for gtest/catch2/doctest/boost-test/cppunit/cpputest (#3495)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,20 +11,20 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ✅ 3/3 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟢 3/3 | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
@@ -157,7 +157,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | 🟢 2/2 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -11,20 +11,20 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟢 3/3 | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [Crow](../detail/lang.c-cpp.framework.crow.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ✅ 3/3 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [C/C++](../by-language/c-cpp.md) | [libev](../detail/lang.c-cpp.framework.libev.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libevent](../detail/lang.c-cpp.framework.libevent.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [C/C++](../by-language/c-cpp.md) | [libuv](../detail/lang.c-cpp.framework.libuv.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [C#](../by-language/csharp.md) | [ASP.NET Core](../detail/lang.csharp.framework.aspnet-core.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [ASP.NET MVC (legacy)](../detail/lang.csharp.framework.aspnet-mvc.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [C#](../by-language/csharp.md) | [Carter](../detail/lang.csharp.framework.carter.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
@@ -157,7 +157,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | 🟢 2/2 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [C/C++](../by-language/c-cpp.md) | [Qt](../detail/lang.c-cpp.framework.qt.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -26,27 +26,27 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ✅ 3/3 | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | — | — | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟢 3/3 | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | 🟢 2/2 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
 
 
 ### Desktop
@@ -85,10 +85,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | ✅ 3/3 | |
-| [ODB](../detail/lang.c-cpp.orm.odb.md) | ✅ 7/7 | |
+| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟢 3/3 | |
+| [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟢 7/7 | |
 | [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟢 3/3 | |
-| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | ✅ 3/3 | |
+| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟢 3/3 | |
 | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟢 3/3 | |
-| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ✅ 1/1 | |
-| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ✅ 3/3 | |
+| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🟢 1/1 | |
+| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟢 3/3 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -26,27 +26,27 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
-| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [Crow](../detail/lang.c-cpp.framework.crow.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | 🟢 3/3 | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | 🟢 3/3 | 🟢 1/1 | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [libev](../detail/lang.c-cpp.framework.libev.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [libevent](../detail/lang.c-cpp.framework.libevent.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [libuv](../detail/lang.c-cpp.framework.libuv.md) | — | — | 🟢 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [ACE (Adaptive Communication Environment)](../detail/lang.c-cpp.framework.ace.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Boost (Boost.Asio + utilities)](../detail/lang.c-cpp.framework.boost.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Boost.Asio](../detail/lang.c-cpp.framework.boost-asio.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Crow](../detail/lang.c-cpp.framework.crow.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Drogon](../detail/lang.c-cpp.framework.drogon.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Oat++](../detail/lang.c-cpp.framework.oatpp.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [POCO C++ Libraries](../detail/lang.c-cpp.framework.poco.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Pistache](../detail/lang.c-cpp.framework.pistache.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [RESTinio](../detail/lang.c-cpp.framework.restinio.md) | ✅ 3/3 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Restbed](../detail/lang.c-cpp.framework.restbed.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [cpprestsdk (Casablanca)](../detail/lang.c-cpp.framework.cpprestsdk.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [libev](../detail/lang.c-cpp.framework.libev.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [libevent](../detail/lang.c-cpp.framework.libevent.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [libuv](../detail/lang.c-cpp.framework.libuv.md) | — | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 
 
 ### UI Frontend
 
 | Name | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|
-| [Qt](../detail/lang.c-cpp.framework.qt.md) | 🟢 2/2 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [Qt](../detail/lang.c-cpp.framework.qt.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 8/8 | |
 
 
 ### Desktop
@@ -85,10 +85,10 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | 🟢 3/3 | |
-| [ODB](../detail/lang.c-cpp.orm.odb.md) | 🟢 7/7 | |
+| [MySQL Connector/C++](../detail/lang.c-cpp.driver.mysql-connector-cpp.md) | ✅ 3/3 | |
+| [ODB](../detail/lang.c-cpp.orm.odb.md) | ✅ 7/7 | |
 | [SOCI](../detail/lang.c-cpp.orm.soci.md) | 🟢 3/3 | |
-| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | 🟢 3/3 | |
+| [libpqxx (PostgreSQL)](../detail/lang.c-cpp.driver.libpqxx.md) | ✅ 3/3 | |
 | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟢 3/3 | |
-| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | 🟢 1/1 | |
-| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | 🟢 3/3 | |
+| [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ✅ 1/1 | |
+| [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ✅ 3/3 | |

--- a/docs/coverage/detail/lang.c-cpp.framework.ace.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.ace.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost-asio.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.boost.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.boost.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cpprestsdk.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.crow.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.crow.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.drogon.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.drogon.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libev.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libev.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libevent.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libevent.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.libuv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.libuv.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.oatpp.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.pistache.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.pistache.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.poco.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.poco.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.qt.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.qt.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | — | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Substrate
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restbed.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restbed.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/detail/lang.c-cpp.framework.restinio.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.restinio.md
@@ -51,7 +51,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/substrate/entry_points_c_cpp.go` | — |
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/extractors/cross/testmap/extractor.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_cpp.go`<br>`internal/extractors/cross/testmap/resolver.go` | gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include <...> headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded. |
 
 ### Observability
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -2019,9 +2019,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -2227,9 +2228,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -2435,9 +2437,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -2652,9 +2655,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -2869,9 +2873,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -3086,9 +3091,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -3294,9 +3300,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -3502,9 +3509,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -3710,9 +3718,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -3926,9 +3935,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -4143,9 +4153,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -4360,9 +4371,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -4574,8 +4586,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"]
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Substrate": {
@@ -4767,9 +4781,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {
@@ -4983,9 +4998,10 @@
         },
         "Testing": {
           "tests_linkage": {
-            "status": "partial",
-            "cites": ["internal/substrate/entry_points_c_cpp.go"],
-            "issue": "backfill:dictionary-completeness"
+            "status": "full",
+            "cites": ["internal/extractors/cross/testmap/extractor.go","internal/extractors/cross/testmap/frameworks.go","internal/extractors/cross/testmap/frameworks_cpp.go","internal/extractors/cross/testmap/resolver.go"],
+            "notes": "gtest (TEST/TEST_F/TEST_P), catch2 + doctest (TEST_CASE/SECTION), boost.test (BOOST_AUTO_TEST_CASE/BOOST_FIXTURE_TEST_CASE), cppunit (CPPUNIT_TEST + void Class::testX bodies, inline and out-of-line), and cpputest (TEST(group,name)) registered in the shared testmap extractor: each case emits a TESTS edge to the production symbol via direct-call resolution (high), suite/fixture/group subject fallback (medium, Test/Fixture affix stripped), and *_test/test_*/FooTest naming convention (low). #include \u003c...\u003e headers feed framework selection; EXPECT_*/ASSERT_*/CHECK/REQUIRE/BOOST_CHECK/CPPUNIT_ASSERT/STRCMP_EQUAL assertion macros stop-worded.",
+            "verified_at": "2026-05-30"
           }
         },
         "Observability": {

--- a/internal/extractors/cross/testmap/extractor.go
+++ b/internal/extractors/cross/testmap/extractor.go
@@ -259,6 +259,31 @@ func productionFileFromTestPath(filePath string) (prodFile, prodSymbol string) {
 			prodStem := stem[:len(stem)-len("_test")]
 			return path.Join(dir, prodStem+".lua"), prodStem
 		}
+	case ".cpp", ".cc", ".cxx", ".c", ".hpp", ".hxx", ".h":
+		// C/C++ test files (#3495). Common conventions, in priority order:
+		//   foo_test.cpp / foo_unittest.cpp → foo.cpp   (gtest / catch2)
+		//   test_foo.cpp                    → foo.cpp
+		//   FooTest.cpp / FooTests.cpp      → Foo.cpp    (cppunit / boost)
+		// The subject guess is the bare stem (C/C++ free functions and classes
+		// are not consistently cased), which the resolver's byLocation lookup
+		// matches against the production file's symbols.
+		switch {
+		case strings.HasSuffix(lowerStem, "_unittest"):
+			prodStem := stem[:len(stem)-len("_unittest")]
+			return path.Join(dir, prodStem+ext), prodStem
+		case strings.HasSuffix(lowerStem, "_test"):
+			prodStem := stem[:len(stem)-len("_test")]
+			return path.Join(dir, prodStem+ext), prodStem
+		case strings.HasPrefix(lowerStem, "test_"):
+			prodStem := stem[len("test_"):]
+			return path.Join(dir, prodStem+ext), prodStem
+		case strings.HasSuffix(stem, "Tests") && len(stem) > len("Tests"):
+			prodStem := stem[:len(stem)-len("Tests")]
+			return path.Join(dir, prodStem+ext), prodStem
+		case strings.HasSuffix(stem, "Test") && len(stem) > len("Test"):
+			prodStem := stem[:len(stem)-len("Test")]
+			return path.Join(dir, prodStem+ext), prodStem
+		}
 	case ".rs":
 		// no standard filename convention for Rust tests — leave empty
 	case ".php":

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -55,6 +55,15 @@ var importCallRE = regexp.MustCompile(
 	`(?mi)\b(?:require|import)\s*\(\s*["']([\w@][\w\-./:]*)["']\s*\)`,
 )
 
+// includeTokenRE captures C/C++ preprocessor includes in both bracket and quote
+// forms: `#include <gtest/gtest.h>` and `#include "catch.hpp"`. The captured
+// token (e.g. "gtest/gtest.h") is added to the import set so the C/C++ test
+// frameworks can be selected by their header path the same way other languages
+// match on import statements. (#3495)
+var includeTokenRE = regexp.MustCompile(
+	`(?m)^\s*#\s*include\s+[<"]([\w@][\w\-./:]*)[>"]`,
+)
+
 // extractImportTokens returns the lower-cased set of import tokens in source.
 func extractImportTokens(source string) map[string]bool {
 	out := map[string]bool{}
@@ -74,6 +83,11 @@ func extractImportTokens(source string) map[string]bool {
 		}
 	}
 	for _, m := range importCallRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 2 {
+			add(m[1])
+		}
+	}
+	for _, m := range includeTokenRE.FindAllStringSubmatch(source, -1) {
 		if len(m) >= 2 {
 			add(m[1])
 		}
@@ -2088,6 +2102,73 @@ var frameworkOrder = []frameworkEntry{
 			regexp.MustCompile(`/tests?/.*\.lua$`),
 		},
 		detect: detectLuaunit,
+	},
+	// ---------------------------------------------------------------------
+	// C/C++ — gtest, catch2, doctest, boost.test, cppunit, cpputest (#3495).
+	//
+	// Ordering matters because several frameworks share macro surfaces:
+	//   - gtest TEST(a,b) and cpputest TEST(a,b) are identical → both gated on
+	//     framework-specific import headers (gtest.h vs CppUTest/TestHarness.h)
+	//     so the right detector is selected by #include, not by the macro.
+	//   - catch2 and doctest share TEST_CASE("name") → catch2 is listed first;
+	//     a doctest file with a doctest.h include is routed to doctest by its
+	//     import hint, otherwise the shared detector (detectCatch2) handles both.
+	//
+	// All C/C++ entries are IMPORT-HINT gated (the #include directive, captured
+	// by importTokenRE as a `<dir/file.h>` token) so plain .cpp/.h source files
+	// are never mis-classified as tests. No filename convention is reliable
+	// across C/C++ projects (tests live in foo_test.cpp, test_foo.cpp,
+	// FooTest.cpp, tests/foo.cpp …), so filename/path hints are added as a
+	// secondary signal only.
+	{
+		name: "gtest",
+		importHints: []string{
+			"gtest/gtest.h", "gtest/gtest", "gtest", "gmock/gmock.h", "gmock/gmock", "gmock",
+		},
+		// No filename hints: gtest, catch2 and cpputest all use *_test.cpp, so a
+		// filename match would shadow the import-correct framework (selectFramework
+		// returns the first match and does not retry). Detection is #include-gated.
+		detect: detectGTest,
+	},
+	{
+		name: "cpputest",
+		importHints: []string{
+			"cpputest/testharness.h", "cpputest/testharness", "cpputest",
+			"cpputest/commandlinetestrunner.h",
+		},
+		detect: detectCppUTest,
+	},
+	{
+		name: "doctest",
+		importHints: []string{
+			"doctest/doctest.h", "doctest/doctest", "doctest.h", "doctest",
+		},
+		detect: detectCatch2,
+	},
+	{
+		name: "catch2",
+		importHints: []string{
+			"catch2/catch_test_macros.hpp", "catch2/catch_all.hpp", "catch2/catch.hpp",
+			"catch2/catch", "catch2", "catch.hpp",
+		},
+		// Import-gated for the same reason as gtest above.
+		detect: detectCatch2,
+	},
+	{
+		name: "boost-test",
+		importHints: []string{
+			"boost/test/unit_test.hpp", "boost/test/included/unit_test.hpp",
+			"boost/test/auto_unit_test.hpp", "boost/test",
+		},
+		detect: detectBoostTest,
+	},
+	{
+		name: "cppunit",
+		importHints: []string{
+			"cppunit/testfixture.h", "cppunit/extensions/helpermacros.h",
+			"cppunit/testcase.h", "cppunit/ui/text/testrunner.h", "cppunit",
+		},
+		detect: detectCppUnit,
 	},
 }
 

--- a/internal/extractors/cross/testmap/frameworks_cpp.go
+++ b/internal/extractors/cross/testmap/frameworks_cpp.go
@@ -1,0 +1,328 @@
+// Package testmap — C/C++ test-framework detection and call resolution.
+//
+// Deep linkage (#3495) for the six dominant C/C++ unit-test frameworks. Each
+// detector returns the test cases in a file together with each case's
+// brace-delimited body so the shared resolver can scan it for direct
+// production calls (high), the suite/fixture subject (medium), or the
+// file-name convention (low).
+//
+//	gtest (GoogleTest):
+//	    TEST(Suite, Name) / TEST_F(Fixture, Name) / TEST_P(Fixture, Name).
+//	    The Suite/Fixture name is the subject-under-test; the body is scanned
+//	    for production calls. EXPECT_*/ASSERT_* assertion macros are
+//	    stop-worded (see resolver.go).
+//
+//	catch2 / doctest:
+//	    TEST_CASE("name", "[tag]") with optional SECTION("…") leaves. Both
+//	    share the same surface (doctest deliberately mirrors Catch2), so one
+//	    detector serves both. CHECK/REQUIRE assertions are stop-worded.
+//
+//	boost.test:
+//	    BOOST_AUTO_TEST_CASE(name) / BOOST_FIXTURE_TEST_CASE(name, Fixture).
+//	    The fixture (when present) is the subject; BOOST_CHECK/REQUIRE macros
+//	    are stop-worded.
+//
+//	cppunit:
+//	    CPPUNIT_TEST(testMethod) registrations inside a TestFixture, plus the
+//	    `void Class::testMethod()` method definitions. The class name (minus a
+//	    trailing "Test") is the subject; CPPUNIT_ASSERT* macros are
+//	    stop-worded.
+//
+//	cpputest:
+//	    TEST(group, name) / TEST_GROUP(group). The group name is the subject;
+//	    CHECK*/LONGS_EQUAL/STRCMP_EQUAL macros are stop-worded.
+//
+// C/C++ bodies are brace-delimited, so all detectors reuse the shared
+// extractBraceBody helper.
+package testmap
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Shared C/C++ subject helpers
+// ---------------------------------------------------------------------------
+
+// cppStripTestAffix removes a leading or trailing "Test"/"Tests"/"Fixture"
+// affix from a gtest suite / cppunit class name so the residual is the
+// production subject. Examples:
+//
+//	UserServiceTest   → UserService
+//	TestUserService   → UserService
+//	AccountFixture    → Account
+//	CalculatorTests   → Calculator
+//
+// When stripping would empty the name (e.g. the name is exactly "Test") the
+// original is returned unchanged so the caller still has a usable subject.
+func cppStripTestAffix(name string) string {
+	for _, suf := range []string{"Tests", "Test", "Fixture", "Suite", "Spec"} {
+		if strings.HasSuffix(name, suf) && len(name) > len(suf) {
+			return name[:len(name)-len(suf)]
+		}
+	}
+	if strings.HasPrefix(name, "Test") && len(name) > len("Test") {
+		return name[len("Test"):]
+	}
+	return name
+}
+
+// ---------------------------------------------------------------------------
+// gtest — GoogleTest
+// ---------------------------------------------------------------------------
+
+// gtestCaseRE matches a GoogleTest case macro:
+//
+//	TEST(SuiteName, TestName) { … }
+//	TEST_F(FixtureName, TestName) { … }
+//	TEST_P(FixtureName, TestName) { … }
+//	TYPED_TEST(SuiteName, TestName) { … }
+//	TYPED_TEST_P(SuiteName, TestName) { … }
+//
+// Group 1 = suite/fixture name (subject), group 2 = test name.
+var gtestCaseRE = regexp.MustCompile(
+	`(?m)\b(?:TYPED_TEST_P|TYPED_TEST|TEST_F|TEST_P|TEST)\s*\(\s*(\w+)\s*,\s*(\w+)\s*\)`,
+)
+
+func detectGTest(source string) []testFunction {
+	var out []testFunction
+	seen := map[string]bool{}
+	for _, m := range gtestCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		suite := source[m[2]:m[3]]
+		name := source[m[4]:m[5]]
+		qname := suite + "_" + name
+		if seen[qname] {
+			continue
+		}
+		seen[qname] = true
+		// Body is the { … } block following the macro's closing paren.
+		body := extractBraceBody(source, m[1])
+		out = append(out, testFunction{
+			qname:           qname,
+			body:            body,
+			describeSubject: cppStripTestAffix(suite),
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// catch2 / doctest — TEST_CASE("name", "[tag]")
+// ---------------------------------------------------------------------------
+
+// catch2CaseRE matches a Catch2 / doctest test case:
+//
+//	TEST_CASE("name") { … }
+//	TEST_CASE("name", "[tag]") { … }
+//	SCENARIO("name") { … }              (Catch2 BDD)
+//	TEST_CASE_METHOD(Fixture, "name") { … }
+//
+// Group 1 = the fixture name for TEST_CASE_METHOD (else empty), group 2 = the
+// description string. The leading optional `(\w+)\s*,` only fires for the
+// _METHOD form because the description is always a quoted string.
+var catch2CaseRE = regexp.MustCompile(
+	`(?m)\b(?:TEST_CASE_METHOD\s*\(\s*(\w+)\s*,|TEST_CASE|SCENARIO)\s*(?:\(\s*)?["']([^"']{1,200})["']`,
+)
+
+func detectCatch2(source string) []testFunction {
+	var out []testFunction
+	seen := map[string]bool{}
+	for _, m := range catch2CaseRE.FindAllStringSubmatchIndex(source, -1) {
+		var fixture string
+		if m[2] >= 0 {
+			fixture = source[m[2]:m[3]]
+		}
+		desc := source[m[4]:m[5]]
+		qname := jestCaseQName(desc) // reuse JS normaliser: spaces → underscores, "it_" prefix
+		if qname == "" || seen[qname] {
+			continue
+		}
+		seen[qname] = true
+		body := extractBraceBody(source, m[1])
+		subject := ""
+		if fixture != "" {
+			subject = cppStripTestAffix(fixture)
+		}
+		out = append(out, testFunction{
+			qname:           qname,
+			body:            body,
+			describeSubject: subject,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// boost.test — BOOST_AUTO_TEST_CASE / BOOST_FIXTURE_TEST_CASE
+// ---------------------------------------------------------------------------
+
+// boostCaseRE matches a Boost.Test case:
+//
+//	BOOST_AUTO_TEST_CASE(name) { … }
+//	BOOST_FIXTURE_TEST_CASE(name, Fixture) { … }
+//	BOOST_AUTO_TEST_CASE_TEMPLATE(name, T, types) { … }
+//
+// Group 1 = test name, group 2 = fixture name (only for the FIXTURE form).
+var boostCaseRE = regexp.MustCompile(
+	`(?m)\bBOOST_(?:FIXTURE_TEST_CASE|AUTO_TEST_CASE_TEMPLATE|AUTO_TEST_CASE)\s*\(\s*(\w+)\s*(?:,\s*(\w+))?`,
+)
+
+func detectBoostTest(source string) []testFunction {
+	var out []testFunction
+	seen := map[string]bool{}
+	for _, m := range boostCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		name := source[m[2]:m[3]]
+		var fixture string
+		if m[4] >= 0 {
+			fixture = source[m[4]:m[5]]
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		body := extractBraceBody(source, m[1])
+		subject := ""
+		if fixture != "" {
+			subject = cppStripTestAffix(fixture)
+		}
+		out = append(out, testFunction{
+			qname:           name,
+			body:            body,
+			describeSubject: subject,
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// cppunit — CPPUNIT_TEST registrations + void Class::testMethod() bodies
+// ---------------------------------------------------------------------------
+
+// cppunitScopedMethodRE matches an OUT-OF-LINE CppUnit test-method definition:
+//
+//	void UserServiceTest::testAddUser() { … }
+//
+// Group 1 = test fixture class, group 2 = method name.
+var cppunitScopedMethodRE = regexp.MustCompile(
+	`(?m)\bvoid\s+(\w+)\s*::\s*(\w+)\s*\(\s*\)`,
+)
+
+// cppunitInlineMethodRE matches an INLINE method definition (inside the fixture
+// class body): `void testAddUser() {`. Group 1 = method name. The fixture class
+// is taken from the CPPUNIT_TEST_SUITE(Class) macro since the inline form omits
+// the scope qualifier.
+var cppunitInlineMethodRE = regexp.MustCompile(
+	`(?m)\bvoid\s+(\w+)\s*\(\s*\)\s*\{`,
+)
+
+// cppunitRegistrationRE matches the CPPUNIT_TEST(method) registration macro so
+// we only treat method definitions as tests when they are actually registered
+// (avoids picking up helper methods on the same fixture class).
+var cppunitRegistrationRE = regexp.MustCompile(
+	`\bCPPUNIT_TEST\s*\(\s*(\w+)\s*\)`,
+)
+
+// cppunitSuiteRE matches CPPUNIT_TEST_SUITE(Class) so the inline-method form can
+// recover the fixture class name.
+var cppunitSuiteRE = regexp.MustCompile(
+	`\bCPPUNIT_TEST_SUITE\s*\(\s*(\w+)\s*\)`,
+)
+
+func detectCppUnit(source string) []testFunction {
+	// Collect the set of registered test method names.
+	registered := map[string]bool{}
+	for _, m := range cppunitRegistrationRE.FindAllStringSubmatch(source, -1) {
+		registered[m[1]] = true
+	}
+	// Fixture class declared by the suite macro (used for the inline form).
+	suiteClass := ""
+	if m := cppunitSuiteRE.FindStringSubmatch(source); m != nil {
+		suiteClass = m[1]
+	}
+
+	var out []testFunction
+	seen := map[string]bool{}
+	emit := func(class, method string, bodyStart int) {
+		if class == "" {
+			class = "CppUnit"
+		}
+		qname := class + "_" + method
+		if seen[qname] {
+			return
+		}
+		seen[qname] = true
+		out = append(out, testFunction{
+			qname:           qname,
+			body:            extractBraceBody(source, bodyStart),
+			describeSubject: cppStripTestAffix(class),
+		})
+	}
+
+	registeredOrTest := func(method string) bool {
+		if len(registered) > 0 {
+			return registered[method]
+		}
+		return strings.HasPrefix(method, "test")
+	}
+
+	// Out-of-line definitions: void Class::method() { … }.
+	for _, m := range cppunitScopedMethodRE.FindAllStringSubmatchIndex(source, -1) {
+		class := source[m[2]:m[3]]
+		method := source[m[4]:m[5]]
+		if !registeredOrTest(method) {
+			continue
+		}
+		emit(class, method, m[1])
+	}
+	// Inline definitions inside the fixture body: void method() { … }.
+	for _, m := range cppunitInlineMethodRE.FindAllStringSubmatchIndex(source, -1) {
+		method := source[m[2]:m[3]]
+		if !registeredOrTest(method) {
+			continue
+		}
+		// Pass the match START so extractBraceBody locates this method's own
+		// opening brace (cppunitInlineMethodRE ends AT the `{`, so m[1] is just
+		// past it and would make the extractor seek the next brace).
+		emit(suiteClass, method, m[0])
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// cpputest — TEST(group, name) / TEST_GROUP(group)
+// ---------------------------------------------------------------------------
+
+// cpputestCaseRE matches a CppUTest case:
+//
+//	TEST(GroupName, TestName) { … }
+//	IGNORE_TEST(GroupName, TestName) { … }
+//
+// Group 1 = group name (subject), group 2 = test name. This shares the
+// TEST(a, b) surface with gtest; the cpputest framework entry is only selected
+// for files whose imports/markers name CppUTest (CppUTest/TestHarness.h), so
+// the overlap does not cause cross-framework confusion.
+var cpputestCaseRE = regexp.MustCompile(
+	`(?m)\b(?:IGNORE_TEST|TEST)\s*\(\s*(\w+)\s*,\s*(\w+)\s*\)`,
+)
+
+func detectCppUTest(source string) []testFunction {
+	var out []testFunction
+	seen := map[string]bool{}
+	for _, m := range cpputestCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		group := source[m[2]:m[3]]
+		name := source[m[4]:m[5]]
+		qname := group + "_" + name
+		if seen[qname] {
+			continue
+		}
+		seen[qname] = true
+		body := extractBraceBody(source, m[1])
+		out = append(out, testFunction{
+			qname:           qname,
+			body:            body,
+			describeSubject: cppStripTestAffix(group),
+		})
+	}
+	return out
+}

--- a/internal/extractors/cross/testmap/frameworks_cpp_test.go
+++ b/internal/extractors/cross/testmap/frameworks_cpp_test.go
@@ -1,0 +1,212 @@
+package testmap
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// C/C++ test-framework deep linkage (#3495).
+//
+// Each test asserts a SPECIFIC test→production TESTS edge (not len>0), proving
+// the detector + resolver bind the test case to a named production symbol.
+// ---------------------------------------------------------------------------
+
+// gtest — TEST(Suite, Name): a direct production call inside the body yields a
+// high-confidence edge to that symbol.
+func TestCpp_GTest_DirectCall(t *testing.T) {
+	src := `#include <gtest/gtest.h>
+#include "calculator.h"
+
+TEST(CalculatorTest, AddsTwoNumbers) {
+    Calculator calc;
+    int result = computeSum(2, 3);
+    EXPECT_EQ(result, 5);
+}`
+	recs := runExtract(t, "calculator_test.cpp", "cpp", src)
+	if !hasEdgeAny(recs, "CalculatorTest_AddsTwoNumbers", "computeSum") {
+		t.Fatalf("expected TESTS edge CalculatorTest_AddsTwoNumbers -> computeSum; got %+v", relSummary(recs))
+	}
+}
+
+// gtest — TEST_F(Fixture, Name): the fixture name (minus trailing "Test") seeds
+// a medium-confidence subject edge when the body has no resolvable call.
+func TestCpp_GTest_FixtureSubject(t *testing.T) {
+	src := `#include <gtest/gtest.h>
+
+TEST_F(UserServiceTest, ReturnsUser) {
+    EXPECT_TRUE(true);
+}`
+	recs := runExtract(t, "user_service_test.cpp", "cpp", src)
+	if !hasEdgeAny(recs, "UserServiceTest_ReturnsUser", "UserService") {
+		t.Fatalf("expected subject edge UserServiceTest_ReturnsUser -> UserService; got %+v", relSummary(recs))
+	}
+}
+
+// gtest — assertion macros (EXPECT_EQ / ASSERT_TRUE) must never become the
+// tested target.
+func TestCpp_GTest_AssertionsStopWorded(t *testing.T) {
+	src := `#include <gtest/gtest.h>
+
+TEST(MathTest, Squares) {
+    int v = square(4);
+    EXPECT_EQ(v, 16);
+    ASSERT_TRUE(v > 0);
+}`
+	recs := runExtract(t, "math_test.cpp", "cpp", src)
+	for _, bad := range []string{"EXPECT_EQ", "ASSERT_TRUE", "expect_eq", "assert_true"} {
+		if hasEdgeAny(recs, "MathTest_Squares", bad) {
+			t.Fatalf("assertion macro %q leaked as a tested target", bad)
+		}
+	}
+	if !hasEdgeAny(recs, "MathTest_Squares", "square") {
+		t.Fatalf("expected TESTS edge MathTest_Squares -> square; got %+v", relSummary(recs))
+	}
+}
+
+// catch2 — TEST_CASE("name", "[tag]") + a direct production call.
+func TestCpp_Catch2_DirectCall(t *testing.T) {
+	src := `#include <catch2/catch_test_macros.hpp>
+#include "parser.h"
+
+TEST_CASE("parses a valid token", "[parser]") {
+    auto tok = parseToken("abc");
+    REQUIRE(tok.valid);
+}`
+	recs := runExtract(t, "parser_test.cpp", "cpp", src)
+	if !hasEdgeAny(recs, "it_parses_a_valid_token", "parseToken") {
+		t.Fatalf("expected TESTS edge it_parses_a_valid_token -> parseToken; got %+v", relSummary(recs))
+	}
+	if hasEdgeAny(recs, "it_parses_a_valid_token", "REQUIRE") {
+		t.Fatalf("REQUIRE leaked as a tested target")
+	}
+}
+
+// doctest — shares the TEST_CASE surface; selected by the doctest header.
+func TestCpp_Doctest_DirectCall(t *testing.T) {
+	src := `#include "doctest/doctest.h"
+
+TEST_CASE("formats a date") {
+    auto s = formatDate(2026, 5, 31);
+    CHECK(s == "2026-05-31");
+}`
+	recs := runExtract(t, "date_test.cpp", "cpp", src)
+	if !hasEdgeAny(recs, "it_formats_a_date", "formatDate") {
+		t.Fatalf("expected TESTS edge it_formats_a_date -> formatDate; got %+v", relSummary(recs))
+	}
+}
+
+// boost.test — BOOST_AUTO_TEST_CASE(name) + direct call.
+func TestCpp_BoostTest_DirectCall(t *testing.T) {
+	src := `#include <boost/test/unit_test.hpp>
+#include "money.h"
+
+BOOST_AUTO_TEST_CASE(adds_amounts) {
+    auto total = addMoney(100, 250);
+    BOOST_CHECK_EQUAL(total, 350);
+}`
+	recs := runExtract(t, "money_test.cpp", "cpp", src)
+	if !hasEdgeAny(recs, "adds_amounts", "addMoney") {
+		t.Fatalf("expected TESTS edge adds_amounts -> addMoney; got %+v", relSummary(recs))
+	}
+	if hasEdgeAny(recs, "adds_amounts", "BOOST_CHECK_EQUAL") {
+		t.Fatalf("BOOST_CHECK_EQUAL leaked as a tested target")
+	}
+}
+
+// boost.test — BOOST_FIXTURE_TEST_CASE(name, Fixture): fixture seeds subject.
+func TestCpp_BoostTest_FixtureSubject(t *testing.T) {
+	src := `#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_CASE(uses_cache, CacheFixture) {
+    BOOST_CHECK(true);
+}`
+	recs := runExtract(t, "cache_test.cpp", "cpp", src)
+	if !hasEdgeAny(recs, "uses_cache", "Cache") {
+		t.Fatalf("expected subject edge uses_cache -> Cache; got %+v", relSummary(recs))
+	}
+}
+
+// cppunit — CPPUNIT_TEST registration + out-of-line method def with a call.
+func TestCpp_CppUnit_DirectCall(t *testing.T) {
+	src := `#include <cppunit/extensions/HelperMacros.h>
+
+class AccountTest : public CppUnit::TestFixture {
+    CPPUNIT_TEST_SUITE(AccountTest);
+    CPPUNIT_TEST(testDeposit);
+    CPPUNIT_TEST_SUITE_END();
+public:
+    void testDeposit() {
+        depositFunds(account, 50);
+        CPPUNIT_ASSERT_EQUAL(50, account.balance);
+    }
+};`
+	recs := runExtract(t, "AccountTest.cpp", "cpp", src)
+	if !hasEdgeAny(recs, "AccountTest_testDeposit", "depositFunds") {
+		t.Fatalf("expected TESTS edge AccountTest_testDeposit -> depositFunds; got %+v", relSummary(recs))
+	}
+	if hasEdgeAny(recs, "AccountTest_testDeposit", "CPPUNIT_ASSERT_EQUAL") {
+		t.Fatalf("CPPUNIT_ASSERT_EQUAL leaked as a tested target")
+	}
+}
+
+// cpputest — TEST(group, name) + direct call; group seeds subject too.
+func TestCpp_CppUTest_DirectCall(t *testing.T) {
+	src := `#include "CppUTest/TestHarness.h"
+
+TEST(StringUtils, Trims) {
+    auto out = trimWhitespace("  hi  ");
+    STRCMP_EQUAL("hi", out.c_str());
+}`
+	recs := runExtract(t, "string_utils_test.cpp", "cpp", src)
+	if !hasEdgeAny(recs, "StringUtils_Trims", "trimWhitespace") {
+		t.Fatalf("expected TESTS edge StringUtils_Trims -> trimWhitespace; got %+v", relSummary(recs))
+	}
+	if hasEdgeAny(recs, "StringUtils_Trims", "STRCMP_EQUAL") {
+		t.Fatalf("STRCMP_EQUAL leaked as a tested target")
+	}
+}
+
+// A plain (non-test) C++ source file must not be classified as a test file.
+func TestCpp_NonTestFileSkipped(t *testing.T) {
+	src := `#include <string>
+int computeSum(int a, int b) { return a + b; }`
+	recs := runExtract(t, "calculator.cpp", "cpp", src)
+	if len(recs) != 0 {
+		t.Fatalf("expected 0 entities from non-test C++ file, got %d", len(recs))
+	}
+}
+
+// cppStripTestAffix unit coverage.
+func TestCpp_StripTestAffix(t *testing.T) {
+	cases := map[string]string{
+		"UserServiceTest": "UserService",
+		"CalculatorTests": "Calculator",
+		"TestUserService": "UserService",
+		"AccountFixture":  "Account",
+		"PlainName":       "PlainName",
+		"Test":            "Test",
+	}
+	for in, want := range cases {
+		if got := cppStripTestAffix(in); got != want {
+			t.Errorf("cppStripTestAffix(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+// relSummary renders the TESTS edges of recs for failure messages.
+func relSummary(recs []types.EntityRecord) string {
+	var b strings.Builder
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "TESTS" {
+				fmt.Fprintf(&b, "[%s -> %s (%s)] ",
+					rel.Properties["test_function"], rel.Properties["tested"], rel.Properties["confidence"])
+			}
+		}
+	}
+	return b.String()
+}

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -316,6 +316,63 @@ var stopwords = map[string]bool{
 	"luaunit.run": true, "lu.assertequals": true, "lu.asserttrue": true,
 	"lu.assertfalse": true, "lu.assertnil": true, "lu.assertnotnil": true,
 	"lu.run": true, "luaunit.assertalmostequals": true,
+	// C/C++ — gtest / catch2 / doctest / boost.test / cppunit / cpputest
+	// assertion and harness macros (#3495). These are test-harness identifiers
+	// and must never surface as the tested production subject. directCallRE
+	// captures the macro name before its `(`. Lower-cased (resolver lowercases
+	// before lookup).
+	//
+	// gtest / gmock:
+	"expect_eq": true, "expect_ne": true, "expect_lt": true, "expect_le": true,
+	"expect_gt": true, "expect_ge": true, "expect_true": true, "expect_false": true,
+	"expect_streq": true, "expect_strne": true, "expect_strcaseeq": true,
+	"expect_float_eq": true, "expect_double_eq": true, "expect_near": true,
+	"expect_throw": true, "expect_no_throw": true, "expect_any_throw": true,
+	"expect_death": true, "expect_nonfatal_failure": true, "expect_call": true,
+	"assert_lt": true, "assert_le": true,
+	"assert_gt": true, "assert_ge": true, "assert_true": true, "assert_false": true,
+	"assert_streq": true, "assert_strne": true, "assert_strcaseeq": true,
+	"assert_float_eq": true, "assert_double_eq": true, "assert_near": true,
+	"assert_throw": true, "assert_no_throw": true, "assert_any_throw": true,
+	"assert_death": true, "succeed": true, "on_call": true,
+	// catch2 / doctest (`require`/`check` are already stop-worded as keywords
+	// above; `capture` and `then` are covered by the MockK / Lua blocks):
+	"require_false": true, "require_throws": true,
+	"require_throws_as": true, "require_throws_with": true, "require_nothrow": true,
+	"check_false": true, "check_throws": true, "check_throws_as": true,
+	"check_throws_with": true, "check_nothrow": true,
+	"require_that": true, "check_that": true,
+	"section": true, "scenario": true, "given": true, "when": true,
+	"and_given": true, "and_when": true, "and_then": true, "info": true, "warn": true,
+	"succeed_catch": true, "fail_catch": true,
+	"doctest_check": true, "check_eq": true, "check_ne": true, "check_lt": true,
+	"check_le": true, "check_gt": true, "check_ge": true,
+	"require_eq": true, "require_ne": true, "subcase": true,
+	"message": true, "warn_eq": true, "warn_ne": true,
+	// boost.test:
+	"boost_check": true, "boost_require": true, "boost_check_equal": true,
+	"boost_require_equal": true, "boost_check_ne": true, "boost_require_ne": true,
+	"boost_check_lt": true, "boost_check_le": true, "boost_check_gt": true,
+	"boost_check_ge": true, "boost_check_close": true, "boost_check_close_fraction": true,
+	"boost_check_small": true, "boost_check_throw": true, "boost_require_throw": true,
+	"boost_check_no_throw": true, "boost_require_no_throw": true,
+	"boost_check_message": true, "boost_check_equal_collections": true,
+	"boost_error": true, "boost_fail": true, "boost_warn": true, "boost_test": true,
+	"boost_check_predicate": true, "boost_test_message": true,
+	// cppunit:
+	"cppunit_assert": true, "cppunit_assert_equal": true,
+	"cppunit_assert_equal_message": true, "cppunit_assert_message": true,
+	"cppunit_assert_doubles_equal": true, "cppunit_assert_throw": true,
+	"cppunit_assert_no_throw": true, "cppunit_fail": true, "cppunit_test": true,
+	"cppunit_test_suite": true, "cppunit_test_suite_end": true,
+	"cppunit_test_suite_registration": true,
+	// cpputest (`check_false` covered by the catch2 block above):
+	"check_equal": true, "check_true": true,
+	"check_text": true, "longs_equal": true, "unsigned_longs_equal": true,
+	"bytes_equal": true, "pointers_equal": true, "doubles_equal": true,
+	"strcmp_equal": true, "strcmp_nocase_equal": true, "strncmp_equal": true,
+	"strcmp_contains": true, "test_exit": true, "fail_test": true,
+	"mock": true, "mock_c": true, "checkequal": true,
 	// Common language keywords that end up in call-like positions
 	"if": true, "for": true, "while": true, "switch": true, "return": true,
 	"func": true, "def": true, "class": true, "struct": true, "new": true,


### PR DESCRIPTION
Closes #3495 (epic #3490).

Deepens the shared `testmap` cross-extractor to the TS/JS bar for the six dominant C/C++ unit-test frameworks, emitting test->production `TESTS` edges with the high/medium/low confidence ladder.

## Frameworks (new `internal/extractors/cross/testmap/frameworks_cpp.go`)
- **gtest** — `TEST` / `TEST_F` / `TEST_P` / `TYPED_TEST(_P)`. Suite/fixture name (Test/Fixture/Suite/Spec affix stripped) seeds the medium-confidence subject.
- **catch2 + doctest** — `TEST_CASE("name","[tag]")` / `SCENARIO` / `TEST_CASE_METHOD(Fixture,...)`. One detector serves both (doctest deliberately mirrors the Catch2 surface).
- **boost.test** — `BOOST_AUTO_TEST_CASE` / `BOOST_FIXTURE_TEST_CASE` / `..._TEMPLATE`. Fixture seeds subject.
- **cppunit** — `CPPUNIT_TEST(...)` registrations + inline and out-of-line `void Class::testX()` bodies. Class name (from def or `CPPUNIT_TEST_SUITE`) seeds subject.
- **cpputest** — `TEST(group,name)` / `IGNORE_TEST`. Group seeds subject.

## Selection & resolution
- New `includeTokenRE` feeds `#include <gtest/gtest.h>` / `#include "catch.hpp"` header paths into the import-token set. All C/C++ entries are **#include-gated** so plain `.cpp/.h` files are never mis-classified, and frameworks that share `*_test.cpp` / `TEST(a,b)` (gtest/catch2/cpputest) are disambiguated by header rather than greedy filename matching.
- C++ production-file naming convention added in `extractor.go` (`foo_test.cpp` / `foo_unittest.cpp` / `test_foo.cpp` / `FooTest.cpp` -> `foo.cpp`) for the low-confidence fallback.
- C++ assertion/harness macros added to the resolver stopword set: `EXPECT_*`/`ASSERT_*`, `CHECK`/`REQUIRE`(+`_THROWS`/`_FALSE`/`_NOTHROW`), `BOOST_CHECK`/`BOOST_REQUIRE`(+variants), `CPPUNIT_ASSERT*`, and CppUTest `CHECK_*`/`LONGS_EQUAL`/`STRCMP_EQUAL` — they never surface as the tested subject.

## Discipline
- `frameworks_cpp_test.go`: 11 cases, each asserting a **specific** test->target edge (not `len>0`) — direct-call (high) for all six frameworks, fixture/group subject (medium) for gtest & boost, assertion-leak guards, non-test-file skip, and `cppStripTestAffix` unit coverage.
- **Full shared `testmap` suite passes** (`go test ./internal/extractors/cross/testmap/`) — no cross-language regression. `internal/types/` and `tools/coverage/` suites also pass; `go vet` clean; `gofmt -l` empty on all touched files.

## Coverage registry
- Flipped `tests_linkage` partial->full on the 15 `lang.c-cpp.framework.*` `http_backend` records (matching the lua #3485 precedent — the deep linkage now serves any c-cpp project regardless of HTTP framework). `ros` / `unreal-engine` (desktop/embedded subcategories, which do not allow `tests_linkage`) correctly excluded.
- `coverage gen` + `validate` (0 errors) + `fmt --check` (canonical) all green. The "no mapping entry" warnings are pre-existing and identical to the lua tests_linkage cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)