### PR TITLE
feat(iac): make AWS CDK (TypeScript) resource + dependency extraction real (#3512)

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -14,7 +14,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [.toml](../detail/config.toml.md) | — | — | ✅ | — | ✅ | |
 | [multi](../by-language/multi.md) | [.yaml / .yml](../detail/config.yaml.md) | — | — | ✅ | — | ✅ | |
 | [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.iac.cdk.md) | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [AWS CDK](../detail/infra.resource.aws-cdk.md) | — | — | — | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | 🟢 | — | — | ✅ | 🟢 | |
 | [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | — | — | — | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | — | — | 🟢 | 🟢 | |

--- a/docs/coverage/detail/infra.iac.cdk.md
+++ b/docs/coverage/detail/infra.iac.cdk.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/cdk/_manifest.yaml` | — |
-| Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/cdk/_manifest.yaml` | — |
+| Dependency attribution | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3512) | `internal/engine/cdk_edges.go` | CDK-TS dependency edges implemented: DEPENDS_ON from grant calls (bucket.grantRead(fn)), Lambda addEventSource, and construct vars passed through props; mirrors the hcl extractor's depends_on->DEPENDS_ON edge kind. CDK-Python/Java/Go/C# pending. Was citing the dormant rules/cdk/_manifest.yaml. |
+| Resource extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3512) | `internal/engine/cdk_edges.go`<br>`internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml` | CDK-TS implemented (applyCDKEdges): SCOPE.InfraResource per construct named by LogicalId. Stack/App scope via rules/javascript_typescript/frameworks/aws_cdk.yaml. CDK-Python/Java/Go/C# pending. Was citing the dormant rules/cdk/_manifest.yaml (knowledge metadata, never fired). |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.resource.aws-cdk.md
+++ b/docs/coverage/detail/infra.resource.aws-cdk.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Resource extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/hcl/extractor.go` | — |
+| Resource extraction | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3512) | `internal/engine/cdk_edges.go`<br>`internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml` | CDK-TS only: applyCDKEdges emits SCOPE.InfraResource per construct named by its 'LogicalId' literal (construct_type + coarse resource_scope). CDK-Python/Java/Go/C# not yet implemented. Previously over-stamped full citing the hcl/Terraform extractor, which cannot parse .ts. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1309,13 +1309,17 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/cdk_edges.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3512",
+          "notes": "CDK-TS dependency edges implemented: DEPENDS_ON from grant calls (bucket.grantRead(fn)), Lambda addEventSource, and construct vars passed through props; mirrors the hcl extractor's depends_on-\u003eDEPENDS_ON edge kind. CDK-Python/Java/Go/C# pending. Was citing the dormant rules/cdk/_manifest.yaml.",
+          "verified_at": "2026-05-30"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/cdk/_manifest.yaml"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/cdk_edges.go","internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3512",
+          "notes": "CDK-TS implemented (applyCDKEdges): SCOPE.InfraResource per construct named by LogicalId. Stack/App scope via rules/javascript_typescript/frameworks/aws_cdk.yaml. CDK-Python/Java/Go/C# pending. Was citing the dormant rules/cdk/_manifest.yaml (knowledge metadata, never fired).",
+          "verified_at": "2026-05-30"
         }
       }
     },
@@ -1553,9 +1557,11 @@
       "label": "AWS CDK",
       "capabilities": {
         "resource_extraction": {
-          "status": "full",
-          "cites": ["internal/extractors/hcl/extractor.go"],
-          "verified_at": "2026-05-28"
+          "status": "partial",
+          "cites": ["internal/engine/cdk_edges.go","internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3512",
+          "notes": "CDK-TS only: applyCDKEdges emits SCOPE.InfraResource per construct named by its 'LogicalId' literal (construct_type + coarse resource_scope). CDK-Python/Java/Go/C# not yet implemented. Previously over-stamped full citing the hcl/Terraform extractor, which cannot parse .ts.",
+          "verified_at": "2026-05-30"
         }
       }
     },

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -32,14 +32,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 11 | 0 | 7 | 4 |
-| [Platform / k8s](by-category/platform.md) | 23 | 12 | 8 | 3 |
+| [Platform / k8s](by-category/platform.md) | 23 | 11 | 9 | 3 |
 | [Message Brokers](by-category/message_broker.md) | 20 | 9 | 9 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 8 | 3 | 3 | 2 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 97 | 32 | 36 | 29 |
+| **Total** | 97 | 31 | 37 | 29 |
 
 ## Languages with extractor support, no records yet
 

--- a/internal/engine/cdk_edges.go
+++ b/internal/engine/cdk_edges.go
@@ -1,0 +1,341 @@
+// AWS CDK (TypeScript) resource + dependency extraction — part of #3512.
+//
+// Background / the gap this closes
+// --------------------------------
+// AWS CDK is the marquee IaC framework, but its resource extraction was 0%
+// functional while the coverage registry stamped it `full`. The cause was two
+// independent defects:
+//
+//  1. The CDK FrameworkRule YAML lived under rules/cdk/, which the loader
+//     buckets by top-level dir name into language key "cdk". The detector
+//     resolves compiled rules by file.Language (typescript/javascript/...), and
+//     no file is ever tagged "cdk", so the rules never fired. (Fixed by
+//     relocating the YAML to rules/javascript_typescript/frameworks/aws_cdk.yaml,
+//     which the existing javascript_typescript → typescript/javascript alias in
+//     detector.compile() maps onto real .ts/.js files.)
+//
+//  2. The registry's resource_extraction `full` stamp for infra.resource.aws-cdk
+//     cited internal/extractors/hcl/extractor.go — the Terraform extractor, which
+//     cannot parse .ts. A pure mis-stamp.
+//
+// What this pass extracts (CDK-TS)
+// --------------------------------
+// The #1 CDK idiom is `new <ns>.<Type>(this, 'LogicalId', { ...props })`:
+//
+//	const dataBucket = new s3.Bucket(this, 'DataBucket', { versioned: true });
+//	const handler    = new lambda.Function(this, 'Handler', { ... });
+//	dataBucket.grantRead(handler);
+//
+// For each construct we emit a SCOPE.InfraResource entity NAMED by its
+// 'LogicalId' string literal (the stable CDK identity), carrying the construct
+// TYPE (`s3.Bucket`) and a coarse scope class (service / datastore / queue) in
+// its properties. L1 escape-hatch constructs `new CfnBucket(this,'id',{...})`
+// are captured the same way.
+//
+// Dependency edges (mirroring the hcl extractor's depends_on → DEPENDS_ON):
+//
+//   - `bucket.grantRead(fn)` / `bucket.grantWrite(fn)` / `*.grant*(fn)` →
+//     DEPENDS_ON  fn-resource → bucket-resource  (the grantee depends on the
+//     resource it was granted access to). Property grant=<method>.
+//   - `fn.addEventSource(new SqsEventSource(queue))` →
+//     DEPENDS_ON  fn-resource → queue-resource.
+//   - a construct variable passed into another construct's props
+//     (`new lambda.Function(this,'F',{ bucket })` or `{ bucket: dataBucket }`)
+//     → DEPENDS_ON  enclosing-construct → passed-construct.
+//
+// The file-local variable → LogicalId binding (built from the `const X = new
+// ...` assignment) is what lets a `dataBucket.grantRead(handler)` call resolve
+// both endpoints to their LogicalId-named resource entities.
+//
+// Scope guard
+// -----------
+// Append-only: this pass never modifies or removes existing entities or edges,
+// so it cannot regress the surrounding pipeline's bug-rate. Establishes the
+// per-language-bucket pattern that CDK-Python / Pulumi / CDK8s reuse.
+//
+// Refs #3512.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// cdkResourceKind is the entity kind for every CDK construct resource. We use
+// the dedicated SCOPE.InfraResource kind (a registered producer kind) rather
+// than overloading SCOPE.Service, so IaC resources are queryable as a class and
+// distinguishable from application services.
+const cdkResourceKind = "SCOPE.InfraResource"
+
+// cdkDependsOnEdgeKind mirrors the hcl extractor's depends_on → DEPENDS_ON edge
+// kind so CDK and Terraform dependency edges are uniform across IaC tools.
+const cdkDependsOnEdgeKind = "DEPENDS_ON"
+
+// cdkSupportsLanguage reports whether applyCDKEdges scans `lang`. This PR scopes
+// CDK to TypeScript/JavaScript (the flagship CDK language); CDK-Python/Java/Go/C#
+// follow later under their own language buckets.
+func cdkSupportsLanguage(lang string) bool {
+	switch lang {
+	case "javascript", "typescript":
+		return true
+	default:
+		return false
+	}
+}
+
+// cdkResourceCoarseScope maps a CDK construct type (e.g. "s3.Bucket",
+// "lambda.Function", "sqs.Queue", "dynamodb.Table", "CfnDBInstance") to a coarse
+// architectural scope class. Mirrors the intent of the (dead) iacResourceKind
+// helper but returns a bare class string recorded as a property — the entity
+// Kind stays SCOPE.InfraResource so all CDK resources remain a single queryable
+// class. Matching is on the lower-cased construct type.
+func cdkResourceCoarseScope(constructType string) string {
+	t := strings.ToLower(constructType)
+	switch {
+	case strings.Contains(t, "rds") || strings.Contains(t, "dynamodb") ||
+		strings.Contains(t, "database") || strings.Contains(t, "dbinstance") ||
+		strings.Contains(t, "dbcluster") || strings.Contains(t, "table") ||
+		strings.Contains(t, "bucket") || strings.Contains(t, "elasticache") ||
+		strings.Contains(t, "redshift"):
+		return "datastore"
+	case strings.Contains(t, "sqs") || strings.Contains(t, "queue") ||
+		strings.Contains(t, "sns") || strings.Contains(t, "topic") ||
+		strings.Contains(t, "kinesis") || strings.Contains(t, "eventbus"):
+		return "queue"
+	default:
+		return "service"
+	}
+}
+
+// cdkConstructDeclRe captures `const|let|var VAR = new <ns>.<Type>(this, 'LogicalId'`.
+// Group 1 = JS var name, group 2 = construct type (ns.Type, e.g. "s3.Bucket"),
+// group 3 = the 'LogicalId' string literal.
+//
+//	const dataBucket = new s3.Bucket(this, 'DataBucket', { versioned: true });
+var cdkConstructDeclRe = regexp.MustCompile(
+	`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*new\s+([A-Za-z_$][\w$.]*)\s*\(\s*(?:this|self|scope|stack|[A-Za-z_$][\w$]*)\s*,\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]`,
+)
+
+// cdkConstructAnonRe captures an UNASSIGNED construct instantiation
+// `new <ns>.<Type>(this, 'LogicalId'` (no `const X =` prefix). Group 1 =
+// construct type, group 2 = 'LogicalId'. Used to emit the resource entity even
+// when the construct is not bound to a variable (still has a stable LogicalId).
+var cdkConstructAnonRe = regexp.MustCompile(
+	`new\s+([A-Za-z_$][\w$.]*)\s*\(\s*(?:this|self|scope|stack|[A-Za-z_$][\w$]*)\s*,\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]`,
+)
+
+// cdkGrantRe captures a grant call `<resourceVar>.grant<Something>(<granteeVar>`.
+// Group 1 = the resource variable being granted, group 2 = the grant method
+// (grantRead / grantWrite / grantReadWrite / grantPutEvents / grant / ...),
+// group 3 = the grantee variable. Semantics: the grantee DEPENDS_ON the
+// resource (it needs access to it).
+var cdkGrantRe = regexp.MustCompile(
+	`([A-Za-z_$][\w$]*)\s*\.\s*(grant[A-Za-z]*)\s*\(\s*([A-Za-z_$][\w$]*)`,
+)
+
+// cdkAddEventSourceRe captures `<fnVar>.addEventSource(new <SourceType>(<resourceVar>`.
+// Group 1 = the function variable, group 2 = the wrapped resource variable
+// (the queue/stream/bucket the event source reads from). The function
+// DEPENDS_ON that resource.
+var cdkAddEventSourceRe = regexp.MustCompile(
+	`([A-Za-z_$][\w$]*)\s*\.\s*addEventSource\s*\(\s*new\s+[A-Za-z_$][\w$.]*\s*\(\s*([A-Za-z_$][\w$]*)`,
+)
+
+// cdkConstructCallRe is a non-greedy matcher for a full construct instantiation
+// up to the closing of its props object/argument list, used to scan props for
+// passed-in construct variables. Group 1 = the LogicalId of the construct whose
+// props we are scanning, group 2 = the raw props text. We bound the props body
+// at the first `})` / `)` that plausibly closes the call to stay file-local and
+// avoid runaway matches; regexp cannot balance braces so this is a heuristic
+// scan, not a parse.
+var cdkConstructPropsRe = regexp.MustCompile(
+	`new\s+[A-Za-z_$][\w$.]*\s*\(\s*(?:this|self|scope|stack|[A-Za-z_$][\w$]*)\s*,\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]\s*,\s*\{([\s\S]{0,600}?)\}\s*\)`,
+)
+
+// cdkPropsRefRe finds construct variables referenced inside a props body, both
+// shorthand (`bucket,` / `bucket }`) and explicit (`bucket: dataBucket`). It
+// captures every identifier that could be a construct reference; we filter
+// against the known var→LogicalId binding map so only real constructs produce
+// edges. Group 1 = explicit-value identifier (RHS of `key: ident`), group 2 =
+// shorthand identifier.
+var cdkPropsRefRe = regexp.MustCompile(
+	`(?:[A-Za-z_$][\w$]*\s*:\s*([A-Za-z_$][\w$]*)|\b([A-Za-z_$][\w$]*)\b)`,
+)
+
+// applyCDKEdges APPENDS SCOPE.InfraResource entities + DEPENDS_ON edges for AWS
+// CDK constructs in TypeScript/JavaScript. Append-only.
+func applyCDKEdges(args DetectorPassArgs) DetectorPassResult {
+	lang := args.Lang
+	content := args.Content
+	entities := args.Entities
+	relationships := args.Relationships
+	if len(content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+	if !cdkSupportsLanguage(lang) {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	src := string(content)
+
+	// Fast pre-filter: a CDK construct file imports from aws-cdk-lib (v2) or
+	// @aws-cdk/* (v1) and instantiates constructs with `new`. Guards against
+	// matching the generic `new X(this,'id',...)` idiom in non-CDK files.
+	if !strings.Contains(src, "aws-cdk") && !strings.Contains(src, "aws_cdk") &&
+		!strings.Contains(src, "constructs") {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	path := args.Path
+
+	seenEnt := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	// varToLogical maps a file-local construct variable to its LogicalId, so a
+	// `dataBucket.grantRead(handler)` call resolves both endpoints to their
+	// LogicalId-named resource entities.
+	varToLogical := map[string]string{}
+	// logicalIDs is the set of LogicalIds we have emitted a resource for, used
+	// to filter props-passed identifiers down to real constructs.
+	logicalIDs := map[string]bool{}
+
+	emitResource := func(logicalID, constructType string, offset int) {
+		if logicalID == "" || constructType == "" {
+			return
+		}
+		key := cdkResourceKind + "|" + logicalID + "|" + path
+		if seenEnt[key] {
+			return
+		}
+		seenEnt[key] = true
+		logicalIDs[logicalID] = true
+		entities = append(entities, types.EntityRecord{
+			Name:       logicalID,
+			Kind:       cdkResourceKind,
+			SourceFile: path,
+			Language:   lang,
+			StartLine:  matchStartLine(src, offset),
+			Properties: map[string]string{
+				"iac_tool":       "aws-cdk",
+				"construct_type": constructType,
+				"resource_scope": cdkResourceCoarseScope(constructType),
+				"logical_id":     logicalID,
+				"pattern_type":   "cdk_synthesis",
+			},
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+	}
+
+	// emitDependsOn records `fromLogical --DEPENDS_ON--> toLogical`, the same
+	// edge kind the hcl extractor emits for Terraform `depends_on`.
+	emitDependsOn := func(fromLogical, toLogical, reason, detail string) {
+		if fromLogical == "" || toLogical == "" || fromLogical == toLogical {
+			return
+		}
+		fromID := fmt.Sprintf("%s:%s", cdkResourceKind, fromLogical)
+		toID := fmt.Sprintf("%s:%s", cdkResourceKind, toLogical)
+		key := fromID + "|" + toID + "|" + reason + "|" + detail
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		props := map[string]string{
+			"iac_tool":     "aws-cdk",
+			"pattern_type": "cdk_synthesis",
+			"reason":       reason,
+		}
+		if detail != "" {
+			props[reason] = detail
+		}
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID:     fromID,
+			ToID:       toID,
+			Kind:       cdkDependsOnEdgeKind,
+			Properties: props,
+		})
+	}
+
+	// Pass 1: assigned construct declarations — `const X = new ns.Type(this,'Id'`.
+	// Record both the resource entity and the var→LogicalId binding.
+	for _, m := range cdkConstructDeclRe.FindAllStringSubmatchIndex(src, -1) {
+		varName := extractGroupFromIndex(src, m, 1)
+		constructType := extractGroupFromIndex(src, m, 2)
+		logicalID := extractGroupFromIndex(src, m, 3)
+		if logicalID == "" || constructType == "" {
+			continue
+		}
+		emitResource(logicalID, constructType, m[0])
+		if varName != "" {
+			varToLogical[varName] = logicalID
+		}
+	}
+
+	// Pass 2: anonymous (unassigned) construct instantiations — still emit the
+	// resource keyed by LogicalId. Dedup against Pass 1 via seenEnt.
+	for _, m := range cdkConstructAnonRe.FindAllStringSubmatchIndex(src, -1) {
+		constructType := extractGroupFromIndex(src, m, 1)
+		logicalID := extractGroupFromIndex(src, m, 2)
+		if logicalID == "" || constructType == "" {
+			continue
+		}
+		// Skip event-source / subscription wrapper constructs whose first arg is
+		// a resource variable, not a (scope, id) pair — these are handled as
+		// dependency edges, not standalone resources. Heuristic: a real construct
+		// declaration always has `this`/scope as the first arg, which the regex
+		// already requires, so anonymous matches here are genuine constructs.
+		emitResource(logicalID, constructType, m[0])
+	}
+
+	// Pass 3: grant edges — `<resourceVar>.grant*(<granteeVar>)`. The grantee
+	// DEPENDS_ON the resource it was granted access to.
+	for _, m := range cdkGrantRe.FindAllStringSubmatch(src, -1) {
+		resourceVar, grantMethod, granteeVar := m[1], m[2], m[3]
+		resLogical := varToLogical[resourceVar]
+		granteeLogical := varToLogical[granteeVar]
+		if resLogical == "" || granteeLogical == "" {
+			continue
+		}
+		emitDependsOn(granteeLogical, resLogical, "grant", grantMethod)
+	}
+
+	// Pass 4: event-source edges — `<fnVar>.addEventSource(new Src(<resourceVar>`.
+	// The function DEPENDS_ON the event-source resource.
+	for _, m := range cdkAddEventSourceRe.FindAllStringSubmatch(src, -1) {
+		fnVar, resourceVar := m[1], m[2]
+		fnLogical := varToLogical[fnVar]
+		resLogical := varToLogical[resourceVar]
+		if fnLogical == "" || resLogical == "" {
+			continue
+		}
+		emitDependsOn(fnLogical, resLogical, "event_source", "")
+	}
+
+	// Pass 5: props-passed construct references. When a construct variable is
+	// passed into another construct's props (`{ bucket }` / `{ bucket: dataBucket }`),
+	// the enclosing construct DEPENDS_ON the passed construct.
+	for _, m := range cdkConstructPropsRe.FindAllStringSubmatch(src, -1) {
+		enclosingLogical := m[1]
+		propsBody := m[2]
+		if !logicalIDs[enclosingLogical] || propsBody == "" {
+			continue
+		}
+		for _, rm := range cdkPropsRefRe.FindAllStringSubmatch(propsBody, -1) {
+			ref := rm[1]
+			if ref == "" {
+				ref = rm[2]
+			}
+			passedLogical, ok := varToLogical[ref]
+			if !ok || passedLogical == enclosingLogical {
+				continue
+			}
+			emitDependsOn(enclosingLogical, passedLogical, "props_ref", ref)
+		}
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}

--- a/internal/engine/cdk_edges_test.go
+++ b/internal/engine/cdk_edges_test.go
@@ -1,0 +1,242 @@
+// Value-asserting tests for the AWS CDK (TypeScript) resource + dependency
+// extraction pass (cdk_edges.go) — part of #3512.
+//
+// The marquee fixture is a Stack with:
+//
+//	const dataBucket = new s3.Bucket(this, 'DataBucket', { versioned: true });
+//	const handler    = new lambda.Function(this, 'Handler', { ... });
+//	dataBucket.grantRead(handler);
+//
+// We assert the EXACT extracted shape (not len>0):
+//   - a SCOPE.InfraResource named 'DataBucket' with construct_type=s3.Bucket
+//   - a SCOPE.InfraResource named 'Handler'    with construct_type=lambda.Function
+//   - a DEPENDS_ON edge Handler → DataBucket (the grantRead grant)
+package engine
+
+import (
+	"testing"
+)
+
+// runCDKDetect is a lightweight in-process driver mirroring runBullMQDetect.
+func runCDKDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
+	t.Helper()
+	res := applyCDKEdges(DetectorPassArgs{Lang: lang, Path: path, Content: []byte(src)})
+	out := make([]entityResult, 0, len(res.Entities))
+	for _, e := range res.Entities {
+		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})
+	}
+	relOut := make([]relResult, 0, len(res.Relationships))
+	for _, r := range res.Relationships {
+		relOut = append(relOut, relResult{from: r.FromID, to: r.ToID, kind: r.Kind, props: r.Properties})
+	}
+	return out, relOut
+}
+
+// cdkResourceByName returns the SCOPE.InfraResource entity with the given
+// LogicalId name, or nil.
+func cdkResourceByName(ents []entityResult, logicalID string) *entityResult {
+	for i := range ents {
+		if ents[i].kind == cdkResourceKind && ents[i].name == logicalID {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestCDK_MarqueeFixture_BucketLambdaGrant is the core value-asserting test
+// from the #3512 task: the two constructs are emitted by LogicalId and the
+// grantRead produces a DEPENDS_ON edge from the grantee (Handler) to the
+// granted resource (DataBucket).
+func TestCDK_MarqueeFixture_BucketLambdaGrant(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+
+export class DataStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const dataBucket = new s3.Bucket(this, 'DataBucket', { versioned: true });
+
+    const handler = new lambda.Function(this, 'Handler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset('lambda'),
+    });
+
+    dataBucket.grantRead(handler);
+  }
+}
+`
+	ents, rels := runCDKDetect(t, "typescript", "lib/data-stack.ts", src)
+
+	// Resource: s3.Bucket named DataBucket.
+	bucket := cdkResourceByName(ents, "DataBucket")
+	if bucket == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'DataBucket', got %+v", ents)
+	}
+	if bucket.props["construct_type"] != "s3.Bucket" {
+		t.Errorf("DataBucket construct_type = %q, want s3.Bucket", bucket.props["construct_type"])
+	}
+	if bucket.props["iac_tool"] != "aws-cdk" {
+		t.Errorf("DataBucket iac_tool = %q, want aws-cdk", bucket.props["iac_tool"])
+	}
+	if bucket.props["resource_scope"] != "datastore" {
+		t.Errorf("DataBucket resource_scope = %q, want datastore", bucket.props["resource_scope"])
+	}
+
+	// Resource: lambda.Function named Handler.
+	handler := cdkResourceByName(ents, "Handler")
+	if handler == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'Handler', got %+v", ents)
+	}
+	if handler.props["construct_type"] != "lambda.Function" {
+		t.Errorf("Handler construct_type = %q, want lambda.Function", handler.props["construct_type"])
+	}
+	if handler.props["resource_scope"] != "service" {
+		t.Errorf("Handler resource_scope = %q, want service", handler.props["resource_scope"])
+	}
+
+	// Dependency edge: Handler --DEPENDS_ON--> DataBucket (the grantRead grant).
+	deps := relsByKind(rels, "DEPENDS_ON")
+	var found *relResult
+	for i := range deps {
+		if deps[i].from == "SCOPE.InfraResource:Handler" && deps[i].to == "SCOPE.InfraResource:DataBucket" {
+			found = &deps[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected DEPENDS_ON edge Handler→DataBucket, got %+v", deps)
+	}
+	if found.props["reason"] != "grant" || found.props["grant"] != "grantRead" {
+		t.Errorf("grant edge props = %+v, want reason=grant grant=grantRead", found.props)
+	}
+}
+
+// TestCDK_L1CfnConstruct asserts L1 escape-hatch constructs
+// (`new CfnBucket(this,'id',…)`) are extracted as resources.
+func TestCDK_L1CfnConstruct(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import { CfnBucket } from 'aws-cdk-lib/aws-s3';
+
+export class RawStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+    const raw = new CfnBucket(this, 'RawBucket', { bucketName: 'raw' });
+  }
+}
+`
+	ents, _ := runCDKDetect(t, "typescript", "lib/raw-stack.ts", src)
+	r := cdkResourceByName(ents, "RawBucket")
+	if r == nil {
+		t.Fatalf("expected SCOPE.InfraResource named 'RawBucket', got %+v", ents)
+	}
+	if r.props["construct_type"] != "CfnBucket" {
+		t.Errorf("RawBucket construct_type = %q, want CfnBucket", r.props["construct_type"])
+	}
+}
+
+// TestCDK_AddEventSource asserts `fn.addEventSource(new SqsEventSource(queue))`
+// produces a DEPENDS_ON edge from the function to the queue.
+func TestCDK_AddEventSource(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+
+export class WorkerStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+    const jobs = new sqs.Queue(this, 'Jobs', {});
+    const worker = new lambda.Function(this, 'Worker', { runtime: 'x', handler: 'h', code: 'c' });
+    worker.addEventSource(new SqsEventSource(jobs));
+  }
+}
+`
+	ents, rels := runCDKDetect(t, "typescript", "lib/worker-stack.ts", src)
+
+	if cdkResourceByName(ents, "Jobs") == nil {
+		t.Fatalf("expected SCOPE.InfraResource 'Jobs', got %+v", ents)
+	}
+	q := cdkResourceByName(ents, "Jobs")
+	if q.props["resource_scope"] != "queue" {
+		t.Errorf("Jobs resource_scope = %q, want queue", q.props["resource_scope"])
+	}
+	deps := relsByKind(rels, "DEPENDS_ON")
+	var ok bool
+	for _, d := range deps {
+		if d.from == "SCOPE.InfraResource:Worker" && d.to == "SCOPE.InfraResource:Jobs" &&
+			d.props["reason"] == "event_source" {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Errorf("expected DEPENDS_ON Worker→Jobs (event_source), got %+v", deps)
+	}
+}
+
+// TestCDK_PropsRef asserts a construct variable passed into another construct's
+// props (`{ bucket: dataBucket }`) yields a DEPENDS_ON edge.
+func TestCDK_PropsRef(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+export class AppStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string) {
+    super(scope, id);
+    const dataBucket = new s3.Bucket(this, 'DataBucket', {});
+    const fn = new lambda.Function(this, 'Api', {
+      runtime: 'x',
+      handler: 'h',
+      code: 'c',
+      environment: { BUCKET: dataBucket.bucketName },
+      bucket: dataBucket,
+    });
+  }
+}
+`
+	_, rels := runCDKDetect(t, "typescript", "lib/app-stack.ts", src)
+	deps := relsByKind(rels, "DEPENDS_ON")
+	var ok bool
+	for _, d := range deps {
+		if d.from == "SCOPE.InfraResource:Api" && d.to == "SCOPE.InfraResource:DataBucket" &&
+			d.props["reason"] == "props_ref" {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Errorf("expected DEPENDS_ON Api→DataBucket (props_ref), got %+v", deps)
+	}
+}
+
+// TestCDK_NonCDKFileEmitsNothing asserts the pre-filter gate: a plain TS file
+// with a `new X(this,'id',…)` idiom but no CDK import emits nothing.
+func TestCDK_NonCDKFileEmitsNothing(t *testing.T) {
+	src := `class Widget {
+  constructor() {
+    const child = new SomeThing(this, 'Foo', {});
+  }
+}
+`
+	ents, rels := runCDKDetect(t, "typescript", "widget.ts", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Errorf("non-CDK file should emit nothing, got %d entities %d rels", len(ents), len(rels))
+	}
+}
+
+// TestCDK_NonJSLanguageSkipped asserts non-JS/TS languages are skipped (this PR
+// scopes CDK to TypeScript/JavaScript).
+func TestCDK_NonJSLanguageSkipped(t *testing.T) {
+	src := `from aws_cdk import Stack
+class DataStack(Stack):
+    def __init__(self, scope, id):
+        bucket = s3.Bucket(self, "DataBucket")
+`
+	ents, rels := runCDKDetect(t, "python", "stack.py", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Errorf("non-JS/TS language should be skipped, got %d entities %d rels", len(ents), len(rels))
+	}
+}

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -558,6 +558,17 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// byQualifiedName index binds them. Append-only — cannot regress the yaml
 	// extractor's output or the surrounding pipeline's bug-rate.
 	applyPass(applyKubernetesEdges)
+	// AWS CDK (TypeScript) resource + dependency extraction (part of #3512).
+	// Emits one SCOPE.InfraResource per construct (`new s3.Bucket(this,'Id',…)`),
+	// NAMED by its 'LogicalId' string literal and tagged with the construct type
+	// + a coarse scope class, plus DEPENDS_ON edges for grant calls
+	// (`bucket.grantRead(fn)`), Lambda event sources (`fn.addEventSource(new
+	// SqsEventSource(queue))`), and construct variables passed through props.
+	// Mirrors the hcl extractor's depends_on → DEPENDS_ON edge kind so CDK and
+	// Terraform dependency edges are uniform. JS/TS only (CDK-Python/Java/Go/C#
+	// follow under their own language buckets). Append-only — cannot regress the
+	// surrounding pipeline's bug-rate.
+	applyPass(applyCDKEdges)
 
 	// Debezium / Kafka-Connect CDC connector edges (#1708). Parses the
 	// JSON config of a CDC connector and emits a SCOPE.Component

--- a/internal/engine/rules/cdk/frameworks/aws_cdk.yaml
+++ b/internal/engine/rules/cdk/frameworks/aws_cdk.yaml
@@ -22,6 +22,17 @@ frameworks:
     AWS CDK is a multi-language IaC framework supporting TypeScript, Python,
     Go, Java, and C#. The App and Stack classes are the root abstractions.
 
+    DORMANT (part of #3512): this file lives under rules/cdk/, which the loader
+    buckets by top-level dir name into language key "cdk". The detector resolves
+    compiled rules by file.Language (typescript/python/...), and no file is ever
+    tagged "cdk", so these patterns NEVER fire. The active CDK-TS rule set lives
+    at rules/javascript_typescript/frameworks/aws_cdk.yaml (Stack/App scope) plus
+    the Go pass internal/engine/cdk_edges.go (resources + dependency edges).
+    This file is retained only because rules/cdk/_manifest.yaml is a coverage
+    discovery citation target; it is knowledge metadata, not a firing rule. Do
+    not add new firing patterns here — add them to the javascript_typescript
+    bucket (or a future per-language bucket cdk-python/.../).
+
 # ---------------------------------------------------------------------------
 # Extraction schema (FrameworkExtractionSchema —)
 # ---------------------------------------------------------------------------

--- a/internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml
@@ -1,0 +1,67 @@
+frameworks:
+  name: AWS CDK
+  vendor: Amazon Web Services
+  category: infrastructure_as_code
+  current_version_2025: 2.140.x
+  registry: constructs.dev (construct hub), npmjs.com
+  detection:
+    file_extensions:
+      - .ts
+      - .js
+    config_files:
+      - cdk.json
+      - cdk.context.json
+    content_patterns:
+      - aws-cdk-lib
+      - "@aws-cdk"
+      - "extends Stack"
+  notes: >-
+    AWS CDK (TypeScript/JavaScript). This rule set fires on real .ts/.js files
+    via the javascript_typescript → typescript/javascript bucket alias in
+    detector.compile(); the older rules/cdk/ bucket was dormant because no file
+    is ever tagged language "cdk".
+
+    SCOPE NOTE: resource extraction (`new s3.Bucket(this,'LogicalId',…)`) and
+    dependency edges (grant calls / addEventSource / props refs) are handled by
+    the dedicated Go pass applyCDKEdges (internal/engine/cdk_edges.go), which
+    captures the 'LogicalId' string literal as the resource NAME, the construct
+    TYPE, and the var→LogicalId binding needed to resolve grant/event-source
+    edges — none of which a single-capture regex source_pattern can express.
+    This YAML therefore only declares the Stack / App scope idioms; it must NOT
+    re-emit constructs as resources (that would double-emit alongside the Go
+    pass and mis-name them by construct type instead of LogicalId).
+
+# ---------------------------------------------------------------------------
+# Extraction schema — Stack/App scope only (resources live in the Go pass).
+# ---------------------------------------------------------------------------
+
+source_patterns:
+  # Stack class (TypeScript/JS): class MyStack extends cdk.Stack / Stack
+  - pattern: "class\\s+(\\w+)\\s+extends\\s+(?:cdk\\.)?Stack\\b"
+    entity_type: Component
+    name_group: 1
+    scope: class
+  # Construct/Stage subclass: class MyConstruct extends Construct / Stage
+  - pattern: "class\\s+(\\w+)\\s+extends\\s+(?:cdk\\.)?(?:Construct|Stage|NestedStack)\\b"
+    entity_type: Component
+    name_group: 1
+    scope: class
+  # App instantiation: new cdk.App() / new App()
+  - pattern: "new\\s+(?:cdk\\.)?App\\s*\\("
+    entity_type: Config
+    name_group: 0
+    scope: file
+  # CfnOutput: new cdk.CfnOutput(this, 'OutputId', …)
+  - pattern: "(?:new\\s+)?(?:cdk\\.)?CfnOutput\\s*\\(\\s*\\w+\\s*,\\s*[\"']([^\"']+)[\"']"
+    entity_type: Config
+    name_group: 1
+    scope: class
+
+relationship_rules:
+  # App instantiates stacks: new MyStack(app, 'StackId', …) → app CALLS stack
+  - pattern: "new\\s+(\\w+Stack)\\s*\\(\\s*(\\w+)"
+    source_type: Config
+    target_type: Component
+    relationship: CALLS
+    source_group: 2
+    target_group: 1


### PR DESCRIPTION
## The over-stamp finding

AWS CDK resource extraction was **0% functional** while the coverage registry stamped it `full`. Two independent defects:

1. **Dormant rules.** The CDK FrameworkRule YAML lived under `rules/cdk/`, which the loader buckets by top-level dir name into language key `cdk`. The detector resolves compiled rules by `file.Language` (`typescript`/`javascript`/…), and **no file is ever tagged `cdk`**, so the rules never fired.
2. **Mis-stamp.** `infra.resource.aws-cdk.resource_extraction` was `full` citing `internal/extractors/hcl/extractor.go` — the **Terraform** extractor, which cannot parse `.ts`.

## Wiring fix chosen — per-language-bucket route

Authored the firing CDK-TS rule set at `rules/javascript_typescript/frameworks/aws_cdk.yaml`, which the existing `javascript_typescript → typescript/javascript` alias in `detector.compile()` maps onto real `.ts`/`.js` files. The old `rules/cdk/frameworks/aws_cdk.yaml` is left in place but marked **DORMANT** (retained only because `rules/cdk/_manifest.yaml` is a coverage *discovery* citation target — knowledge metadata, not a firing rule). This establishes the per-language-bucket pattern that **CDK-Python / Pulumi / CDK8s** reuse.

The YAML only declares Stack/App scope idioms. Resource + dependency extraction needs to capture the `'LogicalId'` literal as the NAME, the construct TYPE, and a var→LogicalId binding to resolve grant edges — none of which a single-capture regex `source_pattern` can express — so it lives in a dedicated Go pass.

## CDK-TS idioms now extracted (`internal/engine/cdk_edges.go`, `applyCDKEdges`)

What fires now (real, value-asserted):
- **Resource:** `new <ns>.<Type>(this,'LogicalId',{...})` → `SCOPE.InfraResource` **named by its `'LogicalId'` literal**, tagged `construct_type` (e.g. `s3.Bucket`) + coarse `resource_scope` (datastore/queue/service). L1 `new Cfn<X>(this,'id',…)` captured the same way.
- **Scope:** `class X extends Stack` / `cdk.Stack` (+ Construct/Stage/NestedStack subclasses), App instantiation, CfnOutput — via the YAML rule set.
- **Dependency edges (`DEPENDS_ON`, mirroring the hcl extractor's `depends_on` edge kind):**
  - grant calls `bucket.grantRead(fn)` / `grantWrite` / `grant*` → grantee `fn` **DEPENDS_ON** `bucket`
  - Lambda `fn.addEventSource(new SqsEventSource(queue))` → `fn` DEPENDS_ON `queue`
  - a construct var passed through another construct's props (`{ bucket }` / `{ bucket: dataBucket }`) → enclosing construct DEPENDS_ON the passed construct

Append-only pass — cannot regress the surrounding pipeline's bug-rate.

## Honest re-stamp

| Record | Capability | Before | After |
|---|---|---|---|
| `infra.resource.aws-cdk` | resource_extraction | `full` (cited hcl) | **`partial`** → cites `cdk_edges.go` + rule YAML |
| `infra.iac.cdk` | resource_extraction | `partial` (cited dormant `_manifest.yaml`) | **`partial`** → cites real pass |
| `infra.iac.cdk` | dependency_attribution | `partial` (cited dormant `_manifest.yaml`) | **`partial`** → cites real pass |

`partial`, not `full`, because **only CDK-TS is implemented** — CDK-Python/Java/Go/C# follow later under their own language buckets. Docs regenerated via `go run ./tools/coverage gen`.

## What fires now vs honest-partial

- **Fires now (CDK-TS, value-asserting test proves it):** construct resources by LogicalId, construct type, coarse scope class, grant/event-source/props DEPENDS_ON edges, Stack/App/CfnOutput scope.
- **Honest-partial (NOT built):** CDK-Python, CDK-Java, CDK-Go, CDK-C#. The wiring + Go-pass shape established here is the template each will reuse.

## Verification

- `go test ./internal/engine/ ./internal/types/ ./tools/coverage/` — pass (incl. existing loader/detector rule-resolution tests, no regressions)
- `go run ./tools/coverage validate` — 0 errors; `fmt --check` — canonical; `gofmt -l` empty; `go vet` clean

**DEPLOY-DEFERRED.** Part of #3512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)