### PR TITLE
feat(iac): add Azure Bicep (.bicep) IaC extractor

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -18,7 +18,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.iac.cloudformation.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [AWS CloudFormation](../detail/infra.resource.cloudformation.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Ansible (playbooks)](../detail/infra.iac.ansible.md) | 🟢 | — | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | 🔴 | — | — | 🔴 | 🔴 | |
+| [multi](../by-language/multi.md) | [Azure Bicep](../detail/infra.iac.bicep.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Dockerfile](../detail/infra.container.dockerfile.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Helm charts](../detail/infra.container.helm.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Helm charts](../detail/infra.resource.helm.md) | — | — | — | ✅ | ✅ | |

--- a/docs/coverage/by-language/bicep.md
+++ b/docs/coverage/by-language/bicep.md
@@ -1,0 +1,12 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# Bicep
+
+**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+
+Back to [summary](../summary.md).
+
+> **No ecosystem records tracked yet.** archigraph has extractor support for
+> this language (see `internal/extractors/bicep/`), but specific framework,
+> ORM, or tool records haven't been added to the registry yet. Contribute by
+> adding records via `go run ./tools/coverage add` with appropriate IDs
+> (e.g. `lang.bicep.framework.<name>`).

--- a/docs/coverage/detail/infra.iac.bicep.md
+++ b/docs/coverage/detail/infra.iac.bicep.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🔴 `missing` | — | — | — | — |
-| Resource extraction | 🔴 `missing` | — | — | — | — |
+| Dependency attribution | ✅ `full` | `2026-05-30` | — | `internal/extractors/bicep/extractor.go` | DEPENDS_ON edges from symbolic-name property references (foo.id / foo.properties.x / foo.outputs.y) and explicit dependsOn:[...] arrays between resources/modules (mirrors hcl depends_on->DEPENDS_ON edge kind); module 'path.bicep' -> IMPORTS edge. Edges emitted as Format-A structural-refs bound via byLocation to sibling entities in the same file. |
+| Resource extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/bicep/extractor.go`<br>`internal/extractors/bicep/kinds.go` | Regex/line-based .bicep extractor (no tree-sitter grammar vendored): SCOPE.InfraResource per 'resource' decl named by symbolic name, Kind-stable with resource_scope from the AzureRP type (bicepResourceCoarseScope); azure_rp_type + api_version + deployed_name on Metadata. SCOPE.Component/module per 'module' decl, SCOPE.Schema for param/var/output. Handles 'existing' resources and [for ...] loops. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1298,10 +1298,16 @@
       "label": "Azure Bicep",
       "capabilities": {
         "dependency_attribution": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/extractors/bicep/extractor.go"],
+          "notes": "DEPENDS_ON edges from symbolic-name property references (foo.id / foo.properties.x / foo.outputs.y) and explicit dependsOn:[...] arrays between resources/modules (mirrors hcl depends_on-\u003eDEPENDS_ON edge kind); module 'path.bicep' -\u003e IMPORTS edge. Edges emitted as Format-A structural-refs bound via byLocation to sibling entities in the same file.",
+          "verified_at": "2026-05-30"
         },
         "resource_extraction": {
-          "status": "missing"
+          "status": "full",
+          "cites": ["internal/extractors/bicep/extractor.go","internal/extractors/bicep/kinds.go"],
+          "notes": "Regex/line-based .bicep extractor (no tree-sitter grammar vendored): SCOPE.InfraResource per 'resource' decl named by symbolic name, Kind-stable with resource_scope from the AzureRP type (bicepResourceCoarseScope); azure_rp_type + api_version + deployed_name on Metadata. SCOPE.Component/module per 'module' decl, SCOPE.Schema for param/var/output. Handles 'existing' resources and [for ...] loops.",
+          "verified_at": "2026-05-30"
         }
       }
     },

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 37 (19 active · 18 placeholder) · **Frameworks**: 198 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 197 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
 
 ## Coverage by language
 
@@ -17,7 +17,7 @@
 | [rust](by-language/rust.md) | 14 | 6 | 14 | 0 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
 | [php](by-language/php.md) | 12 | 6 | 14 | 0 |
-| [scala](by-language/scala.md) | 12 | 3 | 6 | 0 |
+| [scala](by-language/scala.md) | 11 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
@@ -32,14 +32,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 11 | 0 | 7 | 4 |
-| [Platform / k8s](by-category/platform.md) | 23 | 16 | 6 | 1 |
+| [Platform / k8s](by-category/platform.md) | 23 | 17 | 6 | 0 |
 | [Message Brokers](by-category/message_broker.md) | 20 | 9 | 9 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 8 | 3 | 3 | 2 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 97 | 36 | 34 | 27 |
+| **Total** | 97 | 37 | 34 | 26 |
 
 ## Languages with extractor support, no records yet
 
@@ -47,6 +47,7 @@
 
 | Language |
 |---|
+| [Bicep](by-language/bicep.md) |
 | [Clojure](by-language/clojure.md) |
 | [Crystal](by-language/crystal.md) |
 | [Elm](by-language/elm.md) |
@@ -66,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 198 frameworks · 110 tools · 151 ORMs · 115 other
+Total: 197 frameworks · 110 tools · 151 ORMs · 115 other

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 197 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 198 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
 
 ## Coverage by language
 
@@ -17,7 +17,7 @@
 | [rust](by-language/rust.md) | 14 | 6 | 14 | 0 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
 | [php](by-language/php.md) | 12 | 6 | 14 | 0 |
-| [scala](by-language/scala.md) | 11 | 3 | 6 | 0 |
+| [scala](by-language/scala.md) | 12 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 197 frameworks · 110 tools · 151 ORMs · 115 other
+Total: 198 frameworks · 110 tools · 151 ORMs · 115 other

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -469,6 +469,10 @@ var extensionLanguageMap = map[string]string{
 	".tf":     "terraform",
 	".tfvars": "terraform",
 	".hcl":    "hcl",
+	// Azure Bicep — Azure-native IaC DSL (resource/module/param/var/output).
+	// No tree-sitter grammar is vendored; the bicep extractor is regex/line-
+	// based (internal/extractors/bicep) so the tree is nil at dispatch time.
+	".bicep": "bicep",
 	// Protobuf
 	".proto": "protobuf",
 	// CSS / SCSS / LESS

--- a/internal/extractors/bicep/extractor.go
+++ b/internal/extractors/bicep/extractor.go
@@ -1,0 +1,508 @@
+// Package bicep implements a regex/line-based extractor for Azure Bicep
+// infrastructure-as-code files (*.bicep).
+//
+// No tree-sitter grammar for Bicep is vendored in this repo, so — like the
+// COBOL/CDK regex detectors — this extractor parses raw source text. Bicep is
+// structurally HCL-like (resource / module / param / var / output declarations
+// with symbolic-name cross-references), so the entity + edge model mirrors the
+// HCL/Terraform extractor (internal/extractors/hcl):
+//
+//	resource <symbolicName> 'Microsoft.Storage/storageAccounts@2022-09-01' = {…}
+//	    → SCOPE.InfraResource (Kind via bicepResourceKind on the AzureRP type),
+//	      named by symbolicName; the deployed name: '…' is folded into Metadata.
+//	module  <name> '<path>.bicep' = {…}
+//	    → SCOPE.Component/module + IMPORTS edge to the referenced .bicep path.
+//	param   <name> <type>            → SCOPE.Schema/param
+//	var     <name> = …               → SCOPE.Schema/var
+//	output  <name> <type> = …        → SCOPE.Schema/output
+//
+// Relationships (reusing the HCL DEPENDS_ON edge kind):
+//
+//	symbolic-name references in a resource/module body
+//	    (storageAccount.id, storageAccount.properties.x, foo.outputs.y) → DEPENDS_ON
+//	explicit  dependsOn: [a, b]      → DEPENDS_ON to each listed symbolic name
+//
+// `existing` resources and `[for item in items: {…}]` loop bodies are handled:
+// the resource is still emitted (with metadata flags) and references inside a
+// loop body are still attributed to the declaring resource.
+//
+// Edges are emitted as Format-A structural-refs tied to the current file
+// (BuildOperationStructuralRef) so the resolver binds them via byLocation to
+// the sibling entity in the same file — exactly as the HCL extractor does for
+// depends_on.
+//
+// OTel span: "indexer.extract.bicep" with attributes language, file_line_count,
+// entity_count.
+//
+// Registered under the "bicep" language key via init(); .bicep files are routed
+// here by internal/classifier (extension → "bicep").
+package bicep
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("bicep", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Azure Bicep.
+type Extractor struct{}
+
+// Language implements extractor.Extractor.
+func (e *Extractor) Language() string { return "bicep" }
+
+const lang = "bicep"
+
+var (
+	// resource <symbolicName> 'Microsoft.Storage/storageAccounts@2022-09-01' [existing] = {
+	// The trailing portion (existing / = / =[for …]) is matched loosely so the
+	// declaration line is recognised regardless of loop / existing modifiers.
+	reResource = regexp.MustCompile(`(?m)^\s*resource\s+([A-Za-z_][A-Za-z0-9_]*)\s+'([^']+)'\s*(existing)?\s*=`)
+	// module <name> '<path>' = {
+	reModule = regexp.MustCompile(`(?m)^\s*module\s+([A-Za-z_][A-Za-z0-9_]*)\s+'([^']+)'\s*=`)
+	// param <name> <type> [= default]
+	reParam = regexp.MustCompile(`(?m)^\s*param\s+([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z0-9_<>\[\]]+)`)
+	// var <name> = …
+	reVar = regexp.MustCompile(`(?m)^\s*var\s+([A-Za-z_][A-Za-z0-9_]*)\s*=`)
+	// output <name> <type> = …
+	reOutput = regexp.MustCompile(`(?m)^\s*output\s+([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z0-9_<>\[\]]+)\s*=`)
+
+	// name: 'literal' — the deployed Azure resource name inside a body.
+	reNameAttr = regexp.MustCompile(`(?m)^\s*name:\s*'([^']*)'`)
+	// dependsOn: [ … ] — explicit dependency list (may span lines).
+	reDependsOn = regexp.MustCompile(`(?s)dependsOn:\s*\[(.*?)\]`)
+)
+
+// Extract implements extractor.Extractor. Never panics; returns partial
+// results on malformed input.
+func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("extractor.bicep")
+	_, span := tracer.Start(ctx, "indexer.extract.bicep")
+	defer span.End()
+
+	lineCount := 0
+	if len(file.Content) > 0 {
+		lineCount = bytes.Count(file.Content, []byte{'\n'}) + 1
+	}
+
+	if len(file.Content) == 0 {
+		span.SetAttributes(
+			attribute.String("language", lang),
+			attribute.Int("file_line_count", 0),
+			attribute.Int("entity_count", 0),
+		)
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	path := file.Path
+
+	// Pre-scan: collect the set of symbolic names declared as resources or
+	// modules in this file so reference extraction only emits DEPENDS_ON edges
+	// to real local declarations (filters out built-in functions, params, etc.).
+	symbolic := collectSymbolicNames(src)
+
+	var records []types.EntityRecord
+
+	records = append(records, extractResources(src, path, symbolic)...)
+	records = append(records, extractModules(src, path, symbolic)...)
+	records = append(records, extractParams(src, path)...)
+	records = append(records, extractVars(src, path)...)
+	records = append(records, extractOutputs(src, path)...)
+
+	span.SetAttributes(
+		attribute.String("language", lang),
+		attribute.Int("file_line_count", lineCount),
+		attribute.Int("entity_count", len(records)),
+	)
+	return records, nil
+}
+
+// collectSymbolicNames returns the set of resource/module symbolic names
+// declared in the file.
+func collectSymbolicNames(src string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range reResource.FindAllStringSubmatch(src, -1) {
+		out[m[1]] = true
+	}
+	for _, m := range reModule.FindAllStringSubmatch(src, -1) {
+		out[m[1]] = true
+	}
+	return out
+}
+
+// extractResources emits a SCOPE.InfraResource per `resource` declaration and
+// its DEPENDS_ON edges (symbolic-name references + explicit dependsOn).
+func extractResources(src, path string, symbolic map[string]bool) []types.EntityRecord {
+	var out []types.EntityRecord
+	locs := reResource.FindAllStringSubmatchIndex(src, -1)
+	for i, loc := range locs {
+		symName := src[loc[2]:loc[3]]
+		azureType := src[loc[4]:loc[5]]
+		isExisting := loc[6] >= 0 // optional `existing` group matched
+
+		startLine := lineOf(src, loc[0])
+		// Body spans from this declaration to the next top-level declaration.
+		bodyStart := loc[1]
+		bodyEnd := len(src)
+		if i+1 < len(locs) {
+			bodyEnd = locs[i+1][0]
+		}
+		// Clamp against the next module declaration too (resources/modules are
+		// interleaved); find the earliest following declaration boundary.
+		bodyEnd = nextDeclBoundary(src, bodyStart, bodyEnd)
+		body := src[bodyStart:bodyEnd]
+		endLine := startLine + strings.Count(body, "\n")
+
+		rpType, apiVersion := splitAzureType(azureType)
+
+		meta := map[string]interface{}{
+			"subtype":        "resource",
+			"iac_tool":       "bicep",
+			"symbolic_name":  symName,
+			"azure_rp_type":  rpType,
+			"resource_scope": bicepResourceCoarseScope(rpType),
+		}
+		if apiVersion != "" {
+			meta["api_version"] = apiVersion
+		}
+		if isExisting {
+			meta["existing"] = "true"
+		}
+		if nm := reNameAttr.FindStringSubmatch(body); nm != nil {
+			meta["deployed_name"] = nm[1]
+		}
+		if isLoop(body) {
+			meta["loop"] = "true"
+		}
+
+		rec := types.EntityRecord{
+			Name:          symName,
+			Kind:          "SCOPE.InfraResource",
+			Subtype:       "resource",
+			SourceFile:    path,
+			StartLine:     startLine,
+			EndLine:       endLine,
+			Language:      lang,
+			QualityScore:  0.9,
+			QualifiedName: rpType + "." + symName,
+			Metadata:      meta,
+		}
+		rec.Relationships = dependencyEdges(body, path, symName, symbolic)
+		out = append(out, rec)
+	}
+	return out
+}
+
+// extractModules emits a SCOPE.Component/module per `module` declaration with
+// an IMPORTS edge to the referenced .bicep path plus DEPENDS_ON edges.
+func extractModules(src, path string, symbolic map[string]bool) []types.EntityRecord {
+	var out []types.EntityRecord
+	locs := reModule.FindAllStringSubmatchIndex(src, -1)
+	for i, loc := range locs {
+		modName := src[loc[2]:loc[3]]
+		modPath := src[loc[4]:loc[5]]
+
+		startLine := lineOf(src, loc[0])
+		bodyStart := loc[1]
+		bodyEnd := len(src)
+		if i+1 < len(locs) {
+			bodyEnd = locs[i+1][0]
+		}
+		bodyEnd = nextDeclBoundary(src, bodyStart, bodyEnd)
+		body := src[bodyStart:bodyEnd]
+		endLine := startLine + strings.Count(body, "\n")
+
+		meta := map[string]interface{}{
+			"subtype":  "module",
+			"iac_tool": "bicep",
+			"label":    modName,
+			"source":   modPath,
+		}
+		if nm := reNameAttr.FindStringSubmatch(body); nm != nil {
+			meta["deployed_name"] = nm[1]
+		}
+		if isLoop(body) {
+			meta["loop"] = "true"
+		}
+
+		rec := types.EntityRecord{
+			Name:          modName,
+			Kind:          "SCOPE.Component",
+			Subtype:       "module",
+			SourceFile:    path,
+			StartLine:     startLine,
+			EndLine:       endLine,
+			Language:      lang,
+			QualityScore:  0.9,
+			QualifiedName: modPath,
+			Metadata:      meta,
+		}
+
+		// IMPORTS edge to the referenced .bicep module path.
+		rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+			FromID: path,
+			ToID:   "scope:component:file:bicep:" + modPath,
+			Kind:   "IMPORTS",
+		})
+		rec.Relationships = append(rec.Relationships, dependencyEdges(body, path, modName, symbolic)...)
+		out = append(out, rec)
+	}
+	return out
+}
+
+// extractParams emits a SCOPE.Schema/param per `param` declaration.
+func extractParams(src, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, loc := range reParam.FindAllStringSubmatchIndex(src, -1) {
+		name := src[loc[2]:loc[3]]
+		paramType := src[loc[4]:loc[5]]
+		out = append(out, types.EntityRecord{
+			Name:         "param." + name,
+			Kind:         "SCOPE.Schema",
+			Subtype:      "param",
+			SourceFile:   path,
+			StartLine:    lineOf(src, loc[0]),
+			EndLine:      lineOf(src, loc[0]),
+			Language:     lang,
+			QualityScore: 0.8,
+			Metadata: map[string]interface{}{
+				"subtype":    "param",
+				"iac_tool":   "bicep",
+				"label":      name,
+				"param_type": paramType,
+			},
+		})
+	}
+	return out
+}
+
+// extractVars emits a SCOPE.Schema/var per `var` declaration.
+func extractVars(src, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, loc := range reVar.FindAllStringSubmatchIndex(src, -1) {
+		name := src[loc[2]:loc[3]]
+		out = append(out, types.EntityRecord{
+			Name:         "var." + name,
+			Kind:         "SCOPE.Schema",
+			Subtype:      "var",
+			SourceFile:   path,
+			StartLine:    lineOf(src, loc[0]),
+			EndLine:      lineOf(src, loc[0]),
+			Language:     lang,
+			QualityScore: 0.8,
+			Metadata: map[string]interface{}{
+				"subtype":  "var",
+				"iac_tool": "bicep",
+				"label":    name,
+			},
+		})
+	}
+	return out
+}
+
+// extractOutputs emits a SCOPE.Schema/output per `output` declaration.
+func extractOutputs(src, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, loc := range reOutput.FindAllStringSubmatchIndex(src, -1) {
+		name := src[loc[2]:loc[3]]
+		outType := src[loc[4]:loc[5]]
+		out = append(out, types.EntityRecord{
+			Name:         "output." + name,
+			Kind:         "SCOPE.Schema",
+			Subtype:      "output",
+			SourceFile:   path,
+			StartLine:    lineOf(src, loc[0]),
+			EndLine:      lineOf(src, loc[0]),
+			Language:     lang,
+			QualityScore: 0.8,
+			Metadata: map[string]interface{}{
+				"subtype":     "output",
+				"iac_tool":    "bicep",
+				"label":       name,
+				"output_type": outType,
+			},
+		})
+	}
+	return out
+}
+
+// dependencyEdges returns DEPENDS_ON edges for a resource/module body: one per
+// distinct symbolic name referenced (either through a dotted property access
+// like `foo.id` / `foo.outputs.x`, or listed in an explicit dependsOn array).
+// Self-references are skipped. Only names in `symbolic` (locally-declared
+// resources/modules) produce edges.
+func dependencyEdges(body, path, self string, symbolic map[string]bool) []types.RelationshipRecord {
+	deps := referencedSymbols(body, self, symbolic)
+	if len(deps) == 0 {
+		return nil
+	}
+	var rels []types.RelationshipRecord
+	for _, dep := range deps {
+		rels = append(rels, types.RelationshipRecord{
+			FromID: path,
+			ToID:   extractor.BuildOperationStructuralRef(lang, path, dep),
+			Kind:   "DEPENDS_ON",
+		})
+	}
+	return rels
+}
+
+// reSymbolRef matches a symbolic-name property access: `<name>.id`,
+// `<name>.properties.x`, `<name>.outputs.y`. The leading boundary excludes
+// dotted continuations (so `a.b.c` does not also match `b.c`).
+var reSymbolRef = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\.(?:id|name|properties|outputs)\b`)
+
+// referencedSymbols returns the sorted-unique set of locally-declared symbolic
+// names referenced in body (excluding self), via property access or dependsOn.
+func referencedSymbols(body, self string, symbolic map[string]bool) []string {
+	seen := map[string]bool{}
+	var order []string
+	add := func(name string) {
+		if name == self || !symbolic[name] || seen[name] {
+			return
+		}
+		seen[name] = true
+		order = append(order, name)
+	}
+
+	for _, m := range reSymbolRef.FindAllStringSubmatch(body, -1) {
+		// Skip a property access whose token is preceded by a '.' (i.e. it is a
+		// nested segment, not a root symbol). FindAllStringSubmatch loses that
+		// context, so re-check via index below instead.
+		add(m[1])
+	}
+	// Re-filter nested segments: only keep names that appear as a root token
+	// (not immediately preceded by '.').
+	order = filterRootTokens(body, order)
+
+	// Explicit dependsOn: [ a, b ] — names are bare symbolic identifiers,
+	// optionally with array-index / property suffixes.
+	for _, dm := range reDependsOn.FindAllStringSubmatch(body, -1) {
+		for _, tok := range splitDependsOn(dm[1]) {
+			add(tok)
+		}
+	}
+	return order
+}
+
+// filterRootTokens drops names from order that never occur in body as a root
+// token (a token not immediately preceded by '.'), guarding against matching
+// the tail of a longer dotted path such as parent.child.id.
+func filterRootTokens(body string, order []string) []string {
+	var out []string
+	for _, name := range order {
+		if occursAsRoot(body, name) {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// occursAsRoot reports whether name appears in body as a root identifier: a
+// match not immediately preceded by '.' or an identifier character.
+func occursAsRoot(body, name string) bool {
+	idx := 0
+	for {
+		j := strings.Index(body[idx:], name)
+		if j < 0 {
+			return false
+		}
+		pos := idx + j
+		if pos == 0 || !isIdentByte(body[pos-1]) && body[pos-1] != '.' {
+			// Ensure the char after is a '.' (property access) to count.
+			after := pos + len(name)
+			if after < len(body) && body[after] == '.' {
+				return true
+			}
+		}
+		idx = pos + len(name)
+		if idx >= len(body) {
+			return false
+		}
+	}
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}
+
+// splitDependsOn splits a dependsOn array body into bare symbolic-name tokens,
+// stripping array-index / property suffixes (e.g. `vnets[0]` → `vnets`,
+// `sa.id` → `sa`).
+func splitDependsOn(inner string) []string {
+	fields := strings.FieldsFunc(inner, func(r rune) bool {
+		return r == ',' || r == '\n' || r == ' ' || r == '\t' || r == '\r'
+	})
+	var out []string
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		// Strip property/index suffix: keep the leading identifier.
+		for i := 0; i < len(f); i++ {
+			if !isIdentByte(f[i]) {
+				f = f[:i]
+				break
+			}
+		}
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// splitAzureType splits 'Microsoft.Storage/storageAccounts@2022-09-01' into the
+// resource-provider type ("Microsoft.Storage/storageAccounts") and api version.
+func splitAzureType(full string) (rpType, apiVersion string) {
+	if at := strings.IndexByte(full, '@'); at >= 0 {
+		return full[:at], full[at+1:]
+	}
+	return full, ""
+}
+
+// isLoop reports whether a body opens with a `[for … in … :` comprehension.
+func isLoop(body string) bool {
+	trimmed := strings.TrimSpace(body)
+	if strings.HasPrefix(trimmed, "[for ") || strings.HasPrefix(trimmed, "[for\t") {
+		return true
+	}
+	return strings.Contains(trimmed, "[for ") && strings.Contains(trimmed, " in ")
+}
+
+// nextDeclBoundary returns the byte offset (within [start,max)) of the next
+// top-level resource/module/param/var/output/@-decorator declaration after a
+// declaration body begins, so a body never bleeds into the following entity.
+func nextDeclBoundary(src string, start, max int) int {
+	window := src[start:max]
+	earliest := len(window)
+	for _, re := range []*regexp.Regexp{reResource, reModule, reParam, reVar, reOutput} {
+		if loc := re.FindStringIndex(window); loc != nil && loc[0] < earliest {
+			earliest = loc[0]
+		}
+	}
+	return start + earliest
+}
+
+// lineOf returns the 1-indexed line number of byte offset off in src.
+func lineOf(src string, off int) int {
+	if off > len(src) {
+		off = len(src)
+	}
+	return strings.Count(src[:off], "\n") + 1
+}

--- a/internal/extractors/bicep/extractor_test.go
+++ b/internal/extractors/bicep/extractor_test.go
@@ -1,0 +1,269 @@
+package bicep_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/bicep" // trigger init()
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractBicep(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("bicep")
+	if !ok {
+		t.Fatal("bicep extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "bicep",
+		// Tree intentionally nil — no bicep grammar is vendored; the extractor
+		// is regex/line-based.
+	})
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	return recs
+}
+
+func findByName(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func hasEdgeTo(rec *types.EntityRecord, kind, toSuffix string) bool {
+	for _, r := range rec.Relationships {
+		if r.Kind == kind && len(r.ToID) >= len(toSuffix) && r.ToID[len(r.ToID)-len(toSuffix):] == toSuffix {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBicep_TwoResources_DependsOn_AndModuleImport is the primary
+// value-asserting test required by the ticket: two resources where one
+// references the other's symbolic name plus a module. It asserts both resource
+// entities (by symbolic name + AzureRP type + Kind), the DEPENDS_ON edge
+// between them, and the module IMPORTS edge — NOT len>0.
+func TestBicep_TwoResources_DependsOn_AndModuleImport(t *testing.T) {
+	const src = `
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: 'mystg'
+  location: 'eastus'
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
+  name: '${storageAccount.name}/default'
+  properties: {
+    foo: storageAccount.id
+  }
+}
+
+module network './modules/network.bicep' = {
+  name: 'net'
+  params: {
+    sid: storageAccount.id
+  }
+}
+`
+	recs := extractBicep(t, src, "infra/main.bicep")
+
+	// --- resource entity 1: storageAccount ---
+	sa := findByName(recs, "storageAccount")
+	if sa == nil {
+		t.Fatal("storageAccount resource entity not found")
+	}
+	if sa.Kind != "SCOPE.InfraResource" {
+		t.Errorf("storageAccount Kind = %q, want SCOPE.InfraResource", sa.Kind)
+	}
+	if got := sa.Metadata["azure_rp_type"]; got != "Microsoft.Storage/storageAccounts" {
+		t.Errorf("storageAccount azure_rp_type = %v, want Microsoft.Storage/storageAccounts", got)
+	}
+	if got := sa.Metadata["api_version"]; got != "2022-09-01" {
+		t.Errorf("storageAccount api_version = %v, want 2022-09-01", got)
+	}
+	if got := sa.Metadata["deployed_name"]; got != "mystg" {
+		t.Errorf("storageAccount deployed_name = %v, want mystg", got)
+	}
+	if got := sa.Metadata["resource_scope"]; got != "datastore" {
+		t.Errorf("storageAccount resource_scope = %v, want datastore", got)
+	}
+
+	// --- resource entity 2: blobService, references storageAccount ---
+	blob := findByName(recs, "blobService")
+	if blob == nil {
+		t.Fatal("blobService resource entity not found")
+	}
+	if blob.Kind != "SCOPE.InfraResource" {
+		t.Errorf("blobService Kind = %q, want SCOPE.InfraResource", blob.Kind)
+	}
+	if got := blob.Metadata["azure_rp_type"]; got != "Microsoft.Storage/storageAccounts/blobServices" {
+		t.Errorf("blobService azure_rp_type = %v", got)
+	}
+
+	// --- DEPENDS_ON edge: blobService → storageAccount ---
+	wantRef := extractor.BuildOperationStructuralRef("bicep", "infra/main.bicep", "storageAccount")
+	var found bool
+	for _, r := range blob.Relationships {
+		if r.Kind == "DEPENDS_ON" && r.ToID == wantRef {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("blobService missing DEPENDS_ON → storageAccount; rels=%+v", blob.Relationships)
+	}
+
+	// --- module entity + IMPORTS edge to the .bicep path ---
+	mod := findByName(recs, "network")
+	if mod == nil {
+		t.Fatal("network module entity not found")
+	}
+	if mod.Kind != "SCOPE.Component" || mod.Subtype != "module" {
+		t.Errorf("network module Kind/Subtype = %q/%q, want SCOPE.Component/module", mod.Kind, mod.Subtype)
+	}
+	if got := mod.QualifiedName; got != "./modules/network.bicep" {
+		t.Errorf("network module QualifiedName = %q, want ./modules/network.bicep", got)
+	}
+	if !hasEdgeTo(mod, "IMPORTS", "./modules/network.bicep") {
+		t.Errorf("network module missing IMPORTS edge to ./modules/network.bicep; rels=%+v", mod.Relationships)
+	}
+	// module also DEPENDS_ON storageAccount (referenced storageAccount.id in params).
+	if !hasEdgeTo(mod, "DEPENDS_ON", "storageAccount") {
+		t.Errorf("network module missing DEPENDS_ON → storageAccount; rels=%+v", mod.Relationships)
+	}
+}
+
+// TestBicep_ExplicitDependsOn covers the dependsOn: [x] array form.
+func TestBicep_ExplicitDependsOn(t *testing.T) {
+	const src = `
+resource vnet 'Microsoft.Network/virtualNetworks@2022-01-01' = {
+  name: 'vnet1'
+}
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2022-01-01' = {
+  name: 'subnet1'
+  dependsOn: [
+    vnet
+  ]
+}
+`
+	recs := extractBicep(t, src, "net.bicep")
+	subnet := findByName(recs, "subnet")
+	if subnet == nil {
+		t.Fatal("subnet not found")
+	}
+	if !hasEdgeTo(subnet, "DEPENDS_ON", "vnet") {
+		t.Errorf("subnet missing explicit DEPENDS_ON → vnet; rels=%+v", subnet.Relationships)
+	}
+	vnet := findByName(recs, "vnet")
+	if got := vnet.Metadata["resource_scope"]; got != "network" {
+		t.Errorf("vnet resource_scope = %v, want network", got)
+	}
+}
+
+// TestBicep_ParamVarOutput asserts param / var / output entities.
+func TestBicep_ParamVarOutput(t *testing.T) {
+	const src = `
+param storageName string
+param location string = 'eastus'
+var tags = { env: 'prod' }
+output storageId string = sa.id
+`
+	recs := extractBicep(t, src, "p.bicep")
+
+	if p := findByName(recs, "param.storageName"); p == nil {
+		t.Error("param.storageName not found")
+	} else if p.Kind != "SCOPE.Schema" || p.Subtype != "param" {
+		t.Errorf("param Kind/Subtype = %q/%q", p.Kind, p.Subtype)
+	} else if p.Metadata["param_type"] != "string" {
+		t.Errorf("param_type = %v, want string", p.Metadata["param_type"])
+	}
+	if v := findByName(recs, "var.tags"); v == nil || v.Subtype != "var" {
+		t.Errorf("var.tags missing/wrong: %+v", v)
+	}
+	if o := findByName(recs, "output.storageId"); o == nil || o.Subtype != "output" {
+		t.Errorf("output.storageId missing/wrong: %+v", o)
+	} else if o.Metadata["output_type"] != "string" {
+		t.Errorf("output_type = %v, want string", o.Metadata["output_type"])
+	}
+}
+
+// TestBicep_ExistingAndLoop covers `existing` resources and [for …] loops.
+func TestBicep_ExistingAndLoop(t *testing.T) {
+	const src = `
+resource kv 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: 'shared-kv'
+}
+
+resource sas 'Microsoft.Storage/storageAccounts@2022-09-01' = [for name in names: {
+  name: name
+}]
+`
+	recs := extractBicep(t, src, "x.bicep")
+	kv := findByName(recs, "kv")
+	if kv == nil {
+		t.Fatal("kv not found")
+	}
+	if kv.Metadata["existing"] != "true" {
+		t.Errorf("kv existing flag = %v, want true", kv.Metadata["existing"])
+	}
+	sas := findByName(recs, "sas")
+	if sas == nil {
+		t.Fatal("sas (loop) not found")
+	}
+	if sas.Metadata["loop"] != "true" {
+		t.Errorf("sas loop flag = %v, want true", sas.Metadata["loop"])
+	}
+}
+
+// TestBicep_Fixture exercises the on-disk testdata fixture end-to-end.
+func TestBicep_Fixture(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "main.bicep"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	recs := extractBicep(t, string(data), "testdata/main.bicep")
+
+	// Resources: storageAccount, blobService, existingVault.
+	for _, n := range []string{"storageAccount", "blobService", "existingVault"} {
+		if findByName(recs, n) == nil {
+			t.Errorf("fixture missing resource %q", n)
+		}
+	}
+	// Module + IMPORTS.
+	mod := findByName(recs, "network")
+	if mod == nil {
+		t.Fatal("fixture missing module network")
+	}
+	if !hasEdgeTo(mod, "IMPORTS", "./modules/network.bicep") {
+		t.Error("fixture module missing IMPORTS edge")
+	}
+	// blobService DEPENDS_ON storageAccount (via ${storageAccount.name} + dependsOn).
+	blob := findByName(recs, "blobService")
+	if !hasEdgeTo(blob, "DEPENDS_ON", "storageAccount") {
+		t.Error("fixture blobService missing DEPENDS_ON → storageAccount")
+	}
+	// params/outputs present.
+	if findByName(recs, "param.storageName") == nil {
+		t.Error("fixture missing param.storageName")
+	}
+	if findByName(recs, "output.storageId") == nil {
+		t.Error("fixture missing output.storageId")
+	}
+}
+
+// TestBicep_Empty asserts graceful handling of empty input.
+func TestBicep_Empty(t *testing.T) {
+	recs := extractBicep(t, "", "empty.bicep")
+	if len(recs) != 0 {
+		t.Errorf("empty input produced %d records, want 0", len(recs))
+	}
+}

--- a/internal/extractors/bicep/kinds.go
+++ b/internal/extractors/bicep/kinds.go
@@ -1,0 +1,43 @@
+package bicep
+
+import "strings"
+
+// bicepResourceCoarseScope maps an Azure resource-provider type
+// (e.g. "Microsoft.Storage/storageAccounts") to a coarse architectural scope
+// label stored on the resource entity's Metadata. This mirrors the CDK
+// extractor's resource_scope attribute (internal/engine/cdk_edges.go): all
+// Bicep resources stay a single queryable SCOPE.InfraResource entity Kind, with
+// the finer datastore/queue/compute classification captured as an attribute
+// rather than a distinct entity Kind.
+//
+// The classification is deliberately conservative — it keys off the well-known
+// Azure resource-provider namespaces and resource-type segments.
+func bicepResourceCoarseScope(rpType string) string {
+	t := strings.ToLower(rpType)
+	switch {
+	case strings.Contains(t, "microsoft.storage/") ||
+		strings.Contains(t, "microsoft.sql/") ||
+		strings.Contains(t, "microsoft.documentdb/") ||
+		strings.Contains(t, "microsoft.dbforpostgresql/") ||
+		strings.Contains(t, "microsoft.dbformysql/") ||
+		strings.Contains(t, "microsoft.cache/") ||
+		strings.Contains(t, "database") ||
+		strings.Contains(t, "cosmosdb"):
+		return "datastore"
+	case strings.Contains(t, "microsoft.servicebus/") ||
+		strings.Contains(t, "microsoft.eventhub/") ||
+		strings.Contains(t, "microsoft.eventgrid/") ||
+		strings.Contains(t, "/queues") ||
+		strings.Contains(t, "/topics"):
+		return "queue"
+	case strings.Contains(t, "microsoft.web/sites") ||
+		strings.Contains(t, "microsoft.compute/") ||
+		strings.Contains(t, "microsoft.containerservice/") ||
+		strings.Contains(t, "microsoft.app/"):
+		return "compute"
+	case strings.Contains(t, "microsoft.network/"):
+		return "network"
+	default:
+		return "service"
+	}
+}

--- a/internal/extractors/bicep/testdata/main.bicep
+++ b/internal/extractors/bicep/testdata/main.bicep
@@ -1,0 +1,44 @@
+@description('Storage account name')
+param storageName string
+param location string = resourceGroup().location
+
+var tags = {
+  env: 'prod'
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: storageName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  tags: tags
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
+  name: '${storageAccount.name}/default'
+  properties: {
+    deleteRetentionPolicy: {
+      enabled: true
+    }
+  }
+  dependsOn: [
+    storageAccount
+  ]
+}
+
+module network './modules/network.bicep' = {
+  name: 'networkDeploy'
+  params: {
+    storageId: storageAccount.id
+    location: location
+  }
+}
+
+resource existingVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: 'shared-kv'
+}
+
+output storageId string = storageAccount.id
+output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -11,6 +11,7 @@ package extractors
 import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/assembly"
 	_ "github.com/cajasmota/archigraph/internal/extractors/astro"
+	_ "github.com/cajasmota/archigraph/internal/extractors/bicep"
 	_ "github.com/cajasmota/archigraph/internal/extractors/clojure"
 	_ "github.com/cajasmota/archigraph/internal/extractors/cobol"
 	_ "github.com/cajasmota/archigraph/internal/extractors/cpp"


### PR DESCRIPTION
Closes #3535 (epic #3512)

Adds Azure Bicep IaC extraction — previously **zero coverage**.

## Grammar-vs-regex decision
No tree-sitter grammar for Bicep is vendored in the repo (`internal/treesitter/` has no bicep entry; `.bicep` files arrive at dispatch with a **nil tree**). Following the precedent set by the COBOL/CDK regex detectors, the extractor is **regex/line-based** over raw source. Bicep is structurally HCL-like (resource/module/param/var/output declarations with symbolic-name cross-references), so the entity + edge model mirrors `internal/extractors/hcl`.

## What fires
**Entities**
- `resource <sym> 'Microsoft.Storage/storageAccounts@2022-09-01' [existing] = {…}` → **SCOPE.InfraResource** (single queryable Kind, matching CDK), named by symbolic name. `azure_rp_type`, `api_version`, `deployed_name` (from `name:`), and a coarse `resource_scope` (datastore/queue/compute/network/service via `bicepResourceCoarseScope`) on Metadata.
- `module <name> '<path>.bicep' = {…}` → **SCOPE.Component/module** + **IMPORTS** edge to the `.bicep` path.
- `param` / `var` / `output` → **SCOPE.Schema** (param_type / output_type captured).

**Edges** (reusing the hcl `DEPENDS_ON` kind)
- Symbolic-name property references (`foo.id`, `foo.properties.x`, `foo.outputs.y`) → **DEPENDS_ON**.
- Explicit `dependsOn: [a, b]` arrays → **DEPENDS_ON** to each listed symbol.
- Module `'path.bicep'` → **IMPORTS**.
- Edges are Format-A structural-refs (`BuildOperationStructuralRef`) tied to the current file, so the resolver binds them via byLocation to sibling entities in the same file — exactly as the HCL extractor does for `depends_on`.

`existing` resources and `[for item in items: {…}]` loops are recognised (flagged in Metadata; references inside loop bodies are still attributed).

## Wiring
- `.bicep` → `"bicep"` in `internal/classifier/classifier.go`.
- Blank import in `internal/extractors/registry_gen.go` (alphabetical).

## Coverage
`infra.iac.bicep` cells flipped **missing → full** honestly (`resource_extraction`, `dependency_attribution`) with extractor-source cites. `coverage gen` + `validate` (0 errors; only the optional capability-map warnings shared by all peer iac cells) + `fmt --check` all green.

## Tests (value-asserting, not len>0)
Primary test: a `.bicep` with two resources where one references the other's `.id` + a module → asserts **both resource entities** (symbolic name + AzureRP type + Kind), the **DEPENDS_ON** edge, and the module **IMPORTS** edge. Plus explicit `dependsOn`, param/var/output, `existing`/loop flags, an on-disk fixture, and empty-input handling.

`gofmt -l` clean on all new/edited lines, `go vet` clean. Targeted suites green: `./internal/extractors/... ./internal/engine/ ./internal/types/ ./tools/coverage/`.

## DEPLOY-DEFERRED
Strictly isolated worktree; no daemon/MCP/install touched. The live daemon must be rebuilt + the target groups reindexed for `.bicep` extraction to take effect at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)