### PR TITLE
fix(java): string-aware annotation scanning in the two deferred paren sites (#3561)

### DIFF
--- a/internal/custom/java/jakarta_jaxrs_dto.go
+++ b/internal/custom/java/jakarta_jaxrs_dto.go
@@ -31,24 +31,200 @@ var jaxrsDTOFrameworks = map[string]bool{
 }
 
 var (
-	// @Path class declaration — captures class name.
-	jaxrsResourceClassRE = regexp.MustCompile(
-		`(?s)@Path\s*\([^)]*\)\s*(?:(?:@\w+(?:\s*\([^)]*\))?\s*)*)` +
-			`(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+	// jaxrsPathAnchorRE locates an @Path annotation NAME (the argument list is
+	// then consumed string-aware, so a ')' inside the path template string does
+	// not truncate it).
+	jaxrsPathAnchorRE = regexp.MustCompile(`@Path\b`)
 
-	// JAX-RS verb method — captures verb, return type, method name, and param fragment.
-	// The visibility modifier is consumed before the capture group so it does not
-	// leak into the return type.
-	jaxrsVerbMethodRE = regexp.MustCompile(
-		`(?s)@(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b` +
-			`(?:\s*(?:@\w+(?:\s*\([^)]*\))?\s*))*` +
-			`\s*(?:public|protected|private)\s+(?:static\s+)?` +
+	// jaxrsClassDeclRE matches a class declaration head once any annotation block
+	// has been skipped. Captures the class name.
+	jaxrsClassDeclRE = regexp.MustCompile(
+		`^(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)`)
+
+	// jaxrsVerbAnchorRE locates a bare JAX-RS verb annotation. Captures the verb.
+	jaxrsVerbAnchorRE = regexp.MustCompile(`@(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b`)
+
+	// jaxrsMethodDeclRE matches a JAX-RS method declaration head once any
+	// intervening annotation block has been skipped string-aware. The visibility
+	// modifier is consumed before the captures so it does not leak into the
+	// return type. Group 1 = return type, group 2 = method name, group 3 = the
+	// parameter fragment up to (and excluding) the closing ')'.
+	jaxrsMethodDeclRE = regexp.MustCompile(
+		`^(?:public|protected|private)\s+(?:static\s+)?` +
 			`(?:<[^>]*>\s*)?([\w<>\[\], ]+?)\s+(\w+)\s*\(([^)]*)`)
 
 	// Response<T> / CompletionStage<T> / Uni<T> / Multi<T> wrapper unwrap.
 	jaxrsResponseWrapRE = regexp.MustCompile(
 		`(?:Response|CompletionStage|Uni|Multi|CompletableFuture)\s*<\s*([\w<>, ]+?)\s*>`)
 )
+
+// jaxrsIsIdentChar reports whether c is valid in a Java identifier.
+func jaxrsIsIdentChar(c byte) bool {
+	return c == '_' || c == '$' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// jaxrsFindStringEnd walks from `start` (the opening double- or single-quote of
+// a string/char literal) to the matching closing quote of the same kind,
+// honouring backslash escapes. Returns the closing-quote index, or -1 when
+// unterminated.
+func jaxrsFindStringEnd(s string, start int) int {
+	quote := s[start]
+	for i := start + 1; i < len(s); i++ {
+		if s[i] == '\\' {
+			i++
+			continue
+		}
+		if s[i] == quote {
+			return i
+		}
+	}
+	return -1
+}
+
+// jaxrsFindMatchingClose walks from `open` (a '(') to its matching ')',
+// honouring string/char literals so a ')' inside a string does not affect the
+// depth count. Returns the matching-paren index, or -1 when unbalanced.
+func jaxrsFindMatchingClose(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '"', '\'':
+			end := jaxrsFindStringEnd(s, i)
+			if end < 0 {
+				return -1
+			}
+			i = end
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// jaxrsSkipAnnotationsToDecl returns the offset of the first non-whitespace,
+// non-comment, non-annotation token at or after `from`. Annotations (including
+// a balanced, string-aware `(...)` argument list — so a ')' inside an
+// @Operation(summary = "Get (all)") string does not truncate the skip) and
+// whitespace/comments are skipped. Returns -1 if EOF is reached first.
+func jaxrsSkipAnnotationsToDecl(s string, from int) int {
+	i := from
+	for i < len(s) {
+		c := s[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\r' || c == '\n':
+			i++
+		case c == '/' && i+1 < len(s) && s[i+1] == '/':
+			for i < len(s) && s[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < len(s) && s[i+1] == '*':
+			i += 2
+			for i+1 < len(s) && !(s[i] == '*' && s[i+1] == '/') {
+				i++
+			}
+			i += 2
+		case c == '@':
+			i++
+			for i < len(s) && (jaxrsIsIdentChar(s[i]) || s[i] == '.') {
+				i++
+			}
+			for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\r' || s[i] == '\n') {
+				i++
+			}
+			if i < len(s) && s[i] == '(' {
+				closeAt := jaxrsFindMatchingClose(s, i)
+				if closeAt < 0 {
+					return -1
+				}
+				i = closeAt + 1
+			}
+		default:
+			return i
+		}
+	}
+	return -1
+}
+
+// jaxrsResourceClass is a @Path-annotated resource class.
+type jaxrsResourceClass struct {
+	name   string
+	offset int // offset of the @Path anchor that introduced the class
+}
+
+// jaxrsCollectResourceClasses scans `source` for @Path-annotated resource
+// classes. The @Path argument list and any following annotations are consumed
+// string-aware, so a ')' inside the path-template string (or inside an
+// intervening @Operation/@Tag string) does not truncate the class binding.
+func jaxrsCollectResourceClasses(source string) []jaxrsResourceClass {
+	var out []jaxrsResourceClass
+	for _, loc := range jaxrsPathAnchorRE.FindAllStringIndex(source, -1) {
+		// Skip the annotation block (starting at the @Path anchor) string-aware,
+		// then require a class declaration head at the resulting offset.
+		decl := jaxrsSkipAnnotationsToDecl(source, loc[0])
+		if decl < 0 {
+			continue
+		}
+		if m := jaxrsClassDeclRE.FindStringSubmatch(source[decl:]); m != nil {
+			name := m[1]
+			dup := false
+			for _, c := range out {
+				if c.name == name {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				out = append(out, jaxrsResourceClass{name: name, offset: loc[0]})
+			}
+		}
+	}
+	return out
+}
+
+// jaxrsVerbMethod is a JAX-RS verb method binding recovered string-aware.
+type jaxrsVerbMethod struct {
+	verb       string
+	returnType string
+	methodName string
+	paramFrag  string
+	offset     int // offset of the verb anchor
+}
+
+// jaxrsCollectVerbMethods scans `source` for JAX-RS verb annotations and binds
+// each to its method declaration. The intervening annotation block is skipped
+// string-aware, so a ')' inside an @Operation(summary = "Get (all)") string
+// does not break the verb→method binding (which previously dropped the route /
+// DTO). Returns one entry per verb anchor that resolves to a method head.
+func jaxrsCollectVerbMethods(source string) []jaxrsVerbMethod {
+	var out []jaxrsVerbMethod
+	for _, m := range jaxrsVerbAnchorRE.FindAllStringSubmatchIndex(source, -1) {
+		verb := source[m[2]:m[3]]
+		// Skip from just after the verb annotation, over any intervening
+		// annotations, to the method declaration head.
+		decl := jaxrsSkipAnnotationsToDecl(source, m[1])
+		if decl < 0 {
+			continue
+		}
+		dm := jaxrsMethodDeclRE.FindStringSubmatch(source[decl:])
+		if dm == nil {
+			continue
+		}
+		out = append(out, jaxrsVerbMethod{
+			verb:       verb,
+			returnType: dm[1],
+			methodName: dm[2],
+			paramFrag:  dm[3],
+			offset:     m[0],
+		})
+	}
+	return out
+}
 
 // jaxrsDTOSkipTypes extends srrSkipTypes with JAX-RS-specific noisy types.
 var jaxrsDTOSkipTypes = func() map[string]bool {
@@ -129,34 +305,18 @@ func ExtractJakartaJaxrsDTO(ctx PatternContext) PatternResult {
 	source := ctx.Source
 	fp := ctx.FilePath
 
-	// Quick exit: skip files that have no JAX-RS path annotation.
-	if !jaxrsResourceClassRE.MatchString(source) {
+	// Collect resource class offsets so we can identify the owning class for
+	// each method. The scan is string-aware so a ')' inside a @Path template or
+	// an intervening annotation string does not break the class binding.
+	classes := jaxrsCollectResourceClasses(source)
+
+	// Quick exit: skip files that have no JAX-RS resource class.
+	if len(classes) == 0 {
 		return result
 	}
 
 	seenRefs := make(map[string]bool)
 	seenRels := make(map[relKey]bool)
-
-	// Collect resource class offsets so we can identify the owning class for
-	// each method.
-	type classEntry struct {
-		name   string
-		offset int
-	}
-	var classes []classEntry
-	for _, m := range jaxrsResourceClassRE.FindAllStringSubmatchIndex(source, -1) {
-		name := source[m[2]:m[3]]
-		dup := false
-		for _, c := range classes {
-			if c.name == name {
-				dup = true
-				break
-			}
-		}
-		if !dup {
-			classes = append(classes, classEntry{name, m[0]})
-		}
-	}
 
 	findOwner := func(offset int) string {
 		var owner string
@@ -186,14 +346,14 @@ func ExtractJakartaJaxrsDTO(ctx PatternContext) PatternResult {
 		return unwrapReturnType(raw)
 	}
 
-	for _, m := range jaxrsVerbMethodRE.FindAllStringSubmatchIndex(source, -1) {
-		verb := source[m[2]:m[3]]
-		returnTypeRaw := source[m[4]:m[5]]
-		methodName := source[m[6]:m[7]]
-		paramFrag := source[m[8]:m[9]]
-		lineNo := lineOf(source, m[0])
+	for _, vm := range jaxrsCollectVerbMethods(source) {
+		verb := vm.verb
+		returnTypeRaw := vm.returnType
+		methodName := vm.methodName
+		paramFrag := vm.paramFrag
+		lineNo := lineOf(source, vm.offset)
 
-		owner := findOwner(m[0])
+		owner := findOwner(vm.offset)
 		if owner == "" {
 			continue
 		}

--- a/internal/custom/java/jakarta_jaxrs_dto_paren_test.go
+++ b/internal/custom/java/jakarta_jaxrs_dto_paren_test.go
@@ -1,0 +1,116 @@
+package java
+
+import "testing"
+
+// Regression tests for the deferred parens-in-annotation-string site in the
+// JAX-RS DTO extractor (follow-up to PR #3425, closes #3561).
+//
+// Root cause: jaxrsVerbMethodRE / jaxrsResourceClassRE bound a verb annotation
+// to its method (and @Path to its class) with a `[^)]*` skip over intervening
+// annotations. A Swagger @Operation(summary = "Get (all) widgets") between
+// @GET/@Path and the method stopped the skip at the first ')' inside the
+// string, so the verb never reached the method declaration and the route's
+// request/response DTO relationships were silently dropped.
+
+// jaxrsDTORelsByType returns ACCEPTS_INPUT / RETURNS relationship dto_type
+// values keyed by relationship type for the given source.
+func jaxrsDTORels(t *testing.T, source string) (accepts, returns []string) {
+	t.Helper()
+	r := ExtractJakartaJaxrsDTO(PatternContext{
+		Source: source, Language: "java", Framework: "jakarta_ee",
+		FilePath: "WidgetResource.java",
+	})
+	for _, rel := range r.Relationships {
+		switch rel.RelationshipType {
+		case "ACCEPTS_INPUT":
+			accepts = append(accepts, rel.Properties["dto_type"])
+		case "RETURNS":
+			returns = append(returns, rel.Properties["dto_type"])
+		}
+	}
+	return accepts, returns
+}
+
+// A JAX-RS resource method with @Operation(summary = "Get (all) widgets")
+// between @GET/@Path and the method declaration must still emit its RETURNS
+// DTO. A sibling method without the paren proves no undercount.
+func TestParenDeferred_JAXRS_OperationParenInString_DTOSurvives(t *testing.T) {
+	src := `package com.example;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+@Path("/widgets")
+public class WidgetResource {
+
+    @GET
+    @Path("/all")
+    @Operation(summary = "Get (all) widgets")
+    @Produces("application/json")
+    public WidgetList getAll() {
+        return repo.findAll();
+    }
+
+    @GET
+    @Path("/safe")
+    @Operation(summary = "Get safe widgets")
+    public WidgetList getSafe() {
+        return repo.findAll();
+    }
+
+    @POST
+    @Path("/create")
+    @Operation(summary = "Create a widget (v2)")
+    public Widget create(CreateWidgetDto dto) {
+        return repo.save(dto);
+    }
+}
+`
+	accepts, returns := jaxrsDTORels(t, src)
+
+	// The paren-in-@Operation method's return DTO must survive (was dropped).
+	if !contains(returns, "WidgetList") {
+		t.Errorf("RETURNS dto_types = %v, want to contain WidgetList (paren in @Operation must not drop the route DTO)", returns)
+	}
+	// The paren-in-@Operation POST's implicit body DTO must survive.
+	if !contains(accepts, "CreateWidgetDto") {
+		t.Errorf("ACCEPTS_INPUT dto_types = %v, want to contain CreateWidgetDto (paren in @Operation must not drop the body DTO)", accepts)
+	}
+	// Sibling without a paren — proves the binding still works generally and
+	// there is no undercount masking the fix.
+	wantReturns := 0
+	for _, r := range returns {
+		if r == "WidgetList" {
+			wantReturns++
+		}
+	}
+	if wantReturns < 2 {
+		t.Errorf("expected WidgetList returned by BOTH getAll and getSafe (>=2), got %d in %v", wantReturns, returns)
+	}
+}
+
+// The @Path class binding must also survive a ')' inside the path-template
+// string itself (string-internal paren in @Path("...")).
+func TestParenDeferred_JAXRS_PathTemplateParen_ClassBinds(t *testing.T) {
+	src := `package com.example;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+@Path("/items/{id:[0-9()]+}")
+public class ItemResource {
+
+    @GET
+    @Path("/detail")
+    public ItemDetail detail() {
+        return repo.detail();
+    }
+}
+`
+	_, returns := jaxrsDTORels(t, src)
+	if !contains(returns, "ItemDetail") {
+		t.Errorf("RETURNS dto_types = %v, want to contain ItemDetail (paren in @Path template must not drop the class binding)", returns)
+	}
+}

--- a/internal/engine/paren_in_annotation_string_test.go
+++ b/internal/engine/paren_in_annotation_string_test.go
@@ -155,6 +155,68 @@ func TestParenClass_JavaRequestBody_JAXRS_AnnotationParenInString(t *testing.T) 
 }
 
 // ---------------------------------------------------------------------------
+// Deferred site 1 (follow-up to PR #3425) — Java DTO field scanner: a field
+// preceded (same-line OR on the line above) by a @Schema with a ')' inside its
+// description string must still have its type+name captured. The field FindAll
+// scanner's `(?:@\w+(?:\([^)]*\))?\s+)*` annotation prefix stopped at the first
+// ')' inside the string and dropped (or mis-typed) the field.
+// ---------------------------------------------------------------------------
+
+func TestParenDeferred_JavaDtoField_SchemaParenInString_FieldCaptured(t *testing.T) {
+	src := `package com.example;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class PaymentDto {
+    @Schema(description = "amount in cents (USD)")
+    public long amount;
+
+    @Schema(description = "the payer's display name (legal)") public String payerName;
+
+    public String currency;
+}
+`
+	fields := walkJavaClassFields(src, "PaymentDto")
+	// The paren-in-string field (above-line annotation) must survive with type.
+	if got := fields["amount"]; got != "long" {
+		t.Errorf("amount: type = %q, want \"long\" (paren in @Schema string must not drop/mistype the field)", got)
+	}
+	// Same-line annotation+field with a paren in the string must also survive.
+	if got := fields["payerName"]; got != "String" {
+		t.Errorf("payerName: type = %q, want \"String\" (same-line @Schema paren-in-string)", got)
+	}
+	// Sibling field without any annotation — proves no undercount.
+	if got := fields["currency"]; got != "String" {
+		t.Errorf("currency: type = %q, want \"String\" (sibling must still be captured)", got)
+	}
+}
+
+// Lombok @Value variant: private fields are the serialized shape; a @Schema with
+// a paren in its string above a private field must not drop it, and a
+// @JsonProperty alias with a string-internal paren earlier in the stack must
+// still resolve the alias.
+func TestParenDeferred_JavaDtoField_LombokSchemaParen_FieldCaptured(t *testing.T) {
+	src := `package com.example;
+import lombok.Value;
+
+@Value
+public class MoneyDto {
+    @Schema(description = "total (gross)")
+    @JsonProperty("total_amount")
+    Long totalAmount;
+
+    String label;
+}
+`
+	fields := walkJavaClassFields(src, "MoneyDto")
+	if got := fields["total_amount"]; got != "Long" {
+		t.Errorf("total_amount alias: type = %q, want \"Long\" (paren-in-@Schema must not drop the @JsonProperty-aliased field)", got)
+	}
+	if got := fields["label"]; got != "String" {
+		t.Errorf("label: type = %q, want \"String\"", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Target 4 (LOW-MED) — Python FastAPI: a route decorator whose path argument
 // contains a regex with a ')' inside the string must still let the
 // response_model be located.

--- a/internal/engine/response_shape_java.go
+++ b/internal/engine/response_shape_java.go
@@ -315,16 +315,216 @@ func splitJavaParams(params string) []string {
 // - Java records: `public record X(String id, String name)`
 // - Lombok @Value / @Data classes: all declared fields (any access modifier)
 // - @JsonProperty("alias") annotations: use the alias string as the key name
-var javaFieldRe = regexp.MustCompile(`(?m)^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?:public|private|protected|static|final|\s)+\s*([A-Za-z_][\w<>,.\[\]]*?)\s+([a-zA-Z_]\w*)\s*[;=]`)
+//
+// Field declarations are recovered by the string-aware javaScanClassFields
+// walker (below) rather than a monolithic regex, so a ')' inside an
+// annotation string literal does not truncate the type/name capture.
 
 // javaJsonPropertyRe captures the string value from @JsonProperty("fieldName").
 var javaJsonPropertyRe = regexp.MustCompile(`@JsonProperty\s*\(\s*["']?([A-Za-z_][\w-]*)["']?\s*\)`)
 
-// javaAnyFieldRe matches field declarations with any access modifier (or none),
-// used for Lombok classes where private fields are the serialized shape.
-// The modifier group is optional so package-private and Lombok @Value fields
-// without explicit modifiers are also matched.
-var javaAnyFieldRe = regexp.MustCompile(`(?m)^\s*((?:@\w+(?:\([^)]*\))?\s+)*)(?:(?:public|private|protected|static|final|transient|volatile)\s+)*([A-Za-z_][\w<>,.\[\]]*?)\s+([a-zA-Z_]\w*)\s*[;=]`)
+// javaFieldNoAnnoRe matches a single field declaration once its leading
+// annotations have already been stripped (string-aware) from the line.
+// Group 1 = type, group 2 = field name. Modifiers are consumed before the
+// captures so they do not leak into the type.
+var javaFieldNoAnnoRe = regexp.MustCompile(`^\s*(?:(?:public|private|protected|static|final|transient|volatile)\s+)*([A-Za-z_][\w<>,.\[\]]*?)\s+([a-zA-Z_]\w*)\s*[;=]`)
+
+// javaFieldMatch is one field declaration recovered by javaScanClassFields.
+type javaFieldMatch struct {
+	annotations string // raw leading-annotation text (for @JsonProperty lookup)
+	ftype       string // declared field type
+	fname       string // field name
+	line        string // the line with annotations stripped (for modifier checks)
+}
+
+// javaScanClassFields walks a class/record body statement-by-statement and
+// returns the field declarations. Leading annotations (which may span several
+// lines) are consumed with a string-aware scan so a ')' inside an annotation
+// string literal (e.g. `@Schema(description = "amount in cents (USD)")` above or
+// beside a field) does not truncate the field type/name capture. This is the
+// parens-in-string-immune replacement for the `(?:@\w+(?:\([^)]*\))?\s+)*`
+// annotation prefix that the `javaAnyFieldRe` / `javaFieldRe` FindAll scanners
+// used. Nested blocks (`{...}`) and parenthesised groups (method parameter
+// lists, initialisers) are skipped string-aware so method bodies are not
+// mistaken for fields.
+func javaScanClassFields(body string) []javaFieldMatch {
+	var out []javaFieldMatch
+	i := 0
+	annoStart := -1 // start offset of the current accumulated annotation run
+	for i < len(body) {
+		c := body[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\r' || c == '\n':
+			i++
+		case c == '/' && i+1 < len(body) && body[i+1] == '/':
+			for i < len(body) && body[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < len(body) && body[i+1] == '*':
+			i += 2
+			for i+1 < len(body) && !(body[i] == '*' && body[i+1] == '/') {
+				i++
+			}
+			i += 2
+		case c == '@':
+			// Start (or continue) an annotation run. Consume name + optional
+			// string-aware argument list.
+			if annoStart < 0 {
+				annoStart = i
+			}
+			i++
+			for i < len(body) && (isJavaIdentChar(body[i]) || body[i] == '.') {
+				i++
+			}
+			j := i
+			for j < len(body) && (body[j] == ' ' || body[j] == '\t' || body[j] == '\r' || body[j] == '\n') {
+				j++
+			}
+			if j < len(body) && body[j] == '(' {
+				closeAt := javaFindMatchingCloseString(body, j)
+				if closeAt < 0 {
+					i = len(body)
+				} else {
+					i = closeAt + 1
+				}
+			}
+		case c == '{':
+			// Nested block (method body, initialiser, anonymous class). Skip
+			// string-aware to its matching close brace and drop any pending
+			// annotation run.
+			closeAt := javaFindMatchingBrace(body, i)
+			if closeAt < 0 {
+				i = len(body)
+			} else {
+				i = closeAt + 1
+			}
+			annoStart = -1
+		case c == '(':
+			// Parenthesised group at statement level (e.g. a method signature
+			// whose modifiers/return type we just walked, or a record-style
+			// member). Skip it string-aware; it is not a simple field.
+			closeAt := javaFindMatchingCloseString(body, i)
+			if closeAt < 0 {
+				i = len(body)
+			} else {
+				i = closeAt + 1
+			}
+		default:
+			// Statement start. Capture up to the terminating ';' or the first
+			// '=' / '(' / '{' so a field initialiser or a method signature does
+			// not bleed across the field regex.
+			stmtStart := i
+			term := i
+			for term < len(body) && body[term] != ';' && body[term] != '=' && body[term] != '(' && body[term] != '{' {
+				term++
+			}
+			stmt := body[stmtStart:term]
+			// Reconstruct a candidate `<stmt>;` for the field regex so the `[;=]`
+			// terminator anchor is satisfied uniformly.
+			if m := javaFieldNoAnnoRe.FindStringSubmatch(stmt + ";"); m != nil {
+				annotations := ""
+				if annoStart >= 0 {
+					annotations = body[annoStart:stmtStart]
+				}
+				out = append(out, javaFieldMatch{
+					annotations: annotations,
+					ftype:       m[1],
+					fname:       m[2],
+					line:        stmt,
+				})
+			}
+			annoStart = -1
+			// Advance past this statement: to the ';' (consumed) or, when the
+			// terminator was '=' / '(' / '{', skip the remainder of the
+			// statement / block string-aware.
+			i = javaAdvancePastStatement(body, term)
+		}
+	}
+	return out
+}
+
+// javaAdvancePastStatement advances from a terminator offset (a ';', '=', '('
+// or '{') to the offset just past the end of the current statement, skipping
+// balanced brace/paren groups string-aware. A ';' ends the statement directly.
+func javaAdvancePastStatement(body string, term int) int {
+	if term >= len(body) {
+		return len(body)
+	}
+	i := term
+	for i < len(body) {
+		c := body[i]
+		switch c {
+		case ';':
+			return i + 1
+		case '{':
+			closeAt := javaFindMatchingBrace(body, i)
+			if closeAt < 0 {
+				return len(body)
+			}
+			// A '{' may itself terminate a member (e.g. a method body); after
+			// its close the statement is done.
+			return closeAt + 1
+		case '(':
+			closeAt := javaFindMatchingCloseString(body, i)
+			if closeAt < 0 {
+				return len(body)
+			}
+			i = closeAt + 1
+		case '"', '\'':
+			closeAt := javaFindStringEnd(body, i)
+			if closeAt < 0 {
+				return len(body)
+			}
+			i = closeAt + 1
+		default:
+			i++
+		}
+	}
+	return i
+}
+
+// javaFindMatchingBrace walks from `open` (a '{') to its matching '}',
+// honouring string/char literals so a brace inside a string does not affect
+// the depth count. Returns -1 when unbalanced.
+func javaFindMatchingBrace(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '"', '\'':
+			end := javaFindStringEnd(s, i)
+			if end < 0 {
+				return -1
+			}
+			i = end
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// javaFindStringEnd walks from `start` (the opening double- or single-quote of
+// a string/char literal) to the matching closing quote of the same kind,
+// honouring backslash escapes. Returns the closing-quote index, or -1 when
+// unterminated.
+func javaFindStringEnd(s string, start int) int {
+	quote := s[start]
+	for i := start + 1; i < len(s); i++ {
+		if s[i] == '\\' {
+			i++
+			continue
+		}
+		if s[i] == quote {
+			return i
+		}
+	}
+	return -1
+}
 
 func walkJavaClassFields(src, name string) map[string]string {
 	// Record form first: `record X(Type a, Type b)`.
@@ -375,18 +575,18 @@ func walkJavaClassFields(src, name string) map[string]string {
 	body := src[braceIdx+1 : end]
 	out := map[string]string{}
 
+	fields := javaScanClassFields(body)
+
 	if isLombok {
 		// For Lombok classes, walk all declared fields regardless of access modifier.
-		// Use javaAnyFieldRe which accepts any access combination.
-		for _, m := range javaAnyFieldRe.FindAllStringSubmatch(body, -1) {
-			annotations := m[1]
-			ftype := m[2]
-			fname := m[3]
+		for _, f := range fields {
+			fname := f.fname
+			ftype := f.ftype
 			if strings.Contains(ftype, "(") {
 				continue
 			}
 			// Check for @JsonProperty alias.
-			if jp := javaJsonPropertyRe.FindStringSubmatch(annotations); len(jp) >= 2 {
+			if jp := javaJsonPropertyRe.FindStringSubmatch(f.annotations); len(jp) >= 2 {
 				fname = jp[1]
 			}
 			out[fname] = strings.TrimSpace(ftype)
@@ -395,34 +595,29 @@ func walkJavaClassFields(src, name string) map[string]string {
 	}
 
 	// Plain class: walk public/package-visible fields and @JsonProperty-annotated fields.
-	for _, m := range javaAnyFieldRe.FindAllStringSubmatch(body, -1) {
-		annotations := m[1]
-		ftype := m[2]
-		fname := m[3]
+	for _, f := range fields {
+		ftype := f.ftype
 		if strings.Contains(ftype, "(") {
 			continue
 		}
 		// @JsonProperty-annotated field → include regardless of access modifier.
-		if jp := javaJsonPropertyRe.FindStringSubmatch(annotations); len(jp) >= 2 {
+		if jp := javaJsonPropertyRe.FindStringSubmatch(f.annotations); len(jp) >= 2 {
 			out[jp[1]] = strings.TrimSpace(ftype)
 			continue
 		}
 		// Public fields are always included.
-		fieldLine := m[0]
-		if strings.Contains(fieldLine, "public") {
-			out[fname] = strings.TrimSpace(ftype)
+		if strings.Contains(f.line, "public") {
+			out[f.fname] = strings.TrimSpace(ftype)
 		}
 	}
-	// If nothing was found with the new logic, fall back to the original field regex
-	// (for plain public-field DTOs without @JsonProperty).
+	// If nothing was found with the new logic, fall back to including all
+	// scanned fields (for plain public-field DTOs without @JsonProperty).
 	if len(out) == 0 {
-		for _, m := range javaFieldRe.FindAllStringSubmatch(body, -1) {
-			fname := m[2]
-			ftype := m[1]
-			if strings.Contains(ftype, "(") {
+		for _, f := range fields {
+			if strings.Contains(f.ftype, "(") {
 				continue
 			}
-			out[fname] = strings.TrimSpace(ftype)
+			out[f.fname] = strings.TrimSpace(f.ftype)
 		}
 	}
 	return out


### PR DESCRIPTION
Closes #3561

Follow-up to PR #3425, which fixed 6 parens-in-annotation-string sites with a string-aware balanced scan but **DEFERRED two riskier rewrites**. Both relied on a `[^)]*` skip over an annotation argument, which stops at the first `)` inside a quoted string literal (e.g. `@Schema(description = "amount in cents (USD)")` or `@Operation(summary = "Get (all)")`), silently dropping the target field / route / DTO.

## Both sites fixed

### Site 1 — `internal/engine/response_shape_java.go` field scanners
The `javaFieldRe` / `javaAnyFieldRe` `FindAll` scanners used a `(?:@\w+(?:\([^)]*\))?\s+)*` annotation prefix. Replaced with a string-aware, statement-oriented walker (`javaScanClassFields`) that:
- consumes leading annotations (single- **or** multi-line) honouring string/char literals,
- skips nested `{...}` blocks and parenthesised groups (so method bodies aren't mistaken for fields),
- then matches the field type/name.

A `)` inside an annotation string no longer truncates the capture. All existing behaviour preserved: Java records, Lombok `@Value`/`@Data`, `@JsonProperty` aliases, and the public-field fallback.

### Site 2 — `internal/custom/java/jakarta_jaxrs_dto.go`
`jaxrsResourceClassRE` / `jaxrsVerbMethodRE` bound `@Path`→class and verb→method with the same `[^)]*` weakness. Reworked to the engine's line-oriented, string-aware approach (mirrors `synthesizeJAXRS` / #3417): verb and `@Path` anchors + a `jaxrsSkipAnnotationsToDecl` helper (balanced, string-aware `(...)` skip) to reach the declaration head. A `@Operation` with a paren in its string no longer drops the route's `ACCEPTS_INPUT` / `RETURNS` DTO edges, and a paren inside an `@Path` template no longer drops the class binding. All existing behaviour preserved.

## Tests (value-asserting; FAIL before / PASS after)
- **engine** (`paren_in_annotation_string_test.go`): `@Schema(description = "amount in cents (USD)")` above/beside a DTO field → field type+name still captured; plus a Lombok `@Value` + `@JsonProperty`-alias variant.
- **java** (`jakarta_jaxrs_dto_paren_test.go`): `@Operation(summary = "Get (all) widgets")` between `@GET`/`@Path` and the method → `RETURNS`/`ACCEPTS_INPUT` DTO still emitted, with a no-paren sibling proving **no undercount**; plus a paren-in-`@Path`-template class-binding case.

Verified each new test fails on the pre-fix code and passes after.

## Validation
- `go test ./internal/engine/ ./internal/custom/java/ ./internal/types/` — green
- `gofmt -l` on the four touched files — empty
- `go vet ./internal/engine/ ./internal/custom/java/ ./internal/types/` — clean
- No `go test ./...` run (live daemon isolation); no daemon/index rebuild.

**DEPLOY-DEFERRED**: extractor logic only — requires a coordinated daemon rebuild + reindex to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)