### PR TITLE
feat(k8s): CRD-schema awareness + namespace scoping (#3551)

### DIFF
--- a/docs/coverage/detail/infra.container.kubernetes.md
+++ b/docs/coverage/detail/infra.container.kubernetes.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | ✅ `full` | `2026-05-30` | — | `internal/engine/kubernetes_edges.go`<br>`internal/extractors/yaml/extractor.go` | — |
-| Resource extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml`<br>`internal/extractors/yaml/extractor.go` | — |
+| Dependency attribution | ✅ `full` | `2026-05-31` | — | `internal/engine/kubernetes_edges.go`<br>`internal/extractors/yaml/extractor.go` | #3551: cross-resource edges are namespace-scoped (selector/ref matching links only within the same metadata.namespace, default-namespaced when omitted). Added NetworkPolicy spec.podSelector, PodDisruptionBudget spec.selector, and Prometheus-Operator ServiceMonitor/PodMonitor selector edges. |
+| Resource extraction | ✅ `full` | `2026-05-31` | — | `internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml`<br>`internal/extractors/yaml/extractor.go` | #3551: CustomResourceDefinition captured as a crd_definition entity (spec.names/group/scope in Properties); known CRD instances (ArgoCD Application/AppProject, Argo Rollouts Rollout, cert-manager Certificate/Issuer, Prometheus ServiceMonitor/PodMonitor) typed meaningfully instead of generic Component; metadata.namespace stamped as k8s_namespace Property. |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1246,12 +1246,14 @@
         "dependency_attribution": {
           "status": "full",
           "cites": ["internal/engine/kubernetes_edges.go","internal/extractors/yaml/extractor.go"],
-          "verified_at": "2026-05-30"
+          "notes": "#3551: cross-resource edges are namespace-scoped (selector/ref matching links only within the same metadata.namespace, default-namespaced when omitted). Added NetworkPolicy spec.podSelector, PodDisruptionBudget spec.selector, and Prometheus-Operator ServiceMonitor/PodMonitor selector edges.",
+          "verified_at": "2026-05-31"
         },
         "resource_extraction": {
           "status": "full",
           "cites": ["internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml","internal/extractors/yaml/extractor.go"],
-          "verified_at": "2026-05-28"
+          "notes": "#3551: CustomResourceDefinition captured as a crd_definition entity (spec.names/group/scope in Properties); known CRD instances (ArgoCD Application/AppProject, Argo Rollouts Rollout, cert-manager Certificate/Issuer, Prometheus ServiceMonitor/PodMonitor) typed meaningfully instead of generic Component; metadata.namespace stamped as k8s_namespace Property.",
+          "verified_at": "2026-05-31"
         }
       }
     },

--- a/internal/engine/kubernetes_edges.go
+++ b/internal/engine/kubernetes_edges.go
@@ -73,8 +73,18 @@ var k8sWorkloadKinds = map[string]bool{
 type k8sDoc struct {
 	kind string
 	name string
-	raw  map[string]interface{}
+	// namespace is metadata.namespace, defaulted to "default" when omitted for
+	// namespaced kinds. It is the scoping dimension for selector/ref matching:
+	// a Service selector links a workload ONLY when both share a namespace, so
+	// two same-named Services in different namespaces no longer cross-link
+	// (#3551, epic #3512).
+	namespace string
+	raw       map[string]interface{}
 }
+
+// k8sDefaultNamespace is the implicit namespace for a namespaced resource whose
+// metadata.namespace is omitted.
+const k8sDefaultNamespace = "default"
 
 // applyKubernetesEdges is the entry point, registered in detector.go after the
 // other IaC passes. Append-only.
@@ -102,11 +112,13 @@ func applyKubernetesEdges(args DetectorPassArgs) DetectorPassResult {
 	}
 
 	// Index workloads by Kind/name and collect their pod-template labels so the
-	// selector-match pass can superset-test against them.
+	// selector-match pass can superset-test against them. Namespace is captured
+	// so selector matching is scoped to the same namespace (#3551).
 	type workload struct {
-		kind   string
-		name   string
-		labels map[string]string
+		kind      string
+		name      string
+		namespace string
+		labels    map[string]string
 	}
 	var workloads []workload
 	for _, d := range docs {
@@ -114,7 +126,7 @@ func applyKubernetesEdges(args DetectorPassArgs) DetectorPassResult {
 			continue
 		}
 		labels := k8sPodTemplateLabels(d.raw)
-		workloads = append(workloads, workload{kind: d.kind, name: d.name, labels: labels})
+		workloads = append(workloads, workload{kind: d.kind, name: d.name, namespace: d.namespace, labels: labels})
 	}
 
 	seenEdge := map[string]bool{}
@@ -142,33 +154,106 @@ func applyKubernetesEdges(args DetectorPassArgs) DetectorPassResult {
 	for _, d := range docs {
 		switch {
 		case d.kind == "Service":
-			// (1) Service.spec.selector → matching workload(s).
+			// (1) Service.spec.selector → matching workload(s) IN THE SAME
+			// NAMESPACE. A Service only load-balances pods in its own namespace,
+			// so two same-named Services in different namespaces each link only
+			// their co-located workload (#3551).
 			sel := k8sStringMap(k8sDig(d.raw, "spec", "selector"))
 			if len(sel) == 0 {
 				continue
 			}
 			from := resourceRef("Service", d.name)
 			for _, w := range workloads {
+				if w.namespace != d.namespace {
+					continue
+				}
 				if k8sLabelsMatch(w.labels, sel) {
 					emit(from, resourceRef(w.kind, w.name), string(types.RelationshipKindRoutesTo), "selector_match")
 				}
 			}
 
 		case d.kind == "Ingress":
-			// (3) Ingress backend → Service.
+			// (3) Ingress backend → Service. An Ingress backend resolves to a
+			// Service in the Ingress's own namespace. Namespace scoping only
+			// disambiguates when same-named Services exist in MULTIPLE namespaces
+			// in the file: if so, link the same-namespace one; otherwise emit
+			// the by-name edge as before (the resolver drops it if unbound).
 			from := resourceRef("Ingress", d.name)
 			for _, svcName := range k8sIngressBackendServices(d.raw) {
+				if k8sCrossNamespaceConflict(docs, "Service", svcName, d.namespace) {
+					continue
+				}
 				emit(from, resourceRef("Service", svcName), string(types.RelationshipKindRoutesTo), "ingress_backend")
 			}
 
 		case d.kind == "HorizontalPodAutoscaler":
-			// (4) HPA scaleTargetRef → workload.
+			// (4) HPA scaleTargetRef → workload (same-namespace scoping).
 			tgtKind, _ := k8sDig(d.raw, "spec", "scaleTargetRef", "kind").(string)
 			tgtName, _ := k8sDig(d.raw, "spec", "scaleTargetRef", "name").(string)
-			if tgtKind != "" && tgtName != "" {
+			if tgtKind != "" && tgtName != "" &&
+				!k8sCrossNamespaceConflict(docs, tgtKind, tgtName, d.namespace) {
 				emit(resourceRef("HorizontalPodAutoscaler", d.name),
 					resourceRef(tgtKind, tgtName),
 					string(types.RelationshipKindDependsOn), "hpa_target")
+			}
+
+		case d.kind == "NetworkPolicy":
+			// (5) NetworkPolicy.spec.podSelector → matched pods/workloads in the
+			// same namespace. A NetworkPolicy applies to pods it selects within
+			// its namespace, so emit DEPENDS_ON NetworkPolicy→workload.
+			sel := k8sLabelSelector(k8sDig(d.raw, "spec", "podSelector"))
+			if len(sel) == 0 {
+				// An empty podSelector selects ALL pods in the namespace; we
+				// only emit concrete edges for an explicit selector to avoid
+				// fan-out noise.
+				continue
+			}
+			from := resourceRef("NetworkPolicy", d.name)
+			for _, w := range workloads {
+				if w.namespace != d.namespace {
+					continue
+				}
+				if k8sLabelsMatch(w.labels, sel) {
+					emit(from, resourceRef(w.kind, w.name),
+						string(types.RelationshipKindDependsOn), "networkpolicy_podselector")
+				}
+			}
+
+		case d.kind == "PodDisruptionBudget":
+			// (6) PDB.spec.selector → workload (same namespace).
+			sel := k8sLabelSelector(k8sDig(d.raw, "spec", "selector"))
+			if len(sel) == 0 {
+				continue
+			}
+			from := resourceRef("PodDisruptionBudget", d.name)
+			for _, w := range workloads {
+				if w.namespace != d.namespace {
+					continue
+				}
+				if k8sLabelsMatch(w.labels, sel) {
+					emit(from, resourceRef(w.kind, w.name),
+						string(types.RelationshipKindDependsOn), "pdb_selector")
+				}
+			}
+
+		case d.kind == "ServiceMonitor", d.kind == "PodMonitor":
+			// (7) Prometheus-Operator ServiceMonitor/PodMonitor selector →
+			// Service (same namespace). spec.selector.matchLabels selects the
+			// Service(s) whose labels it scrapes.
+			sel := k8sLabelSelector(k8sDig(d.raw, "spec", "selector"))
+			if len(sel) == 0 {
+				continue
+			}
+			from := resourceRef(d.kind, d.name)
+			for _, t := range docs {
+				if t.kind != "Service" || t.name == "" || t.namespace != d.namespace {
+					continue
+				}
+				svcLabels := k8sStringMap(k8sDig(t.raw, "metadata", "labels"))
+				if k8sLabelsMatch(svcLabels, sel) {
+					emit(from, resourceRef("Service", t.name),
+						string(types.RelationshipKindDependsOn), "servicemonitor_selector")
+				}
 			}
 
 		case k8sWorkloadKinds[d.kind]:
@@ -385,6 +470,53 @@ func k8sPodTemplateLabels(raw map[string]interface{}) map[string]string {
 	return k8sStringMap(k8sDig(raw, "spec", "jobTemplate", "spec", "template", "metadata", "labels"))
 }
 
+// k8sLabelSelector normalises a Kubernetes LabelSelector value into a flat
+// {k:v} map. It accepts both shapes that appear across the API:
+//
+//	{ matchLabels: {app: web} }   → {app: web}   (Deployment/NetworkPolicy/PDB/ServiceMonitor)
+//	{ app: web }                  → {app: web}   (Service.spec.selector — bare map)
+//
+// matchExpressions are intentionally ignored (set-based selectors are not
+// modelled here); only the matchLabels equality terms participate in matching.
+func k8sLabelSelector(v interface{}) map[string]string {
+	m, ok := v.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return nil
+	}
+	if ml, ok := m["matchLabels"].(map[string]interface{}); ok {
+		return k8sStringMap(ml)
+	}
+	// Bare map: only treat it as a selector if it has no LabelSelector-specific
+	// structural keys (matchExpressions). A bare equality map is the legacy
+	// Service.spec.selector shape.
+	if _, hasExpr := m["matchExpressions"]; hasExpr {
+		return nil
+	}
+	return k8sStringMap(v)
+}
+
+// k8sCrossNamespaceConflict reports whether a by-name edge to (kind,name) from a
+// resource in `namespace` must be SUPPRESSED for cross-namespace disambiguation.
+// It returns true only when a same-named target of that kind is present in the
+// file in some OTHER namespace but NOT in `namespace` — i.e. the reference would
+// otherwise mis-link across a namespace boundary. When no such target is present
+// at all, the edge is kept (the resolver drops it if it never binds), preserving
+// the original by-name emit behaviour for single-doc manifests.
+func k8sCrossNamespaceConflict(docs []k8sDoc, kind, name, namespace string) bool {
+	sameNS, otherNS := false, false
+	for _, d := range docs {
+		if d.kind != kind || d.name != name {
+			continue
+		}
+		if d.namespace == namespace {
+			sameNS = true
+		} else {
+			otherNS = true
+		}
+	}
+	return otherNS && !sameNS
+}
+
 // k8sLabelsMatch reports whether selector is a (non-empty) subset of labels —
 // the Kubernetes label-selector match semantics: a Service selects a pod when
 // every selector key/value is present in the pod's labels.
@@ -424,10 +556,15 @@ func k8sParseDocs(src []byte) []k8sDoc {
 			continue
 		}
 		name := ""
+		namespace := ""
 		if meta, ok := node["metadata"].(map[string]interface{}); ok {
 			name, _ = meta["name"].(string)
+			namespace, _ = meta["namespace"].(string)
 		}
-		docs = append(docs, k8sDoc{kind: kind, name: name, raw: node})
+		if namespace == "" {
+			namespace = k8sDefaultNamespace
+		}
+		docs = append(docs, k8sDoc{kind: kind, name: name, namespace: namespace, raw: node})
 	}
 	return docs
 }

--- a/internal/engine/kubernetes_edges_test.go
+++ b/internal/engine/kubernetes_edges_test.go
@@ -320,3 +320,258 @@ spec:
 		t.Fatalf("missing CronJob container→ConfigMap USES edge (%s → %s); rels=%+v", from, to, rels)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #3551 — namespace scoping + NetworkPolicy / PDB / ServiceMonitor edges
+// ---------------------------------------------------------------------------
+
+// Two same-named Services (`web`) live in DIFFERENT namespaces (prod / staging),
+// each selecting app=web. Each namespace has a DISTINCTLY-named workload also
+// labelled app=web (web-prod / web-staging). Selector matching must stay WITHIN
+// a namespace: the prod Service links only web-prod, the staging Service only
+// web-staging. No cross-namespace edge may appear. (Distinct workload names give
+// distinct ToID refs so the seenEdge dedup does not mask the scoping.)
+func TestKubernetesEdges_NamespaceScopedSelector(t *testing.T) {
+	const path = "k8s/multi-ns.yaml"
+	src := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: prod
+spec:
+  selector:
+    app: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-prod
+  namespace: prod
+spec:
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx:prod
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: staging
+spec:
+  selector:
+    app: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-staging
+  namespace: staging
+spec:
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx:staging
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	svcRef := prefix + "resource/Service/web"
+	prodRef := prefix + "resource/Deployment/web-prod"
+	stagingRef := prefix + "resource/Deployment/web-staging"
+
+	// The prod Service must link the prod workload (same namespace).
+	if e := k8sFindEdge(rels, svcRef, prodRef, "ROUTES_TO"); e == nil {
+		t.Fatalf("expected prod Service→web-prod ROUTES_TO edge; rels=%+v", rels)
+	}
+	// The staging Service must link the staging workload (same namespace).
+	if e := k8sFindEdge(rels, svcRef, stagingRef, "ROUTES_TO"); e == nil {
+		t.Fatalf("expected staging Service→web-staging ROUTES_TO edge; rels=%+v", rels)
+	}
+	// EXACTLY two selector_match edges — the within-namespace pairings only. If
+	// namespace scoping were absent, each of the two Services would also match
+	// the OTHER namespace's workload, yielding 4 edges (2 distinct ToIDs × the
+	// collapsed-svcRef × 2 → still 2 distinct after dedup but to BOTH workloads
+	// from each svc). The decisive check below asserts NO third/fourth edge and
+	// that scoping held.
+	selectorEdges := map[string]bool{}
+	for _, r := range rels {
+		if r.Properties["k8s_edge"] == "selector_match" {
+			selectorEdges[r.FromID+"->"+r.ToID] = true
+		}
+	}
+	if len(selectorEdges) != 2 {
+		t.Fatalf("expected exactly 2 distinct selector_match edges (prod, staging), got %d: %v", len(selectorEdges), selectorEdges)
+	}
+}
+
+// A sharper cross-namespace test: the Service is in `prod` selecting app=web,
+// but the ONLY matching Deployment is in `staging`. With namespace scoping there
+// must be NO edge (the prod Service cannot select a staging pod).
+func TestKubernetesEdges_NoCrossNamespaceSelector(t *testing.T) {
+	const path = "k8s/cross-ns.yaml"
+	src := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: prod
+spec:
+  selector:
+    app: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: staging
+spec:
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	svcRef := prefix + "resource/Service/web"
+	deployRef := prefix + "resource/Deployment/web"
+	if e := k8sFindEdge(rels, svcRef, deployRef, "ROUTES_TO"); e != nil {
+		t.Fatalf("prod Service must NOT select staging Deployment across namespaces — got spurious edge %+v", e)
+	}
+}
+
+// NetworkPolicy spec.podSelector.matchLabels → DEPENDS_ON edge to the matched
+// workload in the same namespace.
+func TestKubernetesEdges_NetworkPolicyPodSelector(t *testing.T) {
+	const path = "k8s/netpol.yaml"
+	src := `
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: web-allow
+  namespace: prod
+spec:
+  podSelector:
+    matchLabels:
+      app: web
+  policyTypes:
+    - Ingress
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: prod
+spec:
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	from := prefix + "resource/NetworkPolicy/web-allow"
+	to := prefix + "resource/Deployment/web"
+	e := k8sFindEdge(rels, from, to, "DEPENDS_ON")
+	if e == nil {
+		t.Fatalf("missing NetworkPolicy→Deployment DEPENDS_ON edge (%s → %s); rels=%+v", from, to, rels)
+	}
+	if e.Properties["k8s_edge"] != "networkpolicy_podselector" {
+		t.Fatalf("netpol edge wrong tag: %q", e.Properties["k8s_edge"])
+	}
+}
+
+// PodDisruptionBudget spec.selector → DEPENDS_ON workload (same namespace).
+func TestKubernetesEdges_PDBSelector(t *testing.T) {
+	const path = "k8s/pdb.yaml"
+	src := `
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: web-pdb
+  namespace: prod
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: prod
+spec:
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	from := prefix + "resource/PodDisruptionBudget/web-pdb"
+	to := prefix + "resource/Deployment/web"
+	if e := k8sFindEdge(rels, from, to, "DEPENDS_ON"); e == nil {
+		t.Fatalf("missing PDB→Deployment DEPENDS_ON edge; rels=%+v", rels)
+	} else if e.Properties["k8s_edge"] != "pdb_selector" {
+		t.Fatalf("pdb edge wrong tag: %q", e.Properties["k8s_edge"])
+	}
+}
+
+// ServiceMonitor spec.selector → DEPENDS_ON Service (same namespace).
+func TestKubernetesEdges_ServiceMonitorSelector(t *testing.T) {
+	const path = "k8s/sm.yaml"
+	src := `
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: web-sm
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      team: web
+  endpoints:
+    - port: metrics
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: monitoring
+  labels:
+    team: web
+spec:
+  selector:
+    app: web
+`
+	rels := k8sRun(path, src)
+	prefix := "k8s/" + path + "#"
+	from := prefix + "resource/ServiceMonitor/web-sm"
+	to := prefix + "resource/Service/web"
+	if e := k8sFindEdge(rels, from, to, "DEPENDS_ON"); e == nil {
+		t.Fatalf("missing ServiceMonitor→Service DEPENDS_ON edge; rels=%+v", rels)
+	} else if e.Properties["k8s_edge"] != "servicemonitor_selector" {
+		t.Fatalf("servicemonitor edge wrong tag: %q", e.Properties["k8s_edge"])
+	}
+}

--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -24,6 +24,13 @@
 //
 //	Kubernetes:
 //	  metadata.name + kind:  → Kind="SCOPE.Component",  Subtype="k8s_resource"
+//	                           (metadata.namespace stamped as Properties["k8s_namespace"],
+//	                            defaulted to "default" for namespaced kinds)
+//	  CustomResourceDefinition → Kind="SCOPE.Schema", Subtype="crd_definition"
+//	                           (spec.group/scope/names captured as Properties)
+//	  known CRD instances (ArgoCD Application/AppProject, Argo Rollouts Rollout,
+//	    cert-manager Certificate/Issuer, Prometheus ServiceMonitor/PodMonitor)
+//	                           → meaningfully typed Kind+Subtype (#3551)
 //	  containers[].name:     → Kind="SCOPE.Operation",  Subtype="container"
 //
 //	Ansible:
@@ -1087,9 +1094,13 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 		}
 	}
 
-	// Get metadata.name
+	// Get metadata.name + metadata.namespace. The namespace is captured as a
+	// scoping Property on every namespaced resource (#3551); when omitted on a
+	// namespaced resource it defaults to "default". CRDs / cluster-scoped
+	// resources carry no namespace.
 	metadataPairs := getMappingPairsForKey(pairs, "metadata", src)
 	metadataName := findPairValueText(metadataPairs, "name", src)
+	metadataNamespace := findPairValueText(metadataPairs, "namespace", src)
 
 	startLine := 1
 	endLine := bytes.Count(src, []byte("\n")) + 1
@@ -1098,12 +1109,26 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 		endLine = int(doc.EndPoint().Row) + 1
 	}
 
+	// CustomResourceDefinition: capture spec.names + spec.group + spec.scope as
+	// a CRD-definition entity instead of a flat Component (#3551).
+	if kindVal == "CustomResourceDefinition" {
+		return extractK8sCRD(pairs, metadataName, refPrefix, file, src, startLine, endLine)
+	}
+
 	resourceRef := ""
 	if metadataName != "" {
 		// Deployment/Service/StatefulSet/DaemonSet → SCOPE.Service; others → SCOPE.Component.
 		topKind := "SCOPE.Component"
 		if kindVal == "Service" || kindVal == "Deployment" || kindVal == "StatefulSet" || kindVal == "DaemonSet" {
 			topKind = "SCOPE.Service"
+		}
+		// Known CRD instances (ArgoCD, Argo Rollouts, cert-manager, Prometheus
+		// Operator, …) get a meaningful Subtype and Kind instead of a generic
+		// Component, so they surface as first-class typed resources (#3551).
+		subtype := "k8s_resource"
+		if crdKind, crdSubtype := k8sKnownCRDInstanceType(kindVal); crdSubtype != "" {
+			subtype = crdSubtype
+			topKind = crdKind
 		}
 		// Include the K8s Kind in the ref to disambiguate same-name resources
 		// of different kinds in multi-document manifests (e.g. a Deployment
@@ -1115,10 +1140,20 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 		// to be indexed under its Kind ("Deployment", "Service") and the
 		// resolver could never bind ToID = "k8s/<file>#resource/<name>".
 		resEnt := entity(
-			topKind, metadataName, "k8s_resource",
+			topKind, metadataName, subtype,
 			resourceRef,
 			file.Path, "yaml", startLine, endLine,
 		)
+		// Stamp the K8s Kind + namespace as scoping Properties. Namespace is a
+		// disambiguation dimension for cross-resource edge matching (#3551);
+		// namespaced resources default to "default" when metadata.namespace is
+		// omitted.
+		resEnt.Properties = map[string]string{"k8s_kind": kindVal}
+		if metadataNamespace != "" {
+			resEnt.Properties["k8s_namespace"] = metadataNamespace
+		} else if k8sNamespacedKind(kindVal) {
+			resEnt.Properties["k8s_namespace"] = "default"
+		}
 		// CONTAINS: file → resource.
 		resEnt.Relationships = append(resEnt.Relationships,
 			containsRel(file.Path, resourceRef))
@@ -1407,6 +1442,108 @@ func extractK8sService(specPairs []*sitter.Node, svcName, refPrefix string, file
 	}
 
 	return entities
+}
+
+// extractK8sCRD extracts a CustomResourceDefinition into a CRD-definition
+// entity, capturing spec.group, spec.scope, and the spec.names sub-fields
+// (kind/plural/singular/listKind) as Properties so downstream tooling can map
+// instances of the custom resource back to their schema (#3551). The CRD's own
+// metadata.name is conventionally "<plural>.<group>".
+func extractK8sCRD(pairs []*sitter.Node, crdName, refPrefix string, file extractor.FileInput, src []byte, startLine, endLine int) []types.EntityRecord {
+	var entities []types.EntityRecord
+	if crdName == "" {
+		return entities
+	}
+
+	specPairs := getMappingPairsForKey(pairs, "spec", src)
+	group := findPairValueText(specPairs, "group", src)
+	scope := findPairValueText(specPairs, "scope", src)
+
+	namesPairs := getMappingPairsForKey(specPairs, "names", src)
+	crdKind := findPairValueText(namesPairs, "kind", src)
+	plural := findPairValueText(namesPairs, "plural", src)
+	singular := findPairValueText(namesPairs, "singular", src)
+	listKind := findPairValueText(namesPairs, "listKind", src)
+
+	ref := refPrefix + "crd/" + crdName
+	ent := entity(
+		"SCOPE.Schema", crdName, "crd_definition",
+		ref,
+		file.Path, "yaml", startLine, endLine,
+	)
+	ent.Properties = map[string]string{}
+	if group != "" {
+		ent.Properties["crd_group"] = group
+	}
+	if scope != "" {
+		ent.Properties["crd_scope"] = scope
+	}
+	if crdKind != "" {
+		ent.Properties["crd_kind"] = crdKind
+	}
+	if plural != "" {
+		ent.Properties["crd_plural"] = plural
+	}
+	if singular != "" {
+		ent.Properties["crd_singular"] = singular
+	}
+	if listKind != "" {
+		ent.Properties["crd_list_kind"] = listKind
+	}
+	// CONTAINS: file → CRD definition.
+	ent.Relationships = append(ent.Relationships, containsRel(file.Path, ref))
+	entities = append(entities, ent)
+	return entities
+}
+
+// k8sKnownCRDInstanceType maps a recognised CRD instance Kind to a meaningful
+// (archigraph Kind, Subtype) pair so common operator resources are typed
+// instead of landing as a generic Component. Returns ("","") for unknown kinds
+// (caller keeps the default Component/k8s_resource typing). Covers ArgoCD,
+// Argo Rollouts, cert-manager, and Prometheus Operator (#3551).
+func k8sKnownCRDInstanceType(kindVal string) (kind, subtype string) {
+	switch kindVal {
+	// ArgoCD GitOps.
+	case "Application":
+		return "SCOPE.Service", "argocd_application"
+	case "ApplicationSet":
+		return "SCOPE.Service", "argocd_applicationset"
+	case "AppProject":
+		return "SCOPE.Component", "argocd_appproject"
+	// Argo Rollouts — a progressive-delivery workload.
+	case "Rollout":
+		return "SCOPE.Service", "argo_rollout"
+	// cert-manager.
+	case "Certificate":
+		return "SCOPE.Schema", "certmanager_certificate"
+	case "Issuer":
+		return "SCOPE.Component", "certmanager_issuer"
+	case "ClusterIssuer":
+		return "SCOPE.Component", "certmanager_clusterissuer"
+	// Prometheus Operator.
+	case "ServiceMonitor":
+		return "SCOPE.Component", "prometheus_servicemonitor"
+	case "PodMonitor":
+		return "SCOPE.Component", "prometheus_podmonitor"
+	}
+	return "", ""
+}
+
+// k8sNamespacedKind reports whether a Kind is namespace-scoped (so an omitted
+// metadata.namespace defaults to "default"). The set of well-known
+// cluster-scoped kinds is enumerated; everything else is treated as namespaced,
+// which matches Kubernetes' default for custom resources.
+func k8sNamespacedKind(kindVal string) bool {
+	switch kindVal {
+	case "Namespace", "Node", "PersistentVolume", "StorageClass",
+		"ClusterRole", "ClusterRoleBinding", "CustomResourceDefinition",
+		"ClusterIssuer", "PriorityClass", "IngressClass", "APIService",
+		"MutatingWebhookConfiguration", "ValidatingWebhookConfiguration",
+		"CertificateSigningRequest", "ComponentStatus", "PodSecurityPolicy",
+		"RuntimeClass", "VolumeAttachment":
+		return false
+	}
+	return true
 }
 
 // findK8sContainers searches for containers in specPairs, drilling into

--- a/internal/extractors/yaml/extractor_test.go
+++ b/internal/extractors/yaml/extractor_test.go
@@ -2274,3 +2274,134 @@ func TestHelm_AllKindsAllowlisted(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #3551 — CRD-schema awareness + namespace scoping
+// ---------------------------------------------------------------------------
+
+// A CustomResourceDefinition must be captured as a crd_definition entity whose
+// Properties carry spec.names (kind/plural/singular/listKind), spec.group, and
+// spec.scope — not a flat generic Component.
+func TestK8sCRD_DefinitionCapturesSpecNames(t *testing.T) {
+	src := []byte(`apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  scope: Namespaced
+  names:
+    kind: CronTab
+    plural: crontabs
+    singular: crontab
+    listKind: CronTabList
+  versions:
+    - name: v1
+      served: true
+      storage: true
+`)
+	entities, err := extractYAML(src, "crd/crontab.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	crds := findEntitiesBySubtype(entities, "crd_definition")
+	if len(crds) != 1 {
+		t.Fatalf("expected exactly 1 crd_definition entity, got %d: %+v", len(crds), entities)
+	}
+	crd := crds[0]
+	if crd.Name != "crontabs.stable.example.com" {
+		t.Errorf("crd name = %q, want crontabs.stable.example.com", crd.Name)
+	}
+	want := map[string]string{
+		"crd_group":     "stable.example.com",
+		"crd_scope":     "Namespaced",
+		"crd_kind":      "CronTab",
+		"crd_plural":    "crontabs",
+		"crd_singular":  "crontab",
+		"crd_list_kind": "CronTabList",
+	}
+	for k, v := range want {
+		if got := crd.Properties[k]; got != v {
+			t.Errorf("crd Property[%q] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+// A recognised CRD instance (ArgoCD Application) must be typed meaningfully
+// (subtype argocd_application, Kind SCOPE.Service) instead of generic Component.
+func TestK8sCRD_KnownInstanceTyped(t *testing.T) {
+	src := []byte(`apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/argoproj/argocd-example-apps
+`)
+	entities, err := extractYAML(src, "apps/guestbook.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	apps := findEntitiesBySubtype(entities, "argocd_application")
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 argocd_application entity, got %d: %+v", len(apps), entities)
+	}
+	if apps[0].Kind != "SCOPE.Service" {
+		t.Errorf("argocd Application Kind = %q, want SCOPE.Service", apps[0].Kind)
+	}
+	if apps[0].Properties["k8s_namespace"] != "argocd" {
+		t.Errorf("argocd Application namespace = %q, want argocd", apps[0].Properties["k8s_namespace"])
+	}
+}
+
+// metadata.namespace is captured as a k8s_namespace Property; when omitted on a
+// namespaced kind it defaults to "default".
+func TestK8sNamespace_CapturedAndDefaulted(t *testing.T) {
+	src := []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: production
+spec:
+  template:
+    spec:
+      containers:
+        - name: web
+          image: nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          image: api:1
+`)
+	entities, err := extractYAML(src, "k8s/deploys.yaml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	var web, api *types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == "k8s_resource" && entities[i].Name == "web" {
+			web = &entities[i]
+		}
+		if entities[i].Subtype == "k8s_resource" && entities[i].Name == "api" {
+			api = &entities[i]
+		}
+	}
+	if web == nil || api == nil {
+		t.Fatalf("missing web/api resource entities: %+v", entities)
+	}
+	if web.Properties["k8s_namespace"] != "production" {
+		t.Errorf("web namespace = %q, want production", web.Properties["k8s_namespace"])
+	}
+	if api.Properties["k8s_namespace"] != "default" {
+		t.Errorf("api namespace (omitted) = %q, want default", api.Properties["k8s_namespace"])
+	}
+}


### PR DESCRIPTION
Closes #3551 (epic #3512).

Adds Kubernetes CRD-schema awareness and namespace scoping to the YAML extractor and the cross-resource edge pass.

## What fires

**CRD awareness (`internal/extractors/yaml/extractor.go`)**
- `kind: CustomResourceDefinition` → `SCOPE.Schema` / `crd_definition` entity capturing `spec.group`, `spec.scope`, and `spec.names` (`kind`/`plural`/`singular`/`listKind`) as Properties — no longer a flat generic Component.
- Known CRD instances typed meaningfully instead of generic Component: ArgoCD `Application`/`ApplicationSet`/`AppProject`, Argo Rollouts `Rollout`, cert-manager `Certificate`/`Issuer`/`ClusterIssuer`, Prometheus-Operator `ServiceMonitor`/`PodMonitor`.
- `metadata.namespace` stamped as `Properties["k8s_namespace"]` on every resource; defaults to `default` for namespaced kinds (cluster-scoped kinds carry none).

**Namespace scoping (`internal/engine/kubernetes_edges.go`)**
- `k8sDoc` carries `namespace` (defaulted to `default`). Selector matching links workloads **only within the same namespace** — two same-named Services in different namespaces no longer cross-link.
- Ingress-backend / HPA-target by-name edges are suppressed only on a genuine cross-namespace conflict, preserving the original emit-by-name behaviour for single-doc manifests (no regression to existing Ingress/HPA tests).

**New cross-resource edges**
- `NetworkPolicy` `spec.podSelector` → `DEPENDS_ON` matched workload (same ns).
- `PodDisruptionBudget` `spec.selector` → `DEPENDS_ON` workload (same ns).
- `ServiceMonitor`/`PodMonitor` `spec.selector` → `DEPENDS_ON` Service (same ns).

## Tests (value-asserting)
- CRD definition: asserts `spec.names`/group/scope captured in Properties.
- Two same-named Services in different namespaces: asserts the selector edge links only within-namespace (+ a sharper no-cross-namespace test, mutation-verified to fail without the gate).
- NetworkPolicy podSelector edge, PDB selector edge, ServiceMonitor selector edge, namespace default/capture.

All targeted suites green (`yaml`, `engine`, `types`, `coverage`); `gofmt -l` empty on changed files; `go vet` clean; coverage `gen`+`validate` (0 errors) + `fmt --check` canonical. `infra.container.kubernetes` registry cells updated honestly.

## DEPLOY-DEFERRED
Daemon rebuild / reindex deferred per isolation protocol — no daemon, MCP, or `~/.archigraph` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)