### PR TITLE
feat(cpp): grpc++ / Protobuf / nlohmann-json framework coverage (#3510)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 189 records · **C/C++**: 17 · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 14 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 13 · **scala**: 11 · **swift**: 1
+**Total**: 191 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 9 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 14 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 13 · **scala**: 11 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -227,6 +227,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🟡 2/21 | 🟡 3/4 | |
+| [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🟡 2/21 | 🟢 4/4 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | 🟢 21/21 | 🟢 4/4 | |
 | [JS/TS](../by-language/jsts.md) | [GraphQL Resolvers (Apollo Server / GraphQL Yoga / etc.)](../detail/lang.jsts.framework.graphql-resolvers.md) | 🟢 21/21 | ✅ 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [tRPC](../detail/lang.jsts.framework.trpc.md) | 🟢 21/21 | ✅ 4/4 | |

--- a/docs/coverage/by-category/validation.md
+++ b/docs/coverage/by-category/validation.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # validation
 
-**Total**: 4 records · **java**: 1 · **python**: 3
+**Total**: 5 records · **C/C++**: 1 · **java**: 1 · **python**: 3
 
 Back to [summary](../summary.md). Bucket: **Other**.
 

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # C/C++
 
-**Frameworks**: 17 · **Tools**: 16 · **ORMs**: 7 · **Other**: 0
+**Frameworks**: 19 · **Tools**: 16 · **ORMs**: 7 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -57,6 +57,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | 🟢 10/10 | 🟢 2/2 | |
 
 
+### RPC Framework
+
+| Name | Substrate | Other capabilities | Notes |
+|---|---|---|---|
+| [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🟡 2/21 | 🟡 3/4 | |
+| [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | 🟡 2/21 | 🟢 4/4 | |
+
+
 ## Tools
 
 | Name | Dependency graph | Lockfile parsing | Manifest parsing | Target extraction | Notes |
@@ -92,3 +100,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [mongocxx](../detail/lang.c-cpp.driver.mongocxx.md) | 🟢 3/3 | |
 | [redis-plus-plus](../detail/lang.c-cpp.driver.redis-plus-plus.md) | ✅ 1/1 | |
 | [sqlpp11](../detail/lang.c-cpp.orm.sqlpp11.md) | ✅ 3/3 | |
+
+
+## Other
+
+
+### Validation
+
+| Name | Testing | Other capabilities | Notes |
+|---|---|---|---|
+| [nlohmann/json (C++)](../detail/lang.c-cpp.framework.nlohmann-json.md) | ✅ 1/1 | 🟡 3/5 | |

--- a/docs/coverage/detail/lang.c-cpp.framework.grpc.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.grpc.md
@@ -1,0 +1,67 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.c-cpp.framework.grpc` — gRPC C++ (grpc++)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C/C++](../by-language/c-cpp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** RPC Framework
+- **Capability cells:** 25
+
+## Capabilities
+
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Procedure extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | each overridden Status RPC method -> SCOPE.Operation endpoint |
+| Schema extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | req/resp messages emitted as SCOPE.Schema DTO refs (names only) |
+
+### Codegen
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Client codegen | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | Service::NewStub(channel) client-stub site detected |
+
+### Transport
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transport binding | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | RPC endpoint synthesis from service-impl override methods + RegisterService; regex, no AST |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | request message type name from RPC method args; field shapes are protoc-generated |
+| Response shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc.go`<br>`internal/custom/cpp/grpc_protobuf_test.go` | response message type name from RPC method args; field shapes are protoc-generated |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.c-cpp.framework.grpc ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.c-cpp.framework.nlohmann-json.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.nlohmann-json.md
@@ -1,0 +1,48 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.c-cpp.framework.nlohmann-json` — nlohmann/json (C++)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C/C++](../by-language/c-cpp.md)
+- **Category:** [validation](../by-category/validation.md)
+- **Subcategory:** Validation
+- **Capability cells:** 6
+
+## Capabilities
+
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Nested model extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/nlohmann_json.go` | to_json/from_json free-function pairs bind a struct type as serialize/deserialize/bidirectional; nested member C++ types not resolved |
+| Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/nlohmann_json.go` | NLOHMANN_DEFINE_TYPE(_INTRUSIVE/_NON_INTRUSIVE/_WITH_DEFAULT) -> SCOPE.Schema DTO + per-member field entities; member list is the serialization contract |
+
+### Constraints
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Constraint extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Custom validator extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Coercion
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type coercion recognition | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/nlohmann_json.go` | serialization_direction (to_json/from_json) recorded; field C++ types declared in struct body, not resolved here |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/nlohmann_json.go` | value-asserting fixtures assert DTO + exact field list + macro variant + free-function direction |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.c-cpp.framework.nlohmann-json ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.protobuf.md
@@ -1,0 +1,67 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.c-cpp.framework.protobuf` — Protocol Buffers (C++)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C/C++](../by-language/c-cpp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** RPC Framework
+- **Capability cells:** 25
+
+## Capabilities
+
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Procedure extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | each .proto rpc -> SCOPE.Operation endpoint /<Service>/<Method> |
+| Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | .proto messages+fields fully parsed (name/type/number/label); generated .pb.h message classes recovered by name |
+
+### Codegen
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Client codegen | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Transport
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transport binding | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | .proto service+rpc -> SCOPE.Service + RPC SCOPE.Operation endpoints with streaming kind |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | rpc request message names from .proto service rpc decls |
+| Response shape extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/cpp/grpc_protobuf_test.go`<br>`internal/custom/cpp/protobuf.go` | rpc response message names from .proto service rpc decls |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.c-cpp.framework.protobuf ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -3251,6 +3251,141 @@
       }
     },
     {
+      "id": "lang.c-cpp.framework.grpc",
+      "category": "http_framework",
+      "subcategory": "rpc_framework",
+      "language": "c-cpp",
+      "label": "gRPC C++ (grpc++)",
+      "capabilities": {
+        "Schema": {
+          "procedure_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc.go","internal/custom/cpp/grpc_protobuf_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "each overridden Status RPC method -\u003e SCOPE.Operation endpoint",
+            "verified_at": "2026-05-30"
+          },
+          "schema_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc.go","internal/custom/cpp/grpc_protobuf_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "req/resp messages emitted as SCOPE.Schema DTO refs (names only)",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Codegen": {
+          "client_codegen": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc.go","internal/custom/cpp/grpc_protobuf_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Service::NewStub(channel) client-stub site detected",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Transport": {
+          "transport_binding": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc.go","internal/custom/cpp/grpc_protobuf_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "RPC endpoint synthesis from service-impl override methods + RegisterService; regex, no AST",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc.go","internal/custom/cpp/grpc_protobuf_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "request message type name from RPC method args; field shapes are protoc-generated",
+            "verified_at": "2026-05-30"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc.go","internal/custom/cpp/grpc_protobuf_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "response message type name from RPC method args; field shapes are protoc-generated",
+            "verified_at": "2026-05-30"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.c-cpp.framework.libev",
       "category": "http_framework",
       "subcategory": "http_backend",
@@ -3876,6 +4011,57 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_c_cpp.go"],
             "verified_at": "2026-05-28"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.c-cpp.framework.nlohmann-json",
+      "category": "validation",
+      "subcategory": "validation_lib",
+      "language": "c-cpp",
+      "label": "nlohmann/json (C++)",
+      "capabilities": {
+        "Schema": {
+          "nested_model_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/nlohmann_json.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "to_json/from_json free-function pairs bind a struct type as serialize/deserialize/bidirectional; nested member C++ types not resolved",
+            "verified_at": "2026-05-30"
+          },
+          "schema_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/nlohmann_json.go"],
+            "notes": "NLOHMANN_DEFINE_TYPE(_INTRUSIVE/_NON_INTRUSIVE/_WITH_DEFAULT) -\u003e SCOPE.Schema DTO + per-member field entities; member list is the serialization contract",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Constraints": {
+          "constraint_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "custom_validator_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Coercion": {
+          "type_coercion_recognition": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/nlohmann_json.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "serialization_direction (to_json/from_json) recorded; field C++ types declared in struct body, not resolved here",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "full",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/nlohmann_json.go"],
+            "notes": "value-asserting fixtures assert DTO + exact field list + macro variant + free-function direction",
+            "verified_at": "2026-05-30"
           }
         }
       }
@@ -4532,6 +4718,137 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_c_cpp.go"],
             "verified_at": "2026-05-28"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.c-cpp.framework.protobuf",
+      "category": "http_framework",
+      "subcategory": "rpc_framework",
+      "language": "c-cpp",
+      "label": "Protocol Buffers (C++)",
+      "capabilities": {
+        "Schema": {
+          "procedure_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/protobuf.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "each .proto rpc -\u003e SCOPE.Operation endpoint /\u003cService\u003e/\u003cMethod\u003e",
+            "verified_at": "2026-05-30"
+          },
+          "schema_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/protobuf.go"],
+            "notes": ".proto messages+fields fully parsed (name/type/number/label); generated .pb.h message classes recovered by name",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Codegen": {
+          "client_codegen": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transport": {
+          "transport_binding": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/protobuf.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": ".proto service+rpc -\u003e SCOPE.Service + RPC SCOPE.Operation endpoints with streaming kind",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/protobuf.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "rpc request message names from .proto service rpc decls",
+            "verified_at": "2026-05-30"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/cpp/grpc_protobuf_test.go","internal/custom/cpp/protobuf.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "rpc response message names from .proto service rpc decls",
+            "verified_at": "2026-05-30"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 189 · **ORMs**: 151 · **Tools**: 110 · **Other**: 114
+**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 191 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
 
 ## Coverage by language
 
@@ -9,8 +9,8 @@
 |---|---:|---:|---:|---:|
 | [JS/TS](by-language/jsts.md) | 30 | 21 | 18 | 2 |
 | [python](by-language/python.md) | 21 | 15 | 17 | 6 |
+| [C/C++](by-language/c-cpp.md) | 19 | 16 | 7 | 1 |
 | [java](by-language/java.md) | 19 | 10 | 14 | 3 |
-| [C/C++](by-language/c-cpp.md) | 17 | 16 | 7 | 0 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
 | [kotlin](by-language/kotlin.md) | 14 | 0 | 7 | 0 |
@@ -66,4 +66,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 189 frameworks · 110 tools · 151 ORMs · 114 other
+Total: 191 frameworks · 110 tools · 151 ORMs · 115 other

--- a/internal/custom/cpp/grpc.go
+++ b/internal/custom/cpp/grpc.go
@@ -1,0 +1,397 @@
+package cpp
+
+// grpc.go — gRPC C++ (grpc++) service / RPC extractor.
+//
+// A gRPC C++ service is implemented by subclassing the generated
+// `<Service>::Service` base and overriding each RPC method. The method
+// signature carries the request and response message types:
+//
+//	class GreeterServiceImpl final : public Greeter::Service {
+//	    Status SayHello(ServerContext* ctx,
+//	                    const HelloRequest* req,
+//	                    HelloReply* resp) override { ... }
+//	};
+//
+//	ServerBuilder builder;
+//	builder.RegisterService(&service);              // registration
+//
+//	auto stub = Greeter::NewStub(channel);          // client stub
+//	stub->SayHello(&context, request, &reply);
+//
+// Each overridden RPC method maps to a synthetic endpoint with verb RPC and the
+// canonical gRPC path /<Service>/<Method>. The request/response message types
+// are emitted as SCOPE.Schema DTO references. `RegisterService(&svc)` is the
+// registration site; `<Service>::NewStub(channel)` is the client-stub site.
+//
+// Streaming variants are recognised via the gRPC reader/writer stream argument
+// types (ServerWriter / ServerReader / ServerReaderWriter), and the streaming
+// kind is stamped on the endpoint.
+//
+// HONEST LIMIT: the service base trait and the message structs are emitted by
+// protoc into *.pb.h / *.grpc.pb.h. We recover the service name, method names,
+// and request/response message *names* from the hand-written service impl and
+// the stub call sites; full message field shapes live in the generated structs
+// (covered by the protobuf extractor when those headers are present). Hence
+// shape-extraction cells are honest-partial.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_grpc", &cppGrpcExtractor{})
+}
+
+type cppGrpcExtractor struct{}
+
+func (e *cppGrpcExtractor) Language() string { return "custom_cpp_grpc" }
+
+var (
+	// class Foo final : public Greeter::Service { ... }
+	// class Foo : public package::Greeter::Service { ... }
+	// Capture group 1 = impl class name, group 2 = fully-qualified service base
+	// (e.g. "Greeter::Service" or "routeguide::RouteGuide::Service").
+	reCppGrpcServiceImpl = regexp.MustCompile(
+		`(?m)\bclass\s+([A-Za-z_]\w*)\b[^{;]*?:\s*(?:public\s+)?([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*::Service)\b`,
+	)
+
+	// An overridden RPC method inside the service impl body. gRPC RPC methods
+	// return `Status` (grpc::Status) and end with `override`. Captures:
+	//   1 = method name
+	//   2 = full argument list (parsed further for req/resp/stream types)
+	reCppGrpcRpcMethod = regexp.MustCompile(
+		`(?m)\b(?:::grpc::|grpc::)?Status\s+([A-Za-z_]\w*)\s*\(([^;{]*?)\)\s*override\b`,
+	)
+
+	// builder.RegisterService(&service) / RegisterService(&svc)
+	// Capture group 1 = the registered service variable.
+	reCppGrpcRegisterService = regexp.MustCompile(
+		`(?m)\bRegisterService\s*\(\s*&?\s*([A-Za-z_]\w*)\b`,
+	)
+
+	// Greeter::NewStub(channel) / package::Greeter::NewStub(channel)
+	// Capture group 1 = fully-qualified service (strip trailing ::NewStub).
+	reCppGrpcNewStub = regexp.MustCompile(
+		`(?m)\b([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)::NewStub\s*\(`,
+	)
+
+	// A `const Foo* name` / `Foo* name` / `const Foo& name` request-or-response
+	// argument inside the RPC arg list. Captures the bare message type name.
+	reCppGrpcMsgArg = regexp.MustCompile(
+		`(?:const\s+)?([A-Za-z_]\w*)\s*[*&]\s*[A-Za-z_]\w*`,
+	)
+
+	// Streaming stream-arg type: ServerWriter<T> / ServerReader<T> /
+	// ServerReaderWriter<W,R>. Captures the writer/reader kind (group 1).
+	reCppGrpcStreamArg = regexp.MustCompile(
+		`(?:::grpc::|grpc::)?(ServerReaderWriter|ServerWriter|ServerReader)\s*<`,
+	)
+)
+
+func (e *cppGrpcExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpp_grpc.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "grpc++"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "cpp" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// File-signal gate: require a gRPC marker so the extractor is a no-op on
+	// non-gRPC C++ files.
+	if !strings.Contains(src, "::Service") &&
+		!strings.Contains(src, "RegisterService") &&
+		!strings.Contains(src, "NewStub") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Service impl class -> one RPC endpoint per overridden method.
+	for _, m := range reCppGrpcServiceImpl.FindAllStringSubmatchIndex(src, -1) {
+		implClass := src[m[2]:m[3]]
+		serviceBase := src[m[4]:m[5]]
+		// "pkg::Greeter::Service" -> service "Greeter".
+		service := cppGrpcServiceName(serviceBase)
+
+		bodyStart, bodyEnd := cppBraceBody(src, m[1])
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+
+		for _, rm := range reCppGrpcRpcMethod.FindAllStringSubmatchIndex(body, -1) {
+			method := body[rm[2]:rm[3]]
+			argList := body[rm[4]:rm[5]]
+			methodOff := bodyStart + rm[0]
+
+			reqType, respType, streamKind := cppGrpcParseArgs(argList)
+
+			path := "/" + service + "/" + method
+			name := "RPC " + path
+			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, methodOff))
+			setProps(&ent, "framework", "grpc++",
+				"provenance", "INFERRED_FROM_GRPC_RPC",
+				"http_method", "RPC", "verb", "RPC",
+				"route_path", path, "rpc_protocol", "grpc",
+				"grpc_service", service, "grpc_method", method,
+				"impl_type", implClass,
+				"handler_name", implClass+"."+method)
+			if reqType != "" {
+				setProps(&ent, "request_message", reqType)
+			}
+			if respType != "" {
+				setProps(&ent, "response_message", respType)
+			}
+			if streamKind != "" {
+				setProps(&ent, "streaming", streamKind)
+			}
+			add(ent)
+
+			if reqType != "" {
+				cppGrpcAddDTO(add, reqType, "request", file, lineOf(src, methodOff))
+			}
+			if respType != "" {
+				cppGrpcAddDTO(add, respType, "response", file, lineOf(src, methodOff))
+			}
+		}
+	}
+
+	// 2. RegisterService(&svc) -> SCOPE.Service registration.
+	for _, m := range reCppGrpcRegisterService.FindAllStringSubmatchIndex(src, -1) {
+		svcVar := src[m[2]:m[3]]
+		ent := makeEntity("grpc_service:"+svcVar, "SCOPE.Service", "grpc_service", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "grpc++",
+			"provenance", "INFERRED_FROM_GRPC_REGISTER_SERVICE",
+			"service_var", svcVar, "registration", "RegisterService")
+		add(ent)
+	}
+
+	// 3. <Service>::NewStub(channel) -> client stub site.
+	for _, m := range reCppGrpcNewStub.FindAllStringSubmatchIndex(src, -1) {
+		qualified := src[m[2]:m[3]]
+		service := cppGrpcLastSegment(qualified)
+		ent := makeEntity("grpc_stub:"+service, "SCOPE.Service", "grpc_stub", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "grpc++",
+			"provenance", "INFERRED_FROM_GRPC_NEW_STUB",
+			"grpc_service", service, "client_role", "stub")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// cppGrpcServiceName turns a fully-qualified "pkg::Greeter::Service" base into
+// the bare service name "Greeter".
+func cppGrpcServiceName(base string) string {
+	base = strings.TrimSuffix(base, "::Service")
+	return cppGrpcLastSegment(base)
+}
+
+// cppGrpcLastSegment returns the final ::-separated identifier.
+func cppGrpcLastSegment(s string) string {
+	if idx := strings.LastIndex(s, "::"); idx >= 0 {
+		return s[idx+2:]
+	}
+	return s
+}
+
+// cppGrpcParseArgs parses an RPC method argument list and returns the request
+// message type, response message type, and (for streaming RPCs) the stream
+// kind. The gRPC C++ unary signature is:
+//
+//	(ServerContext* ctx, const Req* request, Resp* response)
+//
+// Streaming forms substitute a ServerWriter<Resp> / ServerReader<Req> /
+// ServerReaderWriter<Resp,Req> for one of the message args.
+func cppGrpcParseArgs(argList string) (reqType, respType, streamKind string) {
+	args := cppGrpcSplitArgs(argList)
+	// Drop the leading ServerContext* (or grpc::ServerContext*) argument.
+	var msgArgs []string
+	for _, a := range args {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if strings.Contains(a, "ServerContext") || strings.Contains(a, "ClientContext") {
+			continue
+		}
+		msgArgs = append(msgArgs, a)
+	}
+
+	for _, a := range msgArgs {
+		if sm := reCppGrpcStreamArg.FindStringSubmatch(a); sm != nil {
+			kind := sm[1]
+			streamKind = cppGrpcStreamKind(kind)
+			// Extract the streamed message type(s) from the angle brackets.
+			inner := cppGrpcAngleInner(a)
+			parts := strings.Split(inner, ",")
+			switch kind {
+			case "ServerWriter":
+				// server-streaming: response messages flow out.
+				if len(parts) >= 1 {
+					respType = cppGrpcBareType(parts[0])
+				}
+			case "ServerReader":
+				// client-streaming: request messages flow in.
+				if len(parts) >= 1 {
+					reqType = cppGrpcBareType(parts[0])
+				}
+			case "ServerReaderWriter":
+				// bidi: <Response, Request>.
+				if len(parts) >= 1 {
+					respType = cppGrpcBareType(parts[0])
+				}
+				if len(parts) >= 2 {
+					reqType = cppGrpcBareType(parts[1])
+				}
+			}
+			continue
+		}
+		// Plain message pointer/reference arg.
+		isConst := strings.Contains(a, "const")
+		if sm := reCppGrpcMsgArg.FindStringSubmatch(a); sm != nil {
+			t := sm[1]
+			if isConst && reqType == "" {
+				reqType = t
+			} else if !isConst && respType == "" {
+				respType = t
+			} else if reqType == "" {
+				reqType = t
+			} else if respType == "" {
+				respType = t
+			}
+		}
+	}
+	return reqType, respType, streamKind
+}
+
+// cppGrpcStreamKind maps a gRPC stream-arg type to a canonical streaming label.
+func cppGrpcStreamKind(kind string) string {
+	switch kind {
+	case "ServerWriter":
+		return "server_streaming"
+	case "ServerReader":
+		return "client_streaming"
+	case "ServerReaderWriter":
+		return "bidi_streaming"
+	}
+	return ""
+}
+
+// cppGrpcAngleInner returns the text between the first '<' and its matching '>'.
+func cppGrpcAngleInner(s string) string {
+	open := strings.IndexByte(s, '<')
+	if open < 0 {
+		return ""
+	}
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '<':
+			depth++
+		case '>':
+			depth--
+			if depth == 0 {
+				return s[open+1 : i]
+			}
+		}
+	}
+	return s[open+1:]
+}
+
+// cppGrpcBareType strips namespace qualifiers / whitespace from a type token,
+// returning the final identifier (e.g. " routeguide::Point " -> "Point").
+func cppGrpcBareType(s string) string {
+	s = strings.TrimSpace(s)
+	// Strip any pointer/ref decorations.
+	s = strings.TrimRight(s, "*& \t")
+	return cppGrpcLastSegment(s)
+}
+
+// cppGrpcSplitArgs splits a C++ argument list on top-level commas (ignoring
+// commas nested inside <...> template brackets).
+func cppGrpcSplitArgs(s string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '<', '(':
+			depth++
+		case '>', ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
+// cppGrpcAddDTO emits a SCOPE.Schema DTO reference for a gRPC message type.
+func cppGrpcAddDTO(add func(types.EntityRecord), msg, role string, file extractor.FileInput, line int) {
+	if msg == "" {
+		return
+	}
+	ent := makeEntity("grpc_dto:"+msg, "SCOPE.Schema", "dto", file.Path, file.Language, line)
+	setProps(&ent, "framework", "grpc++",
+		"provenance", "INFERRED_FROM_GRPC_MESSAGE",
+		"dto_name", msg, "grpc_message_role", role, "rpc_protocol", "grpc")
+	add(ent)
+}
+
+// cppBraceBody returns the byte range [start,end) of the brace-balanced body
+// beginning at the '{' that follows headerEnd. Returns (-1,-1) when no opening
+// brace is found.
+func cppBraceBody(src string, headerEnd int) (int, int) {
+	open := strings.IndexByte(src[headerEnd:], '{')
+	if open < 0 {
+		return -1, -1
+	}
+	open += headerEnd
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return open + 1, i
+			}
+		}
+	}
+	return -1, -1
+}

--- a/internal/custom/cpp/grpc_protobuf_test.go
+++ b/internal/custom/cpp/grpc_protobuf_test.go
@@ -1,0 +1,372 @@
+package cpp_test
+
+// grpc_protobuf_test.go — value-asserting fixture tests for the gRPC C++
+// (grpc++), Protocol Buffers, and nlohmann/json DTO extractors (#3510).
+//
+// Each test asserts concrete extracted values (service + method names, RPC
+// paths, request/response DTO type names, registration sites, proto fields,
+// nlohmann field lists) — never len>0.
+
+import "testing"
+
+// propOf returns the value of prop key on the first entity matching kind+name,
+// failing the test if no such entity exists.
+func propOf(t *testing.T, ents []entitySummary, kind, name, key string) string {
+	t.Helper()
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return ents[i].Props[key]
+		}
+	}
+	t.Fatalf("no %s entity named %q (got %+v)", kind, name, ents)
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// grpc++ — service impl, RPC methods, req/resp DTOs, registration, client stub
+// ---------------------------------------------------------------------------
+
+func TestGrpcUnaryService(t *testing.T) {
+	src := `
+#include <grpcpp/grpcpp.h>
+#include "helloworld.grpc.pb.h"
+
+class GreeterServiceImpl final : public Greeter::Service {
+    Status SayHello(ServerContext* context,
+                    const HelloRequest* request,
+                    HelloReply* reply) override {
+        reply->set_message("Hello " + request->name());
+        return Status::OK;
+    }
+};
+`
+	ents := extract(t, "custom_cpp_grpc", fi("greeter.cc", "cpp", src))
+
+	// Endpoint: RPC /Greeter/SayHello
+	ep := findEndpoint(ents, "RPC /Greeter/SayHello")
+	if ep == nil {
+		t.Fatalf("expected RPC /Greeter/SayHello endpoint, got %+v", ents)
+	}
+	if got := ep.Props["grpc_service"]; got != "Greeter" {
+		t.Errorf("grpc_service = %q, want Greeter", got)
+	}
+	if got := ep.Props["grpc_method"]; got != "SayHello" {
+		t.Errorf("grpc_method = %q, want SayHello", got)
+	}
+	if got := ep.Props["request_message"]; got != "HelloRequest" {
+		t.Errorf("request_message = %q, want HelloRequest", got)
+	}
+	if got := ep.Props["response_message"]; got != "HelloReply" {
+		t.Errorf("response_message = %q, want HelloReply", got)
+	}
+	if got := ep.Props["handler_name"]; got != "GreeterServiceImpl.SayHello" {
+		t.Errorf("handler_name = %q, want GreeterServiceImpl.SayHello", got)
+	}
+
+	// Request/response DTOs.
+	if !containsEntity(ents, "SCOPE.Schema", "grpc_dto:HelloRequest") {
+		t.Error("expected grpc_dto:HelloRequest DTO")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "grpc_dto:HelloReply") {
+		t.Error("expected grpc_dto:HelloReply DTO")
+	}
+	if r := propOf(t, ents, "SCOPE.Schema", "grpc_dto:HelloRequest", "grpc_message_role"); r != "request" {
+		t.Errorf("HelloRequest role = %q, want request", r)
+	}
+}
+
+func TestGrpcQualifiedServiceBase(t *testing.T) {
+	src := `
+class RouteGuideImpl final : public routeguide::RouteGuide::Service {
+    Status GetFeature(ServerContext* ctx, const Point* point, Feature* feature) override {
+        return Status::OK;
+    }
+};
+`
+	ents := extract(t, "custom_cpp_grpc", fi("route.cc", "cpp", src))
+	ep := findEndpoint(ents, "RPC /RouteGuide/GetFeature")
+	if ep == nil {
+		t.Fatalf("expected RPC /RouteGuide/GetFeature, got %+v", ents)
+	}
+	if got := ep.Props["request_message"]; got != "Point" {
+		t.Errorf("request_message = %q, want Point", got)
+	}
+	if got := ep.Props["response_message"]; got != "Feature" {
+		t.Errorf("response_message = %q, want Feature", got)
+	}
+}
+
+func TestGrpcServerStreaming(t *testing.T) {
+	src := `
+class RouteGuideImpl final : public RouteGuide::Service {
+    Status ListFeatures(ServerContext* ctx, const Rectangle* rect,
+                        ServerWriter<Feature>* writer) override {
+        return Status::OK;
+    }
+};
+`
+	ents := extract(t, "custom_cpp_grpc", fi("route.cc", "cpp", src))
+	ep := findEndpoint(ents, "RPC /RouteGuide/ListFeatures")
+	if ep == nil {
+		t.Fatalf("expected RPC /RouteGuide/ListFeatures, got %+v", ents)
+	}
+	if got := ep.Props["streaming"]; got != "server_streaming" {
+		t.Errorf("streaming = %q, want server_streaming", got)
+	}
+	if got := ep.Props["request_message"]; got != "Rectangle" {
+		t.Errorf("request_message = %q, want Rectangle", got)
+	}
+	if got := ep.Props["response_message"]; got != "Feature" {
+		t.Errorf("response_message = %q, want Feature", got)
+	}
+}
+
+func TestGrpcBidiStreaming(t *testing.T) {
+	src := `
+class RouteGuideImpl final : public RouteGuide::Service {
+    Status RouteChat(ServerContext* ctx,
+                     ServerReaderWriter<RouteNote, RouteNote>* stream) override {
+        return Status::OK;
+    }
+};
+`
+	ents := extract(t, "custom_cpp_grpc", fi("route.cc", "cpp", src))
+	ep := findEndpoint(ents, "RPC /RouteGuide/RouteChat")
+	if ep == nil {
+		t.Fatalf("expected RPC /RouteGuide/RouteChat, got %+v", ents)
+	}
+	if got := ep.Props["streaming"]; got != "bidi_streaming" {
+		t.Errorf("streaming = %q, want bidi_streaming", got)
+	}
+}
+
+func TestGrpcRegisterServiceAndStub(t *testing.T) {
+	src := `
+void RunServer() {
+    GreeterServiceImpl service;
+    ServerBuilder builder;
+    builder.RegisterService(&service);
+    auto stub = Greeter::NewStub(channel);
+}
+`
+	ents := extract(t, "custom_cpp_grpc", fi("server.cc", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Service", "grpc_service:service") {
+		t.Errorf("expected grpc_service:service registration, got %+v", ents)
+	}
+	if r := propOf(t, ents, "SCOPE.Service", "grpc_service:service", "registration"); r != "RegisterService" {
+		t.Errorf("registration = %q, want RegisterService", r)
+	}
+	if !containsEntity(ents, "SCOPE.Service", "grpc_stub:Greeter") {
+		t.Errorf("expected grpc_stub:Greeter client stub, got %+v", ents)
+	}
+	if r := propOf(t, ents, "SCOPE.Service", "grpc_stub:Greeter", "client_role"); r != "stub" {
+		t.Errorf("client_role = %q, want stub", r)
+	}
+}
+
+func TestGrpcNoMatch(t *testing.T) {
+	src := `#include <iostream>
+int main() { std::cout << "hi"; return 0; }`
+	ents := extract(t, "custom_cpp_grpc", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %+v", ents)
+	}
+}
+
+func TestGrpcWrongLanguage(t *testing.T) {
+	src := `class Foo final : public Greeter::Service { Status Bar(ServerContext* c, const Req* r, Resp* p) override; };`
+	ents := extract(t, "custom_cpp_grpc", fi("x.c", "c", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should yield no entities, got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Protobuf — .proto IDL (messages, fields, enums, services, rpcs)
+// ---------------------------------------------------------------------------
+
+func TestProtobufProtoMessageFields(t *testing.T) {
+	src := `
+syntax = "proto3";
+package helloworld;
+
+message HelloRequest {
+  string name = 1;
+  int32 count = 2;
+  repeated string tags = 3;
+}
+`
+	ents := extract(t, "custom_cpp_protobuf", fi("hello.proto", "protobuf", src))
+
+	if !containsEntity(ents, "SCOPE.Schema", "proto_message:HelloRequest") {
+		t.Fatalf("expected proto_message:HelloRequest DTO, got %+v", ents)
+	}
+	// Fields with type + number.
+	if !ormFindEntityExists(ents, "SCOPE.Schema", "field", "HelloRequest.name") {
+		t.Error("expected HelloRequest.name field")
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "HelloRequest.name", "field_type"); got != "string" {
+		t.Errorf("name field_type = %q, want string", got)
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "HelloRequest.count", "field_number"); got != "2" {
+		t.Errorf("count field_number = %q, want 2", got)
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "HelloRequest.tags", "field_label"); got != "repeated" {
+		t.Errorf("tags field_label = %q, want repeated", got)
+	}
+}
+
+func TestProtobufProtoServiceRpc(t *testing.T) {
+	src := `
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply);
+  rpc ListFeatures (Rectangle) returns (stream Feature);
+}
+`
+	ents := extract(t, "custom_cpp_protobuf", fi("svc.proto", "protobuf", src))
+
+	if !containsEntity(ents, "SCOPE.Service", "grpc_service:Greeter") {
+		t.Fatalf("expected grpc_service:Greeter, got %+v", ents)
+	}
+	ep := findEndpoint(ents, "RPC /Greeter/SayHello")
+	if ep == nil {
+		t.Fatalf("expected RPC /Greeter/SayHello, got %+v", ents)
+	}
+	if got := ep.Props["request_message"]; got != "HelloRequest" {
+		t.Errorf("request_message = %q, want HelloRequest", got)
+	}
+	if got := ep.Props["response_message"]; got != "HelloReply" {
+		t.Errorf("response_message = %q, want HelloReply", got)
+	}
+	ep2 := findEndpoint(ents, "RPC /Greeter/ListFeatures")
+	if ep2 == nil {
+		t.Fatalf("expected RPC /Greeter/ListFeatures, got %+v", ents)
+	}
+	if got := ep2.Props["streaming"]; got != "server_streaming" {
+		t.Errorf("ListFeatures streaming = %q, want server_streaming", got)
+	}
+}
+
+func TestProtobufProtoEnum(t *testing.T) {
+	src := `
+enum Corpus {
+  UNIVERSAL = 0;
+  WEB = 1;
+}
+`
+	ents := extract(t, "custom_cpp_protobuf", fi("e.proto", "protobuf", src))
+	if !containsEntity(ents, "SCOPE.Schema", "proto_enum:Corpus") {
+		t.Errorf("expected proto_enum:Corpus, got %+v", ents)
+	}
+}
+
+func TestProtobufGeneratedHeader(t *testing.T) {
+	src := `
+#include <google/protobuf/message.h>
+namespace helloworld {
+class HelloRequest final : public ::google::protobuf::Message {
+ public:
+  const std::string& name() const;
+};
+}  // namespace helloworld
+`
+	ents := extract(t, "custom_cpp_protobuf", fi("hello.pb.h", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Schema", "proto_message:HelloRequest") {
+		t.Fatalf("expected proto_message:HelloRequest from generated header, got %+v", ents)
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "proto_message:HelloRequest", "message_kind"); got != "generated_message" {
+		t.Errorf("message_kind = %q, want generated_message", got)
+	}
+}
+
+func TestProtobufNoMatch(t *testing.T) {
+	src := `#include <iostream>
+int main() { return 0; }`
+	ents := extract(t, "custom_cpp_protobuf", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %+v", ents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// nlohmann/json — DTO model + fields + free-function serialization binding
+// ---------------------------------------------------------------------------
+
+func TestNlohmannDefineTypeIntrusive(t *testing.T) {
+	src := `
+struct User {
+    std::string name;
+    int age;
+    std::string email;
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(User, name, age, email)
+};
+`
+	ents := extract(t, "custom_cpp_nlohmann_json", fi("user.hpp", "cpp", src))
+
+	if !containsEntity(ents, "SCOPE.Schema", "nlohmann_dto:User") {
+		t.Fatalf("expected nlohmann_dto:User, got %+v", ents)
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "nlohmann_dto:User", "fields"); got != "name,age,email" {
+		t.Errorf("fields = %q, want name,age,email", got)
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "nlohmann_dto:User", "field_count"); got != "3" {
+		t.Errorf("field_count = %q, want 3", got)
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "nlohmann_dto:User", "macro_variant"); got != "INTRUSIVE" {
+		t.Errorf("macro_variant = %q, want INTRUSIVE", got)
+	}
+	// Per-field entities.
+	if !ormFindEntityExists(ents, "SCOPE.Schema", "field", "User.name") {
+		t.Error("expected User.name field entity")
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "User.age", "parent_dto"); got != "User" {
+		t.Errorf("User.age parent_dto = %q, want User", got)
+	}
+}
+
+func TestNlohmannNonIntrusive(t *testing.T) {
+	src := `NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Address, street, city, zip)`
+	ents := extract(t, "custom_cpp_nlohmann_json", fi("addr.hpp", "cpp", src))
+	if got := propOf(t, ents, "SCOPE.Schema", "nlohmann_dto:Address", "fields"); got != "street,city,zip" {
+		t.Errorf("fields = %q, want street,city,zip", got)
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "nlohmann_dto:Address", "macro_variant"); got != "NON_INTRUSIVE" {
+		t.Errorf("macro_variant = %q, want NON_INTRUSIVE", got)
+	}
+}
+
+func TestNlohmannFreeFunctions(t *testing.T) {
+	src := `
+void to_json(json& j, const Color& c) {
+    j = json{{"r", c.r}, {"g", c.g}, {"b", c.b}};
+}
+void from_json(const json& j, Color& c) {
+    j.at("r").get_to(c.r);
+}
+`
+	ents := extract(t, "custom_cpp_nlohmann_json", fi("color.cpp", "cpp", src))
+	if !containsEntity(ents, "SCOPE.Schema", "nlohmann_dto:Color") {
+		t.Fatalf("expected nlohmann_dto:Color, got %+v", ents)
+	}
+	if got := propOf(t, ents, "SCOPE.Schema", "nlohmann_dto:Color", "serialization_direction"); got != "bidirectional" {
+		t.Errorf("serialization_direction = %q, want bidirectional", got)
+	}
+}
+
+func TestNlohmannNoMatch(t *testing.T) {
+	src := `int main() { return 0; }`
+	ents := extract(t, "custom_cpp_nlohmann_json", fi("main.cpp", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %+v", ents)
+	}
+}
+
+// ormFindEntityExists is a small predicate over kind/subtype/name.
+func ormFindEntityExists(ents []entitySummary, kind, subtype, name string) bool {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Subtype == subtype && ents[i].Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/custom/cpp/nlohmann_json.go
+++ b/internal/custom/cpp/nlohmann_json.go
@@ -1,0 +1,212 @@
+package cpp
+
+// nlohmann_json.go — nlohmann/json (C++) DTO / serialization-mapping extractor.
+//
+// nlohmann/json maps a C++ struct to/from JSON in two ways:
+//
+//  1. The intrusive/non-intrusive macros, which list the serialized members:
+//
+//	    NLOHMANN_DEFINE_TYPE_INTRUSIVE(User, name, age, email)
+//	    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Address, street, city)
+//	    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config, host, port)
+//
+//  2. Hand-written free-function pairs:
+//
+//	    void to_json(json& j, const User& u)   { j = json{{"name", u.name}}; }
+//	    void from_json(const json& j, User& u) { j.at("name").get_to(u.name); }
+//
+// For every mapped type we emit one SCOPE.Schema(subtype="dto") entity carrying
+// the serialized field names, plus one SCOPE.Schema(subtype="field") child per
+// macro member. The to_json/from_json pair is recorded as the serialization
+// binding (whether a type is read-from-JSON, written-to-JSON, or both).
+//
+// The validation.go extractor independently emits request_param fields for the
+// same macro (handler-attribution surface); this extractor owns the *DTO model*
+// surface for the dedicated nlohmann/json coverage record. The two are
+// complementary and de-duplicated by Kind+Subtype+Name.
+//
+// Status: full for the DTO type + macro-listed fields (the member list is the
+// serialization contract); honest-partial for nested/typed shapes, since member
+// C++ types are declared elsewhere in the struct body.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_nlohmann_json", &cppNlohmannExtractor{})
+}
+
+type cppNlohmannExtractor struct{}
+
+func (e *cppNlohmannExtractor) Language() string { return "custom_cpp_nlohmann_json" }
+
+var (
+	// NLOHMANN_DEFINE_TYPE[_INTRUSIVE|_NON_INTRUSIVE][_WITH_DEFAULT](Type, m1, m2, ...)
+	// Capture 1 = type, 2 = member list.
+	reNJDefineType = regexp.MustCompile(
+		`(?ms)\bNLOHMANN_DEFINE_TYPE(_INTRUSIVE|_NON_INTRUSIVE)?(?:_WITH_DEFAULT)?\s*\(\s*([A-Za-z_]\w*)\s*,\s*([^)]*)\)`,
+	)
+
+	// to_json(json& j, const User& u) / from_json(const json& j, User& u)
+	// Capture 1 = to_json|from_json, 2 = the user struct type (the non-json arg).
+	reNJToFromJSON = regexp.MustCompile(
+		`(?m)\b(to_json|from_json)\s*\(\s*(?:const\s+)?(?:nlohmann::)?(?:ordered_)?json\s*&\s*\w+\s*,\s*(?:const\s+)?([A-Za-z_]\w*)\s*&`,
+	)
+)
+
+func (e *cppNlohmannExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpp_nlohmann_json.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "nlohmann_json"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || (file.Language != "cpp" && file.Language != "c") {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// File-signal gate.
+	if !strings.Contains(src, "NLOHMANN_DEFINE_TYPE") &&
+		!strings.Contains(src, "to_json") &&
+		!strings.Contains(src, "from_json") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	dtoIdx := make(map[string]int) // type name -> index of its DTO entity
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	ensureDTO := func(typeName string, line int, mapping string) int {
+		name := "nlohmann_dto:" + typeName
+		if idx, ok := dtoIdx[typeName]; ok {
+			return idx
+		}
+		ent := makeEntity(name, "SCOPE.Schema", "dto", file.Path, file.Language, line)
+		setProps(&ent, "framework", "nlohmann_json",
+			"provenance", "INFERRED_FROM_NLOHMANN_JSON",
+			"dto_name", typeName, "serialization", "nlohmann_json")
+		if mapping != "" {
+			setProps(&ent, "mapping", mapping)
+		}
+		seen[ent.Kind+":"+ent.Subtype+":"+ent.Name] = true
+		entities = append(entities, ent)
+		dtoIdx[typeName] = len(entities) - 1
+		return len(entities) - 1
+	}
+
+	// 1. NLOHMANN_DEFINE_TYPE macros -> DTO + per-member fields.
+	for _, m := range reNJDefineType.FindAllStringSubmatchIndex(src, -1) {
+		variant := "" // INTRUSIVE / NON_INTRUSIVE / generic
+		if m[2] >= 0 {
+			variant = strings.TrimPrefix(src[m[2]:m[3]], "_")
+		}
+		typeName := src[m[4]:m[5]]
+		memberList := src[m[6]:m[7]]
+		line := lineOf(src, m[0])
+
+		idx := ensureDTO(typeName, line, "macro")
+		if variant != "" {
+			entities[idx].Properties["macro_variant"] = variant
+		}
+
+		var fields []string
+		for _, raw := range strings.Split(memberList, ",") {
+			member := strings.TrimSpace(raw)
+			if member == "" || !isIdentifier(member) {
+				continue
+			}
+			fields = append(fields, member)
+			fldEnt := makeEntity(typeName+"."+member, "SCOPE.Schema", "field", file.Path, file.Language, line)
+			setProps(&fldEnt, "framework", "nlohmann_json",
+				"provenance", "INFERRED_FROM_NLOHMANN_DEFINE_TYPE",
+				"parent_dto", typeName, "field_name", member,
+				"serialization", "nlohmann_json")
+			add(fldEnt)
+		}
+		entities[idx].Properties["field_count"] = itoa(len(fields))
+		if len(fields) > 0 {
+			entities[idx].Properties["fields"] = strings.Join(fields, ",")
+		}
+	}
+
+	// 2. to_json / from_json free-function pairs -> serialization binding.
+	roles := make(map[string]map[string]bool) // type -> {to_json,from_json}
+	firstLine := make(map[string]int)
+	for _, m := range reNJToFromJSON.FindAllStringSubmatchIndex(src, -1) {
+		fn := src[m[2]:m[3]]
+		typeName := src[m[4]:m[5]]
+		if roles[typeName] == nil {
+			roles[typeName] = map[string]bool{}
+			firstLine[typeName] = lineOf(src, m[0])
+		}
+		roles[typeName][fn] = true
+	}
+	for typeName, r := range roles {
+		idx := ensureDTO(typeName, firstLine[typeName], "free_function")
+		dir := ""
+		switch {
+		case r["to_json"] && r["from_json"]:
+			dir = "bidirectional"
+		case r["to_json"]:
+			dir = "serialize"
+		case r["from_json"]:
+			dir = "deserialize"
+		}
+		if dir != "" {
+			entities[idx].Properties["serialization_direction"] = dir
+		}
+		entities[idx].Properties["has_free_functions"] = "true"
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// itoa is a tiny strconv.Itoa wrapper kept local to avoid an extra import churn
+// in this file (validation.go in the same package already pulls strconv via
+// other files; using a helper keeps the import set minimal here).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}

--- a/internal/custom/cpp/protobuf.go
+++ b/internal/custom/cpp/protobuf.go
@@ -1,0 +1,236 @@
+package cpp
+
+// protobuf.go — Protocol Buffers extractor for C++ projects.
+//
+// Two surfaces are covered:
+//
+//  1. .proto IDL files (Language=="proto"): the message / enum / field / service
+//     / rpc declarations are the source of truth for the DTO + service shapes.
+//
+//	    message HelloRequest {
+//	      string name = 1;
+//	      int32  count = 2;
+//	    }
+//	    service Greeter {
+//	      rpc SayHello (HelloRequest) returns (HelloReply);
+//	    }
+//
+//  2. protoc-generated C++ headers (Language=="cpp"): the generated message
+//     classes subclass ::google::protobuf::Message. We recover the DTO type
+//     name from those classes:
+//
+//	    class HelloRequest final : public ::google::protobuf::Message { ... };
+//
+// .proto parsing yields full message + field shapes (schema_extraction full);
+// generated-header parsing yields the message type names only (the per-field
+// accessors are present but field types require deeper parsing), so the cpp
+// side is honest-partial.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_protobuf", &cppProtobufExtractor{})
+}
+
+type cppProtobufExtractor struct{}
+
+func (e *cppProtobufExtractor) Language() string { return "custom_cpp_protobuf" }
+
+var (
+	// .proto: message Foo {
+	reProtoMessage = regexp.MustCompile(`(?m)^\s*message\s+([A-Za-z_]\w*)\s*\{`)
+	// .proto: enum Foo {
+	reProtoEnum = regexp.MustCompile(`(?m)^\s*enum\s+([A-Za-z_]\w*)\s*\{`)
+	// .proto field: [repeated|optional|required] <type> name = <num>;
+	// Captures: 1=label(optional), 2=type, 3=name, 4=field number.
+	reProtoField = regexp.MustCompile(
+		`(?m)^\s*(repeated\s+|optional\s+|required\s+)?([A-Za-z_][\w.]*(?:<[^>]*>)?)\s+([A-Za-z_]\w*)\s*=\s*(\d+)\s*;`,
+	)
+	// .proto: service Foo {
+	reProtoService = regexp.MustCompile(`(?m)^\s*service\s+([A-Za-z_]\w*)\s*\{`)
+	// .proto rpc: rpc Method (stream? Req) returns (stream? Resp);
+	// Captures: 1=method, 2=req-stream, 3=req-type, 4=resp-stream, 5=resp-type.
+	reProtoRpc = regexp.MustCompile(
+		`(?m)\brpc\s+([A-Za-z_]\w*)\s*\(\s*(stream\s+)?([A-Za-z_][\w.]*)\s*\)\s*returns\s*\(\s*(stream\s+)?([A-Za-z_][\w.]*)\s*\)`,
+	)
+
+	// Generated C++ header: class Foo final : public ::google::protobuf::Message
+	// Also tolerates MessageLite. Capture group 1 = message class name.
+	reProtoGenMessage = regexp.MustCompile(
+		`(?m)\bclass\s+(?:PROTOBUF_[A-Z_]+\s+)?([A-Za-z_]\w*)\b[^{;]*?:\s*(?:public\s+)?::?google::protobuf::(?:Message|MessageLite)\b`,
+	)
+)
+
+func (e *cppProtobufExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpp_protobuf.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "protobuf"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	switch {
+	case file.Language == "proto" || file.Language == "protobuf" || strings.HasSuffix(file.Path, ".proto"):
+		e.extractProto(src, file, add)
+	case file.Language == "cpp":
+		// Only generated protobuf headers; gate on the protobuf base class.
+		if !strings.Contains(src, "google::protobuf") {
+			return nil, nil
+		}
+		e.extractGenerated(src, file, add)
+	default:
+		return nil, nil
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// extractProto parses a .proto IDL file: messages (+fields), enums, services
+// (+rpcs). Messages become SCOPE.Schema DTOs; fields become SCOPE.Schema/field
+// children; each rpc becomes a SCOPE.Operation/endpoint with the canonical
+// gRPC path.
+func (e *cppProtobufExtractor) extractProto(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	// Messages + their fields (field list is the brace-balanced body).
+	for _, m := range reProtoMessage.FindAllStringSubmatchIndex(src, -1) {
+		msgName := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity("proto_message:"+msgName, "SCOPE.Schema", "dto", file.Path, "proto", line)
+		setProps(&ent, "framework", "protobuf",
+			"provenance", "INFERRED_FROM_PROTO_MESSAGE",
+			"dto_name", msgName, "message_kind", "proto_message")
+		add(ent)
+
+		bodyStart, bodyEnd := cppBraceBody(src, m[1]-1)
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, fm := range reProtoField.FindAllStringSubmatchIndex(body, -1) {
+			label := ""
+			if fm[2] >= 0 {
+				label = strings.TrimSpace(body[fm[2]:fm[3]])
+			}
+			ftype := body[fm[4]:fm[5]]
+			fname := body[fm[6]:fm[7]]
+			fnum := body[fm[8]:fm[9]]
+			// Skip 'returns'/'rpc' false-positives — proto field types are not keywords.
+			fldEnt := makeEntity(msgName+"."+fname, "SCOPE.Schema", "field", file.Path, "proto", line+lineOf(body, fm[0])-1)
+			setProps(&fldEnt, "framework", "protobuf",
+				"provenance", "INFERRED_FROM_PROTO_FIELD",
+				"parent_message", msgName,
+				"field_name", fname, "field_type", ftype,
+				"field_number", fnum)
+			if label != "" {
+				setProps(&fldEnt, "field_label", label)
+			}
+			add(fldEnt)
+		}
+	}
+
+	// Enums.
+	for _, m := range reProtoEnum.FindAllStringSubmatchIndex(src, -1) {
+		enumName := src[m[2]:m[3]]
+		ent := makeEntity("proto_enum:"+enumName, "SCOPE.Schema", "enum", file.Path, "proto", lineOf(src, m[0]))
+		setProps(&ent, "framework", "protobuf",
+			"provenance", "INFERRED_FROM_PROTO_ENUM",
+			"enum_name", enumName)
+		add(ent)
+	}
+
+	// Services + rpcs.
+	for _, m := range reProtoService.FindAllStringSubmatchIndex(src, -1) {
+		svcName := src[m[2]:m[3]]
+		svcLine := lineOf(src, m[0])
+		svcEnt := makeEntity("grpc_service:"+svcName, "SCOPE.Service", "grpc_service", file.Path, "proto", svcLine)
+		setProps(&svcEnt, "framework", "protobuf",
+			"provenance", "INFERRED_FROM_PROTO_SERVICE",
+			"grpc_service", svcName, "rpc_protocol", "grpc")
+		add(svcEnt)
+
+		bodyStart, bodyEnd := cppBraceBody(src, m[1]-1)
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+		for _, rm := range reProtoRpc.FindAllStringSubmatchIndex(body, -1) {
+			method := body[rm[2]:rm[3]]
+			reqStream := rm[4] >= 0 && body[rm[4]:rm[5]] != ""
+			reqType := cppGrpcLastSegment(body[rm[6]:rm[7]])
+			respStream := rm[8] >= 0 && body[rm[8]:rm[9]] != ""
+			respType := cppGrpcLastSegment(body[rm[10]:rm[11]])
+			line := svcLine + lineOf(body, rm[0]) - 1
+
+			path := "/" + svcName + "/" + method
+			ent := makeEntity("RPC "+path, "SCOPE.Operation", "endpoint", file.Path, "proto", line)
+			setProps(&ent, "framework", "protobuf",
+				"provenance", "INFERRED_FROM_PROTO_RPC",
+				"http_method", "RPC", "verb", "RPC",
+				"route_path", path, "rpc_protocol", "grpc",
+				"grpc_service", svcName, "grpc_method", method,
+				"request_message", reqType, "response_message", respType)
+			streamKind := protoStreamKind(reqStream, respStream)
+			if streamKind != "" {
+				setProps(&ent, "streaming", streamKind)
+			}
+			add(ent)
+		}
+	}
+}
+
+// protoStreamKind maps the (req,resp) stream flags to a canonical label.
+func protoStreamKind(reqStream, respStream bool) string {
+	switch {
+	case reqStream && respStream:
+		return "bidi_streaming"
+	case respStream:
+		return "server_streaming"
+	case reqStream:
+		return "client_streaming"
+	}
+	return ""
+}
+
+// extractGenerated parses a protoc-generated C++ header for the message classes
+// that subclass google::protobuf::Message. Only the DTO type name is recovered
+// (honest-partial; field shapes live in the accessor bodies).
+func (e *cppProtobufExtractor) extractGenerated(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	for _, m := range reProtoGenMessage.FindAllStringSubmatchIndex(src, -1) {
+		msgName := src[m[2]:m[3]]
+		ent := makeEntity("proto_message:"+msgName, "SCOPE.Schema", "dto", file.Path, "cpp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "protobuf",
+			"provenance", "INFERRED_FROM_PROTOBUF_GENERATED",
+			"dto_name", msgName, "message_kind", "generated_message")
+		add(ent)
+	}
+}

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -50,17 +50,23 @@ var customPrefixForLanguage = map[string]string{
 	// path/language-gates internally and no-ops on files it does not own.
 	"prisma": "custom_js_",
 	"sql":    "custom_js_",
-	"java":       "custom_java_",
-	"kotlin":     "custom_kotlin_",
-	"scala":      "custom_scala_",
-	"ruby":       "custom_ruby_",
-	"php":        "custom_php_",
-	"rust":       "custom_rust_",
-	"swift":      "custom_swift_",
-	"dart":       "custom_dart_",
-	"elixir":     "custom_elixir_",
-	"csharp":     "custom_csharp_",
-	"cpp":        "custom_cpp_",
+	"java":   "custom_java_",
+	"kotlin": "custom_kotlin_",
+	"scala":  "custom_scala_",
+	"ruby":   "custom_ruby_",
+	"php":    "custom_php_",
+	"rust":   "custom_rust_",
+	"swift":  "custom_swift_",
+	"dart":   "custom_dart_",
+	"elixir": "custom_elixir_",
+	"csharp": "custom_csharp_",
+	"cpp":    "custom_cpp_",
+	// Protocol Buffers IDL files (.proto) are classified as their own
+	// "protobuf" language but carry message/service definitions parsed by the
+	// C/C++ protobuf custom extractor (which path/language-gates internally and
+	// no-ops on non-proto files). Route them to the C++ extractor set, mirroring
+	// the prisma/sql → JS routing above.
+	"protobuf": "custom_cpp_",
 }
 
 // CustomExtractorsFor returns all registered custom/framework extractors


### PR DESCRIPTION
Closes #3510 (epic #3505). **EXPANSION** — three new C/C++ framework coverage records + extractors. No existing records modified.

## New records
| Record | Category / Subcategory | Extractor |
|---|---|---|
| `lang.c-cpp.framework.grpc` (gRPC C++ / grpc++) | http_framework / rpc_framework | `internal/custom/cpp/grpc.go` |
| `lang.c-cpp.framework.protobuf` (Protocol Buffers C++) | http_framework / rpc_framework | `internal/custom/cpp/protobuf.go` |
| `lang.c-cpp.framework.nlohmann-json` (nlohmann/json C++) | validation / validation_lib | `internal/custom/cpp/nlohmann_json.go` |

## What each extractor proves
**grpc++** — `class Foo final : public Greeter::Service { Status SayHello(ServerContext*, const HelloRequest*, HelloReply*) override }` → RPC `SCOPE.Operation` endpoint `/Greeter/SayHello` (service+method+req/resp DTO names+handler); streaming via `ServerWriter`/`ServerReader`/`ServerReaderWriter` (server/client/bidi); `RegisterService(&svc)` registration → `SCOPE.Service`; `Greeter::NewStub(channel)` client stub. Qualified bases (`pkg::Greeter::Service`) resolved.

**Protobuf** — `.proto` IDL: messages (+typed/numbered/labelled fields), enums, services, rpcs (+streaming) — full message/field shapes. protoc-generated `.pb.h` classes subclassing `::google::protobuf::Message` recovered by name. `.proto` files routed to the C++ custom-extractor set via a new `protobuf` → `custom_cpp_` dispatch mapping (mirrors prisma/sql → JS).

**nlohmann/json** — `NLOHMANN_DEFINE_TYPE_INTRUSIVE/_NON_INTRUSIVE/_WITH_DEFAULT(User, name, age)` → `SCOPE.Schema` DTO + per-member `field` entities with exact field list; `to_json`/`from_json` free-function pairs → serialization-direction binding.

## Cells flipped (honest)
- **grpc**: transport_binding, request/response_shape_extraction, schema_extraction, client_codegen, procedure_extraction → **partial** (message field shapes are protoc-generated, names recovered).
- **protobuf**: schema_extraction → **full** (.proto fully parsed); request/response_shape, transport_binding, procedure_extraction → **partial**.
- **nlohmann-json**: schema_extraction, tests_linkage → **full**; nested_model_extraction, type_coercion_recognition → **partial**.

## Validation
- New tests in `internal/custom/cpp/grpc_protobuf_test.go` are value-asserting (exact service/method/DTO/path/field-list/streaming values, not len>0).
- `go test ./internal/custom/cpp/ ./internal/types/ ./tools/coverage/ ./internal/extractors/` — pass (producer-kind validator green; no new entity Kinds).
- `coverage gen` + `validate` → ok, 0 errors. `coverage fmt --check` → canonical. `gofmt -l` clean on touched files, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)