### PR TITLE
feat(rust): add validator crate (validation) coverage

### DIFF
--- a/docs/coverage/by-category/validation.md
+++ b/docs/coverage/by-category/validation.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # validation
 
-**Total**: 5 records · **C/C++**: 1 · **java**: 1 · **python**: 3
+**Total**: 6 records · **C/C++**: 1 · **java**: 1 · **python**: 3 · **rust**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # rust
 
-**Frameworks**: 14 · **Tools**: 6 · **ORMs**: 14 · **Other**: 0
+**Frameworks**: 14 · **Tools**: 6 · **ORMs**: 14 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -80,3 +80,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🟢 1/1 | |
 | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟢 4/4 | |
 | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🟢 1/1 | |
+
+
+## Other
+
+
+### Validation
+
+| Name | Testing | Other capabilities | Notes |
+|---|---|---|---|
+| [validator](../detail/lang.rust.validation.validator.md) | 🟢 1/1 | ✅ 4/4 | |

--- a/docs/coverage/detail/lang.rust.validation.validator.md
+++ b/docs/coverage/detail/lang.rust.validation.validator.md
@@ -1,0 +1,48 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.validation.validator` — validator
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [validation](../by-category/validation.md)
+- **Subcategory:** Validation
+- **Capability cells:** 6
+
+## Capabilities
+
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Nested model extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/validator.go`<br>`internal/custom/rust/validator_test.go` | — |
+| Schema extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/validator.go`<br>`internal/custom/rust/validator_test.go` | — |
+
+### Constraints
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Constraint extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/validator.go`<br>`internal/custom/rust/validator_test.go` | — |
+| Custom validator extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/validator.go`<br>`internal/custom/rust/validator_test.go` | — |
+
+### Coercion
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type coercion recognition | — `not_applicable` | `2026-05-30` | — | — | validator does not coerce types; type coercion is serde's responsibility, covered by dto_extraction in fw_validation.go |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🟢 `partial` | `2026-05-30` | [link](https://github.com/cajasmota/archigraph/issues/3545) | `internal/custom/rust/validator_test.go` | validator-specific fixtures assert exact constraint values; general rust test-linkage substrate provides edges |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.validation.validator ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -50201,6 +50201,55 @@
       }
     },
     {
+      "id": "lang.rust.validation.validator",
+      "category": "validation",
+      "subcategory": "validation_lib",
+      "language": "rust",
+      "label": "validator",
+      "capabilities": {
+        "Schema": {
+          "nested_model_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/validator.go","internal/custom/rust/validator_test.go"],
+            "verified_at": "2026-05-30"
+          },
+          "schema_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/validator.go","internal/custom/rust/validator_test.go"],
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Constraints": {
+          "constraint_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/validator.go","internal/custom/rust/validator_test.go"],
+            "verified_at": "2026-05-30"
+          },
+          "custom_validator_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/rust/validator.go","internal/custom/rust/validator_test.go"],
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Coercion": {
+          "type_coercion_recognition": {
+            "status": "not_applicable",
+            "notes": "validator does not coerce types; type coercion is serde's responsibility, covered by dto_extraction in fw_validation.go",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "partial",
+            "cites": ["internal/custom/rust/validator_test.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3545",
+            "notes": "validator-specific fixtures assert exact constraint values; general rust test-linkage substrate provides edges",
+            "verified_at": "2026-05-30"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.scala.framework.akka-http",
       "category": "http_framework",
       "subcategory": "jvm_backend",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 198 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 199 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
 
 ## Coverage by language
 
@@ -16,7 +16,7 @@
 | [kotlin](by-language/kotlin.md) | 15 | 0 | 7 | 0 |
 | [rust](by-language/rust.md) | 14 | 6 | 14 | 1 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
-| [php](by-language/php.md) | 12 | 6 | 14 | 0 |
+| [php](by-language/php.md) | 13 | 6 | 14 | 0 |
 | [scala](by-language/scala.md) | 12 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 198 frameworks · 110 tools · 151 ORMs · 116 other
+Total: 199 frameworks · 110 tools · 151 ORMs · 116 other

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 199 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 198 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
 
 ## Coverage by language
 
@@ -14,9 +14,9 @@
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
 | [kotlin](by-language/kotlin.md) | 15 | 0 | 7 | 0 |
-| [rust](by-language/rust.md) | 14 | 6 | 14 | 0 |
+| [rust](by-language/rust.md) | 14 | 6 | 14 | 1 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
-| [php](by-language/php.md) | 13 | 6 | 14 | 0 |
+| [php](by-language/php.md) | 12 | 6 | 14 | 0 |
 | [scala](by-language/scala.md) | 12 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 199 frameworks · 110 tools · 151 ORMs · 115 other
+Total: 198 frameworks · 110 tools · 151 ORMs · 116 other

--- a/internal/custom/rust/validator.go
+++ b/internal/custom/rust/validator.go
@@ -1,0 +1,224 @@
+package rust
+
+// validator.go — coverage for the Rust `validator` crate as a standalone
+// validation library (record lang.rust.validation.validator, epic #3505,
+// issue #3545).
+//
+// The validator crate is the de-facto declarative validation library in the
+// Rust ecosystem. It is framework-agnostic: a `#[derive(Validate)]` struct with
+// `#[validate(...)]` field attributes can be validated by calling `.validate()`
+// anywhere — inside an HTTP handler, a CLI, a background job, or a test.
+//
+// fw_validation.go already detects validator-crate signals *in the context of
+// HTTP framework DTOs* (records lang.rust.framework.*). This extractor records
+// the same crate as a first-class VALIDATION LIBRARY, emitting library-semantic
+// entities that map onto the validation_lib taxonomy lanes:
+//
+//   schema_extraction          — #[derive(Validate)] struct → validator_schema
+//   nested_model_extraction    — #[validate(nested)] field → nested_validation
+//   constraint_extraction      — each #[validate(<rule>)] → SCOPE.Constraint with
+//                                the SPECIFIC field + constraint kind + bound/regex
+//   custom_validator_extraction— #[validate(custom = "fn")] / schema-level
+//                                #[validate(schema(function = "fn"))]
+//   type_coercion_recognition  — (n/a for validator; coercion is serde's job)
+//   tests_linkage              — substrate via the general rust test linkage
+//
+// Detection is regex-based on source text (honest `partial`→`full` where a
+// fixture proves the exact captured value). The heavy parsing — balanced struct
+// bodies, per-field serde/validate attribute windows, typed constraint parsing
+// with bounds — is reused from fw_validation.go (extractDTOs / parseValidateRules).
+//
+// Issue #3545 — lang.rust.validation.validator.
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_validator", &rustValidatorExtractor{})
+}
+
+type rustValidatorExtractor struct{}
+
+func (e *rustValidatorExtractor) Language() string { return "custom_rust_validator" }
+
+var (
+	// container-level #[validate(schema(function = "fn"))] — struct-wide custom
+	// validator (validator crate's whole-struct hook).
+	reValidatorSchemaFn = regexp.MustCompile(
+		`#\[validate\s*\(\s*schema\s*\(([^)]*)\)\s*\)\]`,
+	)
+
+	// #[derive(... Validate ...)] with validator crate full-path variant too.
+	reValidatorDerive = regexp.MustCompile(
+		`#\[derive\([^)]*\b(?:Validate|validator::Validate)\b[^)]*\)\]`,
+	)
+)
+
+func (e *rustValidatorExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.rust_validator_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// Cheap gate: only act on files that mention the validator crate. This keeps
+	// the extractor a no-op on the vast majority of Rust files and avoids
+	// double-counting plain serde DTOs (which are dto_extraction, not validation).
+	if !reValidatorDerive.MatchString(src) && !strings.Contains(src, "validator") {
+		// `.validate()` alone is too ambiguous (many crates expose it); require a
+		// validator-crate anchor in the file.
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. schema_extraction + constraint_extraction + nested_model_extraction
+	//    + custom_validator_extraction  — from #[derive(Validate)] structs.
+	// -----------------------------------------------------------------------
+	for _, dto := range extractDTOs(src) {
+		if !dto.hasValidate {
+			// validator coverage is about Validate-derived structs specifically.
+			continue
+		}
+
+		// schema_extraction: the validated struct itself.
+		schemaEnt := makeEntity("validator_schema:"+dto.structName,
+			"SCOPE.Schema", "validator_schema",
+			file.Path, file.Language, lineOf(src, dto.offset))
+		setProps(&schemaEnt,
+			"provenance", "INFERRED_FROM_VALIDATE_DERIVE",
+			"crate", "validator",
+			"struct_name", dto.structName,
+			"field_count", itoa(len(dto.fields)),
+		)
+		add(schemaEnt)
+
+		// struct-level custom validator: #[validate(schema(function = "fn"))].
+		// It sits in the container-attribute window between the derive and the
+		// struct body — re-scan a bounded slice ahead of the derive offset.
+		head := src[dto.offset:]
+		if len(head) > 600 {
+			head = head[:600]
+		}
+		for _, sm := range reValidatorSchemaFn.FindAllStringSubmatch(head, -1) {
+			fn := firstStringArg(strings.TrimSpace(sm[1]), "function")
+			cName := "validator_custom:" + dto.structName + ":schema"
+			cEnt := makeEntity(cName, "SCOPE.Pattern", "custom_validator",
+				file.Path, file.Language, lineOf(src, dto.offset))
+			setProps(&cEnt,
+				"provenance", "INFERRED_FROM_VALIDATE_SCHEMA_FN",
+				"crate", "validator",
+				"struct_name", dto.structName,
+				"scope", "struct",
+				"function", fn,
+			)
+			add(cEnt)
+		}
+
+		// Per-field constraints, nested markers, and field-level custom fns.
+		for _, f := range dto.fields {
+			for _, c := range f.constraints {
+				switch c.kind {
+				case "nested":
+					// nested_model_extraction: #[validate(nested)] recurses into
+					// the field's own Validate type.
+					nName := "validator_nested:" + dto.structName + "." + f.name
+					nEnt := makeEntity(nName, "SCOPE.Schema", "nested_validation",
+						file.Path, file.Language, lineOf(src, f.offset))
+					setProps(&nEnt,
+						"provenance", "INFERRED_FROM_VALIDATE_NESTED",
+						"crate", "validator",
+						"struct_name", dto.structName,
+						"field_name", f.name,
+						"field_type", f.typ,
+					)
+					add(nEnt)
+
+				case "custom":
+					// custom_validator_extraction: field-level custom fn.
+					cName := "validator_custom:" + dto.structName + "." + f.name
+					cEnt := makeEntity(cName, "SCOPE.Pattern", "custom_validator",
+						file.Path, file.Language, lineOf(src, f.offset))
+					setProps(&cEnt,
+						"provenance", "INFERRED_FROM_VALIDATE_CUSTOM",
+						"crate", "validator",
+						"struct_name", dto.structName,
+						"field_name", f.name,
+						"scope", "field",
+						"function", c.value,
+					)
+					add(cEnt)
+
+				default:
+					// constraint_extraction: one SCOPE.Constraint per rule,
+					// carrying the SPECIFIC field + kind + bound(s)/regex.
+					cName := "validator_constraint:" + dto.structName + "." + f.name + ":" + c.kind
+					cEnt := makeEntity(cName, "SCOPE.Constraint", "validator_constraint",
+						file.Path, file.Language, lineOf(src, f.offset))
+					setProps(&cEnt,
+						"provenance", "INFERRED_FROM_VALIDATE_ATTR",
+						"crate", "validator",
+						"struct_name", dto.structName,
+						"field_name", f.name,
+						"constraint_kind", c.kind,
+					)
+					if c.min != "" {
+						setProps(&cEnt, "min", c.min)
+					}
+					if c.max != "" {
+						setProps(&cEnt, "max", c.max)
+					}
+					if c.value != "" {
+						setProps(&cEnt, "value", c.value)
+					}
+					add(cEnt)
+				}
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. validation invocation — .validate()? / .validate() call sites.
+	// -----------------------------------------------------------------------
+	for _, m := range reValidateCall.FindAllStringIndex(src, -1) {
+		ent := makeEntity("validator_validate_call", "SCOPE.Pattern", "validation_invocation",
+			file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"provenance", "INFERRED_FROM_VALIDATE_CALL",
+			"crate", "validator",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/rust/validator_test.go
+++ b/internal/custom/rust/validator_test.go
@@ -1,0 +1,192 @@
+package rust_test
+
+// validator_test.go — value-asserting tests for the custom_rust_validator
+// extractor (record lang.rust.validation.validator, issue #3545).
+//
+// These tests assert the SPECIFIC constraint kind + captured bound/regex for
+// each field, not merely that some entity exists. findEntity is shared with
+// auth_policy_test.go.
+
+import (
+	"testing"
+)
+
+// The canonical fixture from the issue brief: a Validate-derived struct with one
+// constraint per kind, plus a nested field.
+const validatorFixture = `
+use validator::Validate;
+
+#[derive(Debug, Validate)]
+struct CreateUser {
+    #[validate(email)]
+    email: String,
+    #[validate(length(min = 1, max = 20))]
+    name: String,
+    #[validate(range(min = 18))]
+    age: u8,
+    #[validate(regex = "RE_X")]
+    code: String,
+    #[validate(nested)]
+    address: Address,
+}
+
+fn handle(input: CreateUser) -> Result<(), validator::ValidationErrors> {
+    input.validate()?;
+    Ok(())
+}
+`
+
+func TestValidator_SchemaExtraction(t *testing.T) {
+	ents := extract(t, "custom_rust_validator", fi("user.rs", "rust", validatorFixture))
+	s, ok := findEntity(ents, "SCOPE.Schema", "validator_schema:CreateUser")
+	if !ok {
+		t.Fatal("expected validator_schema:CreateUser")
+	}
+	if s.Subtype != "validator_schema" {
+		t.Errorf("subtype = %q, want validator_schema", s.Subtype)
+	}
+	if got := s.Props["field_count"]; got != "5" {
+		t.Errorf("field_count = %q, want 5", got)
+	}
+}
+
+func TestValidator_EmailConstraint(t *testing.T) {
+	ents := extract(t, "custom_rust_validator", fi("user.rs", "rust", validatorFixture))
+	c, ok := findEntity(ents, "SCOPE.Constraint", "validator_constraint:CreateUser.email:email")
+	if !ok {
+		t.Fatal("expected email constraint on CreateUser.email")
+	}
+	if got := c.Props["constraint_kind"]; got != "email" {
+		t.Errorf("constraint_kind = %q, want email", got)
+	}
+	if got := c.Props["field_name"]; got != "email" {
+		t.Errorf("field_name = %q, want email", got)
+	}
+}
+
+func TestValidator_LengthConstraintBounds(t *testing.T) {
+	ents := extract(t, "custom_rust_validator", fi("user.rs", "rust", validatorFixture))
+	c, ok := findEntity(ents, "SCOPE.Constraint", "validator_constraint:CreateUser.name:length")
+	if !ok {
+		t.Fatal("expected length constraint on CreateUser.name")
+	}
+	if got := c.Props["min"]; got != "1" {
+		t.Errorf("length min = %q, want 1", got)
+	}
+	if got := c.Props["max"]; got != "20" {
+		t.Errorf("length max = %q, want 20", got)
+	}
+}
+
+func TestValidator_RangeConstraintBound(t *testing.T) {
+	ents := extract(t, "custom_rust_validator", fi("user.rs", "rust", validatorFixture))
+	c, ok := findEntity(ents, "SCOPE.Constraint", "validator_constraint:CreateUser.age:range")
+	if !ok {
+		t.Fatal("expected range constraint on CreateUser.age")
+	}
+	if got := c.Props["min"]; got != "18" {
+		t.Errorf("range min = %q, want 18", got)
+	}
+}
+
+func TestValidator_RegexConstraintValue(t *testing.T) {
+	ents := extract(t, "custom_rust_validator", fi("user.rs", "rust", validatorFixture))
+	c, ok := findEntity(ents, "SCOPE.Constraint", "validator_constraint:CreateUser.code:regex")
+	if !ok {
+		t.Fatal("expected regex constraint on CreateUser.code")
+	}
+	if got := c.Props["value"]; got != "RE_X" {
+		t.Errorf("regex value = %q, want RE_X", got)
+	}
+}
+
+func TestValidator_NestedExtraction(t *testing.T) {
+	ents := extract(t, "custom_rust_validator", fi("user.rs", "rust", validatorFixture))
+	n, ok := findEntity(ents, "SCOPE.Schema", "validator_nested:CreateUser.address")
+	if !ok {
+		t.Fatal("expected nested_validation on CreateUser.address")
+	}
+	if n.Subtype != "nested_validation" {
+		t.Errorf("subtype = %q, want nested_validation", n.Subtype)
+	}
+	if got := n.Props["field_type"]; got != "Address" {
+		t.Errorf("nested field_type = %q, want Address", got)
+	}
+	// A nested marker must NOT also be emitted as a generic constraint.
+	if _, dup := findEntity(ents, "SCOPE.Constraint", "validator_constraint:CreateUser.address:nested"); dup {
+		t.Error("nested should not be double-counted as a constraint")
+	}
+}
+
+func TestValidator_ValidateInvocation(t *testing.T) {
+	ents := extract(t, "custom_rust_validator", fi("user.rs", "rust", validatorFixture))
+	if _, ok := findEntity(ents, "SCOPE.Pattern", "validator_validate_call"); !ok {
+		t.Error("expected validation_invocation from input.validate()? call site")
+	}
+}
+
+func TestValidator_FieldLevelCustom(t *testing.T) {
+	src := `
+use validator::Validate;
+
+#[derive(Validate)]
+struct Payment {
+    #[validate(custom = "validate_currency")]
+    currency: String,
+}
+`
+	ents := extract(t, "custom_rust_validator", fi("pay.rs", "rust", src))
+	c, ok := findEntity(ents, "SCOPE.Pattern", "validator_custom:Payment.currency")
+	if !ok {
+		t.Fatal("expected field-level custom validator on Payment.currency")
+	}
+	if got := c.Props["function"]; got != "validate_currency" {
+		t.Errorf("custom function = %q, want validate_currency", got)
+	}
+	if got := c.Props["scope"]; got != "field" {
+		t.Errorf("scope = %q, want field", got)
+	}
+}
+
+func TestValidator_StructLevelSchemaFn(t *testing.T) {
+	src := `
+use validator::Validate;
+
+#[derive(Validate)]
+#[validate(schema(function = "validate_passwords_match"))]
+struct SignupForm {
+    #[validate(length(min = 8))]
+    password: String,
+    password_confirm: String,
+}
+`
+	ents := extract(t, "custom_rust_validator", fi("signup.rs", "rust", src))
+	c, ok := findEntity(ents, "SCOPE.Pattern", "validator_custom:SignupForm:schema")
+	if !ok {
+		t.Fatal("expected struct-level schema custom validator on SignupForm")
+	}
+	if got := c.Props["function"]; got != "validate_passwords_match" {
+		t.Errorf("schema function = %q, want validate_passwords_match", got)
+	}
+	if got := c.Props["scope"]; got != "struct" {
+		t.Errorf("scope = %q, want struct", got)
+	}
+}
+
+// A plain serde DTO with no Validate derive yields no validator entities.
+func TestValidator_NoMatchPlainSerde(t *testing.T) {
+	src := `
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Plain {
+    name: String,
+}
+`
+	ents := extract(t, "custom_rust_validator", fi("plain.rs", "rust", src))
+	for _, e := range ents {
+		if e.Subtype == "validator_schema" || e.Kind == "SCOPE.Constraint" {
+			t.Errorf("unexpected validator entity for plain serde DTO: %s/%s", e.Kind, e.Name)
+		}
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -7209,6 +7209,90 @@ records:
             Import/call-site heuristic; no cross-file dataflow binding tracer to exporter. Stays partial.
           verified_at: "2026-05-30"
 
+  lang.rust.validation.validator:
+    capabilities:
+      Schema:
+        schema_extraction:
+          # #[derive(Validate)] structs (validator crate) emitted as
+          # SCOPE.Schema validator_schema entities with struct_name + field_count.
+          # Reuses extractDTOs() from fw_validation.go but gated on hasValidate so
+          # plain serde DTOs are not counted here. Issue #3545.
+          status: full
+          symbols:
+            - file: internal/custom/rust/validator.go
+              functions: [Extract]
+            - file: internal/custom/rust/fw_validation.go
+              functions: [extractDTOs]
+          tests:
+            - file: internal/custom/rust/validator_test.go
+          issues_implemented: ["3545"]
+          verified_at: "2026-05-31"
+        nested_model_extraction:
+          # #[validate(nested)] field attribute emitted as SCOPE.Schema
+          # nested_validation entity capturing the field name + nested field_type;
+          # not double-counted as a generic constraint. Asserted in
+          # TestValidator_NestedExtraction. Issue #3545.
+          status: full
+          symbols:
+            - file: internal/custom/rust/validator.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/rust/validator_test.go
+          issues_implemented: ["3545"]
+          verified_at: "2026-05-31"
+      Constraints:
+        constraint_extraction:
+          # Each #[validate(<rule>)] attribute emitted as one SCOPE.Constraint
+          # validator_constraint entity carrying the SPECIFIC field + constraint
+          # kind + bound(s)/regex (length min/max, range min/max, email, regex
+          # path). Typed parsing reused from parseValidateRules in fw_validation.go.
+          # Asserted value-by-value in TestValidator_{Email,Length,Range,Regex}*.
+          # Issue #3545.
+          status: full
+          symbols:
+            - file: internal/custom/rust/validator.go
+              functions: [Extract]
+            - file: internal/custom/rust/fw_validation.go
+              functions: [parseValidateRules, parseDTOFields]
+          tests:
+            - file: internal/custom/rust/validator_test.go
+          issues_implemented: ["3545"]
+          verified_at: "2026-05-31"
+        custom_validator_extraction:
+          # Field-level #[validate(custom = "fn")] and struct-level
+          # #[validate(schema(function = "fn"))] emitted as SCOPE.Pattern
+          # custom_validator entities with scope (field|struct) + function name.
+          # Asserted in TestValidator_FieldLevelCustom and
+          # TestValidator_StructLevelSchemaFn. Issue #3545.
+          status: full
+          symbols:
+            - file: internal/custom/rust/validator.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/rust/validator_test.go
+          issues_implemented: ["3545"]
+          verified_at: "2026-05-31"
+      Coercion:
+        type_coercion_recognition:
+          # not_applicable: the validator crate validates but does not coerce
+          # types. Type coercion in Rust is serde's responsibility and is covered
+          # by dto_extraction in fw_validation.go. Issue #3545.
+          status: not_applicable
+          verified_at: "2026-05-31"
+      Testing:
+        tests_linkage:
+          # validator-specific fixtures assert the exact captured constraint values;
+          # the general Rust test-linkage substrate provides the TESTS edges.
+          # Issue #3545.
+          status: partial
+          symbols:
+            - file: internal/custom/rust/validator.go
+              functions: [Extract]
+          tests:
+            - file: internal/custom/rust/validator_test.go
+          issues_implemented: ["3545"]
+          verified_at: "2026-05-31"
+
   lang.rust.framework.axum:
     capabilities:
       Substrate:


### PR DESCRIPTION
Adds archigraph coverage for the Rust [`validator`](https://crates.io/crates/validator) crate as a standalone, framework-agnostic validation library.

## What
- New coverage record `lang.rust.validation.validator` (category `validation`, subcategory `validation_lib`).
- New extractor `internal/custom/rust/validator.go` (auto-dispatched via the `custom_rust_` prefix), emitting:
  - **schema_extraction** — `#[derive(Validate)]` structs → `SCOPE.Schema validator_schema` (gated on `hasValidate`, so plain serde DTOs aren't counted here).
  - **constraint_extraction** — each `#[validate(<rule>)]` → `SCOPE.Constraint` carrying the **specific** field + constraint kind + bound(s)/regex (length min/max, range min/max, email, regex path), reusing `parseValidateRules`/`parseDTOFields` from `fw_validation.go`.
  - **nested_model_extraction** — `#[validate(nested)]` → `SCOPE.Schema nested_validation` (not double-counted as a constraint).
  - **custom_validator_extraction** — field `#[validate(custom = "fn")]` and struct `#[validate(schema(function = "fn"))]` → `SCOPE.Pattern custom_validator` with scope + function.
  - **validation invocation** — `.validate()?` call sites → `SCOPE.Pattern validation_invocation`.

## Cells flipped
| lane | status |
|---|---|
| schema_extraction | full |
| constraint_extraction | full |
| custom_validator_extraction | full |
| nested_model_extraction | full |
| type_coercion_recognition | not_applicable (validator validates, doesn't coerce — serde's job) |
| tests_linkage | partial |

`capability-map.yaml` entries added for all six lanes (clears the no-mapping warnings).

## Discipline
Value-asserting tests verify the canonical `CreateUser` fixture: `email→email`, `name→length(min=1,max=20)`, `age→range(min=18)`, `code→regex RE_X`, `address→nested` — plus field/struct custom validators and a plain-serde no-match guard.

`go test ./internal/custom/rust/ ./internal/types/ ./tools/coverage/` green · `coverage validate` 0 errors · `coverage fmt --check` canonical · `gofmt -l` empty · `go vet` clean.

Closes #3545

🤖 Generated with [Claude Code](https://claude.com/claude-code)