### PR TITLE
feat(php): add webonyx/graphql-php (GraphQL) coverage

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 198 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 2 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
+**Total**: 199 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 2 · **php**: 13 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -84,6 +84,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/7 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # php
 
-**Frameworks**: 12 · **Tools**: 6 · **ORMs**: 14 · **Other**: 0
+**Frameworks**: 13 · **Tools**: 6 · **ORMs**: 14 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -38,6 +38,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Yii](../detail/lang.php.framework.yii.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [graphql-php](../detail/lang.php.framework.graphql-php.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/7 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.php.framework.graphql-php.md
+++ b/docs/coverage/detail/lang.php.framework.graphql-php.md
@@ -1,0 +1,103 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.php.framework.graphql-php` — graphql-php
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [php](../by-language/php.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | `2026-05-30` | — | `internal/custom/php/graphql.go`<br>`internal/custom/php/graphql_test.go` | — |
+| Handler attribution | ✅ `full` | `2026-05-30` | — | `internal/custom/php/graphql.go`<br>`internal/custom/php/graphql_test.go` | — |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/php/graphql.go`<br>`internal/custom/php/graphql_test.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/php/graphql.go`<br>`internal/custom/php/graphql_test.go` | — |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.php.framework.graphql-php ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -36030,6 +36030,181 @@
       }
     },
     {
+      "id": "lang.php.framework.graphql-php",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "php",
+      "label": "graphql-php",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/custom/php/graphql.go","internal/custom/php/graphql_test.go"],
+            "verified_at": "2026-05-30"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/custom/php/graphql.go","internal/custom/php/graphql_test.go"],
+            "verified_at": "2026-05-30"
+          },
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/php/graphql.go","internal/custom/php/graphql_test.go"],
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/php/graphql.go","internal/custom/php/graphql_test.go"],
+            "verified_at": "2026-05-30"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.php.framework.laminas",
       "category": "http_framework",
       "subcategory": "http_backend",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 198 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 199 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
 
 ## Coverage by language
 
@@ -16,7 +16,7 @@
 | [kotlin](by-language/kotlin.md) | 15 | 0 | 7 | 0 |
 | [rust](by-language/rust.md) | 14 | 6 | 14 | 0 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
-| [php](by-language/php.md) | 12 | 6 | 14 | 0 |
+| [php](by-language/php.md) | 13 | 6 | 14 | 0 |
 | [scala](by-language/scala.md) | 12 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 198 frameworks · 110 tools · 151 ORMs · 115 other
+Total: 199 frameworks · 110 tools · 151 ORMs · 115 other

--- a/internal/custom/php/graphql.go
+++ b/internal/custom/php/graphql.go
@@ -1,0 +1,449 @@
+// Package php — regex/bracket-based webonyx/graphql-php extractor.
+//
+// webonyx/graphql-php is the de-facto code-first GraphQL server library for
+// PHP. A schema is built from PHP `ObjectType` instances whose `fields` array
+// declares the GraphQL fields of that type; each field's `resolve` closure or
+// callable is the field resolver (the route-handler analog):
+//
+//	$queryType = new ObjectType([
+//	    'name' => 'Query',
+//	    'fields' => [
+//	        'user' => [
+//	            'type' => Type::nonNull($userType),
+//	            'args' => ['id' => Type::nonNull(Type::id())],
+//	            'resolve' => fn ($root, $args, $ctx) => $repo->find($args['id']),
+//	        ],
+//	        'users' => [
+//	            'type' => Type::listOf($userType),
+//	            'resolve' => function ($root, $args) { return $repo->all(); },
+//	        ],
+//	    ],
+//	]);
+//
+//	$schema = new Schema([
+//	    'query'    => $queryType,
+//	    'mutation' => $mutationType,
+//	]);
+//
+// Mapping (mirrors rust async-graphql / kotlin graphql-kotlin / jsts
+// strawberry):
+//
+//   - Each field of an ObjectType named Query/Mutation/Subscription becomes a
+//     synthetic GRAPHQL endpoint with verb GRAPHQL and path
+//     /graphql/<TypeName>/<field>. The field's resolve closure/callable is the
+//     handler (handler_name = <TypeName>.<field>).
+//   - `new Schema([...])` is the schema root (SCOPE.Service), capturing its
+//     query / mutation / subscription operation-root variables.
+//   - A field's `'type'` reference (Type::nonNull($userType), Type::listOf(...),
+//     or a bare custom `$userType`) is recorded as a DTO/type ref on the field
+//     entity; ObjectType instances assigned to a variable (`$userType = new
+//     ObjectType([... 'name' => 'User' ...])`) become SCOPE.Schema DTOs.
+//
+// HONEST LIMIT: this is file-local and structural. Schema-first / SDL
+// (Lighthouse, `.graphql` schema files) is NOT handled here and is a separate
+// follow-up. Field `type` refs that resolve to a type defined in another file
+// are recorded by name only, not linked. ObjectTypes whose `name` is computed
+// at runtime, or fields built via a `function () { return [...]; }` thunk
+// rather than an inline array literal, are not chased.
+//
+// Registration key: "custom_php_graphql_php"
+// Issue #3544 (epic #3505) — PHP webonyx/graphql-php coverage.
+package php
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_php_graphql_php", &graphqlPHPExtractor{})
+}
+
+type graphqlPHPExtractor struct{}
+
+func (e *graphqlPHPExtractor) Language() string { return "custom_php_graphql_php" }
+
+var (
+	// `new ObjectType(` — start of a webonyx object-type definition. The byte
+	// offset of the `(` lets the caller balance the argument array.
+	reGQLPObjectType = regexp.MustCompile(`new\s+ObjectType\s*\(`)
+	// `new Schema(` — start of a webonyx schema construction.
+	reGQLPSchema = regexp.MustCompile(`new\s+Schema\s*\(`)
+	// `$var = new ObjectType(` — captures the PHP variable an ObjectType is
+	// assigned to (group 1), used to associate a DTO type name with its var.
+	reGQLPVarAssign = regexp.MustCompile(`\$([A-Za-z_]\w*)\s*=\s*new\s+ObjectType\s*\(`)
+	// `'name' => 'Foo'` / "name" => "Foo" — the GraphQL type name inside an
+	// ObjectType config array. Group 1 is the type name.
+	reGQLPName = regexp.MustCompile(`['"]name['"]\s*=>\s*['"]([A-Za-z_]\w*)['"]`)
+	// `'fields' => [` / "fields" => array( — start of the fields map. The byte
+	// offset of the opening bracket lets the caller balance the fields block.
+	reGQLPFields = regexp.MustCompile(`['"]fields['"]\s*=>\s*(\[|array\s*\()`)
+	// A top-level field key inside a fields map: `'user' =>` / "users" =>.
+	// Matched on the fields-block source with depth tracking by the caller so
+	// only depth-0 keys (the field names) are taken.
+	reGQLPFieldKey = regexp.MustCompile(`(?m)['"]([A-Za-z_]\w*)['"]\s*=>`)
+	// `'resolve' =>` — marks a field config that carries an explicit resolver.
+	reGQLPResolve = regexp.MustCompile(`['"]resolve['"]\s*=>`)
+	// `'type' => <expr>` — captures the raw type expression for a field up to
+	// the next comma at the field's own depth (caller bounds it).
+	reGQLPType = regexp.MustCompile(`['"]type['"]\s*=>\s*`)
+	// A schema operation root: `'query' => $queryType`. Group 1 is the
+	// operation (query/mutation/subscription), group 2 the root variable.
+	reGQLPSchemaRoot = regexp.MustCompile(`['"](query|mutation|subscription)['"]\s*=>\s*\$([A-Za-z_]\w*)`)
+)
+
+// gqlpBalanced returns the byte range [open+1, close) of the bracket group
+// whose opening bracket is the first `[` or `(` at or after `from` in src,
+// balancing both `[]` and `()` so `array( ... )` and `[ ... ]` both work.
+// Returns (-1,-1) when no opening bracket or no balanced close is found.
+// Brackets inside single/double-quoted PHP strings are ignored.
+func gqlpBalanced(src string, from int) (int, int) {
+	open := -1
+	for i := from; i < len(src); i++ {
+		if src[i] == '[' || src[i] == '(' {
+			open = i
+			break
+		}
+	}
+	if open == -1 {
+		return -1, -1
+	}
+	depth := 0
+	inStr := byte(0)
+	for i := open; i < len(src); i++ {
+		c := src[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++ // skip escaped char
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inStr = c
+		case '[', '(':
+			depth++
+		case ']', ')':
+			depth--
+			if depth == 0 {
+				return open + 1, i
+			}
+		}
+	}
+	return -1, -1
+}
+
+// gqlpTopLevelFieldKeys returns the field names declared at depth 0 of a
+// fields-map body, in source order, paired with the byte offset of each key.
+// Depth is tracked over `[]`/`()` (and PHP strings ignored) so only the
+// outermost keys — the field names — are returned, not keys nested inside a
+// field's own config array (type/args/resolve/...).
+func gqlpTopLevelFieldKeys(body string) []struct {
+	name   string
+	offset int
+} {
+	var out []struct {
+		name   string
+		offset int
+	}
+	depth := 0
+	inStr := byte(0)
+	// Precompute key matches so we only have to check depth at their offsets.
+	keys := reGQLPFieldKey.FindAllStringSubmatchIndex(body, -1)
+	ki := 0
+	for i := 0; i < len(body); i++ {
+		// Emit any key whose match starts exactly here and sits at depth 0.
+		for ki < len(keys) && keys[ki][0] == i {
+			if depth == 0 && inStr == 0 {
+				out = append(out, struct {
+					name   string
+					offset int
+				}{body[keys[ki][2]:keys[ki][3]], keys[ki][0]})
+			}
+			ki++
+		}
+		c := body[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inStr = c
+		case '[', '(':
+			depth++
+		case ']', ')':
+			depth--
+		}
+	}
+	return out
+}
+
+// gqlpFieldConfigEnd returns the byte offset (relative to body) at which the
+// field whose value begins at valStart ends — i.e. the comma at the field's
+// own depth, or len(body). valStart should point just after the `=>` of the
+// field key. This bounds a single field's config so type/resolve lookups stay
+// within that field.
+func gqlpFieldConfigEnd(body string, valStart int) int {
+	depth := 0
+	inStr := byte(0)
+	for i := valStart; i < len(body); i++ {
+		c := body[i]
+		if inStr != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			inStr = c
+		case '[', '(':
+			depth++
+		case ']', ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return len(body)
+}
+
+// gqlpTypeRef extracts a human-readable type reference from a field config
+// slice (the body between the field key and its terminating comma). It returns
+// the inner type name of a Type::nonNull($x) / Type::listOf($x) wrapper, the
+// bare custom-type variable ($userType -> userType), or a scalar name
+// (Type::string() -> string). Returns "" when no `'type' =>` is present.
+func gqlpTypeRef(cfg string) string {
+	loc := reGQLPType.FindStringIndex(cfg)
+	if loc == nil {
+		return ""
+	}
+	expr := strings.TrimSpace(cfg[loc[1]:])
+	// Bound the expr to its own value (up to a top-level comma).
+	end := gqlpFieldConfigEnd(expr, 0)
+	expr = strings.TrimSpace(expr[:end])
+
+	// Unwrap Type::nonNull(...) / Type::listOf(...) repeatedly.
+	for {
+		if m := regexp.MustCompile(`^Type::(?:nonNull|listOf)\s*\(`).FindStringIndex(expr); m != nil {
+			s, e := gqlpBalanced(expr, m[1]-1)
+			if s < 0 {
+				break
+			}
+			expr = strings.TrimSpace(expr[s:e])
+			continue
+		}
+		break
+	}
+	// Scalar: Type::string() / Type::id() -> the scalar name.
+	if m := regexp.MustCompile(`^Type::([A-Za-z_]\w*)\s*\(`).FindStringSubmatch(expr); m != nil {
+		return m[1]
+	}
+	// Custom-type variable: $userType -> userType.
+	if m := regexp.MustCompile(`^\$([A-Za-z_]\w*)`).FindStringSubmatch(expr); m != nil {
+		return m[1]
+	}
+	// Bare class ref: UserType::class or UserType.
+	if m := regexp.MustCompile(`^([A-Za-z_]\w*)`).FindStringSubmatch(expr); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// gqlpOperationForType maps an ObjectType `name` to its GraphQL operation kind,
+// or "" when the type is an ordinary object type (a DTO, not an operation
+// root). webonyx convention names the roots Query / Mutation / Subscription.
+func gqlpOperationForType(name string) string {
+	switch name {
+	case "Query":
+		return "Query"
+	case "Mutation":
+		return "Mutation"
+	case "Subscription":
+		return "Subscription"
+	default:
+		return ""
+	}
+}
+
+func (e *graphqlPHPExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/php")
+	_, span := tracer.Start(ctx, "indexer.graphql_php_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "graphql-php"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "php" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// File-signal gate: require a webonyx marker so this extractor is a no-op
+	// on plain PHP / Laravel / Symfony files. `new ObjectType` / `new Schema`
+	// (in conjunction with a GraphQL type expression) are the unambiguous
+	// signals.
+	if !strings.Contains(src, "ObjectType") && !strings.Contains(src, "new Schema") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// Map each ObjectType variable-assignment offset to its variable name so a
+	// DTO ObjectType (named non-root) can record its source variable.
+	varAt := make(map[int]string)
+	for _, m := range reGQLPVarAssign.FindAllStringSubmatchIndex(src, -1) {
+		// m[0] is the start of "$var", and the ObjectType `new` follows; key by
+		// the position of the `new ObjectType(` so we can join with the loop
+		// below, which iterates over `new ObjectType(` matches.
+		newOff := strings.Index(src[m[0]:], "new")
+		if newOff >= 0 {
+			varAt[m[0]+newOff] = src[m[2]:m[3]]
+		}
+	}
+
+	// 1. ObjectType definitions: roots → GRAPHQL endpoints, others → DTOs.
+	for _, m := range reGQLPObjectType.FindAllStringIndex(src, -1) {
+		// Balance the ObjectType( ... ) argument group, then the inner config
+		// array literal.
+		argStart, argEnd := gqlpBalanced(src, m[1]-1)
+		if argStart < 0 {
+			continue
+		}
+		cfg := src[argStart:argEnd]
+
+		nameM := reGQLPName.FindStringSubmatch(cfg)
+		if nameM == nil {
+			continue // anonymous / runtime-computed name — not chased.
+		}
+		typeName := nameM[1]
+		operation := gqlpOperationForType(typeName)
+
+		// Locate the fields map within this ObjectType config.
+		fieldsLoc := reGQLPFields.FindStringIndex(cfg)
+
+		if operation == "" {
+			// Ordinary object type → SCOPE.Schema DTO.
+			ent := makeEntity("graphql_dto:"+typeName, "SCOPE.Schema", "dto", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "graphql-php",
+				"provenance", "INFERRED_FROM_GRAPHQL_PHP_DTO",
+				"dto_name", typeName, "graphql_dto_role", "object")
+			if v, ok := varAt[m[0]]; ok {
+				setProps(&ent, "dto_source_var", v)
+			}
+			add(ent)
+			continue
+		}
+
+		// Operation root → one GRAPHQL endpoint per top-level field.
+		if fieldsLoc == nil {
+			continue
+		}
+		// fieldsLoc[1] points just past the `[`/`array(` token; step back one
+		// char so gqlpBalanced starts on the opening bracket of the fields map.
+		fs, fe := gqlpBalanced(cfg, fieldsLoc[1]-1)
+		if fs < 0 {
+			continue
+		}
+		fieldsBody := cfg[fs:fe]
+
+		for _, fk := range gqlpTopLevelFieldKeys(fieldsBody) {
+			field := fk.name
+			// Bound this field's config to look for resolve / type.
+			valStart := fk.offset
+			if idx := strings.Index(fieldsBody[fk.offset:], "=>"); idx >= 0 {
+				valStart = fk.offset + idx + 2
+			}
+			cfgEnd := gqlpFieldConfigEnd(fieldsBody, valStart)
+			fieldCfg := fieldsBody[valStart:cfgEnd]
+
+			path := "/graphql/" + typeName + "/" + field
+			name := "GRAPHQL " + path
+			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, argStart+fs+fk.offset))
+			setProps(&ent, "framework", "graphql-php",
+				"provenance", "INFERRED_FROM_GRAPHQL_PHP_RESOLVER",
+				"http_method", "GRAPHQL", "verb", "GRAPHQL",
+				"route_path", path, "graphql_operation", operation,
+				"graphql_root", typeName, "graphql_field", field,
+				"handler_name", typeName+"."+field)
+			if reGQLPResolve.MatchString(fieldCfg) {
+				setProps(&ent, "has_resolver", "true")
+			}
+			if ref := gqlpTypeRef(fieldCfg); ref != "" {
+				setProps(&ent, "graphql_field_type", ref)
+			}
+			add(ent)
+		}
+	}
+
+	// 2. new Schema([...]) → SCOPE.Service schema root with operation roots.
+	for _, m := range reGQLPSchema.FindAllStringIndex(src, -1) {
+		argStart, argEnd := gqlpBalanced(src, m[1]-1)
+		if argStart < 0 {
+			continue
+		}
+		cfg := src[argStart:argEnd]
+
+		roots := map[string]string{}
+		for _, rm := range reGQLPSchemaRoot.FindAllStringSubmatch(cfg, -1) {
+			roots[rm[1]] = rm[2]
+		}
+		if len(roots) == 0 {
+			continue
+		}
+		ent := makeEntity("graphql_schema:"+file.Path, "SCOPE.Service", "graphql_schema", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "graphql-php",
+			"provenance", "INFERRED_FROM_GRAPHQL_PHP_SCHEMA")
+		if v, ok := roots["query"]; ok {
+			setProps(&ent, "query_root", v)
+		}
+		if v, ok := roots["mutation"]; ok {
+			setProps(&ent, "mutation_root", v)
+		}
+		if v, ok := roots["subscription"]; ok {
+			setProps(&ent, "subscription_root", v)
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/php/graphql_test.go
+++ b/internal/custom/php/graphql_test.go
@@ -1,0 +1,148 @@
+package php_test
+
+import "testing"
+
+// graphql_test.go — value-asserting tests for the webonyx/graphql-php
+// extractor. Record lang.php.framework.graphql-php; cells endpoint_synthesis /
+// handler_attribution / route_extraction / dto_extraction → full.
+// Issue #3544 (epic #3505).
+
+const gqlpSchemaSrc = `<?php
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+
+$userType = new ObjectType([
+    'name' => 'User',
+    'fields' => [
+        'id'   => Type::nonNull(Type::id()),
+        'name' => Type::string(),
+    ],
+]);
+
+$queryType = new ObjectType([
+    'name' => 'Query',
+    'fields' => [
+        'user' => [
+            'type' => Type::nonNull($userType),
+            'args' => [
+                'id' => Type::nonNull(Type::id()),
+            ],
+            'resolve' => fn ($root, $args, $ctx) => $repo->find($args['id']),
+        ],
+        'users' => [
+            'type' => Type::listOf($userType),
+            'resolve' => function ($root, $args) {
+                return $repo->all();
+            },
+        ],
+    ],
+]);
+
+$mutationType = new ObjectType([
+    'name' => 'Mutation',
+    'fields' => [
+        'createUser' => [
+            'type' => Type::nonNull($userType),
+            'resolve' => fn ($root, $args) => $repo->save($args),
+        ],
+    ],
+]);
+
+$schema = new Schema([
+    'query'    => $queryType,
+    'mutation' => $mutationType,
+]);
+`
+
+// TestGraphQLPHP_ResolverFields asserts each field of the Query/Mutation
+// ObjectType becomes an addressable GRAPHQL endpoint /graphql/<Type>/<field>.
+func TestGraphQLPHP_ResolverFields(t *testing.T) {
+	ents := extract(t, "custom_php_graphql_php", fi("schema.php", "php", gqlpSchemaSrc))
+	if len(ents) == 0 {
+		t.Fatal("[graphql-php] expected entities, got none")
+	}
+
+	for _, want := range []string{
+		"GRAPHQL /graphql/Query/user",
+		"GRAPHQL /graphql/Query/users",
+		"GRAPHQL /graphql/Mutation/createUser",
+	} {
+		if !containsEntity(ents, "SCOPE.Operation", want) {
+			t.Errorf("expected operation %q", want)
+		}
+	}
+
+	// `args`, `type`, `id`, `name` are nested config keys, NOT field names —
+	// they must not leak out as endpoints.
+	for _, notWant := range []string{
+		"GRAPHQL /graphql/Query/type",
+		"GRAPHQL /graphql/Query/args",
+		"GRAPHQL /graphql/Query/resolve",
+		"GRAPHQL /graphql/Query/id",
+	} {
+		if containsEntity(ents, "SCOPE.Operation", notWant) {
+			t.Errorf("nested config key leaked as endpoint: %q", notWant)
+		}
+	}
+}
+
+// TestGraphQLPHP_DTO asserts an ordinary (non-root) ObjectType becomes a
+// SCOPE.Schema DTO, while the Query/Mutation roots do NOT become DTOs.
+func TestGraphQLPHP_DTO(t *testing.T) {
+	ents := extract(t, "custom_php_graphql_php", fi("schema.php", "php", gqlpSchemaSrc))
+
+	if !containsEntity(ents, "SCOPE.Schema", "graphql_dto:User") {
+		t.Error("expected graphql_dto:User schema DTO")
+	}
+	for _, notWant := range []string{"graphql_dto:Query", "graphql_dto:Mutation"} {
+		if containsEntity(ents, "SCOPE.Schema", notWant) {
+			t.Errorf("operation root wrongly emitted as DTO: %q", notWant)
+		}
+	}
+}
+
+// TestGraphQLPHP_Schema asserts new Schema([...]) yields a SCOPE.Service root.
+func TestGraphQLPHP_Schema(t *testing.T) {
+	ents := extract(t, "custom_php_graphql_php", fi("schema.php", "php", gqlpSchemaSrc))
+	if !containsEntity(ents, "SCOPE.Service", "graphql_schema:schema.php") {
+		t.Error("expected graphql_schema:schema.php service root")
+	}
+}
+
+// TestGraphQLPHP_ArraySyntax verifies the legacy `array( ... )` literal form is
+// handled identically to short `[ ... ]` arrays.
+func TestGraphQLPHP_ArraySyntax(t *testing.T) {
+	src := `<?php
+$queryType = new ObjectType(array(
+    'name' => 'Query',
+    'fields' => array(
+        'ping' => array(
+            'type' => Type::string(),
+            'resolve' => function () { return 'pong'; },
+        ),
+    ),
+));
+`
+	ents := extract(t, "custom_php_graphql_php", fi("legacy.php", "php", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GRAPHQL /graphql/Query/ping") {
+		t.Error("expected GRAPHQL /graphql/Query/ping from array() syntax")
+	}
+}
+
+// TestGraphQLPHP_NoMatch verifies the extractor is a no-op on plain PHP.
+func TestGraphQLPHP_NoMatch(t *testing.T) {
+	src := `<?php class Foo { public function bar() { return 1; } }`
+	ents := extract(t, "custom_php_graphql_php", fi("plain.php", "php", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities on plain PHP, got %d", len(ents))
+	}
+}
+
+// TestGraphQLPHP_WrongLanguage verifies the language gate.
+func TestGraphQLPHP_WrongLanguage(t *testing.T) {
+	ents := extract(t, "custom_php_graphql_php", fi("schema.js", "javascript", gqlpSchemaSrc))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-php language, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
Closes #3544 (epic #3505).

Adds a PHP custom extractor for **webonyx/graphql-php**, the code-first GraphQL server library for PHP — closing the PHP GraphQL category gap. EXPANSION (new record).

## Extractor — `internal/custom/php/graphql.go` (key `custom_php_graphql_php`)
- `new ObjectType(['name' => 'Query'|'Mutation'|'Subscription', 'fields' => [...]])` → one **GRAPHQL endpoint** per top-level field at `/graphql/<Type>/<field>`; the field's `resolve` closure/callable is the **handler** (`handler_name = <Type>.<field>`).
- Depth-aware bracket balancing (handles both short `[...]` and legacy `array(...)` literals, PHP strings ignored) so nested config keys (`type`/`args`/`resolve`/scalar arg names) never leak out as fields.
- Ordinary (non-root) `ObjectType`s → **SCOPE.Schema** DTOs; roots are excluded from DTOs.
- `new Schema(['query' => ..., 'mutation' => ...])` → **SCOPE.Service** schema root capturing operation-root variables.
- Field `'type'` refs (`Type::nonNull`/`Type::listOf` unwrapping, scalars, custom `$type` vars) recorded on the field entity.
- File-signal gated (`ObjectType`/`new Schema`) and php language-gated; no-op otherwise. Mirrors the rust `async-graphql` / kotlin `graphql-kotlin` models.

**HONEST LIMIT:** SDL-first (Lighthouse / `.graphql` schema files) is left honest-partial as a separate follow-up.

## Coverage
New record **`lang.php.framework.graphql-php`** (`http_framework` / `http_backend`), backfilled. Flipped to `full` with value-asserting tests:
- `endpoint_synthesis`
- `handler_attribution`
- `route_extraction`
- `dto_extraction`

## Tests / checks
- `internal/custom/php/graphql_test.go` — asserts the specific `user`/`users`/`createUser` GRAPHQL field entities, that nested config keys do NOT leak, the `User` DTO (and that `Query`/`Mutation` roots are NOT DTOs), the `Schema` service root, `array(...)` syntax, and no-op/language gates.
- `go test ./internal/custom/php/ ./internal/types/ ./internal/engine/ ./tools/coverage/` green; `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)