### PR TITLE
feat(iac): deepen Terraform/HCL extraction (#3527)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1390,12 +1390,14 @@
         "dependency_attribution": {
           "status": "full",
           "cites": ["internal/extractors/hcl"],
-          "verified_at": "2026-05-28"
+          "notes": "#3527 deepened: for_each/count meta-args emit USES iteration-source edges (each.*/count.*/self.* pseudo-refs suppressed); module I/O data-flow edges (module.this USES module.x tagged with the consuming input arg); data.terraform_remote_state.X.outputs.Y → cross-stack DEPENDS_ON (cross_stack=true); dynamic blocks emit child dynamic_block entities with CONTAINS+CALLS; terraform{} required_providers → per-provider IMPORTS(import_kind=required_provider, version). Remaining gaps: module input → child variable binding is intra-file CALLS only (no cross-module-file output/variable resolution); moved/import blocks not yet emitted as rename/adopt edges.",
+          "verified_at": "2026-05-31"
         },
         "resource_extraction": {
           "status": "full",
           "cites": ["internal/extractors/hcl"],
-          "verified_at": "2026-05-28"
+          "notes": "#3527: dynamic \"x\" {} nested blocks now emitted as SCOPE.Component/dynamic_block child entities (previously dropped by the top-level-only walker); terraform{} settings captured as a SCOPE.Component/terraform_settings entity (required_providers+backend+required_version) instead of being dropped; lifecycle/provisioner meta-blocks recorded in resource Metadata.meta_blocks.",
+          "verified_at": "2026-05-31"
         }
       }
     },

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -175,8 +175,9 @@ func extractBlock(n *sitter.Node, src []byte, path, lang string) ([]types.Entity
 	case "locals":
 		return extractLocalsBlock(n, src, path, lang)
 	case "terraform":
-		// terraform block → file metadata, not emitted as entity per spec.
-		return nil, false
+		// Issue #3527 — capture required_providers + backend instead of
+		// dropping. Empty / version-only terraform blocks stay metadata-only.
+		return extractTerraformBlock(n, src, path, lang, start, end)
 	}
 	return nil, false
 }
@@ -213,15 +214,26 @@ func extractResourceBlock(n *sitter.Node, src []byte, path, lang string, start, 
 
 	// Extract depends_on relationships.
 	body := blockBody(n)
+	out := []types.EntityRecord{rec}
 	if body != nil {
 		deps := extractDependsOn(body, src, path, lang)
-		rec.Relationships = append(rec.Relationships, deps...)
+		out[0].Relationships = append(out[0].Relationships, deps...)
 		// Issue #387 — interpolation cross-references → CALLS edges.
 		calls := extractCalls(body, src, path, lang, selfRef, selfRef)
-		rec.Relationships = append(rec.Relationships, calls...)
+		out[0].Relationships = append(out[0].Relationships, calls...)
+		// Issue #3527 — iteration meta-args (for_each / count).
+		applyIterationMeta(&out[0], body, src, path, lang, selfRef)
+		// Issue #3527 — terraform_remote_state cross-stack deps.
+		out[0].Relationships = append(out[0].Relationships, extractRemoteStateDeps(body, src, path, lang, selfRef)...)
+		// Issue #3527 — lifecycle / provisioner meta-blocks.
+		if meta := hasLifecycleMetaBlocks(body, src); len(meta) > 0 {
+			out[0].Metadata["meta_blocks"] = strings.Join(meta, ",")
+		}
+		// Issue #3527 — dynamic "x" {} nested blocks as child entities.
+		out = append(out, extractDynamicBlocks(body, src, path, lang, selfRef)...)
 	}
 
-	return []types.EntityRecord{rec}, true
+	return out, true
 }
 
 // extractDataBlock: data "type" "name" → SCOPE.Component / data_source
@@ -251,15 +263,20 @@ func extractDataBlock(n *sitter.Node, src []byte, path, lang string, start, end 
 	}
 
 	body := blockBody(n)
+	out := []types.EntityRecord{rec}
 	if body != nil {
 		deps := extractDependsOn(body, src, path, lang)
-		rec.Relationships = append(rec.Relationships, deps...)
+		out[0].Relationships = append(out[0].Relationships, deps...)
 		// Issue #387 — interpolation cross-references → CALLS edges.
 		calls := extractCalls(body, src, path, lang, selfRef, selfRef)
-		rec.Relationships = append(rec.Relationships, calls...)
+		out[0].Relationships = append(out[0].Relationships, calls...)
+		// Issue #3527 — iteration meta-args (for_each / count).
+		applyIterationMeta(&out[0], body, src, path, lang, selfRef)
+		// Issue #3527 — dynamic "x" {} nested blocks as child entities.
+		out = append(out, extractDynamicBlocks(body, src, path, lang, selfRef)...)
 	}
 
-	return []types.EntityRecord{rec}, true
+	return out, true
 }
 
 // extractModuleBlock: module "name" → SCOPE.Component / module
@@ -298,6 +315,14 @@ func extractModuleBlock(n *sitter.Node, src []byte, path, lang string, start, en
 		// Issue #387 — interpolation cross-references → CALLS edges.
 		calls := extractCalls(body, src, path, lang, selfRef, selfRef)
 		rec.Relationships = append(rec.Relationships, calls...)
+		// Issue #3527 — module I/O data-flow edges (module.this → module.x
+		// where an input arg consumes module.x's output).
+		rec.Relationships = append(rec.Relationships, extractModuleDataFlow(body, src, path, lang, selfRef)...)
+		// Issue #3527 — terraform_remote_state cross-stack deps consumed as
+		// module inputs.
+		rec.Relationships = append(rec.Relationships, extractRemoteStateDeps(body, src, path, lang, selfRef)...)
+		// Issue #3527 — iteration meta-args (for_each / count).
+		applyIterationMeta(&rec, body, src, path, lang, selfRef)
 	}
 
 	return []types.EntityRecord{rec}, true

--- a/internal/extractors/hcl/extractor_test.go
+++ b/internal/extractors/hcl/extractor_test.go
@@ -920,6 +920,8 @@ func TestTerraformFixtureZeroFalsePositives(t *testing.T) {
 		"resource": true, "data_source": true, "module": true,
 		"variable": true, "output": true, "provider": true,
 		"local": true, "file": true,
+		// Issue #3527 — deeper extraction adds these subtypes.
+		"terraform_settings": true, "dynamic_block": true,
 	}
 	for _, r := range records {
 		if r.Name == "" {

--- a/internal/extractors/hcl/relationships.go
+++ b/internal/extractors/hcl/relationships.go
@@ -319,8 +319,19 @@ func canonicalRefFromExpression(expr *sitter.Node, src []byte) string {
 		return "module." + parts[1]
 	case "data":
 		if len(parts) >= 3 {
+			// terraform_remote_state references are cross-stack and are
+			// handled separately as a special DEPENDS_ON edge, not a generic
+			// data-source CALLS edge.
+			if parts[1] == "terraform_remote_state" {
+				return ""
+			}
 			return "data." + parts[1] + "." + parts[2]
 		}
+		return ""
+	case "each", "count", "self":
+		// Iteration / self pseudo-references (each.value, each.key,
+		// count.index, self.*) are not entity references — they resolve
+		// within the surrounding resource set. Suppress the bogus CALLS edge.
 		return ""
 	default:
 		// Resource reference: <type>.<name>

--- a/internal/extractors/hcl/terraform_deep.go
+++ b/internal/extractors/hcl/terraform_deep.go
@@ -1,0 +1,516 @@
+package hcl
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ----------------------------------------------------------------
+// Issue #3527 — deeper Terraform/HCL extraction
+//
+// Adds, on top of the issue #387 baseline (resource/data/module/provider/
+// variable/output/locals + DEPENDS_ON/CALLS/CONTAINS/IMPORTS):
+//
+//   1. Iteration meta-args: for_each / count recognition on
+//      resource/data/module blocks. Records iteration mode in Metadata and
+//      emits a USES edge to the iteration source (e.g. var.instances). The
+//      each.* / count.* / self.* pseudo-references are suppressed (handled
+//      in canonicalRefFromExpression).
+//   2. dynamic "x" {} nested blocks: emitted as a child
+//      SCOPE.Component / dynamic_block entity (previously dropped by
+//      walkBody which only dispatches top-level blocks). Its own for_each
+//      meta-arg is recognised.
+//   3. Module I/O data-flow edges: a module input that consumes another
+//      module's output (vpc_id = module.net.vpc_id) emits a USES data-flow
+//      edge module.this → module.net tagged with the input argument name.
+//   4. terraform_remote_state: data.terraform_remote_state.X.outputs.Y
+//      consumption emits a cross-stack DEPENDS_ON edge (property
+//      cross_stack=true) to the remote-state data source, instead of being
+//      dropped as a generic data ref.
+//   5. terraform {} block: required_providers (provider+version) and
+//      backend (type) captured as a SCOPE.Component / terraform_settings
+//      entity carrying REQUIRES edges per provider, instead of being
+//      dropped. lifecycle / moved / import blocks recognised on resources.
+// ----------------------------------------------------------------
+
+// iterationMeta inspects a block body for for_each / count meta-args.
+// Returns the iteration mode ("for_each", "count", or "") and the canonical
+// reference name of the iteration source if it is an entity reference (e.g.
+// "var.instances", "local.subnets", "module.net"); srcRef is "" for literal
+// counts like `count = 2`.
+func iterationMeta(body *sitter.Node, src []byte) (mode, srcRef string) {
+	if body == nil {
+		return "", ""
+	}
+	for i := 0; i < int(body.ChildCount()); i++ {
+		attr := body.Child(i)
+		if attr == nil || attr.Type() != "attribute" {
+			continue
+		}
+		keyNode := firstChildByType(attr, "identifier")
+		if keyNode == nil {
+			continue
+		}
+		key := nodeText(keyNode, src)
+		if key != "for_each" && key != "count" {
+			continue
+		}
+		mode = key
+		// The first expression child holds the iteration source.
+		if expr := firstChildByType(attr, "expression"); expr != nil {
+			srcRef = canonicalRefFromExpression(expr, src)
+		}
+		return mode, srcRef
+	}
+	return "", ""
+}
+
+// applyIterationMeta records iteration metadata on a block entity and appends
+// a USES edge to the iteration source when it is a resolvable entity ref.
+func applyIterationMeta(rec *types.EntityRecord, body *sitter.Node, src []byte, path, lang, selfRef string) {
+	mode, srcRef := iterationMeta(body, src)
+	if mode == "" {
+		return
+	}
+	if rec.Metadata == nil {
+		rec.Metadata = map[string]interface{}{}
+	}
+	rec.Metadata["iteration"] = mode
+	if srcRef == "" {
+		return
+	}
+	rec.Metadata["iteration_source"] = srcRef
+	rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+		FromID: extractor.BuildOperationStructuralRef(lang, path, selfRef),
+		ToID:   extractor.BuildOperationStructuralRef(lang, path, srcRef),
+		Kind:   "USES",
+		Properties: map[string]string{
+			"dataflow":  "iteration",
+			"meta_arg":  mode,
+			"data_flow": "iteration_source",
+		},
+	})
+}
+
+// extractDynamicBlocks walks a block body and emits one
+// SCOPE.Component / dynamic_block entity per `dynamic "x" {}` nested block.
+// parentRef is the canonical reference of the enclosing block (used to scope
+// the dynamic block's name and to draw a CONTAINS edge). The dynamic block's
+// own for_each meta-arg is recognised and its content interpolations become
+// CALLS edges.
+func extractDynamicBlocks(body *sitter.Node, src []byte, path, lang, parentRef string) []types.EntityRecord {
+	if body == nil {
+		return nil
+	}
+	var out []types.EntityRecord
+	for i := 0; i < int(body.ChildCount()); i++ {
+		child := body.Child(i)
+		if child == nil || child.Type() != "block" {
+			continue
+		}
+		if blockTypeIdent(child, src) != "dynamic" {
+			continue
+		}
+		labels := blockLabels(child, src)
+		if len(labels) < 1 || labels[0] == "" {
+			continue
+		}
+		dynName := labels[0]
+		selfRef := parentRef + ".dynamic." + dynName
+		start, end := nodeLines(child)
+		rec := types.EntityRecord{
+			Name:         selfRef,
+			Kind:         "SCOPE.Component",
+			Subtype:      "dynamic_block",
+			SourceFile:   path,
+			StartLine:    start,
+			EndLine:      end,
+			Language:     lang,
+			QualityScore: 0.85,
+			Metadata: map[string]interface{}{
+				"subtype": "dynamic_block",
+				"label":   dynName,
+				"parent":  parentRef,
+			},
+		}
+		dynBody := blockBody(child)
+		if dynBody != nil {
+			// Iteration source of the dynamic block itself.
+			applyIterationMeta(&rec, dynBody, src, path, lang, selfRef)
+			// content {} interpolations → CALLS edges from the dynamic block.
+			calls := extractCalls(dynBody, src, path, lang, selfRef, selfRef)
+			rec.Relationships = append(rec.Relationships, calls...)
+		}
+		// CONTAINS edge parent → dynamic block.
+		rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+			FromID: extractor.BuildOperationStructuralRef(lang, path, parentRef),
+			ToID:   extractor.BuildOperationStructuralRef(lang, path, selfRef),
+			Kind:   "CONTAINS",
+			Properties: map[string]string{
+				"nested": "dynamic",
+			},
+		})
+		out = append(out, rec)
+	}
+	return out
+}
+
+// extractModuleDataFlow inspects a module block body for input arguments whose
+// value consumes another module's output (e.g. vpc_id = module.net.vpc_id) and
+// returns USES data-flow edges module.this → module.net, tagged with the input
+// argument name. This is the headline module-to-module wiring edge: it is
+// distinct from the generic CALLS edge (which only records the reference) by
+// carrying the consuming input arg in its properties.
+func extractModuleDataFlow(body *sitter.Node, src []byte, path, lang, selfRef string) []types.RelationshipRecord {
+	if body == nil {
+		return nil
+	}
+	var rels []types.RelationshipRecord
+	seen := map[string]struct{}{}
+	for i := 0; i < int(body.ChildCount()); i++ {
+		attr := body.Child(i)
+		if attr == nil || attr.Type() != "attribute" {
+			continue
+		}
+		keyNode := firstChildByType(attr, "identifier")
+		if keyNode == nil {
+			continue
+		}
+		argName := nodeText(keyNode, src)
+		if argName == "" || argName == "source" || argName == "version" {
+			continue
+		}
+		// Walk the attribute value expression for module.X references.
+		var walk func(n *sitter.Node)
+		walk = func(n *sitter.Node) {
+			if n == nil {
+				return
+			}
+			if n.Type() == "expression" {
+				if ref := canonicalRefFromExpression(n, src); strings.HasPrefix(ref, "module.") && ref != selfRef {
+					dedup := argName + "→" + ref
+					if _, ok := seen[dedup]; !ok {
+						seen[dedup] = struct{}{}
+						rels = append(rels, types.RelationshipRecord{
+							FromID: extractor.BuildOperationStructuralRef(lang, path, selfRef),
+							ToID:   extractor.BuildOperationStructuralRef(lang, path, ref),
+							Kind:   "USES",
+							Properties: map[string]string{
+								"dataflow":  "module_io",
+								"input_arg": argName,
+								"data_flow": "module_output",
+							},
+						})
+					}
+				}
+			}
+			for i := 0; i < int(n.ChildCount()); i++ {
+				walk(n.Child(i))
+			}
+		}
+		walk(attr)
+	}
+	return rels
+}
+
+// extractRemoteStateDeps scans a block body for
+// data.terraform_remote_state.<name>.outputs.<key> consumption and returns a
+// cross-stack DEPENDS_ON edge to the remote-state data source (one per distinct
+// remote-state name). These are deliberately NOT generic data-source CALLS
+// edges: they wire one Terraform stack to another stack's published outputs.
+func extractRemoteStateDeps(body *sitter.Node, src []byte, path, lang, fromRef string) []types.RelationshipRecord {
+	if body == nil {
+		return nil
+	}
+	var rels []types.RelationshipRecord
+	seen := map[string]struct{}{}
+
+	var walk func(n *sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "expression" {
+			if name := remoteStateName(n, src); name != "" {
+				if _, ok := seen[name]; !ok {
+					seen[name] = struct{}{}
+					target := "data.terraform_remote_state." + name
+					rels = append(rels, types.RelationshipRecord{
+						FromID: extractor.BuildOperationStructuralRef(lang, path, fromRef),
+						ToID:   extractor.BuildOperationStructuralRef(lang, path, target),
+						Kind:   "DEPENDS_ON",
+						Properties: map[string]string{
+							"cross_stack":  "true",
+							"remote_state": name,
+						},
+					})
+				}
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(body)
+	return rels
+}
+
+// remoteStateName returns the remote-state name if the expression is a
+// data.terraform_remote_state.<name>.* reference, else "".
+func remoteStateName(expr *sitter.Node, src []byte) string {
+	parts := referenceParts(expr, src)
+	if len(parts) >= 3 && parts[0] == "data" && parts[1] == "terraform_remote_state" {
+		return parts[2]
+	}
+	return ""
+}
+
+// referenceParts returns the dotted identifier parts of a reference expression
+// (variable_expr + get_attr chain). Shared shape with
+// canonicalRefFromExpression but returns the raw parts.
+func referenceParts(expr *sitter.Node, src []byte) []string {
+	if expr == nil {
+		return nil
+	}
+	var parts []string
+	for i := 0; i < int(expr.ChildCount()); i++ {
+		child := expr.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Type() {
+		case "variable_expr":
+			if id := firstChildByType(child, "identifier"); id != nil {
+				parts = append(parts, nodeText(id, src))
+			}
+		case "get_attr":
+			if id := firstChildByType(child, "identifier"); id != nil {
+				parts = append(parts, nodeText(id, src))
+			}
+		}
+	}
+	return parts
+}
+
+// ----------------------------------------------------------------
+// terraform {} settings block
+// ----------------------------------------------------------------
+
+// extractTerraformBlock turns a `terraform {}` settings block into a
+// SCOPE.Component / terraform_settings entity capturing required_providers
+// (provider source + version) and backend (type). Returns (record, true) when
+// the block carries at least one provider requirement or a backend; otherwise
+// (zero, false) so empty/version-only terraform blocks stay metadata-only.
+func extractTerraformBlock(n *sitter.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
+	body := blockBody(n)
+	if body == nil {
+		return nil, false
+	}
+
+	rec := types.EntityRecord{
+		Name:         "terraform.settings",
+		Kind:         "SCOPE.Component",
+		Subtype:      "terraform_settings",
+		SourceFile:   path,
+		StartLine:    start,
+		EndLine:      end,
+		Language:     lang,
+		QualityScore: 0.8,
+		Metadata:     map[string]interface{}{"subtype": "terraform_settings"},
+	}
+
+	var providers []string
+	hasContent := false
+
+	for i := 0; i < int(body.ChildCount()); i++ {
+		child := body.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Type() {
+		case "attribute":
+			keyNode := firstChildByType(child, "identifier")
+			if keyNode != nil && nodeText(keyNode, src) == "required_version" {
+				if v := extractStringFromAttr(child, src); v != "" {
+					rec.Metadata["required_version"] = v
+				}
+			}
+		case "block":
+			bt := blockTypeIdent(child, src)
+			switch bt {
+			case "required_providers":
+				rps := parseRequiredProviders(child, src)
+				for name, ver := range rps {
+					providers = append(providers, name)
+					hasContent = true
+					// IMPORTS edge per required provider; reuses the provider
+					// IMPORTS convention so the resolver binds the provider
+					// name through the same dynamic-pattern catalog.
+					rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+						FromID: extractor.BuildOperationStructuralRef(lang, path, "terraform.settings"),
+						ToID:   name,
+						Kind:   "IMPORTS",
+						Properties: map[string]string{
+							"import_kind":   "required_provider",
+							"source_module": name,
+							"imported_name": name,
+							"provider":      name,
+							"version":       ver,
+							"language":      lang,
+						},
+					})
+				}
+			case "backend":
+				labels := blockLabels(child, src)
+				if len(labels) >= 1 && labels[0] != "" {
+					rec.Metadata["backend"] = labels[0]
+					hasContent = true
+				}
+			}
+		}
+	}
+
+	if !hasContent {
+		return nil, false
+	}
+	if len(providers) > 0 {
+		rec.Metadata["required_providers"] = strings.Join(providers, ",")
+	}
+	return []types.EntityRecord{rec}, true
+}
+
+// parseRequiredProviders parses a `required_providers {}` block, returning a
+// map of provider-local-name → { source/version } collapsed to its version
+// string (empty when absent). It handles the object form:
+//
+//	aws = { source = "hashicorp/aws", version = "~> 5.0" }
+func parseRequiredProviders(block *sitter.Node, src []byte) map[string]string {
+	body := blockBody(block)
+	if body == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for i := 0; i < int(body.ChildCount()); i++ {
+		attr := body.Child(i)
+		if attr == nil || attr.Type() != "attribute" {
+			continue
+		}
+		keyNode := firstChildByType(attr, "identifier")
+		if keyNode == nil {
+			continue
+		}
+		name := nodeText(keyNode, src)
+		if name == "" {
+			continue
+		}
+		out[name] = objectAttrString(attr, "version", src)
+	}
+	return out
+}
+
+// objectAttrString finds `key = "..."` inside an attribute's object value and
+// returns the string literal, else "". Used for required_providers entries.
+func objectAttrString(attr *sitter.Node, key string, src []byte) string {
+	obj := findFirstByType(attr, "object")
+	if obj == nil {
+		return ""
+	}
+	for i := 0; i < int(obj.ChildCount()); i++ {
+		elem := obj.Child(i)
+		if elem == nil || elem.Type() != "object_elem" {
+			continue
+		}
+		// object_elem: expression(variable_expr identifier) = expression(...)
+		keyExpr := elem.Child(0)
+		if keyExpr == nil {
+			continue
+		}
+		if firstIdentText(keyExpr, src) != key {
+			continue
+		}
+		return firstTemplateLiteral(elem, src)
+	}
+	return ""
+}
+
+// firstIdentText returns the text of the first identifier descendant.
+func firstIdentText(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	if n.Type() == "identifier" {
+		return nodeText(n, src)
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if t := firstIdentText(n.Child(i), src); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// firstTemplateLiteral returns the first template_literal text under n, but
+// only after the `=` sign (i.e. the value side). Simpler: scan all
+// template_literal descendants and return the last one, which is the value in
+// an object_elem (key side is an identifier, not a string).
+func firstTemplateLiteral(n *sitter.Node, src []byte) string {
+	var found string
+	var walk func(x *sitter.Node)
+	walk = func(x *sitter.Node) {
+		if x == nil {
+			return
+		}
+		if x.Type() == "template_literal" {
+			found = nodeText(x, src)
+		}
+		for i := 0; i < int(x.ChildCount()); i++ {
+			walk(x.Child(i))
+		}
+	}
+	walk(n)
+	return found
+}
+
+// findFirstByType returns the first descendant (DFS) of n with the given type.
+func findFirstByType(n *sitter.Node, typ string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Type() == typ {
+		return n
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if r := findFirstByType(n.Child(i), typ); r != nil {
+			return r
+		}
+	}
+	return nil
+}
+
+// hasLifecycleMetaBlocks scans a resource body for lifecycle / moved / import
+// nested blocks and returns the list of recognised meta-block names. These are
+// recorded in resource Metadata so downstream consumers can see that a resource
+// declares lifecycle rules without us synthesising spurious entities.
+func hasLifecycleMetaBlocks(body *sitter.Node, src []byte) []string {
+	if body == nil {
+		return nil
+	}
+	var found []string
+	for i := 0; i < int(body.ChildCount()); i++ {
+		child := body.Child(i)
+		if child == nil || child.Type() != "block" {
+			continue
+		}
+		switch blockTypeIdent(child, src) {
+		case "lifecycle":
+			found = append(found, "lifecycle")
+		case "provisioner":
+			found = append(found, "provisioner")
+		}
+	}
+	return found
+}

--- a/internal/extractors/hcl/terraform_deep_test.go
+++ b/internal/extractors/hcl/terraform_deep_test.go
@@ -1,0 +1,262 @@
+package hcl_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ----------------------------------------------------------------
+// Issue #3527 — deeper Terraform extraction: value-asserting tests.
+//
+// The headline scenario: a config with for_each, a dynamic block, and two
+// modules where one passes module.net.vpc_id into the other. We assert the
+// concrete iteration recognition, the dynamic-block child entity, and the
+// module→module data-flow edge — not len()>0.
+// ----------------------------------------------------------------
+
+func sref(name string) string {
+	return extractor.BuildOperationStructuralRef("hcl", "main.tf", name)
+}
+
+func relExists(records []types.EntityRecord, kind, from, to string, propKey, propVal string) bool {
+	for _, r := range records {
+		for _, rel := range r.Relationships {
+			if rel.Kind != kind || rel.FromID != from || rel.ToID != to {
+				continue
+			}
+			if propKey == "" {
+				return true
+			}
+			if rel.Properties != nil && rel.Properties[propKey] == propVal {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestDeep_HeadlineScenario exercises iteration, dynamic blocks, and
+// module→module data flow in a single config.
+func TestDeep_HeadlineScenario(t *testing.T) {
+	src := `
+module "net" {
+  source = "./net"
+}
+
+module "app" {
+  source = "./app"
+  vpc_id = module.net.vpc_id
+}
+
+resource "aws_instance" "web" {
+  for_each = var.instances
+  ami      = each.value.ami
+
+  dynamic "ebs_block_device" {
+    for_each = var.volumes
+    content {
+      volume_size = ebs_block_device.value.size
+      kms_key     = aws_kms_key.disk.arn
+    }
+  }
+}
+`
+	records, err := extractHCL(src, "main.tf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// (1) Iteration recognition: the resource records for_each mode and emits
+	// a USES edge to var.instances (the iteration source).
+	web := findBySubtypeAndName(records, "resource", "web")
+	if web == nil {
+		t.Fatal("resource web not found")
+	}
+	if web.Metadata["iteration"] != "for_each" {
+		t.Errorf("expected iteration=for_each, got %v", web.Metadata["iteration"])
+	}
+	if web.Metadata["iteration_source"] != "var.instances" {
+		t.Errorf("expected iteration_source=var.instances, got %v", web.Metadata["iteration_source"])
+	}
+	if !relExists(records, "USES", sref("aws_instance.web"), sref("var.instances"), "dataflow", "iteration") {
+		t.Error("expected USES iteration-source edge aws_instance.web → var.instances")
+	}
+
+	// each.value.ami must NOT produce a bogus CALLS edge to each.value.
+	for _, rel := range collectRels(records, "CALLS") {
+		if rel.ToID == sref("each.value") {
+			t.Errorf("unexpected CALLS edge to each.value pseudo-ref: %+v", rel)
+		}
+	}
+
+	// (2) Dynamic block entity: the nested dynamic "ebs_block_device" block is
+	// emitted as a child SCOPE.Component / dynamic_block entity with its own
+	// for_each source, and a CONTAINS edge from the parent resource.
+	dyn := findBySubtypeAndName(records, "dynamic_block", "ebs_block_device")
+	if dyn == nil {
+		t.Fatal("dynamic_block ebs_block_device not found")
+	}
+	if dyn.Name != "aws_instance.web.dynamic.ebs_block_device" {
+		t.Errorf("unexpected dynamic block name: %s", dyn.Name)
+	}
+	if dyn.Metadata["iteration_source"] != "var.volumes" {
+		t.Errorf("expected dynamic block iteration_source=var.volumes, got %v", dyn.Metadata["iteration_source"])
+	}
+	if !relExists(records, "CONTAINS",
+		sref("aws_instance.web"),
+		sref("aws_instance.web.dynamic.ebs_block_device"), "nested", "dynamic") {
+		t.Error("expected CONTAINS edge resource → dynamic block")
+	}
+	// The dynamic block's content references aws_kms_key.disk → CALLS edge.
+	if !relExists(records, "CALLS",
+		sref("aws_instance.web.dynamic.ebs_block_device"),
+		sref("aws_kms_key.disk"), "", "") {
+		t.Error("expected CALLS edge from dynamic block to aws_kms_key.disk")
+	}
+
+	// (3) Module → module data-flow: module.app consumes module.net.vpc_id via
+	// its vpc_id input → a USES data-flow edge tagged with the input arg name.
+	if !relExists(records, "USES", sref("module.app"), sref("module.net"), "input_arg", "vpc_id") {
+		t.Errorf("expected module→module data-flow USES edge module.app → module.net (input_arg=vpc_id); got %+v",
+			collectRels(records, "USES"))
+	}
+}
+
+// TestDeep_CountIteration asserts count meta-arg recognition with a non-entity
+// (literal) source produces the mode but no USES edge.
+func TestDeep_CountIteration(t *testing.T) {
+	src := `
+resource "aws_instance" "n" {
+  count = 3
+  ami   = "ami-123"
+}
+`
+	records, err := extractHCL(src, "main.tf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := findBySubtypeAndName(records, "resource", "n")
+	if r == nil {
+		t.Fatal("resource n not found")
+	}
+	if r.Metadata["iteration"] != "count" {
+		t.Errorf("expected iteration=count, got %v", r.Metadata["iteration"])
+	}
+	// Literal count has no entity source → no iteration_source, no USES edge.
+	if _, ok := r.Metadata["iteration_source"]; ok {
+		t.Errorf("did not expect iteration_source for literal count, got %v", r.Metadata["iteration_source"])
+	}
+	for _, rel := range collectRels(records, "USES") {
+		if rel.Properties["dataflow"] == "iteration" {
+			t.Errorf("unexpected iteration USES edge for literal count: %+v", rel)
+		}
+	}
+}
+
+// TestDeep_RemoteStateCrossStack asserts that consuming
+// data.terraform_remote_state.X.outputs.Y emits a cross-stack DEPENDS_ON edge
+// (and NOT a generic data-source CALLS edge).
+func TestDeep_RemoteStateCrossStack(t *testing.T) {
+	src := `
+resource "aws_subnet" "s" {
+  vpc_id = data.terraform_remote_state.network.outputs.vpc_id
+}
+`
+	records, err := extractHCL(src, "main.tf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !relExists(records, "DEPENDS_ON",
+		sref("aws_subnet.s"),
+		sref("data.terraform_remote_state.network"), "cross_stack", "true") {
+		t.Errorf("expected cross-stack DEPENDS_ON edge to remote state; got DEPENDS_ON=%+v",
+			collectRels(records, "DEPENDS_ON"))
+	}
+	// Must NOT appear as a generic data CALLS edge.
+	for _, rel := range collectRels(records, "CALLS") {
+		if rel.ToID == sref("data.terraform_remote_state.network") {
+			t.Errorf("remote_state must not be a generic data CALLS edge: %+v", rel)
+		}
+	}
+}
+
+// TestDeep_TerraformBlockProviders asserts the terraform{} block is captured as
+// a terraform_settings entity with required_providers (version) + backend, and
+// emits an IMPORTS edge per required provider.
+func TestDeep_TerraformBlockProviders(t *testing.T) {
+	src := `
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  backend "s3" {
+    bucket = "my-state"
+  }
+}
+`
+	records, err := extractHCL(src, "main.tf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s := findBySubtypeAndName(records, "terraform_settings", "")
+	// label is empty; fall back to name lookup.
+	if s == nil {
+		for i := range records {
+			if records[i].Subtype == "terraform_settings" {
+				s = &records[i]
+				break
+			}
+		}
+	}
+	if s == nil {
+		t.Fatal("terraform_settings entity not found")
+	}
+	if s.Metadata["backend"] != "s3" {
+		t.Errorf("expected backend=s3, got %v", s.Metadata["backend"])
+	}
+	if s.Metadata["required_version"] != ">= 1.5" {
+		t.Errorf("expected required_version=\">= 1.5\", got %v", s.Metadata["required_version"])
+	}
+	// IMPORTS edge for aws provider carrying its version.
+	if !relExists(records, "IMPORTS",
+		sref("terraform.settings"), "aws", "import_kind", "required_provider") {
+		t.Errorf("expected IMPORTS required_provider edge for aws; got %+v", collectRels(records, "IMPORTS"))
+	}
+	awsVer := ""
+	for _, rel := range collectRels(records, "IMPORTS") {
+		if rel.ToID == "aws" && rel.Properties["import_kind"] == "required_provider" {
+			awsVer = rel.Properties["version"]
+		}
+	}
+	if awsVer != "~> 5.0" {
+		t.Errorf("expected aws provider version \"~> 5.0\", got %q", awsVer)
+	}
+}
+
+// TestDeep_TerraformBlockVersionOnlyNoEntity asserts a terraform{} block with
+// only required_version (no providers/backend) stays metadata-only.
+func TestDeep_TerraformBlockVersionOnlyNoEntity(t *testing.T) {
+	src := `
+terraform {
+  required_version = ">= 1.0"
+}
+`
+	records, err := extractHCL(src, "main.tf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range records {
+		if r.Subtype == "terraform_settings" {
+			t.Errorf("did not expect terraform_settings entity for version-only block, got %+v", r)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3527 (epic #3512).

Honest deepening of the Terraform/HCL extractor behind the existing `infra.iac.terraform` "full" stamp. Previously the walker only dispatched top-level blocks and dropped `terraform{}`, `dynamic{}`, and iteration/data-flow semantics entirely.

## Now handled

**1. Iteration meta-args (`for_each` / `count`)** — recognized on resource / data / module blocks. Records `Metadata.iteration` (+`iteration_source`) and emits a `USES` edge (`dataflow=iteration`) to the iteration source ref (e.g. `var.instances`). Literal `count = 2` records the mode but emits no edge. The `each.*` / `count.*` / `self.*` pseudo-references that previously produced bogus `CALLS` edges (e.g. `each.value`) are now suppressed.

**2. Module I/O data-flow edges (headline)** — a module input that consumes another module's output (`vpc_id = module.net.vpc_id`) emits a `USES` data-flow edge `module.this → module.net` tagged with the consuming `input_arg`. Distinct from the generic interpolation `CALLS` edge.

**3. terraform_remote_state cross-stack deps** — `data.terraform_remote_state.X.outputs.Y` consumption emits a cross-stack `DEPENDS_ON` edge (`cross_stack=true`) to the remote-state data source, instead of being recorded as a generic data-source `CALLS` edge.

**4. `dynamic "x" {}` nested blocks** — emitted as child `SCOPE.Component / dynamic_block` entities (previously dropped by the top-level-only `walkBody`), each carrying a `CONTAINS` edge from its parent resource, its own `for_each` iteration source, and `CALLS` edges for its `content {}` interpolations.

**5. `terraform {}` settings block** — `required_providers` (per-provider `IMPORTS` edge with `import_kind=required_provider` + version), `backend` type, and `required_version` captured as a `SCOPE.Component / terraform_settings` entity instead of being dropped. Version-only `terraform{}` blocks stay metadata-only (no entity). `lifecycle` / `provisioner` meta-blocks recorded in resource `Metadata.meta_blocks`.

## Tests
Value-asserting (`terraform_deep_test.go`), not `len>0`: the headline scenario (one config with `for_each`, a `dynamic` block, and two modules where `module.app` passes `module.net.vpc_id`) asserts the exact iteration-source edge, the `dynamic_block` child entity + its `CONTAINS` edge + its content `CALLS`, and the `module → module` data-flow edge; plus dedicated count / remote-state / `terraform{}` provider+backend / version-only-no-entity cases. All existing hcl tests pass unchanged (only the `validSubtypes` allowlist gained `terraform_settings` + `dynamic_block`).

`go test ./internal/extractors/hcl/ ./internal/engine/ ./internal/types/ ./tools/coverage/` green; `gofmt -l` empty; `go vet` clean; coverage `validate` 0 errors; registry `fmt --check` canonical.

## Remaining honest gaps
- Module input → child module `variable` binding is resolved only as intra-file `CALLS`; cross-module-file output/variable resolution is not wired (needs multi-file module resolution).
- `moved` / `import` blocks are not yet emitted as rename/adopt edges.
- `required_providers` captures version only; source registry host not modeled as a distinct edge.

## DEPLOY-DEFERRED
Extractor + registry changes only. No live-daemon rebuild/reindex performed (strict isolation). Requires a coordinated daemon rebuild + reindex to take effect on indexed groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)