### PR TITLE
feat(yaml): Kustomize overlay/patch graph (#3520)

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -24,7 +24,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | — | 🔴 | 🔴 | |
 | [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | 🔴 | — | — | 🔴 | 🔴 | |
+| [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | — | — | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | 🟢 | — | — | 🟢 | 🟢 | |

--- a/docs/coverage/detail/infra.container.kustomize.md
+++ b/docs/coverage/detail/infra.container.kustomize.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | ✅ `full` | `2026-05-30` | — | `internal/extractors/yaml/extractor.go`<br>`internal/extractors/yaml/extractor_test.go` | — |
+| Resource extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/yaml/extractor.go`<br>`internal/extractors/yaml/extractor_test.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1262,10 +1262,14 @@
       "label": "Kustomize",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/extractors/yaml/extractor.go","internal/extractors/yaml/extractor_test.go"],
+          "verified_at": "2026-05-30"
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/extractors/yaml/extractor.go","internal/extractors/yaml/extractor_test.go"],
+          "verified_at": "2026-05-30"
         }
       }
     },

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -32,14 +32,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 11 | 0 | 7 | 4 |
-| [Platform / k8s](by-category/platform.md) | 23 | 11 | 9 | 3 |
+| [Platform / k8s](by-category/platform.md) | 23 | 13 | 8 | 2 |
 | [Message Brokers](by-category/message_broker.md) | 20 | 9 | 9 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 8 | 3 | 3 | 2 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 97 | 31 | 37 | 29 |
+| **Total** | 97 | 33 | 36 | 28 |
 
 ## Languages with extractor support, no records yet
 

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -32,14 +32,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 11 | 0 | 7 | 4 |
-| [Platform / k8s](by-category/platform.md) | 23 | 13 | 8 | 2 |
+| [Platform / k8s](by-category/platform.md) | 23 | 12 | 9 | 2 |
 | [Message Brokers](by-category/message_broker.md) | 20 | 9 | 9 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 8 | 3 | 3 | 2 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 97 | 33 | 36 | 28 |
+| **Total** | 97 | 32 | 37 | 28 |
 
 ## Languages with extractor support, no records yet
 

--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -130,6 +130,7 @@ const (
 	flavorDockerCompose = "docker_compose"
 	flavorKubernetes    = "kubernetes"
 	flavorAnsible       = "ansible"
+	flavorKustomize     = "kustomize"
 	flavorGeneric       = "generic"
 )
 
@@ -162,6 +163,18 @@ func detectFlavor(src []byte, path string) (flavor string) {
 		return flavorDockerCompose
 	}
 
+	// Kustomize: a kustomization.yaml. Must be checked BEFORE Kubernetes because
+	// a kustomization carries `kind: Kustomization` + `apiVersion: kustomize...`
+	// which would otherwise match the generic K8s manifest branch below.
+	// Detect signals (any one suffices):
+	//   - filename is kustomization.yaml / kustomization.yml / Kustomization
+	//   - apiVersion line mentions kustomize.config.k8s.io
+	//   - a top-level `kind: Kustomization`
+	//   - a top-level `resources:` key alongside a kustomize transform/generator
+	if isKustomizeContent(content, path) {
+		return flavorKustomize
+	}
+
 	// Kubernetes: "apiVersion:" and "kind:" at top level
 	if containsTopLevelKey(content, "apiVersion") && containsTopLevelKey(content, "kind") {
 		return flavorKubernetes
@@ -189,6 +202,51 @@ func isAnsibleContent(content string) bool {
 	// A play list starts with a dash at column 0 and has hosts: somewhere nearby.
 	if strings.Contains(content, "hosts:") && containsListItemWithKey(content, "hosts") {
 		return true
+	}
+	return false
+}
+
+// isKustomizeContent reports whether the YAML is a Kustomize kustomization.yaml.
+// Any one signal suffices (filename, apiVersion, kind, or a top-level resources/
+// bases/components list combined with a kustomize-specific transform/generator).
+func isKustomizeContent(content, path string) bool {
+	// Filename signal.
+	base := path
+	if idx := strings.LastIndexByte(base, '/'); idx >= 0 {
+		base = base[idx+1:]
+	}
+	switch base {
+	case "kustomization.yaml", "kustomization.yml", "Kustomization":
+		return true
+	}
+	// apiVersion signal — kustomize.config.k8s.io/v1beta1 (or v1).
+	if strings.Contains(content, "kustomize.config.k8s.io") {
+		return true
+	}
+	// kind: Kustomization at top level.
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimRight(line, " \t\r")
+		if (trimmed == "kind: Kustomization" || strings.HasPrefix(trimmed, "kind: Kustomization ")) &&
+			len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
+			return true
+		}
+	}
+	// Structural signal: a top-level resources/bases/components list AND at least
+	// one kustomize-specific key. `resources:` alone also appears in some CRDs,
+	// so require a corroborating kustomize key to avoid false positives.
+	hasResourceList := containsTopLevelKey(content, "resources") ||
+		containsTopLevelKey(content, "bases") ||
+		containsTopLevelKey(content, "components")
+	if hasResourceList {
+		for _, k := range []string{
+			"patchesStrategicMerge", "patchesJson6902", "patches",
+			"configMapGenerator", "secretGenerator", "namePrefix",
+			"nameSuffix", "commonLabels",
+		} {
+			if containsTopLevelKey(content, k) {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -256,6 +314,8 @@ func extractByFlavor(flavor string, root *sitter.Node, file extractor.FileInput)
 		entities = extractKubernetes(root, file)
 	case flavorAnsible:
 		entities = extractAnsible(root, file)
+	case flavorKustomize:
+		entities = extractKustomize(root, file)
 	default:
 		entities = extractGeneric(root, file)
 	}
@@ -1575,6 +1635,279 @@ func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []
 			)
 			addContains(&ent, ref)
 			entities = append(entities, ent)
+		}
+	}
+
+	return entities
+}
+
+// ---------------------------------------------------------------------------
+// Kustomize extractor (#3520)
+// ---------------------------------------------------------------------------
+
+// extractKustomize processes a kustomization.yaml, building the overlay-
+// composition graph:
+//
+//	resources: / bases: / components:   → IMPORTS edges (kustomization → manifest/overlay)
+//	patches: / patchesStrategicMerge: / patchesJson6902: → PATCHES edges (kustomization → target)
+//	configMapGenerator: / secretGenerator:  → generated-resource entities
+//	namespace: / namePrefix: / nameSuffix: / commonLabels: → transform metadata on the kustomization
+//
+// All IMPORTS/PATCHES edges originate from the kustomization entity whose
+// QualifiedName equals file.Path, so they resolve against the per-file
+// SCOPE.Document anchor (issue #474 chain-fix) via byQualifiedName.
+func extractKustomize(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+	src := file.Content
+	pairs := topLevelMappings(root)
+	var entities []types.EntityRecord
+
+	// The kustomization itself is the root entity for the overlay graph. Its
+	// QualifiedName is file.Path so it coincides with the SCOPE.Document anchor
+	// the dispatcher prepends; IMPORTS/PATCHES edges use file.Path as FromID and
+	// resolve through that anchor.
+	name := file.Path
+	if idx := strings.LastIndexByte(name, '/'); idx >= 0 {
+		name = name[idx+1:]
+	}
+	startLine := 1
+	endLine := bytes.Count(src, []byte("\n")) + 1
+	if root != nil {
+		endLine = int(root.EndPoint().Row) + 1
+	}
+	kustRef := file.Path
+	kustEnt := entity(
+		"SCOPE.Component", name, "kustomization",
+		kustRef,
+		file.Path, "yaml", startLine, endLine,
+	)
+
+	// Collect transform metadata onto the kustomization entity's Properties so
+	// downstream tooling sees namespace / prefix / suffix / commonLabels at a
+	// glance without re-parsing the file.
+	transforms := map[string]string{}
+	for _, p := range pairs {
+		switch pairKeyText(p, src) {
+		case "namespace":
+			if v := getPairValueText(p, src); v != "" {
+				transforms["kust_namespace"] = v
+			}
+		case "namePrefix":
+			if v := getPairValueText(p, src); v != "" {
+				transforms["kust_name_prefix"] = v
+			}
+		case "nameSuffix":
+			if v := getPairValueText(p, src); v != "" {
+				transforms["kust_name_suffix"] = v
+			}
+		case "commonLabels":
+			labelPairs := getMappingPairsForKey(pairs, "commonLabels", src)
+			var kvs []string
+			for _, lp := range labelPairs {
+				k := pairKeyText(lp, src)
+				v := getPairValueText(lp, src)
+				if k != "" {
+					kvs = append(kvs, k+"="+v)
+				}
+			}
+			if len(kvs) > 0 {
+				transforms["kust_common_labels"] = strings.Join(kvs, ",")
+			}
+		}
+	}
+	if len(transforms) > 0 {
+		if kustEnt.Properties == nil {
+			kustEnt.Properties = map[string]string{}
+		}
+		for k, v := range transforms {
+			kustEnt.Properties[k] = v
+		}
+	}
+
+	// IMPORTS: resources / bases / components → referenced manifest/overlay path.
+	// Each is a list of file or directory paths. kustomize_import_kind records
+	// which list the path came from for downstream disambiguation.
+	for _, key := range []struct{ field, importKind string }{
+		{"resources", "kustomize_resource"},
+		{"bases", "kustomize_base"},
+		{"components", "kustomize_component"},
+	} {
+		valNode := findValueNodeForKey(pairs, key.field, src)
+		for _, ref := range getSequenceItems(valNode, src) {
+			ref = kustTrimScalar(ref)
+			if ref == "" {
+				continue
+			}
+			kustEnt.Relationships = append(kustEnt.Relationships,
+				importsRel(kustRef, "kustomize_path:"+ref, key.importKind))
+		}
+	}
+
+	entities = append(entities, kustEnt)
+
+	// PATCHES: patches / patchesStrategicMerge / patchesJson6902. These mutate
+	// the kustomization entity in place (append edges).
+	kustExtractPatches(&kustEnt, pairs, kustRef, file, src)
+	// Re-sync the (value-copied) kustomization entity now that patch edges are
+	// attached — it was appended above by value.
+	entities[len(entities)-1] = kustEnt
+
+	// Generated resources: configMapGenerator / secretGenerator → new entities.
+	entities = append(entities, kustExtractGenerators(pairs, kustRef, file, src)...)
+
+	return entities
+}
+
+// kustTrimScalar strips a leading "- " list marker and surrounding quotes from
+// a raw sequence-item scalar (getSequenceItems returns the verbatim node text).
+func kustTrimScalar(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "- ")
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			s = s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// kustPatchTargetStub builds the synthetic ToID for a patch target. When the
+// patch declares a target {kind,name}, the stub is
+// "kustomize_target:<Kind>/<name>"; otherwise it falls back to a file-reference
+// stub "kustomize_patch_file:<path>" or "kustomize_inline_patch".
+func kustPatchTargetStub(targetKind, targetName, patchFile string) string {
+	switch {
+	case targetKind != "" && targetName != "":
+		return "kustomize_target:" + targetKind + "/" + targetName
+	case targetKind != "":
+		return "kustomize_target:" + targetKind
+	case targetName != "":
+		return "kustomize_target:" + targetName
+	case patchFile != "":
+		return "kustomize_patch_file:" + patchFile
+	default:
+		return "kustomize_inline_patch"
+	}
+}
+
+// kustExtractPatches appends PATCHES edges from the kustomization to each patch
+// target. Handles the three patch list shapes Kustomize accepts:
+//
+//	patchesStrategicMerge: [ file.yaml, ... ]            (scalar file paths)
+//	patches:              [ { path|patch, target:{kind,name} }, ... ]
+//	patchesJson6902:      [ { target:{group,version,kind,name}, path|patch }, ... ]
+func kustExtractPatches(kustEnt *types.EntityRecord, pairs []*sitter.Node, kustRef string, file extractor.FileInput, src []byte) {
+	patchesRel := func(toID, style, targetKind, targetName string) {
+		rel := types.RelationshipRecord{
+			FromID: kustRef,
+			ToID:   toID,
+			Kind:   "PATCHES",
+			Properties: map[string]string{
+				"patch_style": style,
+			},
+		}
+		if targetKind != "" {
+			rel.Properties["target_kind"] = targetKind
+		}
+		if targetName != "" {
+			rel.Properties["target_name"] = targetName
+		}
+		kustEnt.Relationships = append(kustEnt.Relationships, rel)
+	}
+
+	// patchesStrategicMerge: scalar list of file paths.
+	smNode := findValueNodeForKey(pairs, "patchesStrategicMerge", src)
+	for _, ref := range getSequenceItems(smNode, src) {
+		ref = kustTrimScalar(ref)
+		if ref == "" {
+			continue
+		}
+		patchesRel(kustPatchTargetStub("", "", ref), "strategic_merge", "", "")
+	}
+
+	// patches: list of mappings with optional target and path|patch.
+	patchMappings := getSequenceItemMappings(findValueNodeForKey(pairs, "patches", src), src)
+	for _, pp := range patchMappings {
+		kustEmitPatchMapping(pp, "strategic_merge", patchesRel, src)
+	}
+
+	// patchesJson6902: list of mappings with a required target and path|patch.
+	json6902Mappings := getSequenceItemMappings(findValueNodeForKey(pairs, "patchesJson6902", src), src)
+	for _, pp := range json6902Mappings {
+		kustEmitPatchMapping(pp, "json6902", patchesRel, src)
+	}
+}
+
+// kustEmitPatchMapping resolves a single patch mapping's target (from a nested
+// target: {kind,name}) and file/inline body, then emits one PATCHES edge.
+func kustEmitPatchMapping(pp []*sitter.Node, style string, emit func(toID, style, targetKind, targetName string), src []byte) {
+	targetPairs := getMappingPairsForKey(pp, "target", src)
+	targetKind := findPairValueText(targetPairs, "kind", src)
+	targetName := findPairValueText(targetPairs, "name", src)
+	patchFile := findPairValueText(pp, "path", src)
+	finalStyle := style
+	if findPairValueText(pp, "patch", src) != "" && patchFile == "" {
+		finalStyle = "inline"
+	}
+	emit(kustPatchTargetStub(targetKind, targetName, patchFile), finalStyle, targetKind, targetName)
+}
+
+// kustExtractGenerators emits one generated-resource entity per entry in
+// configMapGenerator: / secretGenerator:. The entity Name is the generator's
+// name:; the literals/files it pulls are recorded in Properties so the
+// generated config surface is visible without re-parsing.
+func kustExtractGenerators(pairs []*sitter.Node, kustRef string, file extractor.FileInput, src []byte) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	for _, gen := range []struct{ field, subtype, kind string }{
+		{"configMapGenerator", "generated_configmap", "SCOPE.Schema"},
+		{"secretGenerator", "generated_secret", "SCOPE.Schema"},
+	} {
+		genMappings := getSequenceItemMappings(findValueNodeForKey(pairs, gen.field, src), src)
+		for _, gp := range genMappings {
+			genName := findPairValueText(gp, "name", src)
+			if genName == "" {
+				continue
+			}
+			gStart, gEnd := pairsLineRange(gp)
+			genRef := "kustomize/" + gen.subtype + "/" + file.Path + "#" + genName
+			genEnt := entity(
+				gen.kind, genName, gen.subtype,
+				genRef,
+				file.Path, "yaml", gStart, gEnd,
+			)
+			// CONTAINS: kustomization → generated resource.
+			genEnt.Relationships = append(genEnt.Relationships,
+				containsRel(kustRef, genRef))
+
+			// Record the literals: / files: / envs: the generator pulls from.
+			props := map[string]string{}
+			if lits := getSequenceItems(findValueNodeForKey(gp, "literals", src), src); len(lits) > 0 {
+				cleaned := make([]string, 0, len(lits))
+				for _, l := range lits {
+					cleaned = append(cleaned, kustTrimScalar(l))
+				}
+				props["literals"] = strings.Join(cleaned, ",")
+			}
+			if files := getSequenceItems(findValueNodeForKey(gp, "files", src), src); len(files) > 0 {
+				cleaned := make([]string, 0, len(files))
+				for _, f := range files {
+					cleaned = append(cleaned, kustTrimScalar(f))
+				}
+				props["files"] = strings.Join(cleaned, ",")
+			}
+			if envs := getSequenceItems(findValueNodeForKey(gp, "envs", src), src); len(envs) > 0 {
+				cleaned := make([]string, 0, len(envs))
+				for _, e := range envs {
+					cleaned = append(cleaned, kustTrimScalar(e))
+				}
+				props["envs"] = strings.Join(cleaned, ",")
+			}
+			if len(props) > 0 {
+				genEnt.Properties = props
+			}
+			entities = append(entities, genEnt)
 		}
 	}
 

--- a/internal/extractors/yaml/extractor_test.go
+++ b/internal/extractors/yaml/extractor_test.go
@@ -1680,3 +1680,272 @@ func TestIssue474_ContainsFromIDResolvesToDocumentEntity(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Kustomize (#3520)
+// ---------------------------------------------------------------------------
+
+// kustomizationFixture exercises every Kustomize capability: resource/base/
+// component imports, all three patch shapes, both generators, and the
+// name/namespace/label transforms.
+var kustomizationFixture = []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: production
+namePrefix: prod-
+nameSuffix: -v2
+commonLabels:
+  app: web
+  tier: frontend
+
+resources:
+  - deployment.yaml
+  - ../base
+  - service.yaml
+
+components:
+  - ../components/monitoring
+
+patchesStrategicMerge:
+  - increase-replicas.yaml
+
+patches:
+  - path: cpu-limits.yaml
+    target:
+      kind: Deployment
+      name: web
+
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: web
+    path: add-annotation.yaml
+
+configMapGenerator:
+  - name: app-config
+    literals:
+      - LOG_LEVEL=info
+      - FEATURE_X=true
+    files:
+      - config.properties
+
+secretGenerator:
+  - name: app-secret
+    envs:
+      - secret.env
+`)
+
+func TestKustomize_DetectedAndDocument(t *testing.T) {
+	entities, err := extractYAML(kustomizationFixture, "overlays/prod/kustomization.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	docs := findEntitiesBySubtype(entities, "kustomize")
+	if len(docs) != 1 {
+		t.Fatalf("expected one SCOPE.Document with subtype kustomize, got %d", len(docs))
+	}
+	if docs[0].Kind != "SCOPE.Document" {
+		t.Errorf("kustomize Document Kind=%q, want SCOPE.Document", docs[0].Kind)
+	}
+}
+
+// Detection must work from filename alone even without the kustomize apiVersion.
+func TestKustomize_DetectedByFilename(t *testing.T) {
+	src := []byte("resources:\n  - deployment.yaml\nnamePrefix: dev-\n")
+	entities, err := extractYAML(src, "kustomization.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(findEntitiesBySubtype(entities, "kustomization")) != 1 {
+		t.Fatalf("expected a kustomization entity detected by filename, got entities: %+v", entities)
+	}
+}
+
+// A kustomization carrying kind: Kustomization must NOT be classified as a
+// generic Kubernetes manifest (regression guard for the detect ordering).
+func TestKustomize_NotClassifiedAsKubernetes(t *testing.T) {
+	entities, err := extractYAML(kustomizationFixture, "overlays/prod/kustomization.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, e := range entities {
+		if e.Subtype == "k8s_resource" {
+			t.Fatalf("kustomization was extracted as a k8s_resource (%q) — detect ordering regressed", e.Name)
+		}
+	}
+}
+
+func TestKustomize_ResourceImports(t *testing.T) {
+	const kustRef = "overlays/prod/kustomization.yaml"
+	entities, err := extractYAML(kustomizationFixture, kustRef)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	imports := findRels(entities, "IMPORTS")
+
+	// IMPORTS edges to deployment.yaml and ../base (resources) and the component.
+	wantTargets := []string{
+		"kustomize_path:deployment.yaml",
+		"kustomize_path:../base",
+		"kustomize_path:service.yaml",
+		"kustomize_path:../components/monitoring",
+	}
+	for _, want := range wantTargets {
+		if !relExists(imports, kustRef, want) {
+			t.Errorf("missing IMPORTS edge %s -> %s; got %+v", kustRef, want, imports)
+		}
+	}
+}
+
+func TestKustomize_Patches(t *testing.T) {
+	const kustRef = "overlays/prod/kustomization.yaml"
+	entities, err := extractYAML(kustomizationFixture, kustRef)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	patches := findRels(entities, "PATCHES")
+	if len(patches) != 3 {
+		t.Fatalf("expected 3 PATCHES edges (strategic-merge file, patches target, json6902 target), got %d: %+v", len(patches), patches)
+	}
+
+	// patchesStrategicMerge file reference.
+	if !relExists(patches, kustRef, "kustomize_patch_file:increase-replicas.yaml") {
+		t.Errorf("missing strategic-merge PATCHES edge to increase-replicas.yaml; got %+v", patches)
+	}
+
+	// patches + patchesJson6902 both target Deployment/web — assert the
+	// targeted stub and its target_kind/target_name properties.
+	var targetedWeb int
+	for _, p := range patches {
+		if p.ToID == "kustomize_target:Deployment/web" {
+			targetedWeb++
+			if p.Properties["target_kind"] != "Deployment" {
+				t.Errorf("PATCHES target_kind=%q, want Deployment", p.Properties["target_kind"])
+			}
+			if p.Properties["target_name"] != "web" {
+				t.Errorf("PATCHES target_name=%q, want web", p.Properties["target_name"])
+			}
+		}
+	}
+	if targetedWeb != 2 {
+		t.Errorf("expected 2 PATCHES edges targeting Deployment/web (patches + json6902), got %d", targetedWeb)
+	}
+}
+
+func TestKustomize_ConfigMapGenerator(t *testing.T) {
+	const kustRef = "overlays/prod/kustomization.yaml"
+	entities, err := extractYAML(kustomizationFixture, kustRef)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	cms := findEntitiesBySubtype(entities, "generated_configmap")
+	if len(cms) != 1 {
+		t.Fatalf("expected 1 generated ConfigMap entity, got %d", len(cms))
+	}
+	cm := cms[0]
+	if cm.Name != "app-config" {
+		t.Errorf("generated ConfigMap Name=%q, want app-config", cm.Name)
+	}
+	if cm.Properties["literals"] != "LOG_LEVEL=info,FEATURE_X=true" {
+		t.Errorf("generated ConfigMap literals=%q, want LOG_LEVEL=info,FEATURE_X=true", cm.Properties["literals"])
+	}
+	if cm.Properties["files"] != "config.properties" {
+		t.Errorf("generated ConfigMap files=%q, want config.properties", cm.Properties["files"])
+	}
+	// CONTAINS: kustomization -> generated ConfigMap.
+	if !relExists(findRels(entities, "CONTAINS"), kustRef, cm.QualifiedName) {
+		t.Errorf("missing CONTAINS edge %s -> %s", kustRef, cm.QualifiedName)
+	}
+}
+
+func TestKustomize_SecretGenerator(t *testing.T) {
+	entities, err := extractYAML(kustomizationFixture, "overlays/prod/kustomization.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	secrets := findEntitiesBySubtype(entities, "generated_secret")
+	if len(secrets) != 1 {
+		t.Fatalf("expected 1 generated Secret entity, got %d", len(secrets))
+	}
+	if secrets[0].Name != "app-secret" {
+		t.Errorf("generated Secret Name=%q, want app-secret", secrets[0].Name)
+	}
+	if secrets[0].Properties["envs"] != "secret.env" {
+		t.Errorf("generated Secret envs=%q, want secret.env", secrets[0].Properties["envs"])
+	}
+}
+
+func TestKustomize_Transforms(t *testing.T) {
+	entities, err := extractYAML(kustomizationFixture, "overlays/prod/kustomization.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	ks := findEntitiesBySubtype(entities, "kustomization")
+	if len(ks) != 1 {
+		t.Fatalf("expected 1 kustomization entity, got %d", len(ks))
+	}
+	k := ks[0]
+	if k.Properties["kust_namespace"] != "production" {
+		t.Errorf("kust_namespace=%q, want production", k.Properties["kust_namespace"])
+	}
+	if k.Properties["kust_name_prefix"] != "prod-" {
+		t.Errorf("kust_name_prefix=%q, want prod-", k.Properties["kust_name_prefix"])
+	}
+	if k.Properties["kust_name_suffix"] != "-v2" {
+		t.Errorf("kust_name_suffix=%q, want -v2", k.Properties["kust_name_suffix"])
+	}
+	if !strings.Contains(k.Properties["kust_common_labels"], "app=web") ||
+		!strings.Contains(k.Properties["kust_common_labels"], "tier=frontend") {
+		t.Errorf("kust_common_labels=%q, want app=web and tier=frontend", k.Properties["kust_common_labels"])
+	}
+}
+
+// Minimal acceptance check from the ticket: resources + a patch + a
+// configMapGenerator must produce the IMPORTS edges, the PATCHES edge, and the
+// generated ConfigMap entity.
+func TestKustomize_TicketAcceptance(t *testing.T) {
+	src := []byte(`kind: Kustomization
+resources:
+  - deployment.yaml
+  - ../base
+patchesStrategicMerge:
+  - patch.yaml
+configMapGenerator:
+  - name: settings
+    literals:
+      - A=1
+`)
+	const kustRef = "kustomization.yaml"
+	entities, err := extractYAML(src, kustRef)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	imports := findRels(entities, "IMPORTS")
+	if !relExists(imports, kustRef, "kustomize_path:deployment.yaml") {
+		t.Errorf("missing IMPORTS edge to deployment.yaml")
+	}
+	if !relExists(imports, kustRef, "kustomize_path:../base") {
+		t.Errorf("missing IMPORTS edge to ../base")
+	}
+	if !relExists(findRels(entities, "PATCHES"), kustRef, "kustomize_patch_file:patch.yaml") {
+		t.Errorf("missing PATCHES edge to patch.yaml")
+	}
+	if len(findEntitiesBySubtype(entities, "generated_configmap")) != 1 {
+		t.Errorf("expected the generated ConfigMap entity 'settings'")
+	}
+}
+
+// All Kustomize entity kinds must be allowlisted (no novel Kind escapes).
+func TestKustomize_AllKindsAllowlisted(t *testing.T) {
+	entities, err := extractYAML(kustomizationFixture, "overlays/prod/kustomization.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, e := range entities {
+		if !allowedKinds[e.Kind] {
+			t.Errorf("entity %q has non-allowlisted kind %q", e.Name, e.Kind)
+		}
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -561,6 +561,19 @@ const (
 	//   "via"     : "request_validation" or "dto_extraction" (capability tag)
 	// Append-only — never modifies existing entities or edges.
 	RelationshipKindValidates RelationshipKind = "VALIDATES"
+
+	// #3520: Kustomize overlay-patch edge. Emitted by the YAML extractor's
+	// Kustomize flavor for every entry in `patches:` / `patchesStrategicMerge:`
+	// / `patchesJson6902:`. The edge goes from the kustomization entity →
+	// a synthetic patch-target stub ("kustomize_target:<Kind>/<name>" when the
+	// patch declares a target, or "kustomize_patch_file:<path>" for a bare
+	// strategic-merge file reference). Properties:
+	//   "patch_style" : "strategic_merge" | "json6902" | "inline"
+	//   "target_kind" : the K8s Kind named by the patch target (when present)
+	//   "target_name" : the metadata.name named by the patch target (when present)
+	// Lets the overlay graph show which base resources an overlay mutates.
+	// Append-only — never modifies existing entities or edges.
+	RelationshipKindPatches RelationshipKind = "PATCHES"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -662,6 +675,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindResolvesTo,
 		// #2904 request-validation / DTO-extraction linkage:
 		RelationshipKindValidates,
+		// #3520 Kustomize overlay-patch edge:
+		RelationshipKindPatches,
 	}
 }
 


### PR DESCRIPTION
Closes #3520 (epic #3512).

Adds a dedicated **Kustomize** flavor to the YAML extractor. `kustomization.yaml` previously fell through to generic YAML — now it builds an overlay-composition graph.

## What fires now
- **`resources:` / `bases:` / `components:`** → `IMPORTS` edges from the kustomization to each referenced manifest/overlay path (stub `kustomize_path:<ref>`, `import_kind` = `kustomize_resource|kustomize_base|kustomize_component`).
- **`patches:` / `patchesStrategicMerge:` / `patchesJson6902:`** → `PATCHES` edges (new `RelationshipKindPatches`) to the patch target: `kustomize_target:<Kind>/<name>` when the patch declares a `target:`, else `kustomize_patch_file:<path>`. Edge `Properties` carry `patch_style` (`strategic_merge`/`json6902`/`inline`) + `target_kind`/`target_name`.
- **`configMapGenerator:` / `secretGenerator:`** → generated-resource entities (`SCOPE.Schema`, subtypes `generated_configmap`/`generated_secret`) with the `literals`/`files`/`envs` recorded in `Properties`, plus a `CONTAINS` edge from the kustomization.
- **`namespace:` / `namePrefix:` / `nameSuffix:` / `commonLabels:`** → transform metadata on the kustomization entity's `Properties`.

## Detection
Filename (`kustomization.yaml|yml`, `Kustomization`), `kustomize.config.k8s.io` apiVersion, top-level `kind: Kustomization`, or a `resources/bases/components` list paired with a kustomize-specific key. Ordered **before** the Kubernetes branch so a kustomization carrying `kind: Kustomization` is not misclassified as a generic K8s manifest (regression-guarded by a test).

## Tests
Value-asserting (not `len>0`): asserts the specific `IMPORTS` targets for `deployment.yaml` + `../base`, the three distinct `PATCHES` edges with their `target_kind`/`target_name`, the generated ConfigMap/Secret entities with their `literals`/`envs`, the transform metadata, the detect-ordering guard, and the kind allowlist. New helpers namespaced `kust*`.

## Coverage
`infra.container.kustomize` `dependency_attribution` + `resource_extraction`: `missing` → `full`, citing the new extractor + tests. Docs regenerated, `registry.json` canonical (`fmt --check` ok), `validate` clean (0 errors).

## Verification
- `go test ./internal/extractors/yaml/ ./internal/types/ ./internal/engine/ ./tools/coverage/` — all pass
- `gofmt -l` on edited files empty; `go vet` clean

## DEPLOY-DEFERRED
No live-daemon rebuild/reindex performed (strict isolation). Requires a coordinated daemon rebuild + restart, then reindex to surface the new Kustomize edges/entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)