### PR TITLE
feat(scala): tapir endpoint-DSL + Apache Pekko HTTP framework coverage

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 185 records · **C/C++**: 17 · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 12 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 11 · **scala**: 11 · **swift**: 1
+**Total**: 189 records · **C/C++**: 17 · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 14 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 13 · **scala**: 11 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -112,8 +112,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [Tonic](../detail/lang.rust.framework.tonic.md) | ✅ 3/3 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/20 | 🟡 1/7 | |
 | [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | ✅ 3/3 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/20 | 🟡 1/7 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
@@ -137,12 +139,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [kotlin](../by-language/kotlin.md) | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 12/12 | |
 | [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [kotlin](../by-language/kotlin.md) | [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [scala](../by-language/scala.md) | [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟢 3/3 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🔴 0/20 | 🟡 6/16 | |
 | [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 187 records · **C/C++**: 17 · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 14 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 13 · **scala**: 9 · **swift**: 1
+**Total**: 185 records · **C/C++**: 17 · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 12 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 11 · **scala**: 11 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -112,10 +112,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Tide](../detail/lang.rust.framework.tide.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [Tonic](../detail/lang.rust.framework.tonic.md) | ✅ 3/3 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/20 | 🟡 1/7 | |
 | [rust](../by-language/rust.md) | [Tower (service abstraction)](../detail/lang.rust.framework.tower.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | ✅ 3/3 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/20 | 🟡 1/7 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
@@ -139,15 +137,14 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [kotlin](../by-language/kotlin.md) | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 12/12 | |
 | [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
-| [kotlin](../by-language/kotlin.md) | [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |
 | [scala](../by-language/scala.md) | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟢 3/3 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🔴 0/20 | 🟡 6/16 | |
 | [scala](../by-language/scala.md) | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [scala](../by-language/scala.md) | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [scala](../by-language/scala.md) | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
@@ -155,6 +152,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [scala](../by-language/scala.md) | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [scala](../by-language/scala.md) | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
 | [scala](../by-language/scala.md) | [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [scala](../by-language/scala.md) | [tapir (endpoint DSL)](../detail/lang.scala.framework.tapir.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🟢 1/1 | 🟡 2/20 | 🟡 5/16 | |
 
 
 ## UI Frontend

--- a/docs/coverage/by-language/scala.md
+++ b/docs/coverage/by-language/scala.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # scala
 
-**Frameworks**: 9 · **Tools**: 3 · **ORMs**: 6 · **Other**: 0
+**Frameworks**: 11 · **Tools**: 3 · **ORMs**: 6 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -27,6 +27,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Akka HTTP / Pekko HTTP](../detail/lang.scala.framework.akka-http.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [Apache Pekko HTTP](../detail/lang.scala.framework.pekko-http.md) | 🟢 3/3 | ✅ 1/1 | 🔴 0/4 | 🟢 1/1 | 🔴 0/20 | 🟡 6/16 | |
 | [Cask](../detail/lang.scala.framework.cask.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Cats Effect (concurrency runtime)](../detail/lang.scala.framework.cats-effect.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [Finatra (Twitter Finagle)](../detail/lang.scala.framework.finatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
@@ -34,6 +35,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Scalatra](../detail/lang.scala.framework.scalatra.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [ZIO HTTP / ZIO](../detail/lang.scala.framework.zio-http.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 9/9 | |
 | [http4s](../detail/lang.scala.framework.http4s.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [tapir (endpoint DSL)](../detail/lang.scala.framework.tapir.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🟢 1/1 | 🟡 2/20 | 🟡 5/16 | |
 
 
 ### Meta Framework

--- a/docs/coverage/detail/lang.scala.framework.pekko-http.md
+++ b/docs/coverage/detail/lang.scala.framework.pekko-http.md
@@ -1,0 +1,127 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.pekko-http` — Apache Pekko HTTP
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: pekko-http routes synthesized as http_route entities; cross-file route-tree composition not resolved. |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks: pekko-http route directives detected; complete(...) handler binding is file-local and not resolved to a named handler cross-file. |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | custom_scala_frameworks: pekko-http detected as its own framework (org.apache.pekko import) and routed through the shared akka-http branch (case akka-http,pekko-http). path("users"/LongNumber)/pathPrefix + method directives combined via nearest-path positional context, canonicalScalaPathExpr ({id} from LongNumber). Value-asserting test TestPekkoHttpRoute pins GET:/api/users/{id} + POST + framework=pekko-http. File-local. |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks deep extractor: pekko-http shares the akka-http auth branch — authenticateBasic/OAuth2(+Async/PF) stamp auth_method+realm (paren-safe quoted capture), authorize/authorizeAsync. Value-asserting test TestPekkoHttpAuthDirective asserts auth_method=basic, realm=secure, framework=pekko-http. File-local. |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | custom_scala_frameworks: field-level case-class DTO modeling via extractScalaDTOFields (fields, Option nullability, circe/play-json/zio-json codec, wire-name overrides) runs for pekko-http files. File-local. |
+| Request validation | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/validation.go` | custom_scala_frameworks: field-level request validation via extractScalaValidation (refined/cats Validated/accord/octopus) + entity(as[T]) body directive runs for pekko-http. File-local. |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks deep extractor: pekko-http shares the akka-http middleware branch — handleRejections/handleExceptions(+named handler), cors(), transform directives (mapRequest/mapResponse/encodeResponse/...). pekko-http-cors recognised. File-local. |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks (shared): test suites detected (ScalaTest/Specs2/MUnit/TestKit incl PekkoSpec/ScalaTestWithActorTestKit/ZIOSpec). PARTIAL: test->route linkage not resolved cross-file. |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks (shared): log statement call sites detected (SLF4J/scala-logging/Play/Akka-Pekko/Cats-ZIO). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks (shared): reScalaMetricNamed captures literal metric name per call site (Kamon/Micrometer/Dropwizard). Runs for all Scala frameworks. metric_name in props. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks (shared): reScalaTraceNamed captures literal span name per call site (Kamon/OTel/natchez). Runs for all Scala frameworks. span_name in props. |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.pekko-http ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.scala.framework.tapir.md
+++ b/docs/coverage/detail/lang.scala.framework.tapir.md
@@ -1,0 +1,127 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.scala.framework.tapir` — tapir (endpoint DSL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [scala](../by-language/scala.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go` | custom_scala_frameworks: tapir endpoint values synthesized into http_route entities backend-agnostically (akka/pekko/http4s/netty). method+path+DTO refs+handler in one entity. File-local. |
+| Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go` | custom_scala_frameworks: tapir .serverLogic/.serverLogicSuccess/Pure(handler) bound to the endpoint, stamped as handler + handler_attribution prop. Value-asserting test asserts handler=handleGetUser/createUserHandler. File-local (handler def may live cross-file). |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go` | custom_scala_frameworks: tapir endpoint-DSL. Each endpoint(.get/.post/.method(Method.X)).in("seg" / path[T]("name")).in(query[T]) chain parsed into one http_route with http_method + canonical http_path ({name} from path[T], query params separate). Value-asserting tests TestTapirEndpointRouteAndDTOs/PostRequestBodyDTO/MethodExplicitForm/NamedPathParam pin verb+path. File-local. |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go`<br>`internal/custom/scala/validation.go` | custom_scala_frameworks: tapir jsonBody[T]/plainBody/xmlBody under .in (request) / .out (response) / .errorOut (error) → dto_ref entities with role+dto+route; PLUS field-level case-class DTO modeling via extractScalaDTOFields (fields, Option nullability, circe/play-json/zio-json codec). Value-asserting tests assert response_dto=User, request_dto=CreateUserRequest, error_dto=ErrorInfo + dto_ref entities. File-local. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go`<br>`internal/custom/scala/validation.go` | custom_scala_frameworks: field-level request validation via extractScalaValidation (refined types, cats Validated, accord, octopus) runs for tapir case-class DTOs. PARTIAL: tapir's own .validate()/Validator combinator chain not yet parsed; cross-file. |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks (shared): test suites detected (ScalaTest/Specs2/MUnit/TestKit incl PekkoSpec/ScalaTestWithActorTestKit/ZIOSpec). PARTIAL: test->route linkage not resolved cross-file. |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/scala/frameworks.go` | custom_scala_frameworks (shared): log statement call sites detected (SLF4J/scala-logging/Play/Akka-Pekko/Cats-ZIO). HONEST PARTIAL: logger identity + message<->logger binding need cross-file dataflow. |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks (shared): reScalaMetricNamed captures literal metric name per call site (Kamon/Micrometer/Dropwizard). Runs for all Scala frameworks. metric_name in props. |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go` | custom_scala_frameworks (shared): reScalaTraceNamed captures literal span name per call site (Kamon/OTel/natchez). Runs for all Scala frameworks. span_name in props. |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go`<br>`internal/custom/scala/validation.go` | custom_scala_frameworks: tapir .in(jsonBody[T]) request body DTO captured as request_dto + dto_ref(role=request). Value-asserting test asserts request_dto=CreateUserRequest. File-local. |
+| Response shape extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/tapir.go`<br>`internal/custom/scala/validation.go` | custom_scala_frameworks: tapir .out(jsonBody[T]) / .errorOut(jsonBody[T]) captured as response_dto/error_dto + dto_ref(role=response/error). Value-asserting test asserts response_dto=User, error_dto=ErrorInfo. File-local. |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.scala.framework.tapir ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -50200,6 +50200,245 @@
       }
     },
     {
+      "id": "lang.scala.framework.pekko-http",
+      "category": "http_framework",
+      "subcategory": "jvm_backend",
+      "language": "scala",
+      "label": "Apache Pekko HTTP",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks: pekko-http routes synthesized as http_route entities; cross-file route-tree composition not resolved.",
+            "verified_at": "2026-05-30"
+          },
+          "handler_attribution": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks: pekko-http route directives detected; complete(...) handler binding is file-local and not resolved to a named handler cross-file.",
+            "verified_at": "2026-05-30"
+          },
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/routing.go"],
+            "notes": "custom_scala_frameworks: pekko-http detected as its own framework (org.apache.pekko import) and routed through the shared akka-http branch (case akka-http,pekko-http). path(\"users\"/LongNumber)/pathPrefix + method directives combined via nearest-path positional context, canonicalScalaPathExpr ({id} from LongNumber). Value-asserting test TestPekkoHttpRoute pins GET:/api/users/{id} + POST + framework=pekko-http. File-local.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks deep extractor: pekko-http shares the akka-http auth branch — authenticateBasic/OAuth2(+Async/PF) stamp auth_method+realm (paren-safe quoted capture), authorize/authorizeAsync. Value-asserting test TestPekkoHttpAuthDirective asserts auth_method=basic, realm=secure, framework=pekko-http. File-local.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "custom_scala_frameworks: field-level case-class DTO modeling via extractScalaDTOFields (fields, Option nullability, circe/play-json/zio-json codec, wire-name overrides) runs for pekko-http files. File-local.",
+            "verified_at": "2026-05-30"
+          },
+          "request_validation": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/validation.go"],
+            "notes": "custom_scala_frameworks: field-level request validation via extractScalaValidation (refined/cats Validated/accord/octopus) + entity(as[T]) body directive runs for pekko-http. File-local.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks deep extractor: pekko-http shares the akka-http middleware branch — handleRejections/handleExceptions(+named handler), cors(), transform directives (mapRequest/mapResponse/encodeResponse/...). pekko-http-cors recognised. File-local.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks (shared): test suites detected (ScalaTest/Specs2/MUnit/TestKit incl PekkoSpec/ScalaTestWithActorTestKit/ZIOSpec). PARTIAL: test-\u003eroute linkage not resolved cross-file.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks (shared): log statement call sites detected (SLF4J/scala-logging/Play/Akka-Pekko/Cats-ZIO). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow.",
+            "verified_at": "2026-05-30"
+          },
+          "metric_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks (shared): reScalaMetricNamed captures literal metric name per call site (Kamon/Micrometer/Dropwizard). Runs for all Scala frameworks. metric_name in props.",
+            "verified_at": "2026-05-30"
+          },
+          "trace_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks (shared): reScalaTraceNamed captures literal span name per call site (Kamon/OTel/natchez). Runs for all Scala frameworks. span_name in props.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.scala.framework.play",
       "category": "http_framework",
       "subcategory": "meta_framework",
@@ -50690,6 +50929,244 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.tapir",
+      "category": "http_framework",
+      "subcategory": "jvm_backend",
+      "language": "scala",
+      "label": "tapir (endpoint DSL)",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/tapir.go"],
+            "notes": "custom_scala_frameworks: tapir endpoint values synthesized into http_route entities backend-agnostically (akka/pekko/http4s/netty). method+path+DTO refs+handler in one entity. File-local.",
+            "verified_at": "2026-05-30"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/tapir.go"],
+            "notes": "custom_scala_frameworks: tapir .serverLogic/.serverLogicSuccess/Pure(handler) bound to the endpoint, stamped as handler + handler_attribution prop. Value-asserting test asserts handler=handleGetUser/createUserHandler. File-local (handler def may live cross-file).",
+            "verified_at": "2026-05-30"
+          },
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/tapir.go"],
+            "notes": "custom_scala_frameworks: tapir endpoint-DSL. Each endpoint(.get/.post/.method(Method.X)).in(\"seg\" / path[T](\"name\")).in(query[T]) chain parsed into one http_route with http_method + canonical http_path ({name} from path[T], query params separate). Value-asserting tests TestTapirEndpointRouteAndDTOs/PostRequestBodyDTO/MethodExplicitForm/NamedPathParam pin verb+path. File-local.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/tapir.go","internal/custom/scala/validation.go"],
+            "notes": "custom_scala_frameworks: tapir jsonBody[T]/plainBody/xmlBody under .in (request) / .out (response) / .errorOut (error) → dto_ref entities with role+dto+route; PLUS field-level case-class DTO modeling via extractScalaDTOFields (fields, Option nullability, circe/play-json/zio-json codec). Value-asserting tests assert response_dto=User, request_dto=CreateUserRequest, error_dto=ErrorInfo + dto_ref entities. File-local.",
+            "verified_at": "2026-05-30"
+          },
+          "request_validation": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/tapir.go","internal/custom/scala/validation.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks: field-level request validation via extractScalaValidation (refined types, cats Validated, accord, octopus) runs for tapir case-class DTOs. PARTIAL: tapir's own .validate()/Validator combinator chain not yet parsed; cross-file.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks (shared): test suites detected (ScalaTest/Specs2/MUnit/TestKit incl PekkoSpec/ScalaTestWithActorTestKit/ZIOSpec). PARTIAL: test-\u003eroute linkage not resolved cross-file.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_frameworks (shared): log statement call sites detected (SLF4J/scala-logging/Play/Akka-Pekko/Cats-ZIO). HONEST PARTIAL: logger identity + message\u003c-\u003elogger binding need cross-file dataflow.",
+            "verified_at": "2026-05-30"
+          },
+          "metric_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks (shared): reScalaMetricNamed captures literal metric name per call site (Kamon/Micrometer/Dropwizard). Runs for all Scala frameworks. metric_name in props.",
+            "verified_at": "2026-05-30"
+          },
+          "trace_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go"],
+            "notes": "custom_scala_frameworks (shared): reScalaTraceNamed captures literal span name per call site (Kamon/OTel/natchez). Runs for all Scala frameworks. span_name in props.",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/tapir.go","internal/custom/scala/validation.go"],
+            "notes": "custom_scala_frameworks: tapir .in(jsonBody[T]) request body DTO captured as request_dto + dto_ref(role=request). Value-asserting test asserts request_dto=CreateUserRequest. File-local.",
+            "verified_at": "2026-05-30"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/frameworks.go","internal/custom/scala/tapir.go","internal/custom/scala/validation.go"],
+            "notes": "custom_scala_frameworks: tapir .out(jsonBody[T]) / .errorOut(jsonBody[T]) captured as response_dto/error_dto + dto_ref(role=response/error). Value-asserting test asserts response_dto=User, error_dto=ErrorInfo. File-local.",
+            "verified_at": "2026-05-30"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 185 · **ORMs**: 151 · **Tools**: 110 · **Other**: 114
+**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 189 · **ORMs**: 151 · **Tools**: 110 · **Other**: 114
 
 ## Coverage by language
 
@@ -13,9 +13,9 @@
 | [C/C++](by-language/c-cpp.md) | 17 | 16 | 7 | 0 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
-| [kotlin](by-language/kotlin.md) | 12 | 0 | 7 | 0 |
+| [kotlin](by-language/kotlin.md) | 14 | 0 | 7 | 0 |
+| [rust](by-language/rust.md) | 13 | 6 | 14 | 0 |
 | [php](by-language/php.md) | 12 | 6 | 14 | 0 |
-| [rust](by-language/rust.md) | 11 | 6 | 14 | 0 |
 | [scala](by-language/scala.md) | 11 | 3 | 6 | 0 |
 | [elixir](by-language/elixir.md) | 9 | 5 | 10 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
@@ -66,4 +66,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 185 frameworks · 110 tools · 151 ORMs · 114 other
+Total: 189 frameworks · 110 tools · 151 ORMs · 114 other

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 187 · **ORMs**: 151 · **Tools**: 110 · **Other**: 114
+**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 185 · **ORMs**: 151 · **Tools**: 110 · **Other**: 114
 
 ## Coverage by language
 
@@ -13,11 +13,11 @@
 | [C/C++](by-language/c-cpp.md) | 17 | 16 | 7 | 0 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
-| [kotlin](by-language/kotlin.md) | 14 | 0 | 7 | 0 |
-| [rust](by-language/rust.md) | 13 | 6 | 14 | 0 |
+| [kotlin](by-language/kotlin.md) | 12 | 0 | 7 | 0 |
 | [php](by-language/php.md) | 12 | 6 | 14 | 0 |
+| [rust](by-language/rust.md) | 11 | 6 | 14 | 0 |
+| [scala](by-language/scala.md) | 11 | 3 | 6 | 0 |
 | [elixir](by-language/elixir.md) | 9 | 5 | 10 | 0 |
-| [scala](by-language/scala.md) | 9 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
@@ -66,4 +66,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 187 frameworks · 110 tools · 151 ORMs · 114 other
+Total: 185 frameworks · 110 tools · 151 ORMs · 114 other

--- a/internal/custom/scala/frameworks.go
+++ b/internal/custom/scala/frameworks.go
@@ -508,6 +508,14 @@ func (e *scalaFrameworksExtractor) Extract(ctx context.Context, file extractor.F
 	// Routing extraction
 	// ---------------------------------------------------------------------------
 	switch framework {
+	case "tapir":
+		// tapir endpoint-DSL: routes + request/response/error DTO refs + handler
+		// attribution are parsed from each `endpoint`(.get/.post/...).in(...).out(...)
+		// chain (backend-agnostic). See tapir.go.
+		for _, ent := range extractTapirEndpoints(src, fileMeta{Path: file.Path, Language: file.Language}) {
+			add(ent)
+		}
+
 	case "akka-http", "pekko-http":
 		// Positional combination: associate each HTTP method directive with the nearest
 		// preceding pathPrefix and path segment directives (within a 512-char window).
@@ -1083,7 +1091,20 @@ func max0(a int) int {
 // detectScalaFramework returns the dominant framework based on imports/code patterns.
 func detectScalaFramework(src string) string {
 	switch {
-	case strings.Contains(src, "akka.http") || strings.Contains(src, "pekko.http"):
+	// tapir is endpoint-DSL: routes + DTOs live in `endpoint` values regardless
+	// of the serving backend (it can run ON akka/pekko/http4s/netty). Detect it
+	// FIRST so a tapir file backed by akka/pekko/http4s is labelled `tapir`, not
+	// the backend, since the route/DTO shape is the tapir endpoint chain.
+	case isTapirSource(src):
+		return "tapir"
+	// Apache Pekko is the Apache fork of Akka; same routing DSL, package
+	// org.apache.pekko.* . Detect it as its OWN framework (distinct from akka)
+	// so the registry can track Pekko coverage separately. Checked before the
+	// akka branch because a pekko file never contains `akka.http`.
+	case strings.Contains(src, "org.apache.pekko") || strings.Contains(src, "pekko.http") ||
+		strings.Contains(src, "import org.apache.pekko"):
+		return "pekko-http"
+	case strings.Contains(src, "akka.http"):
 		return "akka-http"
 	case strings.Contains(src, "org.http4s"):
 		return "http4s"

--- a/internal/custom/scala/tapir.go
+++ b/internal/custom/scala/tapir.go
@@ -1,0 +1,413 @@
+// Package scala — tapir endpoint-DSL extraction.
+//
+// tapir (https://tapir.softwaremill.com) describes HTTP endpoints as first-class
+// `Endpoint` values that are independent of the serving backend (akka-http,
+// pekko-http, http4s, netty, …). A single endpoint value carries the method,
+// the path template, the input/output DTO references and the error DTO:
+//
+//	val getUser =
+//	  endpoint
+//	    .get
+//	    .in("users" / path[Long]("id"))
+//	    .in(query[String]("q"))
+//	    .out(jsonBody[User])
+//	    .errorOut(jsonBody[ErrorInfo])
+//	    .serverLogic(handler)
+//
+// Because the routing and the request/response shape both live in the endpoint
+// chain — regardless of which backend interprets it — tapir is the highest-value
+// Scala framework to model structurally.
+//
+// This extractor parses each `endpoint`(.get/.post/…) chain into:
+//   - one SCOPE.Operation/http_route entity carrying http_method + http_path,
+//     where the path template is composed from `.in("seg" / path[T]("name") /
+//     query[T]("q"))` (literal segs + path[T] → {name}; query params recorded
+//     separately as query_params).
+//   - DTO references for jsonBody[T] inputs (request DTO), outputs (response
+//     DTO) and errorOut (error DTO).
+//   - a handler attribution when `.serverLogic(handler)` /
+//     `.serverLogicSuccess(handler)` is present.
+//
+// All matching is regex-based and file-local — the same honest limit as the
+// other Scala framework extractors in frameworks.go. Issue #3507.
+package scala
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+var (
+	// tapirSignalRe gates the framework on a tapir-specific import or the
+	// `sttp.tapir` package, so a plain akka/http4s file is never mis-labelled.
+	tapirSignalRe = regexp.MustCompile(
+		`\bsttp\.tapir\b|\bimport\s+sttp\.tapir|\btapir\.\b`)
+
+	// tapirEndpointStartRe finds the start of an endpoint value chain. We accept
+	// the bare `endpoint` builder as well as the input/output-only variants
+	// (`infallibleEndpoint`). Group 0 is the anchor; the chain body is walked
+	// forward from there with a balanced, statement-bounded scan.
+	tapirEndpointStartRe = regexp.MustCompile(
+		`\b(?:endpoint|infallibleEndpoint)\b`)
+
+	// tapirMethodRe matches the method combinator `.get` / `.post` / … or the
+	// explicit `.method(Method.GET)` form. Group 1 = combinator verb (lower),
+	// group 2 = explicit Method.VERB (upper).
+	tapirMethodRe = regexp.MustCompile(
+		`\.(get|post|put|delete|patch|head|options)\b|\.method\s*\(\s*Method\.(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\)`)
+
+	// tapirInRe matches each `.in( … )` input combinator argument blob.
+	tapirInRe = regexp.MustCompile(`\.in\s*\(`)
+
+	// tapirOutRe / tapirErrOutRe match `.out(` and `.errorOut(` combinators.
+	tapirOutRe    = regexp.MustCompile(`\.out\s*\(`)
+	tapirErrOutRe = regexp.MustCompile(`\.errorOut\s*\(`)
+
+	// tapirJsonBodyRe captures jsonBody[T] / plainBody[T] / xmlBody[T] /
+	// stringBody / byteArrayBody body-codec references. Group 1 = DTO type.
+	tapirJsonBodyRe = regexp.MustCompile(
+		`\b(?:jsonBody|plainBody|xmlBody|binaryBody|customCodecJsonBody)\s*\[\s*([A-Za-z_][\w.]*(?:\s*\[[^\]]*\])?)\s*\]`)
+
+	// tapirPathSegLiteralRe captures a literal path segment string within an
+	// `.in(...)` path expression: "users".
+	tapirPathStringRe = regexp.MustCompile(`"([^"]*)"`)
+
+	// tapirPathParamRe captures `path[T]("name")` typed path params. Group 1 =
+	// the param name; when absent (anonymous path[Long]) we synthesise from type.
+	tapirPathParamRe = regexp.MustCompile(
+		`\bpath\s*\[\s*([A-Za-z_][\w.]*)\s*\]\s*(?:\(\s*"([^"]*)"\s*\))?`)
+
+	// tapirQueryParamRe captures `query[T]("name")` query params.
+	tapirQueryParamRe = regexp.MustCompile(
+		`\bquery\s*\[\s*([A-Za-z_][\w.]*)\s*\]\s*\(\s*"([^"]*)"\s*\)`)
+
+	// tapirServerLogicRe captures the handler reference bound to an endpoint.
+	//   .serverLogic(handler) / .serverLogicSuccess(handler) /
+	//   .serverLogicPure(handler)
+	tapirServerLogicRe = regexp.MustCompile(
+		`\.serverLogic(?:Success|Recover|Pure|Option|Error)?\s*\(\s*([A-Za-z_][\w.]*)`)
+)
+
+// isTapirSource reports whether the file uses tapir's endpoint DSL.
+func isTapirSource(src string) bool {
+	if !tapirSignalRe.MatchString(src) {
+		return false
+	}
+	// Secondary gate: an actual `endpoint` builder must appear, so a file that
+	// merely imports a tapir type alias is not claimed.
+	return strings.Contains(src, "endpoint")
+}
+
+// tapirEndpointChain holds the parsed shape of one endpoint value.
+type tapirEndpointChain struct {
+	method       string   // upper HTTP verb, "" when none declared yet
+	path         string   // canonical path template, e.g. /users/{id}
+	queryParams  []string // query param names
+	requestDTOs  []string // jsonBody[T] referenced under .in(...)
+	responseDTOs []string // jsonBody[T] referenced under .out(...)
+	errorDTOs    []string // jsonBody[T] referenced under .errorOut(...)
+	handler      string   // .serverLogic target, "" when absent
+	startLine    int
+}
+
+// tapirChainBody returns the chain text from the `endpoint` anchor up to the end
+// of the enclosing statement. tapir chains are method-call chains; we stop at a
+// blank line, a top-level `val`/`def` for the NEXT declaration, or after a bounded
+// number of characters. This keeps two adjacent endpoint vals from bleeding into
+// one another while tolerating the idiomatic multi-line `.in(...).out(...)` layout.
+func tapirChainBody(src string, anchor int) string {
+	const maxChain = 1200
+	end := anchor
+	limit := anchor + maxChain
+	if limit > len(src) {
+		limit = len(src)
+	}
+	// Walk forward; stop when we hit a new top-level val/def declaration that is
+	// not part of this chain (a line whose first non-space token is val/def AND
+	// the previous non-space char was not a '.'), or two consecutive newlines.
+	consecutiveNL := 0
+	for end < limit {
+		c := src[end]
+		if c == '\n' {
+			consecutiveNL++
+			// Lookahead: a new `val `/`def `/`object `/`class ` at the next
+			// line's start terminates the chain unless the next line continues
+			// the dot-chain (starts with `.`).
+			j := end + 1
+			for j < limit && (src[j] == ' ' || src[j] == '\t') {
+				j++
+			}
+			rest := src[j:min(j+8, len(src))]
+			if strings.HasPrefix(rest, "val ") || strings.HasPrefix(rest, "def ") ||
+				strings.HasPrefix(rest, "object ") || strings.HasPrefix(rest, "class ") {
+				break
+			}
+			if consecutiveNL >= 2 {
+				break
+			}
+		} else if c != ' ' && c != '\t' && c != '\r' {
+			consecutiveNL = 0
+		}
+		end++
+	}
+	return src[anchor:end]
+}
+
+// parseTapirEndpoint parses a single endpoint chain body into its shape.
+func parseTapirEndpoint(chain string, startLine int) tapirEndpointChain {
+	ep := tapirEndpointChain{startLine: startLine}
+
+	// Method.
+	if m := tapirMethodRe.FindStringSubmatch(chain); m != nil {
+		switch {
+		case m[1] != "":
+			ep.method = strings.ToUpper(m[1])
+		case m[2] != "":
+			ep.method = strings.ToUpper(m[2])
+		}
+	}
+
+	// Path + query: walk every `.in(...)` arg blob IN ORDER. Path segments
+	// (string literals + path[T]) compose the route template positionally;
+	// query[T] are recorded separately. jsonBody[T] inside an `.in(...)` is a
+	// request DTO.
+	var segs []string
+	for _, loc := range tapirInRe.FindAllStringIndex(chain, -1) {
+		blob := balancedParens(chain, loc[1])
+		// Body DTO under .in → request DTO. A jsonBody/query input is never a
+		// path expression, so handle and skip path parsing for it.
+		if tapirJsonBodyRe.MatchString(blob) {
+			for _, bm := range tapirJsonBodyRe.FindAllStringSubmatch(blob, -1) {
+				ep.requestDTOs = appendUnique(ep.requestDTOs, normalizeScalaType(bm[1]))
+			}
+			continue
+		}
+		// Query params query[T]("name") — not part of the path template.
+		if tapirQueryParamRe.MatchString(blob) {
+			for _, qm := range tapirQueryParamRe.FindAllStringSubmatch(blob, -1) {
+				ep.queryParams = appendUnique(ep.queryParams, qm[2])
+			}
+			continue
+		}
+		// Path expression: `"users" / path[Long]("id") / "posts"`. Split on the
+		// top-level `/` separators and classify each token positionally so the
+		// segment order is preserved.
+		segs = append(segs, tapirPathSegments(blob)...)
+	}
+	ep.path = canonicalScalaSlashes("/" + strings.Join(segs, "/"))
+
+	// Response DTOs under .out(...).
+	for _, loc := range tapirOutRe.FindAllStringIndex(chain, -1) {
+		blob := balancedParens(chain, loc[1])
+		for _, bm := range tapirJsonBodyRe.FindAllStringSubmatch(blob, -1) {
+			ep.responseDTOs = appendUnique(ep.responseDTOs, normalizeScalaType(bm[1]))
+		}
+	}
+	// Error DTOs under .errorOut(...).
+	for _, loc := range tapirErrOutRe.FindAllStringIndex(chain, -1) {
+		blob := balancedParens(chain, loc[1])
+		for _, bm := range tapirJsonBodyRe.FindAllStringSubmatch(blob, -1) {
+			ep.errorDTOs = appendUnique(ep.errorDTOs, normalizeScalaType(bm[1]))
+		}
+	}
+
+	// Handler attribution.
+	if hm := tapirServerLogicRe.FindStringSubmatch(chain); hm != nil {
+		ep.handler = hm[1]
+	}
+
+	return ep
+}
+
+// tapirPathSegments parses a tapir `.in(...)` path expression blob into ordered
+// canonical segments. The blob looks like `"users" / path[Long]("id") / "posts"`.
+// Literal quoted strings become literal segments (split on any embedded '/');
+// `path[T]("name")` becomes `{name}` (synthesised from the type when anonymous).
+func tapirPathSegments(blob string) []string {
+	var segs []string
+	for _, raw := range splitTopLevelSlashes(blob) {
+		tok := strings.TrimSpace(raw)
+		if tok == "" {
+			continue
+		}
+		// path[T]("name") typed path param.
+		if pm := tapirPathParamRe.FindStringSubmatch(tok); pm != nil {
+			name := pm[2]
+			if name == "" {
+				name = tapirParamNameForType(pm[1])
+			}
+			segs = append(segs, "{"+name+"}")
+			continue
+		}
+		// Literal quoted segment "users" (may itself contain '/').
+		if sm := tapirPathStringRe.FindStringSubmatch(tok); sm != nil {
+			for _, p := range strings.Split(sm[1], "/") {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					segs = append(segs, p)
+				}
+			}
+		}
+	}
+	return segs
+}
+
+// splitTopLevelSlashes splits a tapir path expression on `/` separators that are
+// not nested inside [] or () — so `path[Long]("id")` is one token, not split on
+// brackets, and a `/` inside a quoted literal or type param does not break a seg.
+func splitTopLevelSlashes(s string) []string {
+	var parts []string
+	depth := 0
+	inStr := false
+	start := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '"':
+			inStr = !inStr
+		case inStr:
+			// skip
+		case c == '[' || c == '(':
+			depth++
+		case c == ']' || c == ')':
+			if depth > 0 {
+				depth--
+			}
+		case c == '/' && depth == 0:
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+// tapirParamNameForType returns a synthetic param name for an anonymous path[T].
+func tapirParamNameForType(typ string) string {
+	switch normalizeScalaType(typ) {
+	case "Long", "Int", "Short", "BigInt":
+		return "id"
+	case "UUID", "java.util.UUID":
+		return "uuid"
+	case "String":
+		return "segment"
+	}
+	return "param"
+}
+
+// normalizeScalaType strips a leading package qualifier for readability while
+// preserving any type-parameter suffix (List[User] stays List[User]).
+func normalizeScalaType(t string) string {
+	t = strings.TrimSpace(t)
+	// Keep generic params intact; only de-qualify the head type name.
+	head := t
+	rest := ""
+	if i := strings.IndexByte(t, '['); i >= 0 {
+		head = t[:i]
+		rest = t[i:]
+	}
+	if dot := strings.LastIndexByte(head, '.'); dot >= 0 {
+		head = head[dot+1:]
+	}
+	return head + rest
+}
+
+// appendUnique appends v to s only when not already present.
+func appendUnique(s []string, v string) []string {
+	if v == "" {
+		return s
+	}
+	for _, x := range s {
+		if x == v {
+			return s
+		}
+	}
+	return append(s, v)
+}
+
+// extractTapirEndpoints parses every endpoint chain in src into entities:
+// one http_route per endpoint (method + path + DTO refs + handler) and one
+// dto_ref entity per request/response/error DTO so consumers can navigate the
+// wire shape independently of the case-class field model in validation.go.
+func extractTapirEndpoints(src string, file fileMeta) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := map[string]bool{}
+
+	for _, loc := range tapirEndpointStartRe.FindAllStringIndex(src, -1) {
+		// Skip the `endpoint` token when it is part of a longer identifier such
+		// as `endpoints` or `myEndpoint`: require a non-identifier (or BOF) just
+		// before and a `.`/whitespace just after to be a builder start.
+		startIdx := loc[0]
+		if startIdx > 0 {
+			p := src[startIdx-1]
+			if p == '_' || p == '.' || (p >= 'a' && p <= 'z') || (p >= 'A' && p <= 'Z') || (p >= '0' && p <= '9') {
+				continue
+			}
+		}
+		chain := tapirChainBody(src, startIdx)
+		// A bare `endpoint` with no method/in/out combinator is not a real route
+		// site (e.g. a base endpoint alias with nothing chained on this line).
+		if !strings.Contains(chain, ".in(") && !strings.Contains(chain, ".out(") &&
+			!tapirMethodRe.MatchString(chain) {
+			continue
+		}
+		ep := parseTapirEndpoint(chain, lineOf(src, startIdx))
+
+		method := ep.method
+		if method == "" {
+			method = "ANY"
+		}
+		name := "tapir:" + method + ":" + ep.path
+		key := "http_route:" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		ent := makeEntity(name, "SCOPE.Operation", "http_route", file.Path, file.Language, ep.startLine)
+		setProps(&ent, "framework", "tapir", "http_method", method, "http_path", ep.path,
+			"provenance", "TAPIR_ENDPOINT_DSL")
+		if len(ep.queryParams) > 0 {
+			setProps(&ent, "query_params", strings.Join(ep.queryParams, ","))
+		}
+		if len(ep.requestDTOs) > 0 {
+			setProps(&ent, "request_dto", strings.Join(ep.requestDTOs, ","))
+		}
+		if len(ep.responseDTOs) > 0 {
+			setProps(&ent, "response_dto", strings.Join(ep.responseDTOs, ","))
+		}
+		if len(ep.errorDTOs) > 0 {
+			setProps(&ent, "error_dto", strings.Join(ep.errorDTOs, ","))
+		}
+		if ep.handler != "" {
+			setProps(&ent, "handler", ep.handler, "handler_attribution", "true")
+		}
+		out = append(out, ent)
+
+		// Emit a dto_ref entity per request/response/error DTO so the wire shape
+		// is navigable. These are SCOPE.Type/dto_ref (distinct from the
+		// case-class SCOPE.Type/dto entities in validation.go) and carry the
+		// role (request/response/error) + the owning route.
+		emitDTORef := func(role string, dtos []string) {
+			for _, dto := range dtos {
+				rn := "tapir_dto:" + role + ":" + dto + ":" + name
+				rk := "dto_ref:" + rn
+				if seen[rk] {
+					continue
+				}
+				seen[rk] = true
+				de := makeEntity(rn, "SCOPE.Type", "dto_ref", file.Path, file.Language, ep.startLine)
+				setProps(&de, "framework", "tapir", "provenance", "TAPIR_BODY_CODEC",
+					"role", role, "dto", dto, "route", name, "http_method", method, "http_path", ep.path)
+				out = append(out, de)
+			}
+		}
+		emitDTORef("request", ep.requestDTOs)
+		emitDTORef("response", ep.responseDTOs)
+		emitDTORef("error", ep.errorDTOs)
+	}
+
+	return out
+}

--- a/internal/custom/scala/tapir_pekko_test.go
+++ b/internal/custom/scala/tapir_pekko_test.go
@@ -1,0 +1,191 @@
+package scala_test
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// tapir — endpoint-DSL routing + DTO extraction (#3507).
+//
+// Value-asserting: each test pins the exact http_route name (verb + canonical
+// path) and the request/response/error DTO type names + handler the extractor
+// produces from the endpoint chain. A "≥1 route exists" check is NOT used.
+// ---------------------------------------------------------------------------
+
+func TestTapirEndpointRouteAndDTOs(t *testing.T) {
+	src := `
+import sttp.tapir._
+import sttp.tapir.json.circe._
+
+val getUser =
+  endpoint
+    .get
+    .in("users" / path[Long]("id"))
+    .in(query[String]("q"))
+    .out(jsonBody[User])
+    .errorOut(jsonBody[ErrorInfo])
+    .serverLogic(handleGetUser)
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserEndpoints.scala", "scala", src))
+	got := dumpEntities(ents)
+
+	e, ok := findBySubtype(ents, "http_route", "tapir:GET:/users/{id}")
+	if !ok {
+		t.Fatalf("expected http_route tapir:GET:/users/{id}; got:%s", got)
+	}
+	if e.Props["http_method"] != "GET" {
+		t.Errorf("http_method = %q, want GET", e.Props["http_method"])
+	}
+	if e.Props["http_path"] != "/users/{id}" {
+		t.Errorf("http_path = %q, want /users/{id}", e.Props["http_path"])
+	}
+	if e.Props["request_dto"] != "" {
+		// request body came from .in(jsonBody[...]) only; this endpoint has none.
+		t.Errorf("request_dto = %q, want empty (no .in(jsonBody))", e.Props["request_dto"])
+	}
+	if e.Props["response_dto"] != "User" {
+		t.Errorf("response_dto = %q, want User", e.Props["response_dto"])
+	}
+	if e.Props["error_dto"] != "ErrorInfo" {
+		t.Errorf("error_dto = %q, want ErrorInfo", e.Props["error_dto"])
+	}
+	if e.Props["query_params"] != "q" {
+		t.Errorf("query_params = %q, want q", e.Props["query_params"])
+	}
+	if e.Props["handler"] != "handleGetUser" {
+		t.Errorf("handler = %q, want handleGetUser", e.Props["handler"])
+	}
+
+	// DTO ref entities for response + error.
+	if _, ok := findBySubtype(ents, "dto_ref", "tapir_dto:response:User:tapir:GET:/users/{id}"); !ok {
+		t.Errorf("expected response dto_ref for User; got:%s", got)
+	}
+	if _, ok := findBySubtype(ents, "dto_ref", "tapir_dto:error:ErrorInfo:tapir:GET:/users/{id}"); !ok {
+		t.Errorf("expected error dto_ref for ErrorInfo; got:%s", got)
+	}
+}
+
+func TestTapirPostRequestBodyDTO(t *testing.T) {
+	src := `
+import sttp.tapir._
+
+val createUser =
+  endpoint
+    .post
+    .in("users")
+    .in(jsonBody[CreateUserRequest])
+    .out(jsonBody[User])
+    .serverLogicSuccess(createUserHandler)
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Create.scala", "scala", src))
+	got := dumpEntities(ents)
+
+	e, ok := findBySubtype(ents, "http_route", "tapir:POST:/users")
+	if !ok {
+		t.Fatalf("expected http_route tapir:POST:/users; got:%s", got)
+	}
+	if e.Props["request_dto"] != "CreateUserRequest" {
+		t.Errorf("request_dto = %q, want CreateUserRequest", e.Props["request_dto"])
+	}
+	if e.Props["response_dto"] != "User" {
+		t.Errorf("response_dto = %q, want User", e.Props["response_dto"])
+	}
+	if e.Props["handler"] != "createUserHandler" {
+		t.Errorf("handler = %q, want createUserHandler", e.Props["handler"])
+	}
+	if _, ok := findBySubtype(ents, "dto_ref", "tapir_dto:request:CreateUserRequest:tapir:POST:/users"); !ok {
+		t.Errorf("expected request dto_ref for CreateUserRequest; got:%s", got)
+	}
+}
+
+func TestTapirMethodExplicitForm(t *testing.T) {
+	src := `
+import sttp.tapir._
+val delUser = endpoint.method(Method.DELETE).in("users" / path[Long]("id"))
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Del.scala", "scala", src))
+	got := dumpEntities(ents)
+	if _, ok := findBySubtype(ents, "http_route", "tapir:DELETE:/users/{id}"); !ok {
+		t.Errorf("expected http_route tapir:DELETE:/users/{id}; got:%s", got)
+	}
+}
+
+func TestTapirNamedPathParam(t *testing.T) {
+	src := `
+import sttp.tapir._
+val getBook = endpoint.get.in("books" / path[String]("isbn")).out(jsonBody[Book])
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Book.scala", "scala", src))
+	got := dumpEntities(ents)
+	if _, ok := findBySubtype(ents, "http_route", "tapir:GET:/books/{isbn}"); !ok {
+		t.Errorf("expected http_route tapir:GET:/books/{isbn}; got:%s", got)
+	}
+}
+
+// A non-tapir Scala file must NOT produce tapir routes (no-op signal gate).
+func TestTapirNoSignalNoOp(t *testing.T) {
+	src := `
+import org.http4s._
+val routes = HttpRoutes.of[IO] { case GET -> Root / "ping" => Ok("pong") }
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Http4s.scala", "scala", src))
+	for _, e := range ents {
+		if e.Props["framework"] == "tapir" {
+			t.Errorf("expected no tapir entities for an http4s file; got %s", dumpEntities(ents))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Apache Pekko (pekko-http) — Apache fork of akka-http. Same routing DSL,
+// package org.apache.pekko.*. Must be detected as its own framework and the
+// akka path canonicaliser reused, producing combined verb+path routes.
+// ---------------------------------------------------------------------------
+
+func TestPekkoHttpRoute(t *testing.T) {
+	src := `
+import org.apache.pekko.http.scaladsl.server.Directives._
+val route =
+  pathPrefix("api") {
+    path("users" / LongNumber) { id =>
+      get { complete(users) } ~
+      post { entity(as[User]) { u => complete(u) } }
+    }
+  }
+`
+	ents := extract(t, "custom_scala_frameworks", fi("UserRoutes.scala", "scala", src))
+	got := dumpEntities(ents)
+
+	e, ok := findBySubtype(ents, "http_route", "GET:/api/users/{id}")
+	if !ok {
+		t.Fatalf("expected http_route GET:/api/users/{id} from pekko-http; got:%s", got)
+	}
+	if e.Props["framework"] != "pekko-http" {
+		t.Errorf("framework = %q, want pekko-http", e.Props["framework"])
+	}
+	if _, ok := findBySubtype(ents, "http_route", "POST:/api/users/{id}"); !ok {
+		t.Errorf("expected http_route POST:/api/users/{id} from pekko-http; got:%s", got)
+	}
+}
+
+func TestPekkoHttpAuthDirective(t *testing.T) {
+	src := `
+import org.apache.pekko.http.scaladsl.server.Directives._
+val route =
+  authenticateBasic(realm = "secure", myAuth) { user =>
+    path("admin") { get { complete("ok") } }
+  }
+`
+	ents := extract(t, "custom_scala_frameworks", fi("Admin.scala", "scala", src))
+	got := dumpEntities(ents)
+	found := false
+	for _, e := range ents {
+		if e.Subtype == "auth_check" && e.Props["framework"] == "pekko-http" &&
+			e.Props["auth_method"] == "basic" && e.Props["realm"] == "secure" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected pekko-http basic auth_check with realm=secure; got:%s", got)
+	}
+}


### PR DESCRIPTION
Closes #3507 (epic #3505).

Adds **two NEW Scala HTTP framework records** + backing extractors. Expansion (new framework coverage), not depth.

## New records

### `lang.scala.framework.tapir` — tapir (endpoint DSL)
Highest-value Scala add: routes + DTOs live in `endpoint` values regardless of the serving backend (akka/pekko/http4s/netty). New `internal/custom/scala/tapir.go` parses each
`endpoint`(.get/.post/.method(Method.X)).in("seg" / path[T]("name")).in(query[T]).out(jsonBody[T]).errorOut(jsonBody[T]).serverLogic(handler)
chain into:
- one `http_route` entity — `http_method` + canonical `http_path` (`{name}` from `path[T]`, literal segs preserved in order, query params recorded separately as `query_params`);
- role-tagged `dto_ref` entities (request / response / error) from `jsonBody[T]`;
- handler attribution from `.serverLogic*`.

**Cells flipped:** route_extraction, endpoint_synthesis, handler_attribution, dto_extraction, request_shape_extraction, response_shape_extraction → **full**; request_validation → **partial** (field-level case-class validation via shared extractor; tapir's own `.validate()` combinator not yet parsed); shared metric/trace → full, log/tests → partial.

### `lang.scala.framework.pekko-http` — Apache Pekko HTTP
Apache fork of Akka. `detectScalaFramework` now recognises `org.apache.pekko` as its **own** framework (previously folded into akka-http) and routes it through the shared `case "akka-http", "pekko-http"` branch — reusing the akka path canonicaliser + deep auth/middleware extraction.

**Cells flipped:** route_extraction, auth_coverage, middleware_coverage, dto_extraction, request_validation → **full**; endpoint_synthesis, handler_attribution → **partial**; shared metric/trace → full, log/tests → partial.

## Tests
Value-asserting (`internal/custom/scala/tapir_pekko_test.go`) — exact verb+path and DTO type names, no `len>0`:
- tapir: `GET /users/{id}` (+ response_dto=User, error_dto=ErrorInfo, query_params=q, handler=handleGetUser), `POST /users` (request_dto=CreateUserRequest), `DELETE /users/{id}`, `GET /books/{isbn}`, no-signal no-op gate.
- pekko: `GET /api/users/{id}` + `POST /api/users/{id}` (framework=pekko-http), basic-auth directive (auth_method=basic, realm=secure).

## Discipline
`coverage add` → `backfill` → `update` (never hand-serialized). `coverage gen` + `validate` (0 errors; the "no mapping entry" warnings match the existing akka-http/http4s scala-family pattern) + `fmt --check` (canonical). `gofmt -l` empty, `go vet` clean. Targeted tests green: `internal/custom/scala/`, `internal/types/`, `internal/engine/`, `tools/coverage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)