### PR TITLE
feat(rust): utoipa (OpenAPI) coverage extractor

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 196 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 14 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 11 · **swift**: 1
+**Total**: 197 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 11 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -149,6 +149,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 196 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 13 · **scala**: 11 · **swift**: 1
+**Total**: 196 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 14 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 11 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -121,6 +121,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | ✅ 3/3 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/20 | 🟡 1/7 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | ✅ 3/3 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/20 | 🟡 1/7 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 
 
@@ -148,7 +149,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
-| [kotlin](../by-language/kotlin.md) | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.coroutines (structured concurrency)](../detail/lang.kotlin.framework.coroutines.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
 | [kotlin](../by-language/kotlin.md) | [kotlinx.serialization (Kotlin DTO/serialization)](../detail/lang.kotlin.framework.kotlinx-serialization.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # rust
 
-**Frameworks**: 13 · **Tools**: 6 · **ORMs**: 14 · **Other**: 0
+**Frameworks**: 14 · **Tools**: 6 · **ORMs**: 14 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -38,6 +38,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Warp](../detail/lang.rust.framework.warp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | ✅ 3/3 | 🔴 0/1 | 🟡 2/4 | 🔴 0/1 | 🟡 2/20 | 🟡 1/7 | |
 | [hyper](../detail/lang.rust.framework.hyper.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [utoipa](../detail/lang.rust.framework.utoipa.md) | ✅ 3/3 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/20 | 🟡 1/7 | |
 
 
 ### Desktop

--- a/docs/coverage/detail/lang.rust.framework.utoipa.md
+++ b/docs/coverage/detail/lang.rust.framework.utoipa.md
@@ -1,0 +1,103 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.utoipa` — utoipa
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | each #[utoipa::path] attribute -> SCOPE.Operation endpoint (verb + canonical path) |
+| Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | handler fn name captured from the fn following each #[utoipa::path] attribute |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | utoipa::path(verb, path=...) yields canonical verb+path (normalises {id}/:id/<id>); captures handler fn; enriches bare axum/actix routes with documented contract |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | #[derive(ToSchema)]/IntoParams structs -> SCOPE.Schema DTO with deep fields; request_body=/responses(body=) refs emitted as request/response DTOs |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | ToSchema struct fields parsed (name/type/wire_name) -> schema_field entities |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | request_body = <DTO> (incl inline()/content=) -> request_dto tied to verb+path |
+| Response shape extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/utoipa.go`<br>`internal/custom/rust/utoipa_test.go` | responses((status=N, body=<DTO>)) -> response_dto per status, tied to verb+path |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.utoipa ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -49328,6 +49328,191 @@
       }
     },
     {
+      "id": "lang.rust.framework.utoipa",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "rust",
+      "label": "utoipa",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/utoipa.go","internal/custom/rust/utoipa_test.go"],
+            "notes": "each #[utoipa::path] attribute -\u003e SCOPE.Operation endpoint (verb + canonical path)",
+            "verified_at": "2026-05-30"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/utoipa.go","internal/custom/rust/utoipa_test.go"],
+            "notes": "handler fn name captured from the fn following each #[utoipa::path] attribute",
+            "verified_at": "2026-05-30"
+          },
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/utoipa.go","internal/custom/rust/utoipa_test.go"],
+            "notes": "utoipa::path(verb, path=...) yields canonical verb+path (normalises {id}/:id/\u003cid\u003e); captures handler fn; enriches bare axum/actix routes with documented contract",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/utoipa.go","internal/custom/rust/utoipa_test.go"],
+            "notes": "#[derive(ToSchema)]/IntoParams structs -\u003e SCOPE.Schema DTO with deep fields; request_body=/responses(body=) refs emitted as request/response DTOs",
+            "verified_at": "2026-05-30"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/utoipa.go","internal/custom/rust/utoipa_test.go"],
+            "notes": "ToSchema struct fields parsed (name/type/wire_name) -\u003e schema_field entities",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/utoipa.go","internal/custom/rust/utoipa_test.go"],
+            "notes": "request_body = \u003cDTO\u003e (incl inline()/content=) -\u003e request_dto tied to verb+path",
+            "verified_at": "2026-05-30"
+          },
+          "response_shape_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/helpers.go","internal/custom/rust/utoipa.go","internal/custom/rust/utoipa_test.go"],
+            "notes": "responses((status=N, body=\u003cDTO\u003e)) -\u003e response_dto per status, tied to verb+path",
+            "verified_at": "2026-05-30"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.rust.framework.warp",
       "category": "http_framework",
       "subcategory": "http_backend",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 196 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
+**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 197 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
 
 ## Coverage by language
 
@@ -13,7 +13,7 @@
 | [java](by-language/java.md) | 19 | 10 | 14 | 3 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
-| [kotlin](by-language/kotlin.md) | 14 | 0 | 7 | 0 |
+| [kotlin](by-language/kotlin.md) | 15 | 0 | 7 | 0 |
 | [rust](by-language/rust.md) | 14 | 6 | 14 | 0 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
 | [php](by-language/php.md) | 12 | 6 | 14 | 0 |
@@ -66,4 +66,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 196 frameworks · 110 tools · 151 ORMs · 115 other
+Total: 197 frameworks · 110 tools · 151 ORMs · 115 other

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -13,9 +13,9 @@
 | [java](by-language/java.md) | 19 | 10 | 14 | 3 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
-| [kotlin](by-language/kotlin.md) | 15 | 0 | 7 | 0 |
+| [kotlin](by-language/kotlin.md) | 14 | 0 | 7 | 0 |
+| [rust](by-language/rust.md) | 14 | 6 | 14 | 0 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
-| [rust](by-language/rust.md) | 13 | 6 | 14 | 0 |
 | [php](by-language/php.md) | 12 | 6 | 14 | 0 |
 | [scala](by-language/scala.md) | 11 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |

--- a/internal/custom/rust/utoipa.go
+++ b/internal/custom/rust/utoipa.go
@@ -1,0 +1,353 @@
+package rust
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_utoipa", &utoipaExtractor{})
+}
+
+type utoipaExtractor struct{}
+
+func (e *utoipaExtractor) Language() string { return "custom_rust_utoipa" }
+
+var (
+	// `#[utoipa::path(` — start of an OpenAPI operation annotation. The full
+	// argument list is read with a balanced-paren scan because it nests
+	// `responses((status = 200, body = User))`, `params(...)`, etc. The handler
+	// fn name is captured from the `fn <name>` that follows the attribute block.
+	reUtoipaPathStart = regexp.MustCompile(`#\[\s*utoipa::path\s*\(`)
+	// `#[path(` form, used when `use utoipa::path;` is in scope. Required `get,`
+	// /`post,` … leading method keyword disambiguates it from unrelated macros.
+	reUtoipaPathBare = regexp.MustCompile(
+		`#\[\s*path\s*\(\s*(?:get|post|put|delete|patch|head|options|trace|connect)\b`)
+
+	// HTTP method keyword as the first positional arg of utoipa::path.
+	reUtoipaMethod = regexp.MustCompile(
+		`(?i)\b(get|post|put|delete|patch|head|options|trace|connect)\b`)
+	// path = "/users/{id}"
+	reUtoipaPathArg = regexp.MustCompile(`\bpath\s*=\s*"([^"]+)"`)
+	// request_body = CreateUser  /  request_body = inline(CreateUser)  /
+	// request_body(content = CreateUser, ...)
+	reUtoipaRequestBody = regexp.MustCompile(
+		`\brequest_body\s*(?:=\s*(?:inline\s*\(\s*)?|\(\s*content\s*=\s*)([A-Za-z_]\w*)`)
+	// responses( (status = 200, body = User), (status = 404, body = ApiError) )
+	// Captures each `body = <Type>` (optionally `inline(<Type>)`) inside responses.
+	reUtoipaResponseBody = regexp.MustCompile(
+		`\bbody\s*=\s*(?:inline\s*\(\s*)?\[?\s*([A-Za-z_]\w*)`)
+	// status = 201  /  status = StatusCode::CREATED — numeric form captured.
+	reUtoipaStatus = regexp.MustCompile(`\bstatus\s*=\s*(\d{3})`)
+	// fn name following the attribute block.
+	reUtoipaFnName = regexp.MustCompile(`\bfn\s+(\w+)`)
+
+	// #[derive(... ToSchema ...)] — the OpenAPI schema marker.
+	reUtoipaDerive = regexp.MustCompile(`#\[derive\(([^)]*)\)\]`)
+	// #[derive(OpenApi)] aggregator + its #[openapi(...)] attribute.
+	reUtoipaOpenAPIStart = regexp.MustCompile(`#\[\s*openapi\s*\(`)
+	// paths(handler_a, crate::users::get_user, ...) inside #[openapi(...)]
+	reUtoipaOpenAPIPaths = regexp.MustCompile(`\bpaths\s*\(([^)]*)\)`)
+	// components(schemas(User, CreateUser, ...)) inside #[openapi(...)]
+	reUtoipaOpenAPISchemas = regexp.MustCompile(`\bschemas\s*\(([^)]*)\)`)
+	// struct ApiDoc; following an #[openapi(...)] aggregator.
+	reUtoipaAggName = regexp.MustCompile(`\bstruct\s+(\w+)`)
+	// IntoParams params struct marker.
+	reUtoipaIntoParams = regexp.MustCompile(`\bIntoParams\b`)
+)
+
+// rustBalancedParens returns the substring inside the paren that opens at or
+// after openParenOff (which must point at the '(' itself), excluding the outer
+// parens, doing a depth-counted scan so nested `(...)` groups are kept intact.
+// Returns the inner text and the index just past the closing ')'.
+func rustBalancedParens(src string, openParenOff int) (inner string, endOff int, ok bool) {
+	if openParenOff >= len(src) || src[openParenOff] != '(' {
+		return "", openParenOff, false
+	}
+	depth := 0
+	for i := openParenOff; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[openParenOff+1 : i], i + 1, true
+			}
+		}
+	}
+	return "", openParenOff, false
+}
+
+func (e *utoipaExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.utoipa_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "utoipa"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. route_extraction / request+response shape — #[utoipa::path(...)]
+	// The attribute is the documented OpenAPI contract for a handler. It is the
+	// authoritative source for verb + path + request/response DTOs and is what
+	// enriches the bare axum/actix route with the wire contract.
+	// -----------------------------------------------------------------------
+	var pathStarts [][]int
+	for _, m := range reUtoipaPathStart.FindAllStringIndex(src, -1) {
+		// m[1]-1 is the '(' that opens the utoipa::path argument list.
+		pathStarts = append(pathStarts, []int{m[0], m[1] - 1})
+	}
+	for _, m := range reUtoipaPathBare.FindAllStringIndex(src, -1) {
+		// The bare `#[path(` form: locate its '(' (the one after `path`).
+		open := strings.IndexByte(src[m[0]:], '(')
+		if open < 0 {
+			continue
+		}
+		pathStarts = append(pathStarts, []int{m[0], m[0] + open})
+	}
+
+	for _, ps := range pathStarts {
+		attrOff, openOff := ps[0], ps[1]
+		inner, endOff, ok := rustBalancedParens(src, openOff)
+		if !ok {
+			continue
+		}
+
+		method := ""
+		if mm := reUtoipaMethod.FindStringSubmatch(inner); mm != nil {
+			method = strings.ToUpper(mm[1])
+		}
+		routePath := ""
+		if pm := reUtoipaPathArg.FindStringSubmatch(inner); pm != nil {
+			routePath = rustNormalizePath(pm[1])
+		}
+		if method == "" || routePath == "" {
+			// Not a usable operation contract; skip rather than emit a partial.
+			continue
+		}
+
+		// Handler fn name: the `fn <name>` that follows the attribute block.
+		handler := ""
+		if fm := reUtoipaFnName.FindStringSubmatchIndex(src[endOff:]); fm != nil {
+			handler = src[endOff+fm[2] : endOff+fm[3]]
+		}
+
+		name := method + " " + routePath
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint",
+			file.Path, file.Language, lineOf(src, attrOff))
+		setProps(&ent,
+			"framework", "utoipa",
+			"provenance", "INFERRED_FROM_UTOIPA_PATH",
+			"http_method", method,
+			"route_path", routePath,
+		)
+		if handler != "" {
+			setProps(&ent, "handler_name", handler)
+		}
+
+		// request_body = <DTO> -> request shape + DTO reference.
+		if rm := reUtoipaRequestBody.FindStringSubmatch(inner); rm != nil {
+			reqDTO := rm[1]
+			setProps(&ent, "request_body", reqDTO)
+			reqEnt := makeEntity("utoipa_request:"+reqDTO, "SCOPE.Schema", "request_dto",
+				file.Path, file.Language, lineOf(src, attrOff))
+			setProps(&reqEnt,
+				"framework", "utoipa",
+				"provenance", "INFERRED_FROM_UTOIPA_REQUEST_BODY",
+				"type_param", reqDTO,
+				"http_method", method,
+				"route_path", routePath,
+			)
+			add(reqEnt)
+		}
+
+		// responses((status = N, body = <DTO>), ...) -> response shapes.
+		// Scan each `body = <DTO>` (with the nearest preceding status, if any).
+		var respDTOs []string
+		for _, bm := range reUtoipaResponseBody.FindAllStringSubmatchIndex(inner, -1) {
+			respDTO := inner[bm[2]:bm[3]]
+			status := ""
+			// Nearest status keyword before this body, within the same response
+			// tuple, is a good-enough association for the contract.
+			if sm := reUtoipaStatus.FindStringSubmatchIndex(inner[:bm[0]]); sm != nil {
+				// take the LAST status before this body
+				all := reUtoipaStatus.FindAllStringSubmatchIndex(inner[:bm[0]], -1)
+				last := all[len(all)-1]
+				status = inner[last[2]:last[3]]
+			}
+			respDTOs = append(respDTOs, respDTO)
+			respEnt := makeEntity("utoipa_response:"+respDTO, "SCOPE.Schema", "response_dto",
+				file.Path, file.Language, lineOf(src, attrOff))
+			setProps(&respEnt,
+				"framework", "utoipa",
+				"provenance", "INFERRED_FROM_UTOIPA_RESPONSE_BODY",
+				"type_param", respDTO,
+				"http_method", method,
+				"route_path", routePath,
+			)
+			if status != "" {
+				setProps(&respEnt, "status_code", status)
+			}
+			add(respEnt)
+		}
+		if len(respDTOs) > 0 {
+			setProps(&ent, "response_bodies", strings.Join(respDTOs, ","))
+		}
+		add(ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. schema/dto_extraction — #[derive(ToSchema)] structs.
+	// Each becomes a SCOPE.Schema DTO with deep fields, mirroring serde DTOs.
+	// -----------------------------------------------------------------------
+	for _, dm := range reUtoipaDerive.FindAllStringSubmatchIndex(src, -1) {
+		deriveList := src[dm[2]:dm[3]]
+		isSchema := strings.Contains(deriveList, "ToSchema")
+		isParams := reUtoipaIntoParams.MatchString(deriveList)
+		if !isSchema && !isParams {
+			continue
+		}
+		// struct name follows the derive/attribute block.
+		tail := src[dm[1]:]
+		if len(tail) > 800 {
+			tail = tail[:800]
+		}
+		sm := reStructNameV.FindStringSubmatchIndex(tail)
+		if sm == nil {
+			continue
+		}
+		sname := tail[sm[2]:sm[3]]
+		structKwOff := dm[1] + sm[0]
+
+		subtype := "schema"
+		if isParams {
+			subtype = "params_schema"
+		}
+
+		var fields []dtoField
+		if body, bodyStart, ok := rustStructBody(src, structKwOff); ok {
+			fields = parseDTOFields(body, bodyStart, "")
+		}
+
+		ent := makeEntity("utoipa_schema:"+sname, "SCOPE.Schema", subtype,
+			file.Path, file.Language, lineOf(src, dm[0]))
+		prov := "INFERRED_FROM_UTOIPA_TOSCHEMA"
+		if isParams {
+			prov = "INFERRED_FROM_UTOIPA_INTOPARAMS"
+		}
+		setProps(&ent,
+			"framework", "utoipa",
+			"provenance", prov,
+			"struct_name", sname,
+			"field_count", itoa(len(fields)),
+		)
+		add(ent)
+
+		for _, f := range fields {
+			fieldEnt := makeEntity(
+				"utoipa_field:"+sname+"."+f.name,
+				"SCOPE.Schema", "schema_field",
+				file.Path, file.Language, lineOf(src, f.offset))
+			setProps(&fieldEnt,
+				"framework", "utoipa",
+				"provenance", "INFERRED_FROM_UTOIPA_SCHEMA_FIELD",
+				"struct_name", sname,
+				"field_name", f.name,
+				"field_type", f.typ,
+				"wire_name", f.wireName,
+			)
+			add(fieldEnt)
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. The OpenApi aggregator — #[derive(OpenApi)] #[openapi(paths(...),
+	// components(schemas(...)))] struct ApiDoc; — links operations + schemas.
+	// -----------------------------------------------------------------------
+	for _, m := range reUtoipaOpenAPIStart.FindAllStringIndex(src, -1) {
+		openOff := m[1] - 1 // the '(' of #[openapi(
+		inner, endOff, ok := rustBalancedParens(src, openOff)
+		if !ok {
+			continue
+		}
+		aggName := "ApiDoc"
+		if am := reUtoipaAggName.FindStringSubmatchIndex(src[endOff:]); am != nil {
+			aggName = src[endOff+am[2] : endOff+am[3]]
+		}
+		ent := makeEntity("utoipa_openapi:"+aggName, "SCOPE.Component", "openapi_doc",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "utoipa",
+			"provenance", "INFERRED_FROM_UTOIPA_OPENAPI",
+			"struct_name", aggName,
+		)
+		if pm := reUtoipaOpenAPIPaths.FindStringSubmatch(inner); pm != nil {
+			paths := splitIdentList(pm[1])
+			if len(paths) > 0 {
+				setProps(&ent, "registered_paths", strings.Join(paths, ","),
+					"path_count", itoa(len(paths)))
+			}
+		}
+		if cm := reUtoipaOpenAPISchemas.FindStringSubmatch(inner); cm != nil {
+			schemas := splitIdentList(cm[1])
+			if len(schemas) > 0 {
+				setProps(&ent, "registered_schemas", strings.Join(schemas, ","),
+					"schema_count", itoa(len(schemas)))
+			}
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// splitIdentList parses a comma-separated list of (possibly path-qualified)
+// identifiers, returning the LAST path segment of each (e.g.
+// `crate::users::get_user` -> `get_user`). Empty entries are dropped.
+func splitIdentList(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		p := strings.TrimSpace(part)
+		if p == "" {
+			continue
+		}
+		if idx := strings.LastIndex(p, "::"); idx >= 0 {
+			p = p[idx+2:]
+		}
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/custom/rust/utoipa_test.go
+++ b/internal/custom/rust/utoipa_test.go
@@ -1,0 +1,223 @@
+package rust_test
+
+import "testing"
+
+// findEntity returns the first entity matching kind+name, or nil.
+func findUtoipaEntity(ents []entitySummary, kind, name string) *entitySummary {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+const utoipaSrc = `
+use utoipa::{OpenApi, ToSchema, IntoParams};
+
+#[derive(ToSchema)]
+pub struct User {
+    id: u64,
+    #[serde(rename = "userName")]
+    name: String,
+    email: String,
+}
+
+#[derive(ToSchema)]
+pub struct CreateUser {
+    name: String,
+    email: String,
+}
+
+#[derive(ToSchema)]
+pub struct ApiError {
+    message: String,
+}
+
+#[derive(IntoParams)]
+pub struct ListParams {
+    limit: u32,
+    offset: u32,
+}
+
+#[utoipa::path(
+    get,
+    path = "/users/{id}",
+    responses(
+        (status = 200, body = User),
+        (status = 404, body = ApiError)
+    ),
+    params(("id" = u64, Path, description = "user id"))
+)]
+async fn get_user(id: u64) -> User { todo!() }
+
+#[utoipa::path(
+    post,
+    path = "/users",
+    request_body = CreateUser,
+    responses(
+        (status = 201, body = User)
+    )
+)]
+async fn create_user(body: CreateUser) -> User { todo!() }
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(get_user, create_user),
+    components(schemas(User, CreateUser, ApiError))
+)]
+pub struct ApiDoc;
+`
+
+func TestUtoipaPostRouteContract(t *testing.T) {
+	ents := extract(t, "custom_rust_utoipa", fi("api.rs", "rust", utoipaSrc))
+
+	// POST /users operation with request + response contract.
+	op := findUtoipaEntity(ents, "SCOPE.Operation", "POST /users")
+	if op == nil {
+		t.Fatalf("expected POST /users operation; got %+v", ents)
+	}
+	if op.Props["http_method"] != "POST" {
+		t.Errorf("http_method = %q, want POST", op.Props["http_method"])
+	}
+	if op.Props["route_path"] != "/users" {
+		t.Errorf("route_path = %q, want /users", op.Props["route_path"])
+	}
+	if op.Props["handler_name"] != "create_user" {
+		t.Errorf("handler_name = %q, want create_user", op.Props["handler_name"])
+	}
+	if op.Props["request_body"] != "CreateUser" {
+		t.Errorf("request_body = %q, want CreateUser", op.Props["request_body"])
+	}
+	if op.Props["response_bodies"] != "User" {
+		t.Errorf("response_bodies = %q, want User", op.Props["response_bodies"])
+	}
+}
+
+func TestUtoipaRequestDTOEmitted(t *testing.T) {
+	ents := extract(t, "custom_rust_utoipa", fi("api.rs", "rust", utoipaSrc))
+
+	req := findUtoipaEntity(ents, "SCOPE.Schema", "utoipa_request:CreateUser")
+	if req == nil {
+		t.Fatalf("expected CreateUser request DTO; got %+v", ents)
+	}
+	if req.Subtype != "request_dto" {
+		t.Errorf("subtype = %q, want request_dto", req.Subtype)
+	}
+	if req.Props["type_param"] != "CreateUser" {
+		t.Errorf("type_param = %q, want CreateUser", req.Props["type_param"])
+	}
+	if req.Props["route_path"] != "/users" || req.Props["http_method"] != "POST" {
+		t.Errorf("request DTO not tied to POST /users: %+v", req.Props)
+	}
+}
+
+func TestUtoipaResponseDTOsWithStatus(t *testing.T) {
+	ents := extract(t, "custom_rust_utoipa", fi("api.rs", "rust", utoipaSrc))
+
+	// GET /users/{id} has two responses: User (200) and ApiError (404).
+	userResp := findUtoipaEntity(ents, "SCOPE.Schema", "utoipa_response:User")
+	if userResp == nil {
+		t.Fatalf("expected User response DTO; got %+v", ents)
+	}
+	if userResp.Subtype != "response_dto" {
+		t.Errorf("subtype = %q, want response_dto", userResp.Subtype)
+	}
+	if userResp.Props["status_code"] != "200" {
+		t.Errorf("User status_code = %q, want 200", userResp.Props["status_code"])
+	}
+
+	errResp := findUtoipaEntity(ents, "SCOPE.Schema", "utoipa_response:ApiError")
+	if errResp == nil {
+		t.Fatalf("expected ApiError response DTO; got %+v", ents)
+	}
+	if errResp.Props["status_code"] != "404" {
+		t.Errorf("ApiError status_code = %q, want 404", errResp.Props["status_code"])
+	}
+}
+
+func TestUtoipaGetRouteNormalisedPath(t *testing.T) {
+	ents := extract(t, "custom_rust_utoipa", fi("api.rs", "rust", utoipaSrc))
+
+	op := findUtoipaEntity(ents, "SCOPE.Operation", "GET /users/{id}")
+	if op == nil {
+		t.Fatalf("expected GET /users/{id} operation; got %+v", ents)
+	}
+	if op.Props["handler_name"] != "get_user" {
+		t.Errorf("handler_name = %q, want get_user", op.Props["handler_name"])
+	}
+}
+
+func TestUtoipaToSchemaDTOWithFields(t *testing.T) {
+	ents := extract(t, "custom_rust_utoipa", fi("api.rs", "rust", utoipaSrc))
+
+	schema := findUtoipaEntity(ents, "SCOPE.Schema", "utoipa_schema:User")
+	if schema == nil {
+		t.Fatalf("expected User schema; got %+v", ents)
+	}
+	if schema.Subtype != "schema" {
+		t.Errorf("subtype = %q, want schema", schema.Subtype)
+	}
+	if schema.Props["field_count"] != "3" {
+		t.Errorf("field_count = %q, want 3", schema.Props["field_count"])
+	}
+
+	// Field id: u64
+	idField := findUtoipaEntity(ents, "SCOPE.Schema", "utoipa_field:User.id")
+	if idField == nil {
+		t.Fatalf("expected User.id field; got %+v", ents)
+	}
+	if idField.Props["field_type"] != "u64" {
+		t.Errorf("id field_type = %q, want u64", idField.Props["field_type"])
+	}
+
+	// Field name carries serde wire name override.
+	nameField := findUtoipaEntity(ents, "SCOPE.Schema", "utoipa_field:User.name")
+	if nameField == nil {
+		t.Fatalf("expected User.name field; got %+v", ents)
+	}
+	if nameField.Props["wire_name"] != "userName" {
+		t.Errorf("name wire_name = %q, want userName", nameField.Props["wire_name"])
+	}
+}
+
+func TestUtoipaIntoParamsSchema(t *testing.T) {
+	ents := extract(t, "custom_rust_utoipa", fi("api.rs", "rust", utoipaSrc))
+
+	p := findUtoipaEntity(ents, "SCOPE.Schema", "utoipa_schema:ListParams")
+	if p == nil {
+		t.Fatalf("expected ListParams params schema; got %+v", ents)
+	}
+	if p.Subtype != "params_schema" {
+		t.Errorf("subtype = %q, want params_schema", p.Subtype)
+	}
+	if p.Props["field_count"] != "2" {
+		t.Errorf("field_count = %q, want 2", p.Props["field_count"])
+	}
+}
+
+func TestUtoipaOpenAPIAggregator(t *testing.T) {
+	ents := extract(t, "custom_rust_utoipa", fi("api.rs", "rust", utoipaSrc))
+
+	agg := findUtoipaEntity(ents, "SCOPE.Component", "utoipa_openapi:ApiDoc")
+	if agg == nil {
+		t.Fatalf("expected ApiDoc OpenApi aggregator; got %+v", ents)
+	}
+	if agg.Props["registered_paths"] != "get_user,create_user" {
+		t.Errorf("registered_paths = %q, want get_user,create_user", agg.Props["registered_paths"])
+	}
+	if agg.Props["registered_schemas"] != "User,CreateUser,ApiError" {
+		t.Errorf("registered_schemas = %q, want User,CreateUser,ApiError", agg.Props["registered_schemas"])
+	}
+	if agg.Props["path_count"] != "2" || agg.Props["schema_count"] != "3" {
+		t.Errorf("counts wrong: %+v", agg.Props)
+	}
+}
+
+func TestUtoipaNoMatch(t *testing.T) {
+	src := `fn main() { println!("hi"); }`
+	ents := extract(t, "custom_rust_utoipa", fi("main.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities, got %+v", ents)
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -7560,6 +7560,82 @@ records:
           issues_implemented: ["3508"]
           verified_at: "2026-05-31"
 
+  lang.rust.framework.utoipa:
+    capabilities:
+      Routing:
+        route_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/utoipa.go
+              functions: [Extract, rustBalancedParens]
+            - file: internal/custom/rust/helpers.go
+              functions: [rustNormalizePath]
+          tests:
+            - file: internal/custom/rust/utoipa_test.go
+          issues_implemented: ["3538"]
+          verified_at: "2026-05-31"
+        handler_attribution:
+          status: full
+          symbols:
+            - file: internal/custom/rust/utoipa.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/rust/utoipa_test.go
+          issues_implemented: ["3538"]
+          verified_at: "2026-05-31"
+        endpoint_synthesis:
+          status: full
+          symbols:
+            - file: internal/custom/rust/utoipa.go
+              functions: [Extract, rustBalancedParens]
+          tests:
+            - file: internal/custom/rust/utoipa_test.go
+          issues_implemented: ["3538"]
+          verified_at: "2026-05-31"
+      Validation:
+        dto_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/utoipa.go
+              functions: [Extract, splitIdentList]
+            - file: internal/custom/rust/fw_validation.go
+              functions: [parseDTOFields, rustStructBody]
+          tests:
+            - file: internal/custom/rust/utoipa_test.go
+          issues_implemented: ["3538"]
+          verified_at: "2026-05-31"
+      Substrate:
+        request_shape_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/utoipa.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/rust/utoipa_test.go
+          issues_implemented: ["3538"]
+          verified_at: "2026-05-31"
+        response_shape_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/utoipa.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/rust/utoipa_test.go
+          issues_implemented: ["3538"]
+          verified_at: "2026-05-31"
+      Type System:
+        type_extraction:
+          status: full
+          symbols:
+            - file: internal/custom/rust/utoipa.go
+              functions: [Extract]
+            - file: internal/custom/rust/fw_validation.go
+              functions: [parseDTOFields]
+          tests:
+            - file: internal/custom/rust/utoipa_test.go
+          issues_implemented: ["3538"]
+          verified_at: "2026-05-31"
+
   lang.rust.framework.tonic:
     capabilities:
       Routing:


### PR DESCRIPTION
Closes #3538 (epic #3505). EXPANSION — new `lang.rust.framework.utoipa` record.

Highest-leverage Rust OpenAPI coverage: attribute-macro matching that enriches already-tracked axum/actix routes with the documented wire contract.

## What it extracts (`internal/custom/rust/utoipa.go`)
- `#[utoipa::path(verb, path = "...", request_body = ..., responses((status = N, body = T)))]` on a handler fn -> `SCOPE.Operation` endpoint (canonical verb + normalised path + handler fn name), plus per-status `response_dto` and a `request_dto` `SCOPE.Schema`, each tied back to verb+path. Balanced-paren scan keeps nested `responses(...)`/`params(...)` intact. Handles the bare `#[path(get, ...)]` form and `request_body = inline()/(content = ...)`.
- `#[derive(ToSchema)]` / `#[derive(IntoParams)]` structs -> `SCOPE.Schema` DTO with deep fields (reuses `rustStructBody` + `parseDTOFields`; serde `wire_name`).
- `#[derive(OpenApi)] #[openapi(paths(...), components(schemas(...)))]` -> `SCOPE.Component` `openapi_doc` aggregator listing registered paths + schemas.

## Cells flipped to `full`
`route_extraction`, `handler_attribution`, `endpoint_synthesis`, `dto_extraction`, `request_shape_extraction`, `response_shape_extraction`, `type_extraction` — plus matching `capability-map.yaml` symbol mappings (validate: 0 errors, no utoipa warnings).

## Tests
8 value-asserting tests in `internal/custom/rust/utoipa_test.go` (POST /users contract incl. request/response DTOs; per-status response DTOs 200/404; GET /users/{id} normalisation; ToSchema fields incl. serde wire name; IntoParams; OpenApi aggregator path/schema lists; no-match).

Targeted suites green; `go vet` clean; `gofmt -l` empty; coverage `validate` 0 errors; `fmt --check` canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)