### PR TITLE
feat(kotlin): Retrofit HTTP-client + Dagger/Hilt DI coverage (#3555)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 201 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 15 · **lua**: 4 · **php**: 13 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
+**Total**: 203 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 13 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -146,11 +146,13 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [java](../by-language/java.md) | [Spring WebFlux (reactive)](../detail/lang.java.framework.spring-webflux.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 20/20 | 🟢 16/16 | |
 | [java](../by-language/java.md) | [Vert.x](../detail/lang.java.framework.vertx.md) | 🟢 3/3 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟢 20/20 | 🟢 7/7 | |
 | [kotlin](../by-language/kotlin.md) | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [kotlin](../by-language/kotlin.md) | [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
 | [kotlin](../by-language/kotlin.md) | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [kotlin](../by-language/kotlin.md) | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
 | [kotlin](../by-language/kotlin.md) | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 12/12 | |
 | [kotlin](../by-language/kotlin.md) | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [kotlin](../by-language/kotlin.md) | [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/3 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/20 | 🔴 0/16 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [kotlin](../by-language/kotlin.md) | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |
 | [kotlin](../by-language/kotlin.md) | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/by-language/kotlin.md
+++ b/docs/coverage/by-language/kotlin.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # kotlin
 
-**Frameworks**: 15 · **Tools**: 0 · **ORMs**: 7 · **Other**: 0
+**Frameworks**: 17 · **Tools**: 0 · **ORMs**: 7 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -27,11 +27,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Arrow (functional Kotlin)](../detail/lang.kotlin.framework.arrow.md) | 🟢 1/1 | — | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 3/3 | |
+| [Dagger / Hilt (Android DI)](../detail/lang.kotlin.framework.dagger-hilt.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
 | [Javalin (Kotlin)](../detail/lang.kotlin.framework.javalin.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |
 | [Koin (Kotlin DI)](../detail/lang.kotlin.framework.koin.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 3/16 | |
 | [Ktor](../detail/lang.kotlin.framework.ktor.md) | ✅ 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 12/12 | |
 | [Micronaut (Kotlin)](../detail/lang.kotlin.framework.micronaut.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [Quarkus (Kotlin)](../detail/lang.kotlin.framework.quarkus.md) | 🟢 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
+| [Retrofit (HTTP client)](../detail/lang.kotlin.framework.retrofit.md) | 🟡 2/3 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 2/20 | 🔴 0/16 | |
 | [Spring Boot (Kotlin)](../detail/lang.kotlin.framework.spring-boot.md) | ✅ 3/3 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 15/15 | |
 | [graphql-kotlin](../detail/lang.kotlin.framework.graphql-kotlin.md) | ✅ 3/3 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/20 | 🟡 1/16 | |
 | [http4k](../detail/lang.kotlin.framework.http4k.md) | 🟢 3/3 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 21/21 | 🟢 6/6 | |

--- a/docs/coverage/detail/lang.kotlin.framework.dagger-hilt.md
+++ b/docs/coverage/detail/lang.kotlin.framework.dagger-hilt.md
@@ -1,0 +1,127 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.dagger-hilt` — Dagger / Hilt (Android DI)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Handler attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | ✅ `full` | — | — | `internal/custom/kotlin/dagger_hilt.go`<br>`internal/custom/kotlin/dagger_hilt_test.go` | Dagger/Hilt @Provides (provider method → return type binding + param deps) and @Binds (interface → impl param) bindings; binding_type, implementation, injected_deps captured. File-local; cross-module binding resolution not linked. Value-asserted in dagger_hilt_test.go. |
+| DI injection point | ✅ `full` | — | — | `internal/custom/kotlin/dagger_hilt.go`<br>`internal/custom/kotlin/dagger_hilt_test.go` | @Inject constructor(...) → one injection point per parameter (constructor_inject); @Inject lateinit var field → field_inject. Field name + injected type + mechanism captured. Value-asserted in dagger_hilt_test.go. |
+| DI scope resolution | ✅ `full` | — | — | `internal/custom/kotlin/dagger_hilt.go`<br>`internal/custom/kotlin/dagger_hilt_test.go` | Scope resolved from @InstallIn(Component::class) (SingletonComponent→singleton, Activity/Fragment/ViewModel/...), method-level @Singleton/@ActivityScoped/... overrides; Hilt entry points @HiltAndroidApp/@AndroidEntryPoint/@HiltViewModel → di_scope_resolution components. Value-asserted in dagger_hilt_test.go. |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.dagger-hilt ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.kotlin.framework.retrofit.md
+++ b/docs/coverage/detail/lang.kotlin.framework.retrofit.md
@@ -1,0 +1,127 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.kotlin.framework.retrofit` — Retrofit (HTTP client)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [kotlin](../by-language/kotlin.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** JVM Backend
+- **Capability cells:** 45
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint synthesis | ✅ `full` | — | — | `internal/engine/http_endpoint_kotlin_client.go`<br>`internal/engine/http_endpoint_kotlin_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Retrofit interface verb annotations (@GET/@POST/@PUT/@DELETE/@PATCH/@HEAD/@OPTIONS) → one outbound http_endpoint (consumer) per annotated method + FETCHES from the method; Retrofit.Builder().baseUrl() composed; {param} paths normalized. Value-asserted in http_endpoint_kotlin_client_test.go. |
+| Handler attribution | ✅ `full` | — | — | `internal/engine/http_endpoint_kotlin_client.go`<br>`internal/engine/http_endpoint_kotlin_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | FETCHES edge attributes each outbound call to the enclosing Retrofit interface method. Value-asserted in http_endpoint_kotlin_client_test.go. |
+| Route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | ✅ `full` | — | — | `internal/engine/http_endpoint_kotlin_client.go`<br>`internal/engine/http_endpoint_kotlin_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Retrofit service is a Kotlin interface; each annotated method head (suspend fun / fun) is attributed as the calling reference for its outbound endpoint. Value-asserted in http_endpoint_kotlin_client_test.go. |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction boundary extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Transaction rollback rules | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### AOP
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Advice attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Aspect extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pointcut resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/engine/http_endpoint_kotlin_client.go`<br>`internal/engine/http_endpoint_kotlin_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | val/const path constants resolved into Retrofit/Ktor URL args via the Kotlin string symbol table; cross-file constants not linked. |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | ✅ `full` | — | — | `internal/engine/http_endpoint_kotlin_client.go`<br>`internal/engine/http_endpoint_kotlin_client_test.go`<br>`internal/engine/http_endpoint_synthesis.go` | Each Retrofit annotated method is recorded as an outbound HTTP effect (verb + path) so the cross-repo linker pairs it with a producer. Value-asserted in http_endpoint_kotlin_client_test.go. |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.kotlin.framework.retrofit ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -31615,6 +31615,222 @@
       }
     },
     {
+      "id": "lang.kotlin.framework.dagger-hilt",
+      "category": "http_framework",
+      "subcategory": "jvm_backend",
+      "language": "kotlin",
+      "label": "Dagger / Hilt (Android DI)",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "handler_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/kotlin/dagger_hilt.go","internal/custom/kotlin/dagger_hilt_test.go"],
+            "notes": "Dagger/Hilt @Provides (provider method → return type binding + param deps) and @Binds (interface → impl param) bindings; binding_type, implementation, injected_deps captured. File-local; cross-module binding resolution not linked. Value-asserted in dagger_hilt_test.go."
+          },
+          "di_injection_point": {
+            "status": "full",
+            "cites": ["internal/custom/kotlin/dagger_hilt.go","internal/custom/kotlin/dagger_hilt_test.go"],
+            "notes": "@Inject constructor(...) → one injection point per parameter (constructor_inject); @Inject lateinit var field → field_inject. Field name + injected type + mechanism captured. Value-asserted in dagger_hilt_test.go."
+          },
+          "di_scope_resolution": {
+            "status": "full",
+            "cites": ["internal/custom/kotlin/dagger_hilt.go","internal/custom/kotlin/dagger_hilt_test.go"],
+            "notes": "Scope resolved from @InstallIn(Component::class) (SingletonComponent→singleton, Activity/Fragment/ViewModel/...), method-level @Singleton/@ActivityScoped/... overrides; Hilt entry points @HiltAndroidApp/@AndroidEntryPoint/@HiltViewModel → di_scope_resolution components. Value-asserted in dagger_hilt_test.go."
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.kotlin.framework.graphql-kotlin",
       "category": "http_framework",
       "subcategory": "jvm_backend",
@@ -33804,6 +34020,225 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_kotlin.go"],
             "verified_at": "2026-05-28"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.kotlin.framework.retrofit",
+      "category": "http_framework",
+      "subcategory": "jvm_backend",
+      "language": "kotlin",
+      "label": "Retrofit (HTTP client)",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_kotlin_client.go","internal/engine/http_endpoint_kotlin_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "Retrofit interface verb annotations (@GET/@POST/@PUT/@DELETE/@PATCH/@HEAD/@OPTIONS) → one outbound http_endpoint (consumer) per annotated method + FETCHES from the method; Retrofit.Builder().baseUrl() composed; {param} paths normalized. Value-asserted in http_endpoint_kotlin_client_test.go."
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_kotlin_client.go","internal/engine/http_endpoint_kotlin_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "FETCHES edge attributes each outbound call to the enclosing Retrofit interface method. Value-asserted in http_endpoint_kotlin_client_test.go."
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_kotlin_client.go","internal/engine/http_endpoint_kotlin_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "Retrofit service is a Kotlin interface; each annotated method head (suspend fun / fun) is attributed as the calling reference for its outbound endpoint. Value-asserted in http_endpoint_kotlin_client_test.go."
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "partial",
+            "cites": ["internal/engine/http_endpoint_kotlin_client.go","internal/engine/http_endpoint_kotlin_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "val/const path constants resolved into Retrofit/Ktor URL args via the Kotlin string symbol table; cross-file constants not linked."
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_kotlin_client.go","internal/engine/http_endpoint_kotlin_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "Each Retrofit annotated method is recorded as an outbound HTTP effect (verb + path) so the cross-repo linker pairs it with a producer. Value-asserted in http_endpoint_kotlin_client_test.go."
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 201 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 203 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
 
 ## Coverage by language
 
@@ -12,8 +12,8 @@
 | [C/C++](by-language/c-cpp.md) | 19 | 16 | 7 | 1 |
 | [java](by-language/java.md) | 19 | 10 | 14 | 3 |
 | [go](by-language/go.md) | 17 | 8 | 17 | 0 |
+| [kotlin](by-language/kotlin.md) | 17 | 0 | 7 | 0 |
 | [C#](by-language/csharp.md) | 15 | 7 | 14 | 0 |
-| [kotlin](by-language/kotlin.md) | 15 | 0 | 7 | 0 |
 | [rust](by-language/rust.md) | 14 | 6 | 14 | 1 |
 | [elixir](by-language/elixir.md) | 13 | 5 | 10 | 0 |
 | [php](by-language/php.md) | 13 | 6 | 14 | 0 |
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 201 frameworks · 110 tools · 151 ORMs · 116 other
+Total: 203 frameworks · 110 tools · 151 ORMs · 116 other

--- a/internal/custom/kotlin/dagger_hilt.go
+++ b/internal/custom/kotlin/dagger_hilt.go
@@ -1,0 +1,479 @@
+// Package kotlin — Dagger / Hilt DI extractor (record
+// lang.kotlin.framework.dagger-hilt).
+//
+// Covers:
+//   - di_binding_extraction  (missing → full)
+//   - di_injection_point     (missing → full)
+//   - di_scope_resolution    (missing → full)
+//
+// Dagger/Hilt annotations are identical in Kotlin and Java; this extractor is
+// gated to `kotlin` source so the Java pipeline is unaffected. It targets the
+// canonical Hilt/Dagger DSL:
+//
+//	@Module
+//	@InstallIn(SingletonComponent::class)
+//	object NetworkModule {
+//	    @Provides
+//	    @Singleton
+//	    fun provideRepo(api: ApiService): Repo = RepoImpl(api)
+//
+//	    @Binds
+//	    abstract fun bindLogger(impl: ConsoleLogger): Logger
+//	}
+//
+//	class UserService @Inject constructor(private val repo: Repo)
+//
+//	@HiltViewModel
+//	class ProfileViewModel @Inject constructor(private val repo: Repo) : ViewModel()
+//
+//	@HiltAndroidApp class App : Application()
+//	@AndroidEntryPoint class MainActivity : ComponentActivity()
+//
+// Bindings (di_binding):
+//   - @Provides fun provideX(deps...): X      → provider binding, binding_type=
+//     return type, implementation=return type, injected_deps=param types.
+//   - @Binds fun bindX(impl: Impl): X         → bind binding, binding_type=
+//     return type (the interface), implementation=parameter type (the impl).
+//     The @InstallIn(Component::class) on the enclosing module sets di_scope to
+//     the component (e.g. SingletonComponent → singleton); a method-level scope
+//     annotation (@Singleton / @ActivityScoped / …) overrides it.
+//
+// Injection points (di_injection_point):
+//   - @Inject constructor(p1: T1, p2: T2)     → one injection point per
+//     constructor parameter, mechanism=constructor_inject.
+//   - @Inject lateinit var field: T           → field injection,
+//     mechanism=field_inject.
+//
+// Component / entry-point markers (di_scope_resolution):
+//   - @HiltAndroidApp / @AndroidEntryPoint / @HiltViewModel on a class →
+//     a di_component entity recording the Hilt entry-point kind and the
+//     component scope it lives in.
+//
+// Honest limit: regex-based and file-local. Cross-module binding resolution
+// (a @Provides whose return type is consumed by an @Inject in another file)
+// is not linked here — that pairing is the engine's job. The proven cells
+// (per-binding scope+type+impl+deps, per-parameter injection points, per-class
+// entry points) are asserted by value in tests, so the three DI cells flip
+// full; the cross-file resolution gap is documented in the cell notes.
+package kotlin
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_dagger_hilt", &daggerHiltExtractor{})
+}
+
+type daggerHiltExtractor struct{}
+
+func (e *daggerHiltExtractor) Language() string { return "custom_kotlin_dagger_hilt" }
+
+var (
+	// @InstallIn(SingletonComponent::class) — g1 = component class name.
+	reHiltInstallIn = regexp.MustCompile(`@InstallIn\s*\(\s*([A-Za-z_][\w]*)\s*::\s*class`)
+
+	// @Provides on a fun: matches the annotation; the method head follows.
+	reDaggerProvides = regexp.MustCompile(`@Provides\b`)
+
+	// @Binds on a fun.
+	reDaggerBinds = regexp.MustCompile(`@Binds\b`)
+
+	// Method head: `fun provideRepo(api: ApiService): Repo`.
+	// g1 = name, g2 = raw params, g3 = return type (optional).
+	reKtFunHead = regexp.MustCompile(
+		`(?:abstract\s+|open\s+|override\s+|internal\s+|private\s+|public\s+|protected\s+|suspend\s+)*` +
+			`fun\s+([A-Za-z_]\w*)\s*\(([^)]*)\)\s*(?::\s*([A-Za-z_][\w<>., ?]*?)\s*)?(?:=|\{|\n|\r|$)`)
+
+	// @Inject constructor(...) — g1 = raw params.
+	reHiltInjectConstructor = regexp.MustCompile(
+		`@Inject\s+(?:internal\s+|private\s+|protected\s+|public\s+)?constructor\s*\(([^)]*)\)`)
+
+	// @Inject lateinit var field: T  — g1 = field name, g2 = type.
+	reHiltInjectField = regexp.MustCompile(
+		`@Inject\s+(?:lateinit\s+)?(?:var|val)\s+([A-Za-z_]\w*)\s*:\s*([A-Za-z_][\w<>., ?]*?)\s*(?:=|$|\n)`)
+
+	// Hilt entry-point markers on a class. g1 = marker, g2 = class name.
+	reHiltEntryPoint = regexp.MustCompile(
+		`@(HiltAndroidApp|AndroidEntryPoint|HiltViewModel)\b[\s\S]{0,160}?\bclass\s+([A-Za-z_]\w*)`)
+
+	// Method-level scope annotation (overrides component scope).
+	reDaggerMethodScope = regexp.MustCompile(
+		`@(Singleton|ActivityScoped|ActivityRetainedScoped|FragmentScoped|ViewScoped|ViewModelScoped|ServiceScoped|Reusable)\b`)
+)
+
+func (e *daggerHiltExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/kotlin")
+	_, span := tracer.Start(ctx, "indexer.dagger_hilt.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "dagger-hilt"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	if !daggerHiltHasAny(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// Component scope from the (file-local) @InstallIn on the enclosing module.
+	componentScope := ""
+	componentName := ""
+	if mm := reHiltInstallIn.FindStringSubmatch(src); len(mm) >= 2 {
+		componentName = mm[1]
+		componentScope = hiltComponentScope(componentName)
+	}
+
+	extractDaggerProviders(add, src, file.Path, componentScope, componentName)
+	extractDaggerBinds(add, src, file.Path, componentScope, componentName)
+	extractHiltInjections(add, src, file.Path)
+	extractHiltEntryPoints(add, src, file.Path, componentScope)
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+func daggerHiltHasAny(src string) bool {
+	return strings.Contains(src, "@Provides") ||
+		strings.Contains(src, "@Binds") ||
+		strings.Contains(src, "@Inject") ||
+		strings.Contains(src, "@HiltAndroidApp") ||
+		strings.Contains(src, "@AndroidEntryPoint") ||
+		strings.Contains(src, "@HiltViewModel") ||
+		strings.Contains(src, "@InstallIn")
+}
+
+// extractDaggerProviders handles `@Provides fun provideX(deps): X`.
+func extractDaggerProviders(add func(types.EntityRecord), src, filePath, componentScope, componentName string) {
+	for _, m := range reDaggerProvides.FindAllStringIndex(src, -1) {
+		head, headStart, ok := nextKtFunHead(src, m[1])
+		if !ok {
+			continue
+		}
+		name := head[1]
+		params := head[2]
+		retType := strings.TrimSpace(head[3])
+		if retType == "" {
+			continue
+		}
+		scope := resolveDaggerScope(src, m[0], headStart, componentScope)
+		deps := paramTypes(params)
+
+		ent := makeEntity("dagger:binding:provides:"+name+":"+retType, "SCOPE.Pattern", "di_binding", filePath, "kotlin", lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "dagger-hilt",
+			"di_framework", "dagger-hilt",
+			"di_scope", scope,
+			"binding_style", "provides",
+			"binding_type", retType,
+			"implementation", retType,
+			"provider_method", name,
+			"provenance", "INFERRED_FROM_DAGGER_DI",
+		)
+		if componentName != "" {
+			setProps(&ent, "component", componentName)
+		}
+		if len(deps) > 0 {
+			setProps(&ent,
+				"injected_deps", strings.Join(deps, ","),
+				"injected_dep_count", strconv.Itoa(len(deps)),
+			)
+		}
+		add(ent)
+	}
+}
+
+// extractDaggerBinds handles `@Binds abstract fun bindX(impl: Impl): Iface`.
+func extractDaggerBinds(add func(types.EntityRecord), src, filePath, componentScope, componentName string) {
+	for _, m := range reDaggerBinds.FindAllStringIndex(src, -1) {
+		head, headStart, ok := nextKtFunHead(src, m[1])
+		if !ok {
+			continue
+		}
+		name := head[1]
+		params := head[2]
+		retType := strings.TrimSpace(head[3])
+		if retType == "" {
+			continue
+		}
+		// @Binds takes exactly one parameter: the implementation.
+		impl := ""
+		if pts := paramTypes(params); len(pts) > 0 {
+			impl = pts[0]
+		}
+		scope := resolveDaggerScope(src, m[0], headStart, componentScope)
+
+		ent := makeEntity("dagger:binding:binds:"+retType+":"+impl, "SCOPE.Pattern", "di_binding", filePath, "kotlin", lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "dagger-hilt",
+			"di_framework", "dagger-hilt",
+			"di_scope", scope,
+			"binding_style", "binds",
+			"binding_type", retType,
+			"bind_method", name,
+			"provenance", "INFERRED_FROM_DAGGER_DI",
+		)
+		if impl != "" {
+			setProps(&ent, "implementation", impl)
+		}
+		if componentName != "" {
+			setProps(&ent, "component", componentName)
+		}
+		add(ent)
+	}
+}
+
+// extractHiltInjections handles @Inject constructor(...) and @Inject fields.
+func extractHiltInjections(add func(types.EntityRecord), src, filePath string) {
+	for _, m := range reHiltInjectConstructor.FindAllStringSubmatchIndex(src, -1) {
+		params := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		for _, p := range splitParams(params) {
+			name, typ := paramNameType(p)
+			if typ == "" {
+				continue
+			}
+			ent := makeEntity("dagger:inject:ctor:"+name+":"+typ, "SCOPE.Pattern", "di_injection_point", filePath, "kotlin", line)
+			setProps(&ent,
+				"framework", "dagger-hilt",
+				"di_framework", "dagger-hilt",
+				"field_name", name,
+				"injected_type", typ,
+				"mechanism", "constructor_inject",
+				"provenance", "INFERRED_FROM_DAGGER_DI",
+			)
+			add(ent)
+		}
+	}
+
+	for _, m := range reHiltInjectField.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		typ := strings.TrimSpace(src[m[4]:m[5]])
+		if typ == "" {
+			continue
+		}
+		ent := makeEntity("dagger:inject:field:"+name+":"+typ, "SCOPE.Pattern", "di_injection_point", filePath, "kotlin", lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "dagger-hilt",
+			"di_framework", "dagger-hilt",
+			"field_name", name,
+			"injected_type", typ,
+			"mechanism", "field_inject",
+			"provenance", "INFERRED_FROM_DAGGER_DI",
+		)
+		add(ent)
+	}
+}
+
+// extractHiltEntryPoints records @HiltAndroidApp / @AndroidEntryPoint /
+// @HiltViewModel markers as di_component scope-resolution entities.
+func extractHiltEntryPoints(add func(types.EntityRecord), src, filePath, componentScope string) {
+	for _, m := range reHiltEntryPoint.FindAllStringSubmatchIndex(src, -1) {
+		marker := src[m[2]:m[3]]
+		className := src[m[4]:m[5]]
+		scope := hiltEntryPointScope(marker)
+		if scope == "" {
+			scope = componentScope
+		}
+		ent := makeEntity("dagger:component:"+marker+":"+className, "SCOPE.Pattern", "di_scope_resolution", filePath, "kotlin", lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "dagger-hilt",
+			"di_framework", "dagger-hilt",
+			"entry_point_kind", marker,
+			"component_class", className,
+			"di_scope", scope,
+			"provenance", "INFERRED_FROM_DAGGER_DI",
+		)
+		add(ent)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (dagger-hilt namespaced)
+// ---------------------------------------------------------------------------
+
+// nextKtFunHead finds the first `fun <name>(params): Ret` head at or after pos
+// (within a 400-byte window so annotation-stacked methods still resolve).
+// Returns the submatch slice, the head's absolute start offset, and ok.
+func nextKtFunHead(src string, pos int) ([]string, int, bool) {
+	end := pos + 400
+	if end > len(src) {
+		end = len(src)
+	}
+	window := src[pos:end]
+	loc := reKtFunHead.FindStringSubmatchIndex(window)
+	if loc == nil {
+		return nil, 0, false
+	}
+	sm := reKtFunHead.FindStringSubmatch(window)
+	return sm, pos + loc[0], true
+}
+
+// resolveDaggerScope returns the method-level scope annotation if present
+// between annStart and headStart, else the component scope, else "unscoped".
+func resolveDaggerScope(src string, annStart, headStart int, componentScope string) string {
+	if headStart > annStart && headStart <= len(src) {
+		// Look back a little before the annotation too — scope annotations may
+		// precede @Provides — by scanning the window around the method head.
+		lo := annStart - 80
+		if lo < 0 {
+			lo = 0
+		}
+		window := src[lo:headStart]
+		if mm := reDaggerMethodScope.FindStringSubmatch(window); len(mm) >= 2 {
+			return daggerScopeName(mm[1])
+		}
+	}
+	if componentScope != "" {
+		return componentScope
+	}
+	return "unscoped"
+}
+
+// hiltComponentScope maps a Hilt component class to its scope name.
+func hiltComponentScope(component string) string {
+	switch component {
+	case "SingletonComponent", "ApplicationComponent":
+		return "singleton"
+	case "ActivityComponent":
+		return "activity"
+	case "ActivityRetainedComponent":
+		return "activity_retained"
+	case "FragmentComponent":
+		return "fragment"
+	case "ViewComponent", "ViewWithFragmentComponent":
+		return "view"
+	case "ViewModelComponent":
+		return "viewmodel"
+	case "ServiceComponent":
+		return "service"
+	}
+	return strings.ToLower(strings.TrimSuffix(component, "Component"))
+}
+
+// daggerScopeName normalizes a method-level scope annotation to a scope name.
+func daggerScopeName(ann string) string {
+	switch ann {
+	case "Singleton":
+		return "singleton"
+	case "ActivityScoped":
+		return "activity"
+	case "ActivityRetainedScoped":
+		return "activity_retained"
+	case "FragmentScoped":
+		return "fragment"
+	case "ViewScoped":
+		return "view"
+	case "ViewModelScoped":
+		return "viewmodel"
+	case "ServiceScoped":
+		return "service"
+	case "Reusable":
+		return "reusable"
+	}
+	return strings.ToLower(ann)
+}
+
+// hiltEntryPointScope maps an entry-point marker to its component scope.
+func hiltEntryPointScope(marker string) string {
+	switch marker {
+	case "HiltAndroidApp":
+		return "singleton"
+	case "HiltViewModel":
+		return "viewmodel"
+	case "AndroidEntryPoint":
+		return "activity"
+	}
+	return ""
+}
+
+// paramTypes returns the declared types of every `name: Type` parameter.
+func paramTypes(params string) []string {
+	var out []string
+	for _, p := range splitParams(params) {
+		if _, typ := paramNameType(p); typ != "" {
+			out = append(out, typ)
+		}
+	}
+	return out
+}
+
+// splitParams splits a Kotlin parameter list on commas at depth 0 (so generic
+// args like Map<K, V> are not split).
+func splitParams(params string) []string {
+	params = strings.TrimSpace(params)
+	if params == "" {
+		return nil
+	}
+	var out []string
+	depth := 0
+	start := 0
+	for i, r := range params {
+		switch r {
+		case '<', '(', '[':
+			depth++
+		case '>', ')', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				out = append(out, params[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, params[start:])
+	return out
+}
+
+// paramNameType parses one `[modifiers] name: Type [= default]` parameter,
+// returning the name and the type (default value and modifiers stripped).
+func paramNameType(p string) (string, string) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", ""
+	}
+	// Drop a default value.
+	if eq := strings.Index(p, "="); eq >= 0 {
+		p = strings.TrimSpace(p[:eq])
+	}
+	colon := strings.Index(p, ":")
+	if colon < 0 {
+		return "", ""
+	}
+	left := strings.Fields(strings.TrimSpace(p[:colon])) // [val|var|private|…] name
+	name := ""
+	if len(left) > 0 {
+		name = left[len(left)-1]
+	}
+	typ := strings.TrimSpace(p[colon+1:])
+	return name, typ
+}

--- a/internal/custom/kotlin/dagger_hilt_test.go
+++ b/internal/custom/kotlin/dagger_hilt_test.go
@@ -1,0 +1,225 @@
+package kotlin_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// dagger_hilt_test.go — value-asserting tests for the Dagger/Hilt DI extractor
+// (record lang.kotlin.framework.dagger-hilt; cells di_binding_extraction /
+// di_injection_point / di_scope_resolution → full).
+
+const hiltModuleSrc = `
+package com.example.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.Binds
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideRepo(api: ApiService, clock: Clock): Repo = RepoImpl(api, clock)
+
+    @Provides
+    fun provideClock(): Clock = SystemClock()
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class BindModule {
+    @Binds
+    abstract fun bindLogger(impl: ConsoleLogger): Logger
+}
+
+class UserService @Inject constructor(
+    private val repo: Repo,
+    private val logger: Logger,
+)
+
+@HiltViewModel
+class ProfileViewModel @Inject constructor(private val repo: Repo) : ViewModel()
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    @Inject lateinit var userService: UserService
+}
+
+@HiltAndroidApp
+class App : Application()
+`
+
+func TestHilt_ProvidesBinding(t *testing.T) {
+	ents := extract(t, "custom_kotlin_dagger_hilt", fi("NetworkModule.kt", "kotlin", hiltModuleSrc))
+	if len(ents) == 0 {
+		t.Fatalf("[hilt] expected entities, got none")
+	}
+
+	byType := map[string]*entitySummary{}
+	for i := range ents {
+		if ents[i].Subtype == "di_binding" && ents[i].Props["binding_style"] == "provides" {
+			byType[ents[i].Props["binding_type"]] = &ents[i]
+		}
+	}
+
+	// @Provides @Singleton fun provideRepo(api, clock): Repo
+	repo := byType["Repo"]
+	if repo == nil {
+		t.Fatalf("[hilt] missing Repo provides binding; got %v", byType)
+	}
+	if repo.Props["di_scope"] != "singleton" {
+		t.Errorf("[hilt] Repo di_scope = %q, want singleton (method @Singleton)", repo.Props["di_scope"])
+	}
+	if repo.Props["implementation"] != "Repo" {
+		t.Errorf("[hilt] Repo implementation = %q, want Repo", repo.Props["implementation"])
+	}
+	if repo.Props["provider_method"] != "provideRepo" {
+		t.Errorf("[hilt] Repo provider_method = %q, want provideRepo", repo.Props["provider_method"])
+	}
+	if repo.Props["injected_dep_count"] != "2" {
+		t.Errorf("[hilt] Repo injected_dep_count = %q, want 2", repo.Props["injected_dep_count"])
+	}
+	if !strings.Contains(repo.Props["injected_deps"], "ApiService") || !strings.Contains(repo.Props["injected_deps"], "Clock") {
+		t.Errorf("[hilt] Repo injected_deps = %q, want ApiService and Clock", repo.Props["injected_deps"])
+	}
+	if repo.Props["component"] != "SingletonComponent" {
+		t.Errorf("[hilt] Repo component = %q, want SingletonComponent", repo.Props["component"])
+	}
+
+	// @Provides fun provideClock(): Clock — no method scope → component scope.
+	clock := byType["Clock"]
+	if clock == nil {
+		t.Fatalf("[hilt] missing Clock provides binding")
+	}
+	if clock.Props["di_scope"] != "singleton" {
+		t.Errorf("[hilt] Clock di_scope = %q, want singleton (from @InstallIn component)", clock.Props["di_scope"])
+	}
+}
+
+func TestHilt_BindsBinding(t *testing.T) {
+	ents := extract(t, "custom_kotlin_dagger_hilt", fi("BindModule.kt", "kotlin", hiltModuleSrc))
+
+	var logger *entitySummary
+	for i := range ents {
+		if ents[i].Subtype == "di_binding" && ents[i].Props["binding_style"] == "binds" && ents[i].Props["binding_type"] == "Logger" {
+			logger = &ents[i]
+		}
+	}
+	// @Binds abstract fun bindLogger(impl: ConsoleLogger): Logger
+	if logger == nil {
+		t.Fatalf("[hilt] missing Logger binds binding")
+	}
+	if logger.Props["binding_type"] != "Logger" {
+		t.Errorf("[hilt] Logger binding_type = %q, want Logger (interface)", logger.Props["binding_type"])
+	}
+	if logger.Props["implementation"] != "ConsoleLogger" {
+		t.Errorf("[hilt] Logger implementation = %q, want ConsoleLogger (impl param)", logger.Props["implementation"])
+	}
+}
+
+func TestHilt_ConstructorInjection(t *testing.T) {
+	ents := extract(t, "custom_kotlin_dagger_hilt", fi("UserService.kt", "kotlin", hiltModuleSrc))
+
+	ctorByType := map[string]*entitySummary{}
+	for i := range ents {
+		if ents[i].Subtype == "di_injection_point" && ents[i].Props["mechanism"] == "constructor_inject" {
+			ctorByType[ents[i].Props["injected_type"]] = &ents[i]
+		}
+	}
+	// UserService @Inject constructor(repo: Repo, logger: Logger)
+	if ctorByType["Repo"] == nil {
+		t.Errorf("[hilt] missing constructor injection point for Repo; got %v", ctorByType)
+	}
+	if ctorByType["Logger"] == nil {
+		t.Errorf("[hilt] missing constructor injection point for Logger")
+	}
+	if ip := ctorByType["Repo"]; ip != nil && ip.Props["field_name"] != "repo" {
+		t.Errorf("[hilt] Repo injection field_name = %q, want repo", ip.Props["field_name"])
+	}
+}
+
+func TestHilt_FieldInjection(t *testing.T) {
+	ents := extract(t, "custom_kotlin_dagger_hilt", fi("MainActivity.kt", "kotlin", hiltModuleSrc))
+
+	var field *entitySummary
+	for i := range ents {
+		if ents[i].Subtype == "di_injection_point" && ents[i].Props["mechanism"] == "field_inject" {
+			field = &ents[i]
+		}
+	}
+	// @Inject lateinit var userService: UserService
+	if field == nil {
+		t.Fatalf("[hilt] missing field injection point")
+	}
+	if field.Props["field_name"] != "userService" || field.Props["injected_type"] != "UserService" {
+		t.Errorf("[hilt] field inject = field %q type %q, want userService/UserService",
+			field.Props["field_name"], field.Props["injected_type"])
+	}
+}
+
+func TestHilt_EntryPointsScope(t *testing.T) {
+	ents := extract(t, "custom_kotlin_dagger_hilt", fi("App.kt", "kotlin", hiltModuleSrc))
+
+	byMarker := map[string]*entitySummary{}
+	for i := range ents {
+		if ents[i].Subtype == "di_scope_resolution" {
+			byMarker[ents[i].Props["entry_point_kind"]] = &ents[i]
+		}
+	}
+
+	// @HiltAndroidApp class App → singleton scope.
+	app := byMarker["HiltAndroidApp"]
+	if app == nil {
+		t.Fatalf("[hilt] missing HiltAndroidApp entry point; got %v", byMarker)
+	}
+	if app.Props["component_class"] != "App" || app.Props["di_scope"] != "singleton" {
+		t.Errorf("[hilt] HiltAndroidApp = class %q scope %q, want App/singleton",
+			app.Props["component_class"], app.Props["di_scope"])
+	}
+
+	// @HiltViewModel class ProfileViewModel → viewmodel scope.
+	vm := byMarker["HiltViewModel"]
+	if vm == nil || vm.Props["component_class"] != "ProfileViewModel" || vm.Props["di_scope"] != "viewmodel" {
+		t.Errorf("[hilt] HiltViewModel entry point wrong: %+v", vm)
+	}
+
+	// @AndroidEntryPoint class MainActivity → activity scope.
+	act := byMarker["AndroidEntryPoint"]
+	if act == nil || act.Props["component_class"] != "MainActivity" || act.Props["di_scope"] != "activity" {
+		t.Errorf("[hilt] AndroidEntryPoint entry point wrong: %+v", act)
+	}
+}
+
+func TestHilt_NonHiltSource(t *testing.T) {
+	src := `
+package com.example
+fun hello() = "world"
+`
+	ents := extract(t, "custom_kotlin_dagger_hilt", fi("Hello.kt", "kotlin", src))
+	if len(ents) != 0 {
+		t.Errorf("[hilt] expected 0 entities for non-Hilt file, got %d", len(ents))
+	}
+}
+
+func TestHilt_EmptySource(t *testing.T) {
+	ents := extract(t, "custom_kotlin_dagger_hilt", fi("Empty.kt", "kotlin", ""))
+	if len(ents) != 0 {
+		t.Errorf("[hilt] expected 0 entities for empty file, got %d", len(ents))
+	}
+}
+
+func TestHilt_JavaSourceIgnored(t *testing.T) {
+	// Dagger annotations are identical in Java; this extractor is gated to
+	// kotlin so the Java pipeline stays untouched.
+	ents := extract(t, "custom_kotlin_dagger_hilt", fi("NetworkModule.java", "java", hiltModuleSrc))
+	if len(ents) != 0 {
+		t.Errorf("[hilt] expected 0 entities for java source, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
Closes #3555 (epic #3505). EXPANSION — two new Kotlin coverage records, no regressions to existing cells.

## Records added

### `lang.kotlin.framework.retrofit` — HTTP client (outbound cross-links)
Retrofit interface verb annotations (`@GET`/`@POST`/`@PUT`/`@DELETE`/`@PATCH`/`@HEAD`/`@OPTIONS`) emit one outbound `http_endpoint` (consumer side) + a `FETCHES` edge per annotated method, with `Retrofit.Builder().baseUrl()` composition and `{param}` path normalization, so the cross-repo linker pairs them with producers. The emission already exists in `internal/engine/http_endpoint_kotlin_client.go` (value-asserted in `http_endpoint_kotlin_client_test.go`); this PR records the coverage.

Cells flipped:
- `endpoint_synthesis` = full
- `http_effect` = full
- `interface_extraction` = full
- `handler_attribution` = full
- `constant_propagation` = partial (val/const path constants resolved file-local)

### `lang.kotlin.framework.dagger-hilt` — Android DI
New file-local regex extractor `custom_kotlin_dagger_hilt`, **language-gated to `kotlin`** (Dagger annotations are identical in Java, so the Java pipeline is untouched; verified by `TestHilt_JavaSourceIgnored`). Auto-dispatched via the `custom_kotlin_` prefix.

Covers:
- `@Provides` provider bindings (return type binding + param deps) and `@Binds` (interface → impl param)
- `@Inject constructor(...)` → one injection point per parameter; `@Inject lateinit var` field injection
- Scope resolution from `@InstallIn(Component::class)` + method-level `@Singleton`/`@ActivityScoped`/… overrides; entry points `@HiltAndroidApp`/`@AndroidEntryPoint`/`@HiltViewModel`

Cells flipped:
- `di_binding_extraction` = full
- `di_injection_point` = full
- `di_scope_resolution` = full

Honest gap: cross-module binding resolution (a `@Provides` consumed by an `@Inject` in another file) is the engine's job, documented in the cell notes.

## Discipline
- Value-asserting tests in `dagger_hilt_test.go`: assert specific bindings (`Repo` provider scope=singleton, impl, 2 deps `ApiService`+`Clock`; `Logger` binds → impl `ConsoleLogger`), constructor/field injection field+type+mechanism, and entry-point scopes — not `len>0`.
- `coverage gen` / `validate` (0 errors) / `fmt` canonical; `gofmt -l` empty; `go vet` clean.
- Targeted suites green: `internal/custom/kotlin/`, `internal/custom/java/`, `internal/engine/`, `internal/types/`, `tools/coverage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)