### PR TITLE
feat(iac): Kubernetes cross-resource edge synthesis (#3517)

### DIFF
--- a/docs/coverage/detail/infra.container.kubernetes.md
+++ b/docs/coverage/detail/infra.container.kubernetes.md
@@ -11,7 +11,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | ✅ `full` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
+| Dependency attribution | ✅ `full` | `2026-05-30` | — | `internal/engine/kubernetes_edges.go`<br>`internal/extractors/yaml/extractor.go` | — |
 | Resource extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml`<br>`internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1245,8 +1245,8 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "full",
-          "cites": ["internal/extractors/yaml/extractor.go"],
-          "verified_at": "2026-05-28"
+          "cites": ["internal/engine/kubernetes_edges.go","internal/extractors/yaml/extractor.go"],
+          "verified_at": "2026-05-30"
         },
         "resource_extraction": {
           "status": "full",

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -547,6 +547,18 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// Append-only — cannot regress the surrounding pipeline's bug-rate.
 	applyPass(applyIaCSNSEdges)
 
+	// Kubernetes cross-resource edge synthesis (#3517 / epic #3512). The yaml
+	// extractor already extracts K8s resources + sub-resources well but emits no
+	// edges BETWEEN resources. This pass re-reads the manifest (file-scoped) and
+	// synthesises: Service.spec.selector → matching workload (ROUTES_TO via pod-
+	// template-label superset match), container env/envFrom + volume references →
+	// ConfigMap/Secret/PVC (USES), Ingress backend → Service (ROUTES_TO), HPA
+	// scaleTargetRef → workload and ownerReferences → parent (DEPENDS_ON). All
+	// endpoints use the same QualifiedName the extractor minted so the resolver's
+	// byQualifiedName index binds them. Append-only — cannot regress the yaml
+	// extractor's output or the surrounding pipeline's bug-rate.
+	applyPass(applyKubernetesEdges)
+
 	// Debezium / Kafka-Connect CDC connector edges (#1708). Parses the
 	// JSON config of a CDC connector and emits a SCOPE.Component
 	// (cdc_connector) plus CAPTURES → captured-table and PUBLISHES_TO →

--- a/internal/engine/kubernetes_edges.go
+++ b/internal/engine/kubernetes_edges.go
@@ -1,0 +1,515 @@
+// Kubernetes cross-resource EDGE synthesis — #3517 (epic #3512).
+//
+// The yaml extractor (internal/extractors/yaml/extractor.go) already extracts
+// K8s resources and their sub-resources well: a Deployment/Service/StatefulSet/
+// DaemonSet becomes a SCOPE.Service entity, containers/env vars/ports/selectors/
+// volumeMounts become SCOPE.Component / SCOPE.Schema children with CONTAINS
+// edges, ConfigMap data keys become SCOPE.Schema config_key entities, and so on.
+//
+// What it does NOT do is connect resources to each OTHER. A Service that selects
+// a Deployment's pods, a container that mounts a ConfigMap/Secret, an Ingress
+// whose backend is a Service, an HPA that scales a Deployment — these are the
+// edges an architecture graph actually wants, and they were entirely absent.
+//
+// This post-pass reads the same K8s manifest file the extractor saw (file-scoped:
+// K8s manifests are conventionally one logical app per file / kustomize base) and
+// synthesises four families of cross-resource edges, addressing each resource by
+// the SAME QualifiedName the extractor minted so the resolver's byQualifiedName
+// index binds them:
+//
+//	resource ref  = "k8s/<file>#resource/<Kind>/<name>"
+//	container ref  = "k8s/<file>#container/<containerName>"
+//	init ref       = "k8s/<file>#init-container/<containerName>"
+//
+// Edge families (reusing existing RelationshipKinds — no new Kind needed):
+//
+//  1. Selector → workload (the #1 K8s edge). A Service whose spec.selector
+//     {k:v} map is a subset of a workload's spec.template.metadata.labels →
+//     ROUTES_TO edge Service→workload. ROUTES_TO is apt: a Service load-balances
+//     traffic TO the matching pods.
+//  2. env / volume references. A container's env[].valueFrom.configMapKeyRef /
+//     secretKeyRef, envFrom[].configMapRef / secretRef, and a pod's
+//     volumes[].configMap / secret / persistentVolumeClaim.claimName → USES
+//     edge container→ConfigMap/Secret (and workload→PVC). The PVC has no
+//     extracted entity of its own, so PVC refs are recorded as a USES edge to
+//     the resource ref shape, which binds only when a PVC manifest is present
+//     in the same file.
+//  3. Ingress backend → Service. An Ingress rule's
+//     http.paths[].backend.service.name → ROUTES_TO edge Ingress→Service.
+//  4. HPA scaleTargetRef → workload. A HorizontalPodAutoscaler's
+//     spec.scaleTargetRef.{kind,name} → DEPENDS_ON edge HPA→workload.
+//
+// Scope guard: append-only. This pass never modifies or removes existing
+// entities or edges, so it cannot regress the yaml extractor's output or the
+// surrounding pipeline's bug-rate. Edges whose endpoint resource is absent from
+// the file are still emitted (the resolver drops unbound refs); they bind iff
+// the target manifest shares the file.
+//
+// Refs #3517.
+package engine
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+	"gopkg.in/yaml.v3"
+)
+
+// k8sWorkloadKinds is the set of K8s Kinds whose spec.template.metadata.labels a
+// Service selector / HPA / etc. may target.
+var k8sWorkloadKinds = map[string]bool{
+	"Deployment":            true,
+	"StatefulSet":           true,
+	"DaemonSet":             true,
+	"ReplicaSet":            true,
+	"ReplicationController": true,
+	"Job":                   true,
+	"CronJob":               true,
+}
+
+// k8sDoc is one parsed Kubernetes document from a manifest file. Only the fields
+// this pass needs are modelled; everything else is ignored by the decoder.
+type k8sDoc struct {
+	kind string
+	name string
+	raw  map[string]interface{}
+}
+
+// applyKubernetesEdges is the entry point, registered in detector.go after the
+// other IaC passes. Append-only.
+func applyKubernetesEdges(args DetectorPassArgs) DetectorPassResult {
+	entities := args.Entities
+	relationships := args.Relationships
+	if args.Lang != "yaml" || len(args.Content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+	src := args.Content
+	// Cheap guard: a K8s manifest has top-level apiVersion + kind. Mirror the
+	// extractor's detectFlavor heuristic so this pass only fires on manifests.
+	if !k8sHasTopLevelKey(src, "apiVersion") || !k8sHasTopLevelKey(src, "kind") {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	docs := k8sParseDocs(src)
+	if len(docs) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	refPrefix := "k8s/" + args.Path + "#"
+	resourceRef := func(kind, name string) string {
+		return refPrefix + "resource/" + kind + "/" + name
+	}
+
+	// Index workloads by Kind/name and collect their pod-template labels so the
+	// selector-match pass can superset-test against them.
+	type workload struct {
+		kind   string
+		name   string
+		labels map[string]string
+	}
+	var workloads []workload
+	for _, d := range docs {
+		if !k8sWorkloadKinds[d.kind] || d.name == "" {
+			continue
+		}
+		labels := k8sPodTemplateLabels(d.raw)
+		workloads = append(workloads, workload{kind: d.kind, name: d.name, labels: labels})
+	}
+
+	seenEdge := map[string]bool{}
+	emit := func(fromID, toID, kind, edgeType string) {
+		if fromID == "" || toID == "" {
+			return
+		}
+		key := fromID + "|" + toID + "|" + kind
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID: fromID,
+			ToID:   toID,
+			Kind:   kind,
+			Properties: map[string]string{
+				"language":  "yaml",
+				"k8s_edge":  edgeType,
+				"synthesis": "kubernetes_edges",
+			},
+		})
+	}
+
+	for _, d := range docs {
+		switch {
+		case d.kind == "Service":
+			// (1) Service.spec.selector → matching workload(s).
+			sel := k8sStringMap(k8sDig(d.raw, "spec", "selector"))
+			if len(sel) == 0 {
+				continue
+			}
+			from := resourceRef("Service", d.name)
+			for _, w := range workloads {
+				if k8sLabelsMatch(w.labels, sel) {
+					emit(from, resourceRef(w.kind, w.name), string(types.RelationshipKindRoutesTo), "selector_match")
+				}
+			}
+
+		case d.kind == "Ingress":
+			// (3) Ingress backend → Service.
+			from := resourceRef("Ingress", d.name)
+			for _, svcName := range k8sIngressBackendServices(d.raw) {
+				emit(from, resourceRef("Service", svcName), string(types.RelationshipKindRoutesTo), "ingress_backend")
+			}
+
+		case d.kind == "HorizontalPodAutoscaler":
+			// (4) HPA scaleTargetRef → workload.
+			tgtKind, _ := k8sDig(d.raw, "spec", "scaleTargetRef", "kind").(string)
+			tgtName, _ := k8sDig(d.raw, "spec", "scaleTargetRef", "name").(string)
+			if tgtKind != "" && tgtName != "" {
+				emit(resourceRef("HorizontalPodAutoscaler", d.name),
+					resourceRef(tgtKind, tgtName),
+					string(types.RelationshipKindDependsOn), "hpa_target")
+			}
+
+		case k8sWorkloadKinds[d.kind]:
+			// (2) env / volume references from a workload's pod template.
+			k8sEmitWorkloadRefs(d, refPrefix, resourceRef, emit)
+		}
+	}
+
+	// (4b) ownerReferences → parent resource (cheap, any kind).
+	for _, d := range docs {
+		owners := k8sOwnerReferences(d.raw)
+		for _, o := range owners {
+			if o.kind == "" || o.name == "" || d.name == "" {
+				continue
+			}
+			emit(resourceRef(d.kind, d.name), resourceRef(o.kind, o.name),
+				string(types.RelationshipKindDependsOn), "owner_reference")
+		}
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}
+
+// k8sEmitWorkloadRefs emits USES edges for a workload's container env / envFrom
+// references and its pod-spec volume references. Container env refs are attached
+// to the specific container entity (k8s/<file>#container/<name>); volume refs are
+// pod-scoped and attach to the workload resource.
+func k8sEmitWorkloadRefs(
+	d k8sDoc,
+	refPrefix string,
+	resourceRef func(kind, name string) string,
+	emit func(fromID, toID, kind, edgeType string),
+) {
+	podSpec := k8sPodSpec(d.raw)
+	if podSpec == nil {
+		return
+	}
+	usesKind := string(types.RelationshipKindUses)
+
+	emitContainerRefs := func(containers []interface{}, refSeg string) {
+		for _, ci := range containers {
+			c, ok := ci.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cName, _ := c["name"].(string)
+			if cName == "" {
+				continue
+			}
+			from := refPrefix + refSeg + "/" + cName
+
+			// env[].valueFrom.configMapKeyRef / secretKeyRef
+			for _, ei := range k8sSlice(c["env"]) {
+				e, ok := ei.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				vf, _ := e["valueFrom"].(map[string]interface{})
+				if vf == nil {
+					continue
+				}
+				if name := k8sRefName(vf["configMapKeyRef"]); name != "" {
+					emit(from, resourceRef("ConfigMap", name), usesKind, "env_configmap_ref")
+				}
+				if name := k8sRefName(vf["secretKeyRef"]); name != "" {
+					emit(from, resourceRef("Secret", name), usesKind, "env_secret_ref")
+				}
+			}
+
+			// envFrom[].configMapRef / secretRef
+			for _, ei := range k8sSlice(c["envFrom"]) {
+				e, ok := ei.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if name := k8sRefName(e["configMapRef"]); name != "" {
+					emit(from, resourceRef("ConfigMap", name), usesKind, "envfrom_configmap_ref")
+				}
+				if name := k8sRefName(e["secretRef"]); name != "" {
+					emit(from, resourceRef("Secret", name), usesKind, "envfrom_secret_ref")
+				}
+			}
+		}
+	}
+
+	emitContainerRefs(k8sSlice(podSpec["containers"]), "container")
+	emitContainerRefs(k8sSlice(podSpec["initContainers"]), "init-container")
+
+	// volumes[].configMap / secret / persistentVolumeClaim.claimName — pod-scoped,
+	// attach to the workload resource itself.
+	workloadRef := resourceRef(d.kind, d.name)
+	for _, vi := range k8sSlice(podSpec["volumes"]) {
+		v, ok := vi.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cm, ok := v["configMap"].(map[string]interface{}); ok {
+			if name, _ := cm["name"].(string); name != "" {
+				emit(workloadRef, resourceRef("ConfigMap", name), usesKind, "volume_configmap_ref")
+			}
+		}
+		if sec, ok := v["secret"].(map[string]interface{}); ok {
+			// secret volumes use `secretName`, not `name`.
+			if name, _ := sec["secretName"].(string); name != "" {
+				emit(workloadRef, resourceRef("Secret", name), usesKind, "volume_secret_ref")
+			}
+		}
+		if pvc, ok := v["persistentVolumeClaim"].(map[string]interface{}); ok {
+			if name, _ := pvc["claimName"].(string); name != "" {
+				emit(workloadRef, resourceRef("PersistentVolumeClaim", name), usesKind, "volume_pvc_ref")
+			}
+		}
+	}
+}
+
+// k8sOwnerRef is a parsed ownerReferences[] entry.
+type k8sOwnerRef struct {
+	kind string
+	name string
+}
+
+func k8sOwnerReferences(raw map[string]interface{}) []k8sOwnerRef {
+	meta, ok := raw["metadata"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	var out []k8sOwnerRef
+	for _, oi := range k8sSlice(meta["ownerReferences"]) {
+		o, ok := oi.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		k, _ := o["kind"].(string)
+		n, _ := o["name"].(string)
+		out = append(out, k8sOwnerRef{kind: k, name: n})
+	}
+	return out
+}
+
+// k8sIngressBackendServices returns every backend Service name referenced by an
+// Ingress, covering both networking.k8s.io/v1 (backend.service.name) and the
+// legacy extensions/v1beta1 (backend.serviceName) shapes, plus the
+// spec.defaultBackend.
+func k8sIngressBackendServices(raw map[string]interface{}) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	backendService := func(backend map[string]interface{}) {
+		if backend == nil {
+			return
+		}
+		// v1: backend.service.name
+		if svc, ok := backend["service"].(map[string]interface{}); ok {
+			if name, _ := svc["name"].(string); name != "" {
+				add(name)
+			}
+		}
+		// v1beta1: backend.serviceName
+		if name, _ := backend["serviceName"].(string); name != "" {
+			add(name)
+		}
+	}
+
+	if defBackend, ok := k8sDig(raw, "spec", "defaultBackend").(map[string]interface{}); ok {
+		backendService(defBackend)
+	}
+	for _, ri := range k8sSlice(k8sDig(raw, "spec", "rules")) {
+		rule, ok := ri.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		httpVal, ok := rule["http"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, pi := range k8sSlice(httpVal["paths"]) {
+			p, ok := pi.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if backend, ok := p["backend"].(map[string]interface{}); ok {
+				backendService(backend)
+			}
+		}
+	}
+	return out
+}
+
+// k8sPodSpec returns the pod spec for a workload: spec.template.spec for
+// Deployment/StatefulSet/DaemonSet/Job/ReplicaSet/ReplicationController, and
+// spec.jobTemplate.spec.template.spec for CronJob.
+func k8sPodSpec(raw map[string]interface{}) map[string]interface{} {
+	if ps, ok := k8sDig(raw, "spec", "template", "spec").(map[string]interface{}); ok {
+		return ps
+	}
+	// CronJob nests an extra jobTemplate layer.
+	if ps, ok := k8sDig(raw, "spec", "jobTemplate", "spec", "template", "spec").(map[string]interface{}); ok {
+		return ps
+	}
+	return nil
+}
+
+// k8sPodTemplateLabels returns spec.template.metadata.labels (or the CronJob
+// jobTemplate-nested equivalent) as a string map.
+func k8sPodTemplateLabels(raw map[string]interface{}) map[string]string {
+	if l := k8sStringMap(k8sDig(raw, "spec", "template", "metadata", "labels")); len(l) > 0 {
+		return l
+	}
+	return k8sStringMap(k8sDig(raw, "spec", "jobTemplate", "spec", "template", "metadata", "labels"))
+}
+
+// k8sLabelsMatch reports whether selector is a (non-empty) subset of labels —
+// the Kubernetes label-selector match semantics: a Service selects a pod when
+// every selector key/value is present in the pod's labels.
+func k8sLabelsMatch(labels, selector map[string]string) bool {
+	if len(selector) == 0 || len(labels) == 0 {
+		return false
+	}
+	for k, v := range selector {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// YAML traversal helpers (yaml.v3 decodes mappings into map[string]interface{}).
+// ---------------------------------------------------------------------------
+
+// k8sParseDocs decodes a (possibly multi-document) manifest into k8sDoc records,
+// skipping any document that lacks a kind. Decode errors on one document do not
+// abort the rest of the stream.
+func k8sParseDocs(src []byte) []k8sDoc {
+	dec := yaml.NewDecoder(strings.NewReader(string(src)))
+	var docs []k8sDoc
+	for {
+		var node map[string]interface{}
+		err := dec.Decode(&node)
+		if err != nil {
+			break
+		}
+		if node == nil {
+			continue
+		}
+		kind, _ := node["kind"].(string)
+		if kind == "" {
+			continue
+		}
+		name := ""
+		if meta, ok := node["metadata"].(map[string]interface{}); ok {
+			name, _ = meta["name"].(string)
+		}
+		docs = append(docs, k8sDoc{kind: kind, name: name, raw: node})
+	}
+	return docs
+}
+
+// k8sDig walks a nested map[string]interface{} along the given string keys,
+// returning the value at the end or nil if any hop is missing / not a map.
+func k8sDig(v interface{}, keys ...string) interface{} {
+	cur := v
+	for _, k := range keys {
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		cur = m[k]
+	}
+	return cur
+}
+
+// k8sSlice coerces a value to []interface{} (nil-safe).
+func k8sSlice(v interface{}) []interface{} {
+	s, _ := v.([]interface{})
+	return s
+}
+
+// k8sStringMap coerces a map[string]interface{} of scalars to map[string]string.
+// Non-string scalar values (ints, bools) are rendered via their YAML scalar
+// text so e.g. a numeric label still participates in matching.
+func k8sStringMap(v interface{}) map[string]string {
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, val := range m {
+		switch t := val.(type) {
+		case string:
+			out[k] = t
+		case bool:
+			if t {
+				out[k] = "true"
+			} else {
+				out[k] = "false"
+			}
+		case int:
+			out[k] = strconv.Itoa(t)
+		case int64:
+			out[k] = strconv.FormatInt(t, 10)
+		case float64:
+			// YAML ints often decode as float64 via interface{}; render whole
+			// numbers without a trailing ".0".
+			if t == float64(int64(t)) {
+				out[k] = strconv.FormatInt(int64(t), 10)
+			}
+		}
+	}
+	return out
+}
+
+// k8sRefName extracts the `.name` field from a {name: x, ...} reference object
+// (configMapKeyRef / secretKeyRef / configMapRef / secretRef).
+func k8sRefName(v interface{}) string {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	name, _ := m["name"].(string)
+	return name
+}
+
+// k8sHasTopLevelKey reports whether the manifest has a top-level (column-0)
+// `key:` line. Mirrors the yaml extractor's containsTopLevelKey gate so this
+// pass fires on exactly the files extractKubernetes ran on.
+func k8sHasTopLevelKey(src []byte, key string) bool {
+	marker := key + ":"
+	for _, line := range strings.Split(string(src), "\n") {
+		if len(line) == 0 || line[0] == ' ' || line[0] == '\t' {
+			continue
+		}
+		trimmed := strings.TrimRight(line, " \t\r")
+		if trimmed == marker || strings.HasPrefix(trimmed, marker+" ") || strings.HasPrefix(trimmed, marker+"\t") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/kubernetes_edges_test.go
+++ b/internal/engine/kubernetes_edges_test.go
@@ -1,0 +1,322 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// k8sFindEdge returns the first relationship matching (fromID, toID, kind), or
+// nil. Endpoints are compared exactly — these are the QualifiedName refs the
+// resolver binds via byQualifiedName.
+func k8sFindEdge(rels []types.RelationshipRecord, fromID, toID, kind string) *types.RelationshipRecord {
+	for i := range rels {
+		r := rels[i]
+		if r.FromID == fromID && r.ToID == toID && r.Kind == kind {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+func k8sRun(path, src string) []types.RelationshipRecord {
+	res := applyKubernetesEdges(DetectorPassArgs{
+		Lang:    "yaml",
+		Path:    path,
+		Content: []byte(src),
+	})
+	return res.Relationships
+}
+
+// The headline assertion: a Service (selector app=web) + a Deployment (template
+// labels app=web) whose container pulls env from a ConfigMap must produce BOTH
+// the Service→Deployment ROUTES_TO edge AND the container→ConfigMap USES edge,
+// with the exact endpoint refs.
+func TestKubernetesEdges_SelectorMatchAndConfigMapRef(t *testing.T) {
+	const path = "k8s/web.yaml"
+	src := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  selector:
+    app: web
+  ports:
+    - port: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+        tier: frontend
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.25
+          env:
+            - name: DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: web-config
+                  key: db.host
+          envFrom:
+            - secretRef:
+                name: web-secrets
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web-config
+data:
+  db.host: postgres
+`
+	rels := k8sRun(path, src)
+
+	prefix := "k8s/" + path + "#"
+	svcRef := prefix + "resource/Service/web"
+	deployRef := prefix + "resource/Deployment/web"
+	containerRef := prefix + "container/web"
+	cmRef := prefix + "resource/ConfigMap/web-config"
+	secretRef := prefix + "resource/Secret/web-secrets"
+
+	// (1) Service → Deployment ROUTES_TO (label superset match).
+	if e := k8sFindEdge(rels, svcRef, deployRef, "ROUTES_TO"); e == nil {
+		t.Fatalf("missing Service→Deployment ROUTES_TO edge (%s → %s); rels=%+v", svcRef, deployRef, rels)
+	} else if e.Properties["k8s_edge"] != "selector_match" {
+		t.Fatalf("ROUTES_TO edge has wrong k8s_edge tag: %q", e.Properties["k8s_edge"])
+	}
+
+	// (2) container → ConfigMap USES (env configMapKeyRef).
+	if e := k8sFindEdge(rels, containerRef, cmRef, "USES"); e == nil {
+		t.Fatalf("missing container→ConfigMap USES edge (%s → %s); rels=%+v", containerRef, cmRef, rels)
+	}
+
+	// (2b) container → Secret USES (envFrom secretRef).
+	if e := k8sFindEdge(rels, containerRef, secretRef, "USES"); e == nil {
+		t.Fatalf("missing container→Secret USES edge (%s → %s); rels=%+v", containerRef, secretRef, rels)
+	}
+}
+
+// A selector that is NOT a subset of the pod labels must NOT match.
+func TestKubernetesEdges_SelectorNoMatch(t *testing.T) {
+	const path = "k8s/mismatch.yaml"
+	src := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+spec:
+  selector:
+    app: api
+    tier: backend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: api:1
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	if e := k8sFindEdge(rels, prefix+"resource/Service/api", prefix+"resource/Deployment/api", "ROUTES_TO"); e != nil {
+		t.Fatalf("selector {app,tier} must NOT match pod labels {app} — got spurious edge %+v", e)
+	}
+}
+
+func TestKubernetesEdges_VolumeRefs(t *testing.T) {
+	const path = "k8s/vol.yaml"
+	src := `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+spec:
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+        - name: db
+          image: postgres:16
+      volumes:
+        - name: config
+          configMap:
+            name: db-config
+        - name: tls
+          secret:
+            secretName: db-tls
+        - name: data
+          persistentVolumeClaim:
+            claimName: db-data
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	stsRef := prefix + "resource/StatefulSet/db"
+
+	cases := []struct {
+		to   string
+		desc string
+	}{
+		{prefix + "resource/ConfigMap/db-config", "volume configMap"},
+		{prefix + "resource/Secret/db-tls", "volume secret"},
+		{prefix + "resource/PersistentVolumeClaim/db-data", "volume pvc"},
+	}
+	for _, c := range cases {
+		if e := k8sFindEdge(rels, stsRef, c.to, "USES"); e == nil {
+			t.Fatalf("missing %s USES edge (%s → %s); rels=%+v", c.desc, stsRef, c.to, rels)
+		}
+	}
+}
+
+func TestKubernetesEdges_IngressBackend(t *testing.T) {
+	const path = "k8s/ing.yaml"
+	src := `
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-ing
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            backend:
+              service:
+                name: web
+                port:
+                  number: 80
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	from := prefix + "resource/Ingress/web-ing"
+	to := prefix + "resource/Service/web"
+	if e := k8sFindEdge(rels, from, to, "ROUTES_TO"); e == nil {
+		t.Fatalf("missing Ingress→Service ROUTES_TO edge (%s → %s); rels=%+v", from, to, rels)
+	} else if e.Properties["k8s_edge"] != "ingress_backend" {
+		t.Fatalf("ingress edge wrong tag: %q", e.Properties["k8s_edge"])
+	}
+}
+
+func TestKubernetesEdges_HPATarget(t *testing.T) {
+	const path = "k8s/hpa.yaml"
+	src := `
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: web-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web
+  minReplicas: 2
+  maxReplicas: 10
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	from := prefix + "resource/HorizontalPodAutoscaler/web-hpa"
+	to := prefix + "resource/Deployment/web"
+	if e := k8sFindEdge(rels, from, to, "DEPENDS_ON"); e == nil {
+		t.Fatalf("missing HPA→Deployment DEPENDS_ON edge (%s → %s); rels=%+v", from, to, rels)
+	} else if e.Properties["k8s_edge"] != "hpa_target" {
+		t.Fatalf("hpa edge wrong tag: %q", e.Properties["k8s_edge"])
+	}
+}
+
+func TestKubernetesEdges_OwnerReference(t *testing.T) {
+	const path = "k8s/owner.yaml"
+	src := `
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: web-rs
+  ownerReferences:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: web
+spec:
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	from := prefix + "resource/ReplicaSet/web-rs"
+	to := prefix + "resource/Deployment/web"
+	if e := k8sFindEdge(rels, from, to, "DEPENDS_ON"); e == nil {
+		t.Fatalf("missing ownerReference DEPENDS_ON edge (%s → %s); rels=%+v", from, to, rels)
+	} else if e.Properties["k8s_edge"] != "owner_reference" {
+		t.Fatalf("owner edge wrong tag: %q", e.Properties["k8s_edge"])
+	}
+}
+
+// Non-K8s YAML (a docker-compose file) must be a complete no-op.
+func TestKubernetesEdges_NonManifestNoOp(t *testing.T) {
+	src := `
+services:
+  web:
+    image: nginx
+    ports:
+      - "80:80"
+`
+	rels := k8sRun("docker-compose.yml", src)
+	if len(rels) != 0 {
+		t.Fatalf("expected no edges for non-manifest YAML, got %+v", rels)
+	}
+}
+
+// CronJob nests the pod template one layer deeper (spec.jobTemplate.spec.template).
+func TestKubernetesEdges_CronJobConfigMapRef(t *testing.T) {
+	const path = "k8s/cron.yaml"
+	src := `
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: reporter
+spec:
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: reporter
+        spec:
+          containers:
+            - name: reporter
+              image: reporter:1
+              envFrom:
+                - configMapRef:
+                    name: reporter-config
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	from := prefix + "container/reporter"
+	to := prefix + "resource/ConfigMap/reporter-config"
+	if e := k8sFindEdge(rels, from, to, "USES"); e == nil {
+		t.Fatalf("missing CronJob container→ConfigMap USES edge (%s → %s); rels=%+v", from, to, rels)
+	}
+}


### PR DESCRIPTION
Closes #3517 (epic #3512).

## Problem
The yaml extractor already extracts K8s resources + sub-resources well (Deployment/Service → SCOPE.Service, containers/env/ports/selectors/volumeMounts as children with CONTAINS edges, ConfigMap data keys, Ingress hosts/paths, …). The gap was cross-resource **edges** — resources were not connected to each other.

## What now fires
New append-only engine post-pass `applyKubernetesEdges` (`internal/engine/kubernetes_edges.go`), registered after `applyIaCSNSEdges`. It re-reads each manifest file-scoped (multi-doc via `gopkg.in/yaml.v3`) and addresses every endpoint by the **same QualifiedName the extractor minted** so the resolver's `byQualifiedName` index binds them. Reuses existing RelationshipKinds — **no new Kind** (no producer-kind validator change).

- **Selector → workload (the #1 K8s edge):** `Service.spec.selector {k:v}` subset-matches a workload's `spec.template.metadata.labels` → **ROUTES_TO** Service→Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/CronJob. CronJob's nested `jobTemplate` pod template handled.
- **env / volume refs → ConfigMap/Secret/PVC (USES):** container `env.valueFrom.configMapKeyRef`/`secretKeyRef`, `envFrom.configMapRef`/`secretRef` (attached to the specific container entity); pod `volumes[].configMap` / `secret.secretName` / `persistentVolumeClaim.claimName` (attached to the workload).
- **Ingress backend → Service (ROUTES_TO):** `networking.k8s.io/v1` (`backend.service.name`), legacy `v1beta1` (`backend.serviceName`), and `spec.defaultBackend`.
- **HPA scaleTargetRef → workload + ownerReferences → parent (DEPENDS_ON).**

## Discipline
- Value-asserting tests (`kubernetes_edges_test.go`): the headline case — a Service (selector `app=web`) + a Deployment (template labels `app=web`) + a container env-from-ConfigMap — asserts the exact Service→Deployment ROUTES_TO **and** container→ConfigMap USES endpoint refs. Plus negative selector-mismatch, volume refs, ingress, HPA, ownerReference, CronJob, and a non-manifest no-op. Not `len>0`.
- Append-only: never modifies/removes existing entities or edges — cannot regress the yaml extractor or pipeline bug-rate. All helpers namespaced `k8s*`.
- `go test ./internal/engine/ ./internal/extractors/yaml/ ./internal/types/` green; `go vet` clean; `gofmt -l` empty.
- Coverage: `infra.container.kubernetes` `dependency_attribution` cell kept **full**, now genuinely full — cites `internal/engine/kubernetes_edges.go`. `coverage gen` + `validate` (0 errors) + `fmt --check` (canonical) all pass.

## DEPLOY-DEFERRED
This PR does not rebuild/restart the live daemon or reindex any group. Edges take effect after a coordinated daemon rebuild + reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)