### PR TITLE
feat(iac): real Serverless Framework (serverless.yml) topology extraction (#3519)

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -27,7 +27,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | — | — | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | — | ✅ | ✅ | |
-| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | 🟢 | — | — | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Terraform / OpenTofu / Vault / Nomad / Packer / Waypoint](../detail/infra.resource.terraform.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [docker-compose.yml](../detail/config.docker-compose.md) | — | — | ✅ | — | ✅ | |

--- a/docs/coverage/detail/infra.iac.serverless-framework.md
+++ b/docs/coverage/detail/infra.iac.serverless-framework.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/serverless_edges.go` | — |
-| Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/serverless_edges.go` | — |
+| Dependency attribution | ✅ `full` | `2026-05-30` | — | `internal/engine/serverless_edges.go`<br>`internal/engine/serverless_framework_edges.go` | — |
+| Resource extraction | ✅ `full` | `2026-05-30` | — | `internal/engine/serverless_framework_edges.go`<br>`internal/engine/serverless_framework_parse.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1370,14 +1370,14 @@
       "label": "Serverless Framework",
       "capabilities": {
         "dependency_attribution": {
-          "status": "partial",
-          "cites": ["internal/engine/serverless_edges.go"],
-          "verified_at": "2026-05-28"
+          "status": "full",
+          "cites": ["internal/engine/serverless_edges.go","internal/engine/serverless_framework_edges.go"],
+          "verified_at": "2026-05-30"
         },
         "resource_extraction": {
-          "status": "partial",
-          "cites": ["internal/engine/serverless_edges.go"],
-          "verified_at": "2026-05-28"
+          "status": "full",
+          "cites": ["internal/engine/serverless_framework_edges.go","internal/engine/serverless_framework_parse.go"],
+          "verified_at": "2026-05-30"
         }
       }
     },

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -32,14 +32,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 11 | 0 | 7 | 4 |
-| [Platform / k8s](by-category/platform.md) | 23 | 13 | 7 | 3 |
+| [Platform / k8s](by-category/platform.md) | 23 | 15 | 6 | 2 |
 | [Message Brokers](by-category/message_broker.md) | 20 | 9 | 9 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 8 | 3 | 3 | 2 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 97 | 33 | 35 | 29 |
+| **Total** | 97 | 35 | 34 | 28 |
 
 ## Languages with extractor support, no records yet
 

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -32,14 +32,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 11 | 0 | 7 | 4 |
-| [Platform / k8s](by-category/platform.md) | 23 | 14 | 7 | 2 |
+| [Platform / k8s](by-category/platform.md) | 23 | 13 | 7 | 3 |
 | [Message Brokers](by-category/message_broker.md) | 20 | 9 | 9 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 8 | 3 | 3 | 2 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 97 | 34 | 35 | 28 |
+| **Total** | 97 | 33 | 35 | 29 |
 
 ## Languages with extractor support, no records yet
 

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -660,6 +660,18 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// them without new linker code. Append-only — cannot regress surrounding passes.
 	// Lays groundwork for #927 EventBridge (Lambda synthetics as anchor targets).
 	applyPass(applyServerlessEdges)
+	// Serverless Framework (serverless.yml) topology extraction (#3519, epic
+	// #3512). Parses a serverless.yml manifest and emits first-class graph
+	// entities/edges: functions.<name> → SCOPE.ServerlessFunction (keyed
+	// aws-lambda:<name>, collapsing with the code-side handler synthetics from
+	// applyServerlessEdges); http/httpApi events → http_endpoint_definition +
+	// SERVES; sqs/sns/stream/kinesis events → queue/topic + TRIGGERS; schedule
+	// events → SCOPE.ScheduledJob + TRIGGERS; functions.<name>.handler →
+	// HANDLES edge to the resolved code symbol. Also populates
+	// serverlessYMLHandlerIndex so resolveServerlessYMLName performs the real
+	// topology join (previously a #927-deferred stub). Append-only — cannot
+	// regress surrounding passes. resources: is left to the CFN pass.
+	applyPass(applyServerlessFrameworkEdges)
 	// Workflow orchestration edges (#934). Emits SCOPE.Workflow, SCOPE.Activity,
 	// and SCOPE.StateMachine entities plus STARTS_WORKFLOW, EXECUTES_ACTIVITY,
 	// and STEPFUNCTION_STEP_INVOKES edges for Temporal (Python, Go, Java, Node),

--- a/internal/engine/serverless_edges.go
+++ b/internal/engine/serverless_edges.go
@@ -418,12 +418,18 @@ func findFollowingPyDef(src string, offset int) string {
 // the file during tests — callers pass the source-file path so that fixtures
 // work without a filesystem sidecar.
 func resolveServerlessYMLName(sourcePath, handlerSymbol string) string {
-	// In tests (and when no serverless.yml is present) we fall back to the
-	// handler symbol as the logical name. Real deployments should register the
-	// serverless.yml topology via the deployment_topology_extractor which already
-	// captures `functions.<logicalName>.handler` entries. The #927 EventBridge
-	// pass will wire that index together. For now, handler symbol == logical name.
+	// #3519 — the serverless.yml topology pass (serverless_framework_edges.go)
+	// populates serverlessYMLHandlerIndex with handler-symbol → logical-function
+	// -name mappings as manifests are parsed. When the manifest for this handler
+	// has already been processed in the run, return the logical name so the
+	// code-side synthetic collapses onto the same aws-lambda:<logical> node the
+	// manifest emitted. Otherwise fall back to the handler symbol (the prior
+	// behaviour) — safe because the symbol is still a stable cross-side key when
+	// no manifest is present.
 	_ = sourcePath
+	if logical, ok := serverlessYMLHandlerIndex[handlerSymbol]; ok && logical != "" {
+		return logical
+	}
 	return handlerSymbol
 }
 

--- a/internal/engine/serverless_framework_edges.go
+++ b/internal/engine/serverless_framework_edges.go
@@ -1,0 +1,399 @@
+// Serverless Framework (serverless.yml) topology extraction — #3519 (epic #3512).
+//
+// Before this pass, serverless.yml was handled only by a regex side-channel in
+// internal/enrichers/deployment_topology_extractor.go (extractServerless) that
+// pulled `functions:` keys and `path:` values into flat DeploymentTopologyEntry
+// records — NOT graph entities, with no edges. The companion
+// serverless_edges.go pass detects Lambda *SDK invocations in code* and emits
+// `aws-lambda:<name>` synthetics, but `resolveServerlessYMLName` was an explicit
+// STUB (handler symbol == logical name) because the serverless.yml topology join
+// was deferred to #927.
+//
+// This pass wires the real thing. For a serverless.yml it emits first-class
+// graph entities and edges:
+//
+//   - functions.<name>  → SCOPE.ServerlessFunction keyed `aws-lambda:<name>` —
+//     the SAME synthetic ID serverless_edges.go emits, so a Lambda handler
+//     defined in code (HANDLES edge) and the serverless.yml declaration collapse
+//     onto a single node. provider runtime/region land as function metadata.
+//   - functions.<name>.handler (e.g. `src/handler.hello`) → a HANDLES edge from
+//     the resolved code symbol (file.method) to the function. This also
+//     populates the package-level serverlessYMLHandlerIndex so the previously
+//     stubbed resolveServerlessYMLName can map a handler symbol → logical name.
+//   - events:
+//     http / httpApi → http_endpoint_definition (verb+path) + SERVES edge
+//     function → endpoint, using the canonical `http:<METHOD>:<path>` ID so
+//     the endpoint collapses with any code-side definition / consumer call.
+//     sqs / sns / stream / kinesis → a synthetic queue/topic entity + TRIGGERS
+//     edge from the queue/topic to the function (the event source triggers
+//     the function).
+//     schedule → SCOPE.ScheduledJob + TRIGGERS edge job → function.
+//   - resources: (raw CloudFormation passthrough) is intentionally NOT parsed
+//     here — that is the CFN pass's job; duplicating it would double-emit.
+//
+// # Scope guard
+//
+// Append-only — never modifies or removes existing entities or edges, so it
+// cannot regress the surrounding pipeline's bug-rate. Only fires for a file the
+// content sniffer recognises as a serverless.yml (top-level service: + provider:
+// + functions:, or a serverless.yml/.yaml basename).
+//
+// Closes #3519. Epic #3512.
+package engine
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// slsScheduledJobKind / slsServesEdge / slsTriggersEdge alias the canonical
+// kind constants this pass emits so the producer-kind guard (producer_kinds_test)
+// stays green via the typed constants already declared elsewhere in the package.
+const (
+	slsServesEdgeKind   = "SERVES"   // function → endpoint
+	slsTriggersEdgeKind = "TRIGGERS" // event source / schedule → function
+)
+
+// serverlessYMLHandlerIndex maps a handler *symbol* (the trailing dotted method
+// of a `handler:` value, e.g. "hello" from "src/handler.hello") to its logical
+// serverless.yml function name. Populated as serverless.yml files are parsed so
+// the formerly-stubbed resolveServerlessYMLName can perform the topology join
+// without re-reading the YAML at code-pass time. Append-only within a run.
+var serverlessYMLHandlerIndex = map[string]string{}
+
+// slsServiceKeyRe / slsProviderKeyRe / slsFunctionsKeyRe detect the three
+// top-level keys that together identify a Serverless Framework manifest.
+var (
+	slsServiceKeyRe   = regexp.MustCompile(`(?m)^service\s*:`)
+	slsProviderKeyRe  = regexp.MustCompile(`(?m)^provider\s*:`)
+	slsFunctionsKeyRe = regexp.MustCompile(`(?m)^functions\s*:`)
+)
+
+// isServerlessFrameworkFile reports whether (path, src) is a Serverless
+// Framework manifest. Recognised by basename (serverless.yml/.yaml) OR by the
+// co-occurrence of the three signature top-level keys.
+func isServerlessFrameworkFile(path, src string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	if base == "serverless.yml" || base == "serverless.yaml" {
+		return true
+	}
+	return slsServiceKeyRe.MatchString(src) &&
+		slsProviderKeyRe.MatchString(src) &&
+		slsFunctionsKeyRe.MatchString(src)
+}
+
+// applyServerlessFrameworkEdges is the per-file entry point. Append-only.
+func applyServerlessFrameworkEdges(args DetectorPassArgs) DetectorPassResult {
+	entities := args.Entities
+	relationships := args.Relationships
+	if len(args.Content) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+	// Serverless Framework manifests are YAML.
+	if args.Lang != "yaml" {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+	src := string(args.Content)
+	if !isServerlessFrameworkFile(args.Path, src) {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	manifest := parseServerlessYML(src)
+	if len(manifest.functions) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	path := args.Path
+	seenEnt := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	emitEntity := func(rec types.EntityRecord) {
+		key := rec.Kind + "|" + rec.Name
+		if seenEnt[key] {
+			return
+		}
+		seenEnt[key] = true
+		entities = append(entities, rec)
+	}
+	emitEdge := func(fromID, toID, kind string, props map[string]string) {
+		if fromID == "" || toID == "" {
+			return
+		}
+		key := kind + "|" + fromID + "|" + toID
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID:     fromID,
+			ToID:       toID,
+			Kind:       kind,
+			Properties: props,
+		})
+	}
+
+	for _, fn := range manifest.functions {
+		fnID := lambdaFunctionID(fn.name)
+		fnEntityRef := fmt.Sprintf("%s:%s", serverlessFunctionKind, fnID)
+
+		fnProps := map[string]string{
+			"provider":      "aws-lambda",
+			"function_name": fn.name,
+			"pattern_type":  "serverless_framework",
+			"iac_tool":      "serverless-framework",
+		}
+		if fn.handler != "" {
+			fnProps["handler"] = fn.handler
+		}
+		if manifest.runtime != "" {
+			fnProps["runtime"] = manifest.runtime
+		}
+		if manifest.region != "" {
+			fnProps["region"] = manifest.region
+		}
+		if manifest.service != "" {
+			fnProps["service"] = manifest.service
+		}
+		emitEntity(types.EntityRecord{
+			Name:             fnID,
+			Kind:             serverlessFunctionKind,
+			SourceFile:       path,
+			Language:         "yaml",
+			Properties:       fnProps,
+			EnrichmentStatus: types.StatusPending,
+			QualityScore:     0.8,
+		})
+
+		// HANDLES: handler code symbol → function. The handler value is
+		// `path/to/file.method`; the trailing dotted segment is the exported
+		// symbol, the rest is the module path. We emit a HANDLES edge from the
+		// SCOPE.Function:<symbol> entity (the same FromID shape serverless_edges.go
+		// uses for code-side handlers) and register the symbol→logical-name map.
+		if symbol := handlerSymbol(fn.handler); symbol != "" {
+			serverlessYMLHandlerIndex[symbol] = fn.name
+			emitEdge(
+				fmt.Sprintf("SCOPE.Function:%s", symbol),
+				fnEntityRef,
+				serverlessHandlesEdgeKind,
+				map[string]string{
+					"provider":       "aws-lambda",
+					"pattern_type":   "serverless_framework",
+					"handler":        fn.handler,
+					"handler_module": handlerModule(fn.handler),
+				},
+			)
+		}
+
+		for _, ev := range fn.events {
+			switch ev.kind {
+			case "http", "httpApi":
+				if ev.method == "" || ev.path == "" {
+					continue
+				}
+				method := strings.ToUpper(ev.method)
+				canonPath := canonicalizeServerlessPath(ev.path)
+				epID := httproutes.SyntheticID(method, canonPath)
+				emitEntity(types.EntityRecord{
+					ID:            epID,
+					Name:          epID,
+					QualifiedName: epID,
+					Kind:          httpEndpointDefinitionKind,
+					SourceFile:    path,
+					Language:      "yaml",
+					Properties: map[string]string{
+						"verb":           method,
+						"path":           canonPath,
+						"framework":      "serverless-framework",
+						"pattern_type":   "serverless_framework",
+						"source_handler": fnEntityRef,
+						"event_type":     ev.kind,
+					},
+					EnrichmentStatus: types.StatusPending,
+					QualityScore:     0.8,
+				})
+				// SERVES: function → endpoint.
+				emitEdge(fnEntityRef, fmt.Sprintf("%s:%s", httpEndpointDefinitionKind, epID),
+					slsServesEdgeKind, map[string]string{
+						"pattern_type": "serverless_framework",
+						"event_type":   ev.kind,
+					})
+
+			case "sqs":
+				if ev.source == "" {
+					continue
+				}
+				qID := sqsQueueID(ev.source)
+				emitEntity(types.EntityRecord{
+					Name:     qID,
+					Kind:     queueEntityKind,
+					Language: "yaml",
+					Properties: map[string]string{
+						"broker":       "sqs",
+						"queue_name":   sqsQueueDisplayName(ev.source),
+						"pattern_type": "serverless_framework",
+						"iac_tool":     "serverless-framework",
+					},
+					EnrichmentStatus: types.StatusPending,
+					QualityScore:     0.8,
+				})
+				// TRIGGERS: queue → function (the event source triggers the fn).
+				emitEdge(fmt.Sprintf("%s:%s", queueEntityKind, qID), fnEntityRef,
+					slsTriggersEdgeKind, map[string]string{
+						"broker":       "sqs",
+						"pattern_type": "serverless_framework",
+						"event_type":   "sqs",
+					})
+
+			case "sns":
+				if ev.source == "" {
+					continue
+				}
+				tID := snsTopicID(snsTopicNameFromARN(ev.source))
+				emitEntity(types.EntityRecord{
+					Name:     tID,
+					Kind:     messageTopicKind,
+					Language: "yaml",
+					Properties: map[string]string{
+						"broker":       "sns",
+						"topic_name":   snsTopicNameFromARN(ev.source),
+						"pattern_type": "serverless_framework",
+						"iac_tool":     "serverless-framework",
+					},
+					EnrichmentStatus: types.StatusPending,
+					QualityScore:     0.8,
+				})
+				emitEdge(fmt.Sprintf("%s:%s", messageTopicKind, tID), fnEntityRef,
+					slsTriggersEdgeKind, map[string]string{
+						"broker":       "sns",
+						"pattern_type": "serverless_framework",
+						"event_type":   "sns",
+					})
+
+			case "stream", "kinesis":
+				if ev.source == "" {
+					continue
+				}
+				streamName := streamNameFromARN(ev.source)
+				sID := "stream:" + streamName
+				emitEntity(types.EntityRecord{
+					Name:     sID,
+					Kind:     queueEntityKind,
+					Language: "yaml",
+					Properties: map[string]string{
+						"broker":       "kinesis",
+						"stream_name":  streamName,
+						"pattern_type": "serverless_framework",
+						"iac_tool":     "serverless-framework",
+					},
+					EnrichmentStatus: types.StatusPending,
+					QualityScore:     0.8,
+				})
+				emitEdge(fmt.Sprintf("%s:%s", queueEntityKind, sID), fnEntityRef,
+					slsTriggersEdgeKind, map[string]string{
+						"broker":       "kinesis",
+						"pattern_type": "serverless_framework",
+						"event_type":   ev.kind,
+					})
+
+			case "schedule":
+				if ev.source == "" {
+					continue
+				}
+				jobID := "serverless-framework:" + fn.name + ":schedule"
+				emitEntity(types.EntityRecord{
+					Name:     jobID,
+					Kind:     scheduledJobKind,
+					Language: "yaml",
+					Properties: map[string]string{
+						"schedule":     ev.source,
+						"pattern_type": "serverless_framework",
+						"iac_tool":     "serverless-framework",
+						"function":     fn.name,
+					},
+					EnrichmentStatus: types.StatusPending,
+					QualityScore:     0.8,
+				})
+				// TRIGGERS: scheduled job → function.
+				emitEdge(fmt.Sprintf("%s:%s", scheduledJobKind, jobID), fnEntityRef,
+					slsTriggersEdgeKind, map[string]string{
+						"pattern_type": "serverless_framework",
+						"event_type":   "schedule",
+						"schedule":     ev.source,
+					})
+			}
+		}
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}
+
+// ---------------------------------------------------------------------------
+// Handler symbol resolution (wires the resolveServerlessYMLName stub)
+// ---------------------------------------------------------------------------
+
+// handlerSymbol returns the exported symbol of a serverless `handler:` value.
+// `src/handler.hello` → `hello`; `handler.main` → `main`; `dir/handler` → "".
+// A handler with no dotted method is a Go/Java-style file ref and yields no
+// symbol-level HANDLES edge.
+func handlerSymbol(handler string) string {
+	h := strings.TrimSpace(handler)
+	if h == "" {
+		return ""
+	}
+	idx := strings.LastIndex(h, ".")
+	if idx < 0 || idx == len(h)-1 {
+		return ""
+	}
+	return h[idx+1:]
+}
+
+// handlerModule returns the module-path portion of a serverless `handler:`
+// value: `src/handler.hello` → `src/handler`.
+func handlerModule(handler string) string {
+	h := strings.TrimSpace(handler)
+	idx := strings.LastIndex(h, ".")
+	if idx <= 0 {
+		return h
+	}
+	return h[:idx]
+}
+
+// ---------------------------------------------------------------------------
+// Path canonicalisation
+// ---------------------------------------------------------------------------
+
+// canonicalizeServerlessPath normalises a serverless.yml event path to the
+// canonical `/`-prefixed `{param}` form used by httproutes synthetic IDs.
+// Serverless already uses `{proxy+}` / `{id}` curly params, so we mainly ensure
+// the leading slash and collapse the `+` greedy marker.
+func canonicalizeServerlessPath(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	// `{proxy+}` greedy catch-all → `{proxy}` so the canonical path is stable.
+	p = strings.ReplaceAll(p, "+}", "}")
+	return p
+}
+
+// streamNameFromARN extracts the trailing stream name from a Kinesis/DynamoDB
+// stream ARN, or returns the input unchanged when it is already a bare name.
+// `arn:aws:kinesis:us-east-1:123:stream/orders` → `orders`.
+func streamNameFromARN(arnOrName string) string {
+	s := strings.TrimSpace(arnOrName)
+	if idx := strings.LastIndex(s, "/"); idx >= 0 {
+		return s[idx+1:]
+	}
+	if idx := strings.LastIndex(s, ":"); idx >= 0 {
+		return s[idx+1:]
+	}
+	return s
+}

--- a/internal/engine/serverless_framework_edges_test.go
+++ b/internal/engine/serverless_framework_edges_test.go
@@ -1,0 +1,231 @@
+// Tests for the Serverless Framework (serverless.yml) topology pass — #3519.
+//
+// Value-asserting: a serverless.yml with a function `hello` (handler
+// `src/handler.hello`) + an `http GET /users` event + an `sqs` event must yield
+//   - the SCOPE.ServerlessFunction entity (aws-lambda:hello),
+//   - the GET /users http_endpoint_definition,
+//   - the sqs queue TRIGGERS edge,
+//   - the HANDLES edge to the handler symbol,
+//
+// plus provider runtime/region metadata, schedule + sns coverage, the
+// resolveServerlessYMLName join, and detection / no-op guards.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runSLSFrameworkDetect(t *testing.T, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	res := applyServerlessFrameworkEdges(DetectorPassArgs{Lang: "yaml", Path: path, Content: []byte(src)})
+	return res.Entities, res.Relationships
+}
+
+func slsEntityByKindName(ents []types.EntityRecord, kind, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func slsHasEdge(rels []types.RelationshipRecord, kind, fromID, toID string) bool {
+	for _, r := range rels {
+		if r.Kind == kind && r.FromID == fromID && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestServerlessFramework_FullManifest is the core value-asserting test.
+func TestServerlessFramework_FullManifest(t *testing.T) {
+	src := `service: orders-api
+provider:
+  name: aws
+  runtime: nodejs18.x
+  region: us-east-1
+functions:
+  hello:
+    handler: src/handler.hello
+    events:
+      - http:
+          method: GET
+          path: /users
+      - sqs:
+          arn: arn:aws:sqs:us-east-1:123456789012:order-events
+`
+	ents, rels := runSLSFrameworkDetect(t, "serverless.yml", src)
+
+	// 1. ServerlessFunction entity, keyed aws-lambda:hello, with provider meta.
+	fn := slsEntityByKindName(ents, serverlessFunctionKind, lambdaFunctionID("hello"))
+	if fn == nil {
+		t.Fatalf("expected ServerlessFunction entity %q; ents=%v", lambdaFunctionID("hello"), ents)
+	}
+	if fn.Properties["runtime"] != "nodejs18.x" {
+		t.Errorf("expected runtime nodejs18.x, got %q", fn.Properties["runtime"])
+	}
+	if fn.Properties["region"] != "us-east-1" {
+		t.Errorf("expected region us-east-1, got %q", fn.Properties["region"])
+	}
+	if fn.Properties["handler"] != "src/handler.hello" {
+		t.Errorf("expected handler src/handler.hello, got %q", fn.Properties["handler"])
+	}
+	fnRef := serverlessFunctionKind + ":" + lambdaFunctionID("hello")
+
+	// 2. GET /users endpoint entity.
+	epID := httproutes.SyntheticID("GET", "/users")
+	ep := slsEntityByKindName(ents, httpEndpointDefinitionKind, epID)
+	if ep == nil {
+		t.Fatalf("expected http_endpoint_definition %q; ents=%v", epID, ents)
+	}
+	if ep.Properties["verb"] != "GET" || ep.Properties["path"] != "/users" {
+		t.Errorf("endpoint verb/path wrong: %v", ep.Properties)
+	}
+	// SERVES: function → endpoint.
+	if !slsHasEdge(rels, slsServesEdgeKind, fnRef, httpEndpointDefinitionKind+":"+epID) {
+		t.Errorf("expected SERVES edge %s -> %s; rels=%v", fnRef, epID, rels)
+	}
+
+	// 3. sqs queue entity + TRIGGERS edge queue → function.
+	qID := sqsQueueID("arn:aws:sqs:us-east-1:123456789012:order-events")
+	if slsEntityByKindName(ents, queueEntityKind, qID) == nil {
+		t.Fatalf("expected sqs queue entity %q; ents=%v", qID, ents)
+	}
+	if !slsHasEdge(rels, slsTriggersEdgeKind, queueEntityKind+":"+qID, fnRef) {
+		t.Errorf("expected sqs TRIGGERS edge %s -> %s; rels=%v", qID, fnRef, rels)
+	}
+
+	// 4. HANDLES edge: handler symbol → function.
+	if !slsHasEdge(rels, serverlessHandlesEdgeKind, "SCOPE.Function:hello", fnRef) {
+		t.Errorf("expected HANDLES edge SCOPE.Function:hello -> %s; rels=%v", fnRef, rels)
+	}
+}
+
+// TestServerlessFramework_HttpShortForm covers the inline `http: GET /users` form.
+func TestServerlessFramework_HttpShortForm(t *testing.T) {
+	src := `service: svc
+provider:
+  name: aws
+  runtime: python3.11
+functions:
+  list:
+    handler: app.list
+    events:
+      - http: GET /items
+`
+	ents, rels := runSLSFrameworkDetect(t, "serverless.yml", src)
+	epID := httproutes.SyntheticID("GET", "/items")
+	if slsEntityByKindName(ents, httpEndpointDefinitionKind, epID) == nil {
+		t.Fatalf("expected endpoint %q from short form; ents=%v", epID, ents)
+	}
+	fnRef := serverlessFunctionKind + ":" + lambdaFunctionID("list")
+	if !slsHasEdge(rels, slsServesEdgeKind, fnRef, httpEndpointDefinitionKind+":"+epID) {
+		t.Errorf("expected SERVES edge for short-form http; rels=%v", rels)
+	}
+}
+
+// TestServerlessFramework_ScheduleAndSNS covers schedule + sns events.
+func TestServerlessFramework_ScheduleAndSNS(t *testing.T) {
+	src := `service: svc
+provider:
+  name: aws
+  runtime: go1.x
+functions:
+  cron:
+    handler: bin/cron
+    events:
+      - schedule: rate(5 minutes)
+  notify:
+    handler: src/notify.handler
+    events:
+      - sns:
+          arn: arn:aws:sns:us-east-1:123456789012:user-signups
+`
+	ents, rels := runSLSFrameworkDetect(t, "serverless.yml", src)
+
+	// schedule → ScheduledJob + TRIGGERS → cron function.
+	cronRef := serverlessFunctionKind + ":" + lambdaFunctionID("cron")
+	jobID := "serverless-framework:cron:schedule"
+	job := slsEntityByKindName(ents, scheduledJobKind, jobID)
+	if job == nil {
+		t.Fatalf("expected ScheduledJob %q; ents=%v", jobID, ents)
+	}
+	if job.Properties["schedule"] != "rate(5 minutes)" {
+		t.Errorf("expected schedule expr, got %q", job.Properties["schedule"])
+	}
+	if !slsHasEdge(rels, slsTriggersEdgeKind, scheduledJobKind+":"+jobID, cronRef) {
+		t.Errorf("expected schedule TRIGGERS edge; rels=%v", rels)
+	}
+
+	// sns → MessageTopic + TRIGGERS → notify function.
+	notifyRef := serverlessFunctionKind + ":" + lambdaFunctionID("notify")
+	tID := snsTopicID("user-signups")
+	if slsEntityByKindName(ents, messageTopicKind, tID) == nil {
+		t.Fatalf("expected sns topic %q; ents=%v", tID, ents)
+	}
+	if !slsHasEdge(rels, slsTriggersEdgeKind, messageTopicKind+":"+tID, notifyRef) {
+		t.Errorf("expected sns TRIGGERS edge; rels=%v", rels)
+	}
+}
+
+// TestServerlessFramework_ResolveYMLName verifies the resolveServerlessYMLName
+// stub is wired: after a manifest is parsed, the handler symbol resolves to the
+// logical function name.
+func TestServerlessFramework_ResolveYMLName(t *testing.T) {
+	// Clean slate for the package-level index.
+	delete(serverlessYMLHandlerIndex, "doWork")
+	src := `service: svc
+provider:
+  name: aws
+  runtime: nodejs18.x
+functions:
+  processOrder:
+    handler: src/orders.doWork
+`
+	runSLSFrameworkDetect(t, "serverless.yml", src)
+	if got := resolveServerlessYMLName("src/orders.js", "doWork"); got != "processOrder" {
+		t.Errorf("expected resolveServerlessYMLName to map doWork -> processOrder, got %q", got)
+	}
+	// Unknown symbol falls back to itself.
+	if got := resolveServerlessYMLName("x.js", "unknownSym"); got != "unknownSym" {
+		t.Errorf("expected fallback to symbol, got %q", got)
+	}
+}
+
+// TestServerlessFramework_Detection covers the content-sniff path (no
+// serverless.yml basename) and the no-op guards.
+func TestServerlessFramework_Detection(t *testing.T) {
+	// Content-sniff: signature keys present though the file is named oddly.
+	src := `service: svc
+provider:
+  name: aws
+  runtime: nodejs18.x
+functions:
+  h:
+    handler: a.b
+    events:
+      - http: GET /ping
+`
+	ents, _ := runSLSFrameworkDetect(t, "config/sls.yml", src)
+	if slsEntityByKindName(ents, serverlessFunctionKind, lambdaFunctionID("h")) == nil {
+		t.Errorf("expected content-sniff detection to fire; ents=%v", ents)
+	}
+
+	// No-op: a non-serverless YAML (docker-compose-ish) yields nothing.
+	other := "version: '3'\nservices:\n  web:\n    image: nginx\n"
+	e2, r2 := runSLSFrameworkDetect(t, "docker-compose.yml", other)
+	if len(e2) != 0 || len(r2) != 0 {
+		t.Errorf("expected no entities/edges for non-serverless yaml, got %d ents %d rels", len(e2), len(r2))
+	}
+
+	// No-op: non-yaml language is skipped even with serverless content.
+	res := applyServerlessFrameworkEdges(DetectorPassArgs{Lang: "python", Path: "serverless.yml", Content: []byte(src)})
+	if len(res.Entities) != 0 {
+		t.Errorf("expected non-yaml language to be skipped, got %d ents", len(res.Entities))
+	}
+}

--- a/internal/engine/serverless_framework_parse.go
+++ b/internal/engine/serverless_framework_parse.go
@@ -1,0 +1,371 @@
+// Serverless Framework manifest parser — #3519.
+//
+// A small indentation-aware line parser for serverless.yml. It deliberately
+// avoids a full YAML library (the package's other IaC passes — iac_sns_edges,
+// event_bus_edges — are regex/line based for the same reason: the engine pass
+// receives raw bytes and must stay dependency-light) and extracts exactly the
+// subset the topology join needs: service name, provider runtime/region, and
+// the functions block with each function's handler and events.
+package engine
+
+import (
+	"strings"
+)
+
+// slsManifest is the parsed subset of a serverless.yml.
+type slsManifest struct {
+	service   string
+	runtime   string
+	region    string
+	functions []slsFunction
+}
+
+// slsFunction is one entry under `functions:`.
+type slsFunction struct {
+	name    string
+	handler string
+	events  []slsEvent
+}
+
+// slsEvent is one entry under a function's `events:` list. `kind` is the event
+// type (http, httpApi, sqs, sns, stream, kinesis, schedule). For http events
+// method+path are set; for queue/stream/schedule events `source` carries the
+// ARN / queue name / rate-or-cron expression.
+type slsEvent struct {
+	kind   string
+	method string
+	path   string
+	source string
+}
+
+// indentOf returns the number of leading spaces on a line (tabs are invalid in
+// YAML indentation, so we count spaces only).
+func indentOf(line string) int {
+	n := 0
+	for _, r := range line {
+		if r == ' ' {
+			n++
+		} else {
+			break
+		}
+	}
+	return n
+}
+
+// splitKeyValue splits a `key: value` line into (key, value), trimming quotes
+// and inline comments from the value. Returns ok=false when there is no colon.
+func splitKeyValue(line string) (key, value string, ok bool) {
+	trimmed := strings.TrimSpace(line)
+	trimmed = strings.TrimPrefix(trimmed, "- ")
+	idx := strings.Index(trimmed, ":")
+	if idx < 0 {
+		return "", "", false
+	}
+	key = strings.TrimSpace(trimmed[:idx])
+	value = strings.TrimSpace(trimmed[idx+1:])
+	value = stripInlineComment(value)
+	value = strings.Trim(value, `"'`)
+	return key, value, true
+}
+
+// stripInlineComment removes a trailing ` # comment` from a scalar value while
+// preserving `#` that appears inside a quoted string.
+func stripInlineComment(v string) string {
+	if v == "" {
+		return v
+	}
+	inSingle, inDouble := false, false
+	for i := 0; i < len(v); i++ {
+		switch v[i] {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '#':
+			if !inSingle && !inDouble && i > 0 && (v[i-1] == ' ' || v[i-1] == '\t') {
+				return strings.TrimSpace(v[:i])
+			}
+		}
+	}
+	return strings.TrimSpace(v)
+}
+
+// parseServerlessYML extracts the topology-relevant subset of a serverless.yml.
+func parseServerlessYML(src string) slsManifest {
+	lines := strings.Split(src, "\n")
+	var m slsManifest
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if indentOf(line) != 0 {
+			continue
+		}
+		key, value, ok := splitKeyValue(line)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "service":
+			if value != "" {
+				m.service = value
+			}
+		case "provider":
+			parseProviderBlock(lines, i+1, &m)
+		case "functions":
+			m.functions = parseFunctionsBlock(lines, i+1)
+		}
+	}
+	return m
+}
+
+// parseProviderBlock reads runtime/region from the `provider:` mapping. `start`
+// is the first line after the `provider:` header. Stops at the next top-level
+// (indent 0) key.
+func parseProviderBlock(lines []string, start int, m *slsManifest) {
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if indentOf(line) == 0 {
+			return
+		}
+		key, value, ok := splitKeyValue(line)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "runtime":
+			if value != "" {
+				m.runtime = value
+			}
+		case "region":
+			if value != "" {
+				m.region = value
+			}
+		}
+	}
+}
+
+// parseFunctionsBlock reads each function entry under `functions:`. `start` is
+// the first line after the `functions:` header. A function header is the first
+// indentation level inside the block; its body (handler, events) is more deeply
+// indented. Stops at the next top-level key.
+func parseFunctionsBlock(lines []string, start int) []slsFunction {
+	var fns []slsFunction
+	// Determine the function-key indent from the first non-blank child line.
+	fnIndent := -1
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		ind := indentOf(line)
+		if ind == 0 {
+			break // hit next top-level key before any function
+		}
+		fnIndent = ind
+		break
+	}
+	if fnIndent < 0 {
+		return fns
+	}
+
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		ind := indentOf(line)
+		if ind == 0 {
+			break // next top-level key — functions block done
+		}
+		if ind != fnIndent {
+			continue // deeper line consumed by a function body scan below
+		}
+		key, _, ok := splitKeyValue(line)
+		if !ok || key == "" {
+			continue
+		}
+		fn := slsFunction{name: key}
+		// Find the end of this function's body: up to the next line at <= fnIndent.
+		end := len(lines)
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == "" {
+				continue
+			}
+			if indentOf(lines[j]) <= fnIndent {
+				end = j
+				break
+			}
+		}
+		parseFunctionBody(lines[i+1:end], &fn)
+		fns = append(fns, fn)
+	}
+	return fns
+}
+
+// parseFunctionBody reads handler + events from a single function's body lines.
+func parseFunctionBody(body []string, fn *slsFunction) {
+	for i := 0; i < len(body); i++ {
+		line := body[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		key, value, ok := splitKeyValue(line)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "handler":
+			if value != "" {
+				fn.handler = value
+			}
+		case "events":
+			eventsIndent := indentOf(line)
+			// Events list lives below the `events:` line at deeper indent.
+			end := len(body)
+			for j := i + 1; j < len(body); j++ {
+				if strings.TrimSpace(body[j]) == "" {
+					continue
+				}
+				if indentOf(body[j]) <= eventsIndent {
+					end = j
+					break
+				}
+			}
+			fn.events = parseEventsBlock(body[i+1 : end])
+			i = end - 1
+		}
+	}
+}
+
+// parseEventsBlock reads the `- <type>:` list items of an events block.
+func parseEventsBlock(lines []string) []slsEvent {
+	var events []slsEvent
+	// Each list item starts with a `-` at the shallowest indent in the block.
+	itemIndent := -1
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "-") {
+			itemIndent = indentOf(line)
+			break
+		}
+	}
+	if itemIndent < 0 {
+		return events
+	}
+
+	// Split into per-item line groups.
+	var itemStarts []int
+	for idx, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		t := strings.TrimSpace(line)
+		if indentOf(line) == itemIndent && strings.HasPrefix(t, "-") {
+			itemStarts = append(itemStarts, idx)
+		}
+	}
+	for k, s := range itemStarts {
+		e := len(lines)
+		if k+1 < len(itemStarts) {
+			e = itemStarts[k+1]
+		}
+		if ev, ok := parseEventItem(lines[s:e], itemIndent); ok {
+			events = append(events, ev)
+		}
+	}
+	return events
+}
+
+// parseEventItem parses one `- <type>: ...` event list item.
+func parseEventItem(lines []string, itemIndent int) (slsEvent, bool) {
+	if len(lines) == 0 {
+		return slsEvent{}, false
+	}
+	// First line: `- http:` or `- http: GET /users` or `- schedule: rate(...)`.
+	first := strings.TrimSpace(lines[0])
+	first = strings.TrimPrefix(first, "-")
+	first = strings.TrimSpace(first)
+	idx := strings.Index(first, ":")
+	if idx < 0 {
+		return slsEvent{}, false
+	}
+	kind := strings.TrimSpace(first[:idx])
+	inlineVal := stripInlineComment(strings.TrimSpace(first[idx+1:]))
+	inlineVal = strings.Trim(inlineVal, `"'`)
+
+	ev := slsEvent{kind: kind}
+
+	switch kind {
+	case "http", "httpApi":
+		// Inline short form: `http: GET /users` or `http: 'GET /users'`.
+		if inlineVal != "" && inlineVal != "{" {
+			parts := strings.Fields(inlineVal)
+			if len(parts) >= 2 {
+				ev.method = parts[0]
+				ev.path = parts[1]
+			} else if len(parts) == 1 {
+				ev.path = parts[0]
+			}
+		}
+		// Object form: method:/path: on following indented lines.
+		for _, l := range lines[1:] {
+			k, v, ok := splitKeyValue(l)
+			if !ok {
+				continue
+			}
+			switch k {
+			case "method":
+				ev.method = strings.ToUpper(v)
+			case "path":
+				ev.path = v
+			}
+		}
+		return ev, ev.path != "" || ev.method != ""
+
+	case "schedule":
+		if inlineVal != "" {
+			ev.source = inlineVal
+		}
+		for _, l := range lines[1:] {
+			k, v, ok := splitKeyValue(l)
+			if !ok {
+				continue
+			}
+			switch k {
+			case "rate", "expression":
+				ev.source = v
+			}
+		}
+		return ev, ev.source != ""
+
+	case "sqs", "sns", "stream", "kinesis":
+		if inlineVal != "" {
+			ev.source = inlineVal
+		}
+		for _, l := range lines[1:] {
+			k, v, ok := splitKeyValue(l)
+			if !ok {
+				continue
+			}
+			switch k {
+			case "arn", "queueName", "topicName", "streamName":
+				if v != "" {
+					ev.source = v
+				}
+			}
+		}
+		return ev, ev.source != ""
+	}
+
+	return slsEvent{}, false
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -15848,3 +15848,28 @@ records:
             - file: internal/extractors/cpp/typesystem_test.go
           issues_implemented: ["3491"]
           verified_at: "2026-05-31"
+
+  infra.iac.serverless-framework:
+    capabilities:
+      dependency_attribution:
+        status: full
+        symbols:
+          - file: internal/engine/serverless_framework_edges.go
+            functions: [applyServerlessFrameworkEdges, handlerSymbol]
+          - file: internal/engine/serverless_edges.go
+            functions: [resolveServerlessYMLName]
+        tests:
+          - file: internal/engine/serverless_framework_edges_test.go
+        issues_implemented: ["3519"]
+        verified_at: "2026-05-30"
+      resource_extraction:
+        status: full
+        symbols:
+          - file: internal/engine/serverless_framework_edges.go
+            functions: [applyServerlessFrameworkEdges, isServerlessFrameworkFile]
+          - file: internal/engine/serverless_framework_parse.go
+            functions: [parseServerlessYML, parseFunctionsBlock, parseEventsBlock]
+        tests:
+          - file: internal/engine/serverless_framework_edges_test.go
+        issues_implemented: ["3519"]
+        verified_at: "2026-05-30"


### PR DESCRIPTION
Closes #3519 (epic #3512).

## Problem
`serverless.yml` was handled only by a regex side-channel in `internal/enrichers/deployment_topology_extractor.go` (`extractServerless`) that pulled `functions:` keys and `path:` values into flat `DeploymentTopologyEntry` records — **not graph entities, no edges**. The companion `serverless_edges.go` pass detects Lambda **SDK invocations in code** and emits `aws-lambda:<name>` synthetics, but `resolveServerlessYMLName` was an explicit **stub** (handler symbol == logical name) because the serverless.yml topology join was deferred to #927.

## What fires now
New append-only engine pass `applyServerlessFrameworkEdges` (`serverless_framework_edges.go` + `serverless_framework_parse.go`), registered right after `applyServerlessEdges`, self-gated to a serverless.yml (basename `serverless.yml`/`.yaml`, or `service:`+`provider:`+`functions:` content sniff):

- **`functions.<name>` → `SCOPE.ServerlessFunction`** keyed `aws-lambda:<name>` — the *same* synthetic ID `serverless_edges.go` emits, so the manifest declaration and the code-side Lambda handler collapse onto a single node. `provider` runtime/region/service become function metadata.
- **`functions.<name>.handler`** (e.g. `src/handler.hello`) → **HANDLES edge** from the resolved code symbol (`SCOPE.Function:hello`) to the function. Also populates the package-level `serverlessYMLHandlerIndex`, so the formerly-stubbed `resolveServerlessYMLName` now performs the real symbol → logical-name join.
- **`events:`**
  - `http` / `httpApi` (object form and `http: GET /path` short form) → **`http_endpoint_definition`** (verb+path, canonical `http:<METHOD>:<path>` ID) + **SERVES** edge function → endpoint.
  - `sqs` / `sns` / `stream` / `kinesis` → synthetic queue/topic entity + **TRIGGERS** edge from the event source to the function.
  - `schedule` → **`SCOPE.ScheduledJob`** + **TRIGGERS** edge job → function.
- **`resources:`** (raw CloudFormation passthrough) intentionally **not** parsed here — that is the CFN pass's job; duplicating it would double-emit.

## Discipline
- **Value-asserting tests** (`serverless_framework_edges_test.go`): the core test feeds a manifest with function `hello` (handler `src/handler.hello`) + an `http GET /users` event + an `sqs` event and asserts the function entity (with runtime/region), the `GET /users` endpoint + SERVES edge, the sqs queue + TRIGGERS edge, and the HANDLES edge — plus http short-form, schedule+sns, the `resolveServerlessYMLName` join, and detection / no-op guards (non-serverless YAML, non-yaml language). Not `len>0`.
- Coverage cells `infra.iac.serverless-framework.{dependency_attribution,resource_extraction}` flipped `partial → full` citing the new pass, with backing `capability-map.yaml` entries. `coverage update` + `gen` + `validate` (0 errors) + `fmt --check` (canonical) all clean. `gofmt -l` empty, `go vet` clean. Targeted suites green (`engine`, `extractors/yaml`, `enrichers`, `types`, `tools/coverage`).

## DEPLOY-DEFERRED
This change ships the indexer pass only. The live rewrite daemon must be rebuilt + restarted and `upvate`/other groups re-indexed before the new ServerlessFunction/endpoint/trigger nodes appear in the graph and MCP — not done here per isolation rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)