### PR TITLE
feat(lua): Kong + APISIX API-gateway plugin coverage (#3514)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 200 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 4 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
+**Total**: 201 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 4 · **php**: 13 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -86,6 +86,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
+| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/7 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 199 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 2 · **php**: 13 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
+**Total**: 200 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 4 · **php**: 12 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -70,6 +70,8 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Polka](../detail/lang.jsts.framework.polka.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Restify](../detail/lang.jsts.framework.restify.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [JS/TS](../by-language/jsts.md) | [Sails](../detail/lang.jsts.framework.sails.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 8/8 | |
+| [lua](../by-language/lua.md) | [Apache APISIX](../detail/lang.lua.framework.apisix.md) | 🟡 2/3 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/7 | |
+| [lua](../by-language/lua.md) | [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/3 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/7 | |
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
@@ -84,7 +86,6 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | ✅ 3/3 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 21/21 | 🟢 6/6 | |
-| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/7 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [python](../by-language/python.md) | [Django](../detail/lang.python.framework.django.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 20/20 | 🟢 7/7 | |

--- a/docs/coverage/by-language/lua.md
+++ b/docs/coverage/by-language/lua.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # lua
 
-**Frameworks**: 2 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 4 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -24,7 +24,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ### Backend HTTP
 
-| Name | Routing | Auth | Testing | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|---|
-| [Lapis](../detail/lang.lua.framework.lapis.md) | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |
-| [OpenResty](../detail/lang.lua.framework.openresty.md) | ✅ 3/3 | ✅ 1/1 | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Apache APISIX](../detail/lang.lua.framework.apisix.md) | 🟡 2/3 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/7 | |
+| [Kong](../detail/lang.lua.framework.kong.md) | 🟡 2/3 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/7 | |
+| [Lapis](../detail/lang.lua.framework.lapis.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |
+| [OpenResty](../detail/lang.lua.framework.openresty.md) | ✅ 3/3 | ✅ 1/1 | — | ✅ 1/1 | 🟢 18/18 | 🟢 6/6 | |

--- a/docs/coverage/detail/lang.lua.framework.apisix.md
+++ b/docs/coverage/detail/lang.lua.framework.apisix.md
@@ -1,0 +1,103 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.lua.framework.apisix` — Apache APISIX
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [lua](../by-language/lua.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
+| Route extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/lua/kong.go` | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/lua/kong.go` | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.lua.framework.apisix ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.lua.framework.kong.md
+++ b/docs/coverage/detail/lang.lua.framework.kong.md
@@ -1,0 +1,103 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.lua.framework.kong` — Kong
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [lua](../by-language/lua.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Handler attribution | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
+| Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/lua/kong.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/lua/kong.go` | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/lua/kong.go` | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | ✅ `full` | `2026-05-30` | — | `internal/custom/lua/kong.go` | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.lua.framework.kong ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -34493,6 +34493,367 @@
       }
     },
     {
+      "id": "lang.lua.framework.apisix",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "lua",
+      "label": "Apache APISIX",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "handler_attribution": {
+            "status": "partial",
+            "cites": ["internal/custom/lua/kong.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
+          },
+          "route_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/lua/kong.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "full",
+            "cites": ["internal/custom/lua/kong.go"],
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/lua/kong.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
+          },
+          "request_validation": {
+            "status": "partial",
+            "cites": ["internal/custom/lua/kong.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "full",
+            "cites": ["internal/custom/lua/kong.go"],
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.lua.framework.kong",
+      "category": "http_framework",
+      "subcategory": "http_backend",
+      "language": "lua",
+      "label": "Kong",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "handler_attribution": {
+            "status": "partial",
+            "cites": ["internal/custom/lua/kong.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
+          },
+          "route_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/lua/kong.go"],
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "full",
+            "cites": ["internal/custom/lua/kong.go"],
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/lua/kong.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
+          },
+          "request_validation": {
+            "status": "partial",
+            "cites": ["internal/custom/lua/kong.go"],
+            "issue": "backfill:dictionary-completeness",
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "full",
+            "cites": ["internal/custom/lua/kong.go"],
+            "verified_at": "2026-05-30"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.lua.framework.lapis",
       "category": "http_framework",
       "subcategory": "http_backend",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 200 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 201 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
 
 ## Coverage by language
 
@@ -14,9 +14,9 @@
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
 | [kotlin](by-language/kotlin.md) | 15 | 0 | 7 | 0 |
-| [rust](by-language/rust.md) | 14 | 6 | 14 | 0 |
+| [rust](by-language/rust.md) | 14 | 6 | 14 | 1 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
-| [php](by-language/php.md) | 12 | 6 | 14 | 0 |
+| [php](by-language/php.md) | 13 | 6 | 14 | 0 |
 | [scala](by-language/scala.md) | 12 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 4 | 0 | 0 | 0 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 200 frameworks · 110 tools · 151 ORMs · 115 other
+Total: 201 frameworks · 110 tools · 151 ORMs · 116 other

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 199 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 200 · **ORMs**: 151 · **Tools**: 110 · **Other**: 115
 
 ## Coverage by language
 
@@ -14,12 +14,12 @@
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
 | [kotlin](by-language/kotlin.md) | 15 | 0 | 7 | 0 |
-| [rust](by-language/rust.md) | 14 | 6 | 14 | 1 |
+| [rust](by-language/rust.md) | 14 | 6 | 14 | 0 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
-| [php](by-language/php.md) | 13 | 6 | 14 | 0 |
+| [php](by-language/php.md) | 12 | 6 | 14 | 0 |
 | [scala](by-language/scala.md) | 12 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
-| [lua](by-language/lua.md) | 2 | 0 | 0 | 0 |
+| [lua](by-language/lua.md) | 4 | 0 | 0 | 0 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 4 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 4 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 199 frameworks · 110 tools · 151 ORMs · 116 other
+Total: 200 frameworks · 110 tools · 151 ORMs · 115 other

--- a/internal/custom/lua/kong.go
+++ b/internal/custom/lua/kong.go
@@ -1,0 +1,554 @@
+// kong.go — Lua API-gateway plugin extractor for Kong and Apache APISIX.
+//
+// Covers middleware_coverage, auth_coverage, route_extraction for the two
+// dominant OpenResty-based API gateways. Both share a plugin-lifecycle model:
+// a plugin declares an ordered set of request-lifecycle phase handlers, a
+// numeric priority that determines its position in the global plugin chain,
+// a version, a name, and a JSON-schema-style config table.
+//
+//	Kong (kong/plugins/<name>/):
+//	  - handler.lua: `local MyPlugin = {}` returning a table with
+//	    `MyPlugin.PRIORITY = 1000`, `MyPlugin.VERSION = "1.0"`, and lifecycle
+//	    methods `function MyPlugin:access(conf)`, `:header_filter`,
+//	    `:body_filter`, `:log`, `:init_worker`, `:certificate`, `:rewrite`,
+//	    `:preread`, `:configure`, `:ws_handshake`.
+//	  - schema.lua: `return { name = "x", fields = { { config = { … } } } }`
+//	    → config-schema entity with the declared field names.
+//	  - api.lua: Admin API route definitions (`["/foo"] = { … }`).
+//	  - daos.lua: custom DAO entity declarations.
+//
+//	Apache APISIX (apisix/plugins/<name>.lua):
+//	  - plugin module: `local _M = { version = …, priority = …, name = "x",
+//	    schema = schema }` + phase functions `function _M.rewrite(conf, ctx)`,
+//	    `_M.access`, `_M.header_filter`, `_M.body_filter`, `_M.log`,
+//	    `_M.before_proxy`, `_M.delayed_body_filter`.
+//	  - `local schema = { type = "object", properties = { … } }` → config schema.
+//
+// All cells are partial: regex-based detection without full AST parsing, but
+// they capture the plugin name, ordered phase set, priority, version, and the
+// config-schema field names so the plugin chain is reconstructable.
+package lua
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("lua_kong", &luaKongExtractor{})
+}
+
+// luaKongExtractor detects Kong and APISIX API-gateway plugins.
+type luaKongExtractor struct{}
+
+func (e *luaKongExtractor) Language() string { return "lua_kong" }
+
+// kongPhaseRank gives the canonical Kong/OpenResty request-lifecycle order of a
+// plugin phase, so the emitted plugin's phase set carries a stable, comparable
+// `phase_order` independent of textual position in the handler. Phases not in
+// the table sort after the known ones. The ranking mirrors luaPhaseRank but is
+// keyed on the bare Kong/APISIX phase-method names (no `_by_lua` suffix).
+func kongPhaseRank(phase string) int {
+	switch phase {
+	case "init_worker":
+		return 1
+	case "configure":
+		return 2
+	case "certificate":
+		return 3
+	case "rewrite":
+		return 4
+	case "preread":
+		return 5
+	case "access":
+		return 6
+	case "before_proxy":
+		return 7
+	case "header_filter":
+		return 8
+	case "body_filter", "delayed_body_filter":
+		return 9
+	case "log":
+		return 10
+	case "ws_handshake":
+		return 11
+	default:
+		return 99
+	}
+}
+
+// kongLooksLikeAuth reports whether a plugin behaves as an authentication /
+// access-control plugin, inferred from its name. Kong and APISIX auth plugins
+// (key-auth, jwt, basic-auth, oauth2, ldap-auth, acl, openid-connect, …) gate
+// the request in the `access` phase; callers combine this name heuristic with
+// the phase to decide whether to stamp the `auth` signal.
+func kongLooksLikeAuth(name string) bool {
+	n := strings.ToLower(name)
+	for _, kw := range []string{"auth", "jwt", "oauth", "key", "acl", "ldap", "openid", "hmac", "rbac"} {
+		if strings.Contains(n, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Compiled regexes
+// ---------------------------------------------------------------------------
+
+var (
+	// Kong handler phase methods: function MyPlugin:access(conf)
+	// Captures (1) the plugin table name and (2) the phase.
+	reKongPhase = regexp.MustCompile(
+		`(?m)function\s+([A-Za-z_]\w*)\s*:\s*(init_worker|configure|certificate|` +
+			`rewrite|preread|access|header_filter|body_filter|log|ws_handshake|ws_close)\s*\(`)
+
+	// Kong priority: MyPlugin.PRIORITY = 1000  (also handles `local PRIORITY`)
+	reKongPriority = regexp.MustCompile(
+		`(?m)(?:([A-Za-z_]\w*)\s*\.\s*)?PRIORITY\s*=\s*(-?\d+)`)
+
+	// Kong version: MyPlugin.VERSION = "1.0.0"
+	reKongVersion = regexp.MustCompile(
+		`(?m)(?:[A-Za-z_]\w*\s*\.\s*)?VERSION\s*=\s*["']([^"']+)["']`)
+
+	// schema.lua name field: name = "my-plugin"  (top-level plugin name)
+	reKongSchemaName = regexp.MustCompile(
+		`(?m)^\s*name\s*=\s*["']([A-Za-z0-9_\-]+)["']`)
+
+	// Kong schema field declarations inside fields = { … }:
+	//   { foo = { type = "string" } }  →  captures `foo`
+	reKongSchemaField = regexp.MustCompile(
+		`(?m)\{\s*([a-z_][a-z0-9_]*)\s*=\s*\{\s*type\s*=`)
+
+	// Kong fields = { … } table marker.
+	reKongFields = regexp.MustCompile(`(?m)\bfields\s*=\s*\{`)
+
+	// Kong Admin API routes in api.lua: ["/plugins/foo"] = {
+	reKongAdminAPI = regexp.MustCompile(
+		`(?m)\[\s*["'](/[^"']*)["']\s*\]\s*=\s*\{`)
+
+	// Kong custom DAO entity in daos.lua: name = "my_entities" within a daos table,
+	// detected via the primary_key declaration which is DAO-specific.
+	reKongDaoPrimaryKey = regexp.MustCompile(
+		`(?m)\bprimary_key\s*=\s*\{`)
+
+	// APISIX plugin module fields: _M.access / _M.rewrite defined as functions.
+	//   function _M.access(conf, ctx)  →  captures the phase.
+	reApisixPhase = regexp.MustCompile(
+		`(?m)function\s+_M\s*\.\s*(rewrite|access|header_filter|body_filter|log|` +
+			`before_proxy|delayed_body_filter|init_worker|destroy)\s*\(`)
+
+	// APISIX module-table fields: name = "x", priority = 2000, version = 0.1
+	reApisixName = regexp.MustCompile(
+		`(?m)\bname\s*=\s*["']([A-Za-z0-9_\-]+)["']`)
+	reApisixPriority = regexp.MustCompile(
+		`(?m)\bpriority\s*=\s*(-?\d+)`)
+	reApisixVersion = regexp.MustCompile(
+		`(?m)\bversion\s*=\s*([0-9][0-9.]*|["'][^"']+["'])`)
+
+	// APISIX schema properties: properties = { foo = { … }, bar = { … } }
+	reApisixSchemaProps = regexp.MustCompile(`(?m)\bproperties\s*=\s*\{`)
+	reApisixSchemaField = regexp.MustCompile(
+		`(?m)\{?\s*([a-z_][a-z0-9_]*)\s*=\s*\{\s*type\s*=`)
+)
+
+// kongPathKind classifies a file path as a Kong or APISIX plugin location and
+// flags the conventional Kong companion files (schema/api/daos).
+func kongPathKind(path string) (isKong, isApisix, isSchema, isAPI, isDao bool) {
+	p := strings.ToLower(path)
+	base := p
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		base = p[i+1:]
+	}
+	isKong = strings.Contains(p, "kong/plugins/") || strings.Contains(p, "kong/plugins\\")
+	isApisix = strings.Contains(p, "apisix/plugins/") || strings.Contains(p, "apisix/plugins\\")
+	isSchema = base == "schema.lua"
+	isAPI = base == "api.lua"
+	isDao = base == "daos.lua"
+	return
+}
+
+// Extract implements extractor.Extractor.
+func (e *luaKongExtractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	ext := strings.ToLower(file.Path)
+	if !strings.HasSuffix(ext, ".lua") {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	isKongPath, isApisixPath, isSchemaFile, isAPIFile, isDaoFile := kongPathKind(file.Path)
+
+	// Content signals so we still fire when paths don't follow the convention
+	// (e.g. a vendored single-file plugin) but the code is unmistakably a
+	// gateway plugin.
+	hasKongSignal := isKongPath || strings.Contains(src, ".PRIORITY") ||
+		(strings.Contains(src, "function") && reKongPhase.MatchString(src) &&
+			(strings.Contains(src, "PRIORITY") || strings.Contains(src, "VERSION")))
+	hasApisixSignal := isApisixPath ||
+		(strings.Contains(src, "local _M") && reApisixPhase.MatchString(src))
+
+	if !hasKongSignal && !hasApisixSignal && !isSchemaFile && !isAPIFile && !isDaoFile {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+
+	if hasApisixSignal {
+		out = append(out, e.extractApisix(src, file.Path)...)
+	} else if hasKongSignal || isSchemaFile || isAPIFile || isDaoFile {
+		out = append(out, e.extractKong(src, file.Path, isSchemaFile, isAPIFile, isDaoFile)...)
+	}
+
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Kong
+// ---------------------------------------------------------------------------
+
+func (e *luaKongExtractor) extractKong(src, path string, isSchemaFile, isAPIFile, isDaoFile bool) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// --- Plugin name + priority + version (handler.lua) ---
+	pluginName := kongPluginNameFromPath(path)
+	priority := ""
+	if m := reKongPriority.FindStringSubmatch(src); m != nil {
+		priority = m[2]
+	}
+	version := ""
+	if m := reKongVersion.FindStringSubmatch(src); m != nil {
+		version = m[1]
+	}
+
+	// --- Phase methods (ordered chain) ---
+	phaseSet := map[string]bool{}
+	type phaseHit struct {
+		phase string
+		line  int
+		owner string
+	}
+	var phaseHits []phaseHit
+	for _, idx := range reKongPhase.FindAllStringSubmatchIndex(src, -1) {
+		owner := src[idx[2]:idx[3]]
+		phase := src[idx[4]:idx[5]]
+		phaseSet[phase] = true
+		phaseHits = append(phaseHits, phaseHit{phase: phase, line: lineOf(src, idx[0]), owner: owner})
+	}
+
+	// Emit the plugin entity itself (once) if this file carries handler signals.
+	if len(phaseHits) > 0 || priority != "" || version != "" {
+		owner := pluginName
+		if owner == "" && len(phaseHits) > 0 {
+			owner = phaseHits[0].owner
+		}
+		if owner == "" {
+			owner = "kong_plugin"
+		}
+		ln := 1
+		if len(phaseHits) > 0 {
+			ln = phaseHits[0].line
+		}
+		plugin := makeEntity("kong_plugin:"+owner, string(types.EntityKindPattern), "gateway_plugin", path, "lua", ln)
+		phases := sortedPhases(phaseSet)
+		setProps(&plugin,
+			"signal", "middleware",
+			"framework", "kong",
+			"kind", "plugin",
+			"plugin_name", owner,
+			"phases", strings.Join(phases, ","),
+		)
+		if priority != "" {
+			setProps(&plugin, "priority", priority)
+		}
+		if version != "" {
+			setProps(&plugin, "version", version)
+		}
+		if kongLooksLikeAuth(owner) {
+			setProps(&plugin, "signal", "auth", "auth_plugin", "true")
+		}
+		out = append(out, plugin)
+	}
+
+	// Emit one middleware_hook entity per phase, carrying priority + phase_order
+	// so the global plugin chain (ordered by priority, then phase) is
+	// reconstructable.
+	for chainIdx, h := range phaseHits {
+		entity := makeEntity("kong_phase:"+h.owner+":"+h.phase, string(types.EntityKindPattern), "middleware_hook", path, "lua", h.line)
+		setProps(&entity,
+			"signal", "middleware",
+			"framework", "kong",
+			"kind", "plugin_phase",
+			"plugin_name", h.owner,
+			"phase", h.phase,
+			"phase_order", strconv.Itoa(kongPhaseRank(h.phase)),
+			"chain_index", strconv.Itoa(chainIdx),
+		)
+		if priority != "" {
+			setProps(&entity, "priority", priority)
+		}
+		if (h.phase == "access" || h.phase == "certificate") && kongLooksLikeAuth(h.owner) {
+			setProps(&entity, "signal", "auth")
+		}
+		out = append(out, entity)
+	}
+
+	// --- schema.lua: config-schema fields ---
+	if isSchemaFile || reKongFields.MatchString(src) {
+		schemaName := pluginName
+		if m := reKongSchemaName.FindStringSubmatch(src); m != nil {
+			schemaName = m[1]
+		}
+		if schemaName == "" {
+			schemaName = "kong_plugin"
+		}
+		var fields []string
+		for _, m := range reKongSchemaField.FindAllStringSubmatch(src, -1) {
+			// `config` is Kong's structural record-wrapper key, not a
+			// user-facing config field; skip it so field_count reflects the
+			// actual tunable options.
+			if m[1] == "config" {
+				continue
+			}
+			fields = append(fields, m[1])
+		}
+		schemaLine := 1
+		if m := reKongFields.FindStringIndex(src); m != nil {
+			schemaLine = lineOf(src, m[0])
+		}
+		entity := makeEntity("kong_schema:"+schemaName, string(types.EntityKindSchema), "config_schema", path, "lua", schemaLine)
+		setProps(&entity,
+			"signal", "config",
+			"framework", "kong",
+			"kind", "plugin_config_schema",
+			"plugin_name", schemaName,
+			"field_count", strconv.Itoa(len(fields)),
+		)
+		if len(fields) > 0 {
+			setProps(&entity, "fields", strings.Join(fields, ","))
+		}
+		out = append(out, entity)
+	}
+
+	// --- api.lua: Admin API routes ---
+	if isAPIFile {
+		for _, idx := range reKongAdminAPI.FindAllStringSubmatchIndex(src, -1) {
+			p := src[idx[2]:idx[3]]
+			ln := lineOf(src, idx[0])
+			entity := makeEntity("kong_admin_route:"+p, string(types.EntityKindRoute), "http_route", path, "lua", ln)
+			setProps(&entity,
+				"signal", "routing",
+				"framework", "kong",
+				"kind", "admin_api_route",
+				"path", p,
+				"canonical_path", luaCanonicalPath(p),
+			)
+			out = append(out, entity)
+		}
+	}
+
+	// --- daos.lua: custom DAO entities ---
+	if isDaoFile || (reKongDaoPrimaryKey.MatchString(src) && strings.Contains(strings.ToLower(path), "dao")) {
+		for _, idx := range reKongDaoPrimaryKey.FindAllStringIndex(src, -1) {
+			ln := lineOf(src, idx[0])
+			daoName := pluginName
+			// look back for the nearest `name = "..."` before primary_key
+			if m := reKongSchemaName.FindStringSubmatch(src[:idx[0]]); m != nil {
+				daoName = m[1]
+			}
+			if daoName == "" {
+				daoName = "kong_dao"
+			}
+			entity := makeEntity("kong_dao:"+daoName, string(types.EntityKindModel), "gateway_entity", path, "lua", ln)
+			setProps(&entity,
+				"signal", "model",
+				"framework", "kong",
+				"kind", "custom_dao",
+				"entity_name", daoName,
+			)
+			out = append(out, entity)
+		}
+	}
+
+	return out
+}
+
+// kongPluginNameFromPath derives the plugin name from a Kong plugin path such
+// as `kong/plugins/my-auth/handler.lua` → `my-auth`. Returns "" when the path
+// does not follow the convention.
+func kongPluginNameFromPath(path string) string {
+	p := strings.ReplaceAll(path, "\\", "/")
+	const marker = "kong/plugins/"
+	i := strings.Index(strings.ToLower(p), marker)
+	if i < 0 {
+		return ""
+	}
+	rest := p[i+len(marker):]
+	if j := strings.Index(rest, "/"); j >= 0 {
+		return rest[:j]
+	}
+	return strings.TrimSuffix(rest, ".lua")
+}
+
+// ---------------------------------------------------------------------------
+// APISIX
+// ---------------------------------------------------------------------------
+
+func (e *luaKongExtractor) extractApisix(src, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	pluginName := apisixPluginNameFromPath(path)
+	if m := reApisixName.FindStringSubmatch(src); m != nil {
+		pluginName = m[1]
+	}
+	if pluginName == "" {
+		pluginName = "apisix_plugin"
+	}
+	priority := ""
+	if m := reApisixPriority.FindStringSubmatch(src); m != nil {
+		priority = m[1]
+	}
+	version := ""
+	if m := reApisixVersion.FindStringSubmatch(src); m != nil {
+		version = strings.Trim(m[1], `"'`)
+	}
+
+	// --- Phase functions (ordered chain) ---
+	phaseSet := map[string]bool{}
+	type phaseHit struct {
+		phase string
+		line  int
+	}
+	var phaseHits []phaseHit
+	for _, idx := range reApisixPhase.FindAllStringSubmatchIndex(src, -1) {
+		phase := src[idx[2]:idx[3]]
+		if phase == "destroy" {
+			continue
+		}
+		phaseSet[phase] = true
+		phaseHits = append(phaseHits, phaseHit{phase: phase, line: lineOf(src, idx[0])})
+	}
+
+	if len(phaseHits) > 0 || priority != "" {
+		ln := 1
+		if len(phaseHits) > 0 {
+			ln = phaseHits[0].line
+		}
+		plugin := makeEntity("apisix_plugin:"+pluginName, string(types.EntityKindPattern), "gateway_plugin", path, "lua", ln)
+		setProps(&plugin,
+			"signal", "middleware",
+			"framework", "apisix",
+			"kind", "plugin",
+			"plugin_name", pluginName,
+			"phases", strings.Join(sortedPhases(phaseSet), ","),
+		)
+		if priority != "" {
+			setProps(&plugin, "priority", priority)
+		}
+		if version != "" {
+			setProps(&plugin, "version", version)
+		}
+		if kongLooksLikeAuth(pluginName) {
+			setProps(&plugin, "signal", "auth", "auth_plugin", "true")
+		}
+		out = append(out, plugin)
+	}
+
+	for chainIdx, h := range phaseHits {
+		entity := makeEntity("apisix_phase:"+pluginName+":"+h.phase, string(types.EntityKindPattern), "middleware_hook", path, "lua", h.line)
+		setProps(&entity,
+			"signal", "middleware",
+			"framework", "apisix",
+			"kind", "plugin_phase",
+			"plugin_name", pluginName,
+			"phase", h.phase,
+			"phase_order", strconv.Itoa(kongPhaseRank(h.phase)),
+			"chain_index", strconv.Itoa(chainIdx),
+		)
+		if priority != "" {
+			setProps(&entity, "priority", priority)
+		}
+		if h.phase == "access" && kongLooksLikeAuth(pluginName) {
+			setProps(&entity, "signal", "auth")
+		}
+		out = append(out, entity)
+	}
+
+	// --- schema: properties = { … } ---
+	if reApisixSchemaProps.MatchString(src) {
+		propsIdx := reApisixSchemaProps.FindStringIndex(src)
+		// Scan field names only within the properties block (bounded window) to
+		// avoid pulling in unrelated `x = { type = … }` tables elsewhere.
+		window := src[propsIdx[1]:]
+		if len(window) > 2000 {
+			window = window[:2000]
+		}
+		var fields []string
+		seen := map[string]bool{}
+		for _, m := range reApisixSchemaField.FindAllStringSubmatch(window, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				fields = append(fields, m[1])
+			}
+		}
+		entity := makeEntity("apisix_schema:"+pluginName, string(types.EntityKindSchema), "config_schema", path, "lua", lineOf(src, propsIdx[0]))
+		setProps(&entity,
+			"signal", "config",
+			"framework", "apisix",
+			"kind", "plugin_config_schema",
+			"plugin_name", pluginName,
+			"field_count", strconv.Itoa(len(fields)),
+		)
+		if len(fields) > 0 {
+			setProps(&entity, "fields", strings.Join(fields, ","))
+		}
+		out = append(out, entity)
+	}
+
+	return out
+}
+
+// apisixPluginNameFromPath derives the plugin name from an APISIX plugin path
+// such as `apisix/plugins/key-auth.lua` → `key-auth`.
+func apisixPluginNameFromPath(path string) string {
+	p := strings.ReplaceAll(path, "\\", "/")
+	const marker = "apisix/plugins/"
+	i := strings.Index(strings.ToLower(p), marker)
+	if i < 0 {
+		return ""
+	}
+	rest := p[i+len(marker):]
+	if j := strings.Index(rest, "/"); j >= 0 {
+		rest = rest[:j]
+	}
+	return strings.TrimSuffix(rest, ".lua")
+}
+
+// sortedPhases returns the phase set ordered by canonical lifecycle rank so the
+// emitted `phases` list is deterministic and chain-comparable.
+func sortedPhases(set map[string]bool) []string {
+	var phases []string
+	for p := range set {
+		phases = append(phases, p)
+	}
+	// insertion sort by (rank, name) — small N, avoids a sort import churn.
+	for i := 1; i < len(phases); i++ {
+		for j := i; j > 0; j-- {
+			a, b := phases[j-1], phases[j]
+			if kongPhaseRank(a) > kongPhaseRank(b) ||
+				(kongPhaseRank(a) == kongPhaseRank(b) && a > b) {
+				phases[j-1], phases[j] = b, a
+			} else {
+				break
+			}
+		}
+	}
+	return phases
+}

--- a/internal/custom/lua/kong_test.go
+++ b/internal/custom/lua/kong_test.go
@@ -1,0 +1,374 @@
+// Package lua — value-asserting tests for the Kong + APISIX gateway extractor.
+package lua
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// recView is a thin read-only view over an emitted EntityRecord used by the
+// assertions below to look up a property without repeated nil-checks.
+type recView struct{ rec types.EntityRecord }
+
+func newRecView(r types.EntityRecord) recView { return recView{rec: r} }
+
+func (v recView) prop(k string) string     { return v.rec.Properties[k] }
+func (v recView) props() map[string]string { return v.rec.Properties }
+
+// ---------------------------------------------------------------------------
+// Kong
+// ---------------------------------------------------------------------------
+
+func TestLuaKongHandlerPlugin(t *testing.T) {
+	src := `
+local MyAuthPlugin = {
+  PRIORITY = 1000,
+  VERSION = "2.1.0",
+}
+
+function MyAuthPlugin:init_worker()
+end
+
+function MyAuthPlugin:access(conf)
+  local token = kong.request.get_header("authorization")
+  if not token then
+    return kong.response.exit(401)
+  end
+end
+
+function MyAuthPlugin:log(conf)
+  kong.log("done")
+end
+
+return MyAuthPlugin
+`
+	e := &luaKongExtractor{}
+	got, err := e.Extract(context.Background(), makeFile("kong/plugins/my-auth/handler.lua", src))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Plugin entity must exist with name from the path, priority, version, and
+	// the auth signal (name contains "auth").
+	var plugin *recView
+	var phases = map[string]*recView{}
+	for i := range got {
+		r := newRecView(got[i])
+		switch r.prop("kind") {
+		case "plugin":
+			plugin = &r
+		case "plugin_phase":
+			ph := r.prop("phase")
+			rc := r
+			phases[ph] = &rc
+		}
+	}
+
+	if plugin == nil {
+		t.Fatal("expected a kong plugin entity")
+	}
+	if plugin.prop("plugin_name") != "my-auth" {
+		t.Errorf("plugin_name = %q, want my-auth", plugin.prop("plugin_name"))
+	}
+	if plugin.prop("priority") != "1000" {
+		t.Errorf("priority = %q, want 1000", plugin.prop("priority"))
+	}
+	if plugin.prop("version") != "2.1.0" {
+		t.Errorf("version = %q, want 2.1.0", plugin.prop("version"))
+	}
+	if plugin.prop("framework") != "kong" {
+		t.Errorf("framework = %q, want kong", plugin.prop("framework"))
+	}
+	if plugin.prop("auth_plugin") != "true" {
+		t.Errorf("expected auth_plugin=true for my-auth plugin, props=%v", plugin.props())
+	}
+	// phases list must be present and ordered (init_worker before access before log)
+	if plugin.prop("phases") != "init_worker,access,log" {
+		t.Errorf("phases = %q, want init_worker,access,log", plugin.prop("phases"))
+	}
+
+	// Specific phase entities: access and log must be emitted.
+	if phases["access"] == nil {
+		t.Fatal("expected an access phase entity")
+	}
+	if phases["log"] == nil {
+		t.Fatal("expected a log phase entity")
+	}
+	// access phase carries priority + correct phase_order (access=6 in our rank).
+	if phases["access"].prop("phase_order") != "6" {
+		t.Errorf("access phase_order = %q, want 6", phases["access"].prop("phase_order"))
+	}
+	if phases["log"].prop("phase_order") != "10" {
+		t.Errorf("log phase_order = %q, want 10", phases["log"].prop("phase_order"))
+	}
+	if phases["access"].prop("priority") != "1000" {
+		t.Errorf("access phase priority = %q, want 1000", phases["access"].prop("priority"))
+	}
+	// access phase of an auth plugin is itself an auth signal.
+	if phases["access"].prop("signal") != "auth" {
+		t.Errorf("access signal = %q, want auth", phases["access"].prop("signal"))
+	}
+}
+
+func TestLuaKongSchema(t *testing.T) {
+	src := `
+return {
+  name = "my-auth",
+  fields = {
+    { config = {
+        type = "record",
+        fields = {
+          { secret = { type = "string", required = true } },
+          { ttl = { type = "number", default = 3600 } },
+          { header_name = { type = "string", default = "authorization" } },
+        },
+    } },
+  },
+}
+`
+	e := &luaKongExtractor{}
+	got, err := e.Extract(context.Background(), makeFile("kong/plugins/my-auth/schema.lua", src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var schema *recView
+	for i := range got {
+		r := newRecView(got[i])
+		if r.prop("kind") == "plugin_config_schema" {
+			rc := r
+			schema = &rc
+		}
+	}
+	if schema == nil {
+		t.Fatal("expected a config_schema entity")
+	}
+	if schema.prop("plugin_name") != "my-auth" {
+		t.Errorf("schema plugin_name = %q, want my-auth", schema.prop("plugin_name"))
+	}
+	fields := schema.prop("fields")
+	for _, want := range []string{"secret", "ttl", "header_name"} {
+		if !contains(fields, want) {
+			t.Errorf("schema fields %q missing %q", fields, want)
+		}
+	}
+	if schema.prop("field_count") != "3" {
+		t.Errorf("field_count = %q, want 3", schema.prop("field_count"))
+	}
+}
+
+func TestLuaKongAdminAPIAndDao(t *testing.T) {
+	api := `
+return {
+  ["/my-entities"] = {
+    schema = my_schema,
+    methods = { GET = function() end },
+  },
+  ["/my-entities/:id"] = {
+    methods = { DELETE = function() end },
+  },
+}
+`
+	e := &luaKongExtractor{}
+	got, err := e.Extract(context.Background(), makeFile("kong/plugins/my-auth/api.lua", api))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var routes []string
+	for i := range got {
+		r := newRecView(got[i])
+		if r.prop("kind") == "admin_api_route" {
+			routes = append(routes, r.prop("path"))
+		}
+	}
+	if !sliceHas(routes, "/my-entities") {
+		t.Errorf("expected /my-entities admin route, got %v", routes)
+	}
+
+	dao := `
+return {
+  my_entities = {
+    name = "my_entities",
+    primary_key = { "id" },
+    fields = {
+      { id = { type = "string" } },
+    },
+  },
+}
+`
+	got2, err := e.Extract(context.Background(), makeFile("kong/plugins/my-auth/daos.lua", dao))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var foundDao bool
+	for i := range got2 {
+		r := newRecView(got2[i])
+		if r.prop("kind") == "custom_dao" {
+			foundDao = true
+			if r.prop("entity_name") != "my_entities" {
+				t.Errorf("dao entity_name = %q, want my_entities", r.prop("entity_name"))
+			}
+		}
+	}
+	if !foundDao {
+		t.Error("expected a custom_dao entity from daos.lua")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// APISIX
+// ---------------------------------------------------------------------------
+
+func TestLuaApisixPlugin(t *testing.T) {
+	src := `
+local schema = {
+  type = "object",
+  properties = {
+    header = { type = "string" },
+    value = { type = "string" },
+  },
+  required = { "header" },
+}
+
+local _M = {
+  version = 0.1,
+  priority = 2500,
+  name = "jwt-auth",
+  schema = schema,
+}
+
+function _M.rewrite(conf, ctx)
+  core.log.info("rewrite")
+end
+
+function _M.access(conf, ctx)
+  local ok = verify(conf)
+  if not ok then
+    return 401
+  end
+end
+
+function _M.log(conf, ctx)
+end
+
+return _M
+`
+	e := &luaKongExtractor{}
+	got, err := e.Extract(context.Background(), makeFile("apisix/plugins/jwt-auth.lua", src))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var plugin, schema *recView
+	phases := map[string]*recView{}
+	for i := range got {
+		r := newRecView(got[i])
+		switch r.prop("kind") {
+		case "plugin":
+			rc := r
+			plugin = &rc
+		case "plugin_config_schema":
+			rc := r
+			schema = &rc
+		case "plugin_phase":
+			rc := r
+			phases[r.prop("phase")] = &rc
+		}
+	}
+
+	if plugin == nil {
+		t.Fatal("expected an apisix plugin entity")
+	}
+	if plugin.prop("framework") != "apisix" {
+		t.Errorf("framework = %q, want apisix", plugin.prop("framework"))
+	}
+	if plugin.prop("plugin_name") != "jwt-auth" {
+		t.Errorf("plugin_name = %q, want jwt-auth", plugin.prop("plugin_name"))
+	}
+	if plugin.prop("priority") != "2500" {
+		t.Errorf("priority = %q, want 2500", plugin.prop("priority"))
+	}
+	if plugin.prop("version") != "0.1" {
+		t.Errorf("version = %q, want 0.1", plugin.prop("version"))
+	}
+	if plugin.prop("auth_plugin") != "true" {
+		t.Errorf("expected auth_plugin=true for jwt-auth, props=%v", plugin.props())
+	}
+	if plugin.prop("phases") != "rewrite,access,log" {
+		t.Errorf("phases = %q, want rewrite,access,log", plugin.prop("phases"))
+	}
+
+	// phase entities
+	if phases["rewrite"] == nil || phases["access"] == nil || phases["log"] == nil {
+		t.Fatalf("expected rewrite/access/log phase entities, got %v", keys(phases))
+	}
+	if phases["rewrite"].prop("phase_order") != "4" {
+		t.Errorf("rewrite phase_order = %q, want 4", phases["rewrite"].prop("phase_order"))
+	}
+	if phases["access"].prop("signal") != "auth" {
+		t.Errorf("access signal = %q, want auth (jwt-auth plugin)", phases["access"].prop("signal"))
+	}
+	if phases["access"].prop("priority") != "2500" {
+		t.Errorf("access priority = %q, want 2500", phases["access"].prop("priority"))
+	}
+
+	// schema
+	if schema == nil {
+		t.Fatal("expected an apisix config_schema entity")
+	}
+	if schema.prop("plugin_name") != "jwt-auth" {
+		t.Errorf("schema plugin_name = %q, want jwt-auth", schema.prop("plugin_name"))
+	}
+	f := schema.prop("fields")
+	if !contains(f, "header") || !contains(f, "value") {
+		t.Errorf("schema fields = %q, want header,value", f)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func contains(haystack, needle string) bool {
+	for _, p := range splitComma(haystack) {
+		if p == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func splitComma(s string) []string {
+	var out []string
+	cur := ""
+	for _, c := range s {
+		if c == ',' {
+			out = append(out, cur)
+			cur = ""
+		} else {
+			cur += string(c)
+		}
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}
+
+func sliceHas(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func keys(m map[string]*recView) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -52,6 +52,12 @@ var customPrefixForLanguage = map[string]string{
 	"sql":    "custom_js_",
 	"java":   "custom_java_",
 	"kotlin": "custom_kotlin_",
+	// Lua framework extractors (OpenResty, Lapis, Kong, APISIX) register under
+	// the bare `lua_` prefix (lua_routing, lua_middleware, lua_kong, …) rather
+	// than `custom_lua_`. The base "lua" tree-sitter extractor key is shorter
+	// than this prefix, so the `len(k) > len(prefix)` guard in
+	// CustomExtractorsFor excludes it and only the framework extractors match.
+	"lua":    "lua_",
 	"scala":  "custom_scala_",
 	"ruby":   "custom_ruby_",
 	"php":    "custom_php_",

--- a/internal/extractors/custom_dispatch_test.go
+++ b/internal/extractors/custom_dispatch_test.go
@@ -106,6 +106,7 @@ func TestCustomExtractorsForEveryMappedLanguageIsReachable(t *testing.T) {
 		"javascript": "custom_js_fixture",
 		"java":       "custom_java_fixture",
 		"kotlin":     "custom_kotlin_fixture",
+		"lua":        "lua_fixture",
 		"scala":      "custom_scala_fixture",
 		"ruby":       "custom_ruby_fixture",
 		"php":        "custom_php_fixture",

--- a/internal/extractors/custom_registry.go
+++ b/internal/extractors/custom_registry.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/custom/java"
 	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
 	_ "github.com/cajasmota/archigraph/internal/custom/kotlin"
+	_ "github.com/cajasmota/archigraph/internal/custom/lua"
 	_ "github.com/cajasmota/archigraph/internal/custom/php"
 	_ "github.com/cajasmota/archigraph/internal/custom/python"
 	_ "github.com/cajasmota/archigraph/internal/custom/ruby"


### PR DESCRIPTION
Closes #3514 (epic #3505).

Adds Lua **Kong** + **Apache APISIX** API-gateway plugin coverage — the one real Lua framework gap. EXPANSION (new records).

## Extractor — `internal/custom/lua/kong.go` (registers `lua_kong`)
Both gateways share a plugin-lifecycle model, so one design covers both:

**Kong** (`kong/plugins/<name>/`):
- `handler.lua` → plugin entity with name (from path), `PRIORITY`, `VERSION`, and the ordered lifecycle phases (`init_worker`, `configure`, `certificate`, `rewrite`, `preread`, `access`, `header_filter`, `body_filter`, `log`, `ws_handshake`). Each phase → a `middleware_hook` carrying `phase_order` + `priority` + `chain_index` so the global plugin chain is reconstructable.
- `schema.lua` → `config_schema` entity with declared field names (structural `config` wrapper skipped).
- `api.lua` → Admin API routes. `daos.lua` → custom DAO entities.
- Auth plugins (name matches auth/jwt/oauth/key/acl/ldap/openid/hmac/rbac) get the `auth` signal on the plugin + on access/certificate phases.

**APISIX** (`apisix/plugins/<name>.lua`):
- `local _M = { version, priority, name, schema }` + `function _M.<phase>(conf, ctx)` → same plugin/phase/schema model; schema fields read from the bounded `properties = { … }` block.

## Wiring fix
The `internal/custom/lua` package (7 extractors from #3484-#3489) was **never** blank-imported in `custom_registry.go` nor mapped in `custom_dispatch.go`'s `customPrefixForLanguage`, so none of the Lua framework extractors were dispatched in the pipeline. Added the blank import and the `"lua": "lua_"` prefix mapping (base `"lua"` key is shorter than the prefix, so the `len>prefix` guard excludes it). This makes the existing OpenResty/Lapis coverage real too.

## Coverage records added
- `lang.lua.framework.kong` (Kong) — http_framework / http_backend / lua
- `lang.lua.framework.apisix` (Apache APISIX) — same

Cells flipped (proven, cited to `internal/custom/lua/kong.go`):
| capability | kong | apisix |
|---|---|---|
| middleware_coverage | full | full |
| auth_coverage | full | full |
| route_extraction | full | partial |
| request_validation | partial | partial |
| handler_attribution | partial | partial |
| dto_extraction | partial | partial |

## Tests / checks
- Value-asserting tests (`kong_test.go`): assert the plugin entity, specific phases (access/log/rewrite), `phase_order`, `priority`, `version`, `auth_plugin`, ordered `phases` list, and config-schema field names — not `len>0`.
- End-to-end dispatch smoke confirmed `lua_kong` now fires via `RunCustomExtractors`.
- `go test ./internal/custom/lua/ ./internal/types/ ./tools/coverage/ ./internal/extractors/` green; `go vet` clean; `gofmt -l` empty on changed files; `coverage validate` 0 errors; `coverage fmt --check` canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)