### PR TITLE
feat(iac): unify resource categorization across all four IaC tools (#3549)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1306,8 +1306,8 @@
         "resource_extraction": {
           "status": "full",
           "cites": ["internal/extractors/bicep/extractor.go","internal/extractors/bicep/kinds.go"],
-          "notes": "Regex/line-based .bicep extractor (no tree-sitter grammar vendored): SCOPE.InfraResource per 'resource' decl named by symbolic name, Kind-stable with resource_scope from the AzureRP type (bicepResourceCoarseScope); azure_rp_type + api_version + deployed_name on Metadata. SCOPE.Component/module per 'module' decl, SCOPE.Schema for param/var/output. Handles 'existing' resources and [for ...] loops.",
-          "verified_at": "2026-05-30"
+          "notes": "Regex/line-based .bicep extractor (no tree-sitter grammar vendored): SCOPE.InfraResource per 'resource' decl named by symbolic name, Kind-stable with uniform resource_category from the shared types.IaCResourceCategory classifier (#3549; bicepResourceCoarseScope now delegates to it, resource_scope kept as an alias); azure_rp_type + api_version + deployed_name on Metadata. SCOPE.Component/module per 'module' decl, SCOPE.Schema for param/var/output. Handles 'existing' resources and [for ...] loops.",
+          "verified_at": "2026-05-31"
         }
       }
     },
@@ -1576,7 +1576,7 @@
           "status": "partial",
           "cites": ["internal/engine/cdk_edges.go","internal/engine/rules/javascript_typescript/frameworks/aws_cdk.yaml","internal/engine/rules/python/frameworks/aws_cdk.yaml"],
           "issue": "https://github.com/cajasmota/archigraph/issues/3512",
-          "notes": "CDK-TS + CDK-Python: applyCDKEdges (TS) / applyCDKEdgesPython emit SCOPE.InfraResource per construct named by its 'LogicalId' literal (construct_type + coarse resource_scope). CDK-Java/Go/C# not yet implemented. Previously over-stamped full citing the hcl/Terraform extractor, which cannot parse .ts/.py.",
+          "notes": "CDK-TS + CDK-Python: applyCDKEdges (TS) / applyCDKEdgesPython emit SCOPE.InfraResource per construct named by its 'LogicalId' literal (construct_type + uniform resource_category from the shared types.IaCResourceCategory classifier, #3549; resource_scope kept as an alias). CDK-Java/Go/C# not yet implemented. Previously over-stamped full citing the hcl/Terraform extractor, which cannot parse .ts/.py.",
           "verified_at": "2026-05-31"
         }
       }
@@ -1595,7 +1595,8 @@
         "resource_extraction": {
           "status": "full",
           "cites": ["internal/engine/iac_cloudformation_edges.go"],
-          "verified_at": "2026-05-30"
+          "notes": "cfnResourceKind now derives the SCOPE.Datastore/Queue/ServerlessFunction entity Kind from the shared types.IaCResourceCategory classifier and stamps the uniform resource_category property (#3549), so the CFN Kind and the cross-tool category can never diverge.",
+          "verified_at": "2026-05-31"
         }
       }
     },
@@ -1635,7 +1636,7 @@
           "status": "partial",
           "cites": ["internal/engine/pulumi_edges.go","internal/engine/rules/javascript_typescript/frameworks/pulumi.yaml","internal/engine/rules/python/frameworks/pulumi.yaml"],
           "issue": "https://github.com/cajasmota/archigraph/issues/3528",
-          "notes": "Pulumi-TS + Pulumi-Python only: applyPulumiEdges emits SCOPE.InfraResource per resource constructor named by its logical-name string literal (construct_type + coarse resource_scope). Pulumi-Go/C#/Java not yet implemented. Previously over-stamped full citing the hcl/Terraform extractor, which cannot parse .ts/.py.",
+          "notes": "Pulumi-TS + Pulumi-Python only: applyPulumiEdges emits SCOPE.InfraResource per resource constructor named by its logical-name string literal (construct_type + uniform resource_category from the shared types.IaCResourceCategory classifier, #3549; resource_scope kept as an alias). Pulumi-Go/C#/Java not yet implemented. Previously over-stamped full citing the hcl/Terraform extractor, which cannot parse .ts/.py.",
           "verified_at": "2026-05-31"
         }
       }
@@ -1654,7 +1655,8 @@
         "resource_extraction": {
           "status": "full",
           "cites": ["internal/extractors/hcl/extractor.go","internal/extractors/hcl/relationships.go"],
-          "verified_at": "2026-05-28"
+          "notes": "resource blocks now carry the uniform resource_category metadata from the shared types.IaCResourceCategory classifier (#3549), so aws_db_instance→datastore, aws_sqs_queue→queue, aws_lambda_function→function are queryable cross-tool. Entity Kind stays SCOPE.Component/resource (edges unchanged).",
+          "verified_at": "2026-05-31"
         }
       }
     },

--- a/internal/engine/cdk_edges.go
+++ b/internal/engine/cdk_edges.go
@@ -96,28 +96,16 @@ func cdkSupportsLanguage(lang string) bool {
 // `new s3.Bucket(this, 'Id', {...})` form.
 func cdkIsPython(lang string) bool { return lang == "python" }
 
-// cdkResourceCoarseScope maps a CDK construct type (e.g. "s3.Bucket",
-// "lambda.Function", "sqs.Queue", "dynamodb.Table", "CfnDBInstance") to a coarse
-// architectural scope class. Mirrors the intent of the (dead) iacResourceKind
-// helper but returns a bare class string recorded as a property — the entity
-// Kind stays SCOPE.InfraResource so all CDK resources remain a single queryable
-// class. Matching is on the lower-cased construct type.
+// cdkResourceCoarseScope returns the uniform IaC resource_category for a CDK
+// construct type (e.g. "s3.Bucket", "lambda.Function", "sqs.Queue",
+// "dynamodb.Table", "CfnDBInstance"). It now delegates to the ONE shared
+// classifier (types.IaCResourceCategory) so CDK resources carry exactly the same
+// `resource_category` values as Terraform / Pulumi / CFN / Bicep, making a
+// cross-tool "all datastores" query possible (#3549). The entity Kind stays
+// SCOPE.InfraResource so existing CDK QualifiedNames and DEPENDS_ON edges are
+// unchanged. Matching is on the lower-cased construct type.
 func cdkResourceCoarseScope(constructType string) string {
-	t := strings.ToLower(constructType)
-	switch {
-	case strings.Contains(t, "rds") || strings.Contains(t, "dynamodb") ||
-		strings.Contains(t, "database") || strings.Contains(t, "dbinstance") ||
-		strings.Contains(t, "dbcluster") || strings.Contains(t, "table") ||
-		strings.Contains(t, "bucket") || strings.Contains(t, "elasticache") ||
-		strings.Contains(t, "redshift"):
-		return "datastore"
-	case strings.Contains(t, "sqs") || strings.Contains(t, "queue") ||
-		strings.Contains(t, "sns") || strings.Contains(t, "topic") ||
-		strings.Contains(t, "kinesis") || strings.Contains(t, "eventbus"):
-		return "queue"
-	default:
-		return "service"
-	}
+	return types.IaCResourceCategory(constructType)
 }
 
 // cdkConstructDeclRe captures `const|let|var VAR = new <ns>.<Type>(this, 'LogicalId'`.
@@ -287,8 +275,11 @@ func applyCDKEdges(args DetectorPassArgs) DetectorPassResult {
 			Language:   lang,
 			StartLine:  matchStartLine(src, offset),
 			Properties: map[string]string{
-				"iac_tool":       "aws-cdk",
-				"construct_type": constructType,
+				"iac_tool":          "aws-cdk",
+				"construct_type":    constructType,
+				"resource_category": cdkResourceCoarseScope(constructType),
+				// resource_scope kept (== resource_category) for back-compat with
+				// any consumer reading the older property name.
 				"resource_scope": cdkResourceCoarseScope(constructType),
 				"logical_id":     logicalID,
 				"pattern_type":   "cdk_synthesis",

--- a/internal/engine/cdk_edges_test.go
+++ b/internal/engine/cdk_edges_test.go
@@ -82,8 +82,13 @@ export class DataStack extends cdk.Stack {
 	if bucket.props["iac_tool"] != "aws-cdk" {
 		t.Errorf("DataBucket iac_tool = %q, want aws-cdk", bucket.props["iac_tool"])
 	}
-	if bucket.props["resource_scope"] != "datastore" {
-		t.Errorf("DataBucket resource_scope = %q, want datastore", bucket.props["resource_scope"])
+	// #3549 — uniform cross-tool category. s3.Bucket → "storage" (more precise
+	// than the old coarse "datastore"); resource_scope aliases resource_category.
+	if bucket.props["resource_category"] != "storage" {
+		t.Errorf("DataBucket resource_category = %q, want storage", bucket.props["resource_category"])
+	}
+	if bucket.props["resource_scope"] != "storage" {
+		t.Errorf("DataBucket resource_scope = %q, want storage", bucket.props["resource_scope"])
 	}
 
 	// Resource: lambda.Function named Handler.
@@ -94,8 +99,12 @@ export class DataStack extends cdk.Stack {
 	if handler.props["construct_type"] != "lambda.Function" {
 		t.Errorf("Handler construct_type = %q, want lambda.Function", handler.props["construct_type"])
 	}
-	if handler.props["resource_scope"] != "service" {
-		t.Errorf("Handler resource_scope = %q, want service", handler.props["resource_scope"])
+	// lambda.Function → "function" (was the coarse "service").
+	if handler.props["resource_category"] != "function" {
+		t.Errorf("Handler resource_category = %q, want function", handler.props["resource_category"])
+	}
+	if handler.props["resource_scope"] != "function" {
+		t.Errorf("Handler resource_scope = %q, want function", handler.props["resource_scope"])
 	}
 
 	// Dependency edge: Handler --DEPENDS_ON--> DataBucket (the grantRead grant).
@@ -280,8 +289,11 @@ class DataStack(Stack):
 	if data.props["iac_tool"] != "aws-cdk" {
 		t.Errorf("Data iac_tool = %q, want aws-cdk", data.props["iac_tool"])
 	}
-	if data.props["resource_scope"] != "datastore" {
-		t.Errorf("Data resource_scope = %q, want datastore", data.props["resource_scope"])
+	if data.props["resource_category"] != "storage" {
+		t.Errorf("Data resource_category = %q, want storage", data.props["resource_category"])
+	}
+	if data.props["resource_scope"] != "storage" {
+		t.Errorf("Data resource_scope = %q, want storage", data.props["resource_scope"])
 	}
 
 	fn := cdkResourceByName(ents, "Fn")

--- a/internal/engine/iac_cloudformation_edges.go
+++ b/internal/engine/iac_cloudformation_edges.go
@@ -55,10 +55,9 @@ import (
 // ---------------------------------------------------------------------------
 
 const (
-	cfnResourceEntityKind = "SCOPE.InfraResource"
-	cfnSchemaEntityKind   = "SCOPE.Schema"
-	cfnConfigEntityKind   = "SCOPE.Config"
-	cfnScheduledJobKind   = "SCOPE.ScheduledJob"
+	cfnSchemaEntityKind = "SCOPE.Schema"
+	cfnConfigEntityKind = "SCOPE.Config"
+	cfnScheduledJobKind = "SCOPE.ScheduledJob"
 
 	cfnDependsOnEdgeKind = "DEPENDS_ON"
 	cfnUsesEdgeKind      = "USES"
@@ -69,28 +68,16 @@ const (
 )
 
 // cfnResourceKind maps an AWS CloudFormation resource Type (e.g.
-// "AWS::S3::Bucket") to the SCOPE.* scope used for the resource entity. It is
-// the CloudFormation analogue of patterns.iacResourceKind but operates on the
-// `AWS::Service::Resource` triple and keeps datastore / queue precision.
+// "AWS::S3::Bucket") to the SCOPE.* scope used for the resource entity. It now
+// delegates to the ONE shared classifier (types.IaCResourceCategory →
+// types.IaCKindForCategory) so the CFN entity Kind can never diverge from the
+// uniform `resource_category` property stamped on every IaC tool's resources
+// (#3549). The historical CFN Kinds (SCOPE.Datastore / SCOPE.Queue /
+// SCOPE.ServerlessFunction) are preserved by IaCKindForCategory's mapping:
+// datastore/storage/cache→Datastore, queue/topic/stream→Queue, function→
+// ServerlessFunction, everything else→SCOPE.InfraResource.
 func cfnResourceKind(awsType string) string {
-	t := strings.ToLower(awsType)
-	switch {
-	case strings.Contains(t, "::rds::") || strings.Contains(t, "::dynamodb::") ||
-		strings.Contains(t, "::elasticache::") || strings.Contains(t, "::redshift::") ||
-		strings.Contains(t, "::s3::") || strings.Contains(t, "::docdb::") ||
-		strings.Contains(t, "database") || strings.Contains(t, "::neptune::") ||
-		strings.Contains(t, "::timestream::") || strings.Contains(t, "::efs::"):
-		return "SCOPE.Datastore"
-	case strings.Contains(t, "::sqs::") || strings.Contains(t, "::sns::") ||
-		strings.Contains(t, "::kinesis::") || strings.Contains(t, "::mq::") ||
-		strings.Contains(t, "::events::") || strings.Contains(t, "queue") ||
-		strings.Contains(t, "topic"):
-		return "SCOPE.Queue"
-	case strings.Contains(t, "::lambda::") || strings.Contains(t, "::serverless::function"):
-		return "SCOPE.ServerlessFunction"
-	default:
-		return cfnResourceEntityKind
-	}
+	return types.IaCKindForCategory(types.IaCResourceCategory(awsType))
 }
 
 // ---------------------------------------------------------------------------
@@ -519,10 +506,11 @@ func applyCloudFormationEdges(args DetectorPassArgs) DetectorPassResult {
 		kind := cfnResourceKind(r.typ)
 		eid := resourceRef(r.logicalID)
 		props := map[string]string{
-			"kind":          "iac",
-			"iac_tool":      "cloudformation",
-			"resource_type": r.typ,
-			"logical_id":    r.logicalID,
+			"kind":              "iac",
+			"iac_tool":          "cloudformation",
+			"resource_type":     r.typ,
+			"logical_id":        r.logicalID,
+			"resource_category": types.IaCResourceCategory(r.typ),
 		}
 		if strings.HasPrefix(r.typ, "AWS::Serverless::") {
 			props["iac_tool"] = "sam"

--- a/internal/engine/iac_resource_category_consistency_test.go
+++ b/internal/engine/iac_resource_category_consistency_test.go
@@ -1,0 +1,162 @@
+// Cross-tool IaC resource_category consistency — #3549 (epic #3512).
+//
+// Proves the ONE shared classifier (types.IaCResourceCategory) yields the SAME
+// resource_category for EQUIVALENT resources across CDK, Pulumi and
+// CloudFormation (HCL/Terraform + Bicep are covered in their own packages).
+// These are VALUE-asserting: each checks a specific category string, not len>0.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// catOf returns the resource_category property of the entity with the given
+// name from a detector result, or "" if absent.
+func catOf(ents []entityResult, name string) string {
+	for i := range ents {
+		if ents[i].name == name {
+			return ents[i].props["resource_category"]
+		}
+	}
+	return ""
+}
+
+// TestIaCCategory_Classifier_ValueTable asserts the shared classifier directly
+// for one representative type per category, in each tool dialect, proving the
+// SAME category for equivalent resources regardless of tool syntax.
+func TestIaCCategory_Classifier_ValueTable(t *testing.T) {
+	cases := []struct {
+		typeString string
+		want       string
+	}{
+		// datastore — equivalents across all five dialects
+		{"aws_db_instance", types.IaCCategoryDatastore},                 // Terraform
+		{"Microsoft.Sql/servers/databases", types.IaCCategoryDatastore}, // Bicep
+		{"dynamodb.Table", types.IaCCategoryDatastore},                  // CDK
+		{"aws.rds.Instance", types.IaCCategoryDatastore},                // Pulumi
+		{"AWS::RDS::DBInstance", types.IaCCategoryDatastore},            // CFN
+		// queue
+		{"aws_sqs_queue", types.IaCCategoryQueue},
+		{"sqs.Queue", types.IaCCategoryQueue},
+		{"aws.sqs.Queue", types.IaCCategoryQueue},
+		{"AWS::SQS::Queue", types.IaCCategoryQueue},
+		// topic
+		{"aws_sns_topic", types.IaCCategoryTopic},
+		{"sns.Topic", types.IaCCategoryTopic},
+		{"aws.sns.Topic", types.IaCCategoryTopic},
+		{"AWS::SNS::Topic", types.IaCCategoryTopic},
+		// stream
+		{"aws_kinesis_stream", types.IaCCategoryStream},
+		{"AWS::Kinesis::Stream", types.IaCCategoryStream},
+		// function
+		{"aws_lambda_function", types.IaCCategoryFunction},
+		{"lambda.Function", types.IaCCategoryFunction},
+		{"aws.lambda.Function", types.IaCCategoryFunction},
+		{"AWS::Lambda::Function", types.IaCCategoryFunction},
+		// cache
+		{"aws_elasticache_cluster", types.IaCCategoryCache},
+		{"AWS::ElastiCache::CacheCluster", types.IaCCategoryCache},
+		// secret
+		{"aws_secretsmanager_secret", types.IaCCategorySecret},
+		{"AWS::SecretsManager::Secret", types.IaCCategorySecret},
+		{"Microsoft.KeyVault/vaults", types.IaCCategorySecret},
+		// storage
+		{"aws_s3_bucket", types.IaCCategoryStorage},
+		{"s3.Bucket", types.IaCCategoryStorage},
+		{"AWS::S3::Bucket", types.IaCCategoryStorage},
+		{"Microsoft.Storage/storageAccounts", types.IaCCategoryStorage},
+		// network
+		{"aws_vpc", types.IaCCategoryNetwork},
+		{"AWS::EC2::VPC", types.IaCCategoryNetwork},
+		{"Microsoft.Network/virtualNetworks", types.IaCCategoryNetwork},
+		// compute
+		{"aws_instance", types.IaCCategoryCompute},
+		{"AWS::ECS::Cluster", types.IaCCategoryCompute},
+		// other
+		{"aws_iam_policy_attachment_unknownthing", types.IaCCategoryOther},
+	}
+	for _, c := range cases {
+		if got := types.IaCResourceCategory(c.typeString); got != c.want {
+			t.Errorf("IaCResourceCategory(%q) = %q, want %q", c.typeString, got, c.want)
+		}
+	}
+}
+
+// TestIaCCategory_CDK_StampsCategory proves a CDK dynamodb.Table → datastore,
+// sqs.Queue → queue (value-asserting on the stamped property).
+func TestIaCCategory_CDK_StampsCategory(t *testing.T) {
+	src := `import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+const t1 = new dynamodb.Table(this, 'Orders', {});
+const q1 = new sqs.Queue(this, 'Jobs', {});
+`
+	ents, _ := runCDKDetect(t, "typescript", "lib/stack.ts", src)
+	if got := catOf(ents, "Orders"); got != types.IaCCategoryDatastore {
+		t.Errorf("CDK dynamodb.Table resource_category = %q, want datastore", got)
+	}
+	if got := catOf(ents, "Jobs"); got != types.IaCCategoryQueue {
+		t.Errorf("CDK sqs.Queue resource_category = %q, want queue", got)
+	}
+}
+
+// TestIaCCategory_Pulumi_StampsTopic proves a Pulumi aws.sns.Topic → topic.
+func TestIaCCategory_Pulumi_StampsTopic(t *testing.T) {
+	src := `import * as aws from "@pulumi/aws";
+const events = new aws.sns.Topic("events", {});
+`
+	res := applyPulumiEdges(DetectorPassArgs{Lang: "typescript", Path: "index.ts", Content: []byte(src)})
+	ents := make([]entityResult, 0, len(res.Entities))
+	for _, e := range res.Entities {
+		ents = append(ents, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})
+	}
+	if got := catOf(ents, "events"); got != types.IaCCategoryTopic {
+		t.Errorf("Pulumi aws.sns.Topic resource_category = %q, want topic", got)
+	}
+}
+
+// TestIaCCategory_CFN_StampsCategory proves AWS::RDS::DBInstance → datastore,
+// AND that the aligned entity Kind is SCOPE.Datastore (derived from the same
+// classifier so Kind and property can never diverge).
+func TestIaCCategory_CFN_StampsCategory(t *testing.T) {
+	src := `AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  Db:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      Engine: postgres
+  Q:
+    Type: AWS::SQS::Queue
+    Properties: {}
+  Fn:
+    Type: AWS::Lambda::Function
+    Properties: {}
+`
+	res := applyCloudFormationEdges(DetectorPassArgs{Lang: "yaml", Path: "template.yaml", Content: []byte(src)})
+
+	byName := map[string]struct {
+		kind string
+		cat  string
+	}{}
+	for _, e := range res.Entities {
+		// Logical ids are name-suffixed in the cfn: id; match on Properties.
+		if e.Properties["logical_id"] != "" {
+			byName[e.Properties["logical_id"]] = struct {
+				kind string
+				cat  string
+			}{e.Kind, e.Properties["resource_category"]}
+		}
+	}
+
+	if got := byName["Db"]; got.cat != types.IaCCategoryDatastore || got.kind != "SCOPE.Datastore" {
+		t.Errorf("CFN AWS::RDS::DBInstance = kind %q cat %q, want SCOPE.Datastore/datastore", got.kind, got.cat)
+	}
+	if got := byName["Q"]; got.cat != types.IaCCategoryQueue || got.kind != "SCOPE.Queue" {
+		t.Errorf("CFN AWS::SQS::Queue = kind %q cat %q, want SCOPE.Queue/queue", got.kind, got.cat)
+	}
+	if got := byName["Fn"]; got.cat != types.IaCCategoryFunction || got.kind != "SCOPE.ServerlessFunction" {
+		t.Errorf("CFN AWS::Lambda::Function = kind %q cat %q, want SCOPE.ServerlessFunction/function", got.kind, got.cat)
+	}
+}

--- a/internal/engine/pulumi_edges.go
+++ b/internal/engine/pulumi_edges.go
@@ -79,26 +79,15 @@ func pulumiSupportsLanguage(lang string) bool {
 
 func pulumiIsPython(lang string) bool { return lang == "python" }
 
-// pulumiResourceCoarseScope maps a Pulumi resource type (e.g. "aws.s3.Bucket",
-// "aws.lambda.Function", "aws.sqs.Queue", "aws.dynamodb.Table") to a coarse
-// architectural scope class, recorded as a property (the Kind stays
-// SCOPE.InfraResource). Matching is on the lower-cased type.
+// pulumiResourceCoarseScope returns the uniform IaC resource_category for a
+// Pulumi resource type (e.g. "aws.s3.Bucket", "aws.lambda.Function",
+// "aws.sqs.Queue", "aws.dynamodb.Table"). It now delegates to the ONE shared
+// classifier (types.IaCResourceCategory) so Pulumi resources carry exactly the
+// same `resource_category` values as Terraform / CDK / CFN / Bicep (#3549). The
+// entity Kind stays SCOPE.InfraResource so existing Pulumi QualifiedNames and
+// DEPENDS_ON edges are unchanged. Matching is on the lower-cased type.
 func pulumiResourceCoarseScope(resourceType string) string {
-	t := strings.ToLower(resourceType)
-	switch {
-	case strings.Contains(t, "rds") || strings.Contains(t, "dynamodb") ||
-		strings.Contains(t, "database") || strings.Contains(t, "dbinstance") ||
-		strings.Contains(t, "dbcluster") || strings.Contains(t, "table") ||
-		strings.Contains(t, "bucket") || strings.Contains(t, "elasticache") ||
-		strings.Contains(t, "redshift") || strings.Contains(t, "s3."):
-		return "datastore"
-	case strings.Contains(t, "sqs") || strings.Contains(t, "queue") ||
-		strings.Contains(t, "sns") || strings.Contains(t, "topic") ||
-		strings.Contains(t, "kinesis") || strings.Contains(t, "eventbus"):
-		return "queue"
-	default:
-		return "service"
-	}
+	return types.IaCResourceCategory(resourceType)
 }
 
 // pulumiCrossStackNodeID is the canonical node id for a StackReference target,
@@ -248,8 +237,10 @@ func applyPulumiEdges(args DetectorPassArgs) DetectorPassResult {
 			Language:   lang,
 			StartLine:  matchStartLine(src, offset),
 			Properties: map[string]string{
-				"iac_tool":       "pulumi",
-				"construct_type": resourceType,
+				"iac_tool":          "pulumi",
+				"construct_type":    resourceType,
+				"resource_category": scope,
+				// resource_scope kept (== resource_category) for back-compat.
 				"resource_scope": scope,
 				"logical_id":     logicalName,
 				"pattern_type":   "pulumi_program",
@@ -304,11 +295,12 @@ func applyPulumiEdges(args DetectorPassArgs) DetectorPassResult {
 				Language:   lang,
 				StartLine:  matchStartLine(src, offset),
 				Properties: map[string]string{
-					"iac_tool":       "pulumi",
-					"construct_type": "pulumi.StackReference",
-					"resource_scope": "stack_reference",
-					"logical_id":     ref,
-					"pattern_type":   "pulumi_program",
+					"iac_tool":          "pulumi",
+					"construct_type":    "pulumi.StackReference",
+					"resource_category": "stack_reference",
+					"resource_scope":    "stack_reference",
+					"logical_id":        ref,
+					"pattern_type":      "pulumi_program",
 				},
 				EnrichmentRequired: false,
 				EnrichmentStatus:   types.StatusPending,

--- a/internal/engine/pulumi_edges_test.go
+++ b/internal/engine/pulumi_edges_test.go
@@ -62,8 +62,11 @@ const fn = new aws.lambda.Function("fn", {
 	if data.props["iac_tool"] != "pulumi" {
 		t.Errorf("data iac_tool = %q, want pulumi", data.props["iac_tool"])
 	}
-	if data.props["resource_scope"] != "datastore" {
-		t.Errorf("data resource_scope = %q, want datastore", data.props["resource_scope"])
+	if data.props["resource_category"] != "storage" {
+		t.Errorf("data resource_category = %q, want storage", data.props["resource_category"])
+	}
+	if data.props["resource_scope"] != "storage" {
+		t.Errorf("data resource_scope = %q, want storage", data.props["resource_scope"])
 	}
 
 	fn := pulumiResourceByName(ents, "fn")
@@ -174,8 +177,11 @@ fn = aws.lambda_.Function("fn",
 	if data.props["construct_type"] != "aws.s3.Bucket" {
 		t.Errorf("data construct_type = %q, want aws.s3.Bucket", data.props["construct_type"])
 	}
-	if data.props["resource_scope"] != "datastore" {
-		t.Errorf("data resource_scope = %q, want datastore", data.props["resource_scope"])
+	if data.props["resource_category"] != "storage" {
+		t.Errorf("data resource_category = %q, want storage", data.props["resource_category"])
+	}
+	if data.props["resource_scope"] != "storage" {
+		t.Errorf("data resource_scope = %q, want storage", data.props["resource_scope"])
 	}
 
 	fn := pulumiResourceByName(ents, "fn")

--- a/internal/extractors/bicep/extractor.go
+++ b/internal/extractors/bicep/extractor.go
@@ -166,12 +166,15 @@ func extractResources(src, path string, symbolic map[string]bool) []types.Entity
 
 		rpType, apiVersion := splitAzureType(azureType)
 
+		category := bicepResourceCoarseScope(rpType)
 		meta := map[string]interface{}{
-			"subtype":        "resource",
-			"iac_tool":       "bicep",
-			"symbolic_name":  symName,
-			"azure_rp_type":  rpType,
-			"resource_scope": bicepResourceCoarseScope(rpType),
+			"subtype":           "resource",
+			"iac_tool":          "bicep",
+			"symbolic_name":     symName,
+			"azure_rp_type":     rpType,
+			"resource_category": category,
+			// resource_scope kept (== resource_category) for back-compat.
+			"resource_scope": category,
 		}
 		if apiVersion != "" {
 			meta["api_version"] = apiVersion

--- a/internal/extractors/bicep/extractor_test.go
+++ b/internal/extractors/bicep/extractor_test.go
@@ -93,8 +93,13 @@ module network './modules/network.bicep' = {
 	if got := sa.Metadata["deployed_name"]; got != "mystg" {
 		t.Errorf("storageAccount deployed_name = %v, want mystg", got)
 	}
-	if got := sa.Metadata["resource_scope"]; got != "datastore" {
-		t.Errorf("storageAccount resource_scope = %v, want datastore", got)
+	// Storage accounts now classify as the more precise "storage" category via
+	// the shared cross-tool classifier (#3549); resource_scope aliases it.
+	if got := sa.Metadata["resource_category"]; got != "storage" {
+		t.Errorf("storageAccount resource_category = %v, want storage", got)
+	}
+	if got := sa.Metadata["resource_scope"]; got != "storage" {
+		t.Errorf("storageAccount resource_scope = %v, want storage", got)
 	}
 
 	// --- resource entity 2: blobService, references storageAccount ---
@@ -164,6 +169,9 @@ resource subnet 'Microsoft.Network/virtualNetworks/subnets@2022-01-01' = {
 		t.Errorf("subnet missing explicit DEPENDS_ON → vnet; rels=%+v", subnet.Relationships)
 	}
 	vnet := findByName(recs, "vnet")
+	if got := vnet.Metadata["resource_category"]; got != "network" {
+		t.Errorf("vnet resource_category = %v, want network", got)
+	}
 	if got := vnet.Metadata["resource_scope"]; got != "network" {
 		t.Errorf("vnet resource_scope = %v, want network", got)
 	}

--- a/internal/extractors/bicep/kinds.go
+++ b/internal/extractors/bicep/kinds.go
@@ -1,43 +1,16 @@
 package bicep
 
-import "strings"
+import "github.com/cajasmota/archigraph/internal/types"
 
-// bicepResourceCoarseScope maps an Azure resource-provider type
-// (e.g. "Microsoft.Storage/storageAccounts") to a coarse architectural scope
-// label stored on the resource entity's Metadata. This mirrors the CDK
-// extractor's resource_scope attribute (internal/engine/cdk_edges.go): all
-// Bicep resources stay a single queryable SCOPE.InfraResource entity Kind, with
-// the finer datastore/queue/compute classification captured as an attribute
-// rather than a distinct entity Kind.
-//
-// The classification is deliberately conservative — it keys off the well-known
-// Azure resource-provider namespaces and resource-type segments.
+// bicepResourceCoarseScope returns the uniform IaC resource_category for an
+// Azure resource-provider type (e.g. "Microsoft.Storage/storageAccounts"). It
+// now delegates to the ONE shared classifier (types.IaCResourceCategory) so
+// Bicep resources carry exactly the same `resource_category` values as
+// Terraform / CDK / Pulumi / CFN, making a cross-tool "all datastores" query
+// possible (#3549). All Bicep resources stay a single queryable
+// SCOPE.InfraResource entity Kind; the finer category is captured as an
+// attribute rather than a distinct entity Kind, so existing QualifiedNames and
+// DEPENDS_ON edges are unchanged.
 func bicepResourceCoarseScope(rpType string) string {
-	t := strings.ToLower(rpType)
-	switch {
-	case strings.Contains(t, "microsoft.storage/") ||
-		strings.Contains(t, "microsoft.sql/") ||
-		strings.Contains(t, "microsoft.documentdb/") ||
-		strings.Contains(t, "microsoft.dbforpostgresql/") ||
-		strings.Contains(t, "microsoft.dbformysql/") ||
-		strings.Contains(t, "microsoft.cache/") ||
-		strings.Contains(t, "database") ||
-		strings.Contains(t, "cosmosdb"):
-		return "datastore"
-	case strings.Contains(t, "microsoft.servicebus/") ||
-		strings.Contains(t, "microsoft.eventhub/") ||
-		strings.Contains(t, "microsoft.eventgrid/") ||
-		strings.Contains(t, "/queues") ||
-		strings.Contains(t, "/topics"):
-		return "queue"
-	case strings.Contains(t, "microsoft.web/sites") ||
-		strings.Contains(t, "microsoft.compute/") ||
-		strings.Contains(t, "microsoft.containerservice/") ||
-		strings.Contains(t, "microsoft.app/"):
-		return "compute"
-	case strings.Contains(t, "microsoft.network/"):
-		return "network"
-	default:
-		return "service"
-	}
+	return types.IaCResourceCategory(rpType)
 }

--- a/internal/extractors/bicep/resource_category_test.go
+++ b/internal/extractors/bicep/resource_category_test.go
@@ -1,0 +1,45 @@
+package bicep_test
+
+import "testing"
+
+// TestBicep_ResourceCategoryStamp proves the Bicep extractor carries the SAME
+// cross-tool resource_category property as the other IaC tools (#3549):
+// a Service Bus queue → queue, a Function App → function, a SQL database →
+// datastore. Value-asserting on the exact category, not len>0.
+func TestBicep_ResourceCategoryStamp(t *testing.T) {
+	const src = `
+resource sbQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01' = {
+  name: 'jobs'
+}
+
+resource fnApp 'Microsoft.Web/sites/functions@2022-09-01' = {
+  name: 'worker'
+}
+
+resource sqlDb 'Microsoft.Sql/servers/databases@2022-05-01' = {
+  name: 'orders'
+}
+`
+	recs := extractBicep(t, src, "main.bicep")
+
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"sbQueue", "queue"},
+		{"fnApp", "function"},
+		{"sqlDb", "datastore"},
+	}
+	for _, c := range cases {
+		r := findByName(recs, c.name)
+		if r == nil {
+			t.Fatalf("resource %q not found", c.name)
+		}
+		if got := r.Metadata["resource_category"]; got != c.want {
+			t.Errorf("%s resource_category = %v, want %q", c.name, got, c.want)
+		}
+		if got := r.Metadata["resource_scope"]; got != c.want {
+			t.Errorf("%s resource_scope = %v, want %q (alias)", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -209,7 +209,18 @@ func extractResourceBlock(n *sitter.Node, src []byte, path, lang string, start, 
 		Language:      lang,
 		QualityScore:  0.9,
 		QualifiedName: "resource." + resourceType + "." + resourceName,
-		Metadata:      map[string]interface{}{"subtype": "resource", "resource_type": resourceType, "label": resourceName},
+		// Issue #3549 — stamp the uniform cross-tool resource_category from the
+		// ONE shared classifier so a Terraform aws_db_instance, a CDK
+		// dynamodb.Table, a Pulumi aws.rds.Instance, a CFN AWS::RDS::DBInstance
+		// and a Bicep Microsoft.Sql/servers all answer a single "datastores"
+		// query. The Kind stays SCOPE.Component/resource so existing
+		// QualifiedNames and DEPENDS_ON/CALLS edges are unchanged.
+		Metadata: map[string]interface{}{
+			"subtype":           "resource",
+			"resource_type":     resourceType,
+			"label":             resourceName,
+			"resource_category": types.IaCResourceCategory(resourceType),
+		},
 	}
 
 	// Extract depends_on relationships.

--- a/internal/extractors/hcl/resource_category_test.go
+++ b/internal/extractors/hcl/resource_category_test.go
@@ -1,0 +1,37 @@
+// Value-asserting test for the Terraform resource_category stamp — #3549.
+// Proves the HCL extractor now carries the SAME cross-tool category property
+// the other IaC tools emit: aws_db_instance → datastore, aws_sqs_queue → queue,
+// aws_lambda_function → function.
+package hcl_test
+
+import "testing"
+
+func TestTerraform_ResourceCategoryStamp(t *testing.T) {
+	src := `
+resource "aws_db_instance" "primary" {}
+resource "aws_sqs_queue" "jobs" {}
+resource "aws_lambda_function" "worker" {}
+`
+	records, err := extractHCL(src, "main.tf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"primary", "datastore"},
+		{"jobs", "queue"},
+		{"worker", "function"},
+	}
+	for _, c := range cases {
+		r := findBySubtypeAndName(records, "resource", c.name)
+		if r == nil {
+			t.Fatalf("resource %q not found", c.name)
+		}
+		if got := r.Metadata["resource_category"]; got != c.want {
+			t.Errorf("resource %q resource_category = %v, want %q", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/types/iac_resource_category.go
+++ b/internal/types/iac_resource_category.go
@@ -1,0 +1,217 @@
+package types
+
+import "strings"
+
+// IaC resource categorization — the ONE shared classifier used by every IaC
+// extractor/detector in archigraph (Terraform/HCL, AWS CDK TS+JS+Python,
+// Pulumi TS+JS+Python, CloudFormation/SAM, and Azure Bicep). #3549, epic #3512.
+//
+// # The consistency model (decided, applied everywhere)
+//
+// Historically each IaC tool classified resources its own way, so a cross-tool
+// query like "show me all the datastores" was impossible:
+//
+//   - CloudFormation mapped AWS::* types to coarse SCOPE.Datastore /
+//     SCOPE.Queue / SCOPE.ServerlessFunction entity Kinds.
+//   - CDK + Pulumi emitted SCOPE.InfraResource with a private, three-valued
+//     `resource_scope` property (service / datastore / queue) computed by a
+//     per-tool helper.
+//   - Terraform emitted SCOPE.Component/resource with only a `resource_type`,
+//     no semantic typing at all.
+//   - Bicep emitted SCOPE.InfraResource with its own `resource_scope` helper.
+//
+// The unifying decision: a single fine-grained `resource_category` PROPERTY is
+// the cross-tool join key. Every IaC resource entity, regardless of tool or
+// source language, now carries `resource_category` computed by the one
+// IaCResourceCategory function below. A query that wants "all datastores"
+// filters on `resource_category == datastore` and gets Terraform aws_db_instance,
+// CDK dynamodb.Table, Pulumi aws.rds.Instance, CFN AWS::RDS::DBInstance and Bicep
+// Microsoft.Sql/servers alike.
+//
+// We deliberately do NOT force a single entity Kind on every tool:
+//
+//   - The semantic Kinds CloudFormation already emits (SCOPE.Datastore /
+//     SCOPE.Queue / SCOPE.ServerlessFunction) are preserved — they are derived
+//     from the same category via IaCKindForCategory so they can never diverge
+//     from the property.
+//   - CDK / Pulumi / Bicep keep SCOPE.InfraResource and Terraform keeps
+//     SCOPE.Component/resource, because their QualifiedNames and the
+//     DEPENDS_ON/USES edges already in the graph are keyed off those Kinds;
+//     changing the Kind would break edge resolution. The `resource_category`
+//     property gives uniform cross-tool semantics WITHOUT that risk.
+//
+// So: ONE classifier, ONE property name, applied to ALL FOUR tools; the CFN
+// entity Kind stays aligned because it is derived from the same classifier.
+
+// IaC resource category constants — the closed set returned by
+// IaCResourceCategory. "other" is the fallback for anything unrecognised.
+const (
+	IaCCategoryDatastore = "datastore"
+	IaCCategoryQueue     = "queue"
+	IaCCategoryTopic     = "topic"
+	IaCCategoryStream    = "stream"
+	IaCCategoryFunction  = "function"
+	IaCCategoryCache     = "cache"
+	IaCCategorySecret    = "secret"
+	IaCCategoryNetwork   = "network"
+	IaCCategoryCompute   = "compute"
+	IaCCategoryStorage   = "storage"
+	IaCCategoryOther     = "other"
+)
+
+// IaCResourceCategory maps an IaC resource type string — in ANY of the tool
+// dialects below — to one of the IaCCategory* constants. It is provider-aware
+// and matches case-insensitively on substrings so it tolerates the differing
+// shapes the tools use for the "same" resource:
+//
+//   - Terraform / OpenTofu:  aws_db_instance, azurerm_storage_account, google_sql_database_instance
+//   - Azure Bicep:           Microsoft.Sql/servers, Microsoft.ServiceBus/namespaces/queues
+//   - AWS CDK construct type: s3.Bucket, dynamodb.Table, sqs.Queue, lambda.Function, CfnDBInstance
+//   - Pulumi resource type:   aws.s3.Bucket, aws.rds.Instance, aws.sns.Topic, azure.storage.Account
+//   - CloudFormation/SAM:     AWS::RDS::DBInstance, AWS::SQS::Queue, AWS::Lambda::Function
+//
+// Ordering matters: more specific categories (cache/secret/stream/topic/queue/
+// function) are tested before the broad datastore/storage/compute/network
+// buckets so e.g. an ElastiCache resource is `cache`, not `datastore`, and an
+// SNS topic is `topic`, not `queue`.
+func IaCResourceCategory(typeString string) string {
+	t := strings.ToLower(typeString)
+	switch {
+	// --- cache (before datastore: elasticache/redis/memcached) ------------
+	case containsAny(t,
+		"elasticache", "elasti_cache", "memorydb", "dax",
+		"aws_dax_", "::elasticache::", "::dax::", "::memorydb::",
+		"elasticache.", ".dax.", "memorydb.",
+		"microsoft.cache/", "/rediscache", "rediscache",
+		"google_redis_", "redis.", "memcache"):
+		return IaCCategoryCache
+
+	// --- secret -----------------------------------------------------------
+	case containsAny(t,
+		"secretsmanager", "secrets_manager", "::secretsmanager::",
+		"secretsmanager.", "aws_ssm_parameter",
+		"microsoft.keyvault/", "keyvault", "key_vault",
+		"google_secret_manager", "secretmanager.", ".secret"):
+		return IaCCategorySecret
+
+	// --- stream (kinesis / event hubs / pubsub streams) -------------------
+	case containsAny(t,
+		"kinesis", "::kinesis::", "kinesis.",
+		"aws_kinesis", "msk", "managedstreaming", "::msk::",
+		"microsoft.eventhub/", "eventhub",
+		"google_pubsub_lite", "kafka"):
+		return IaCCategoryStream
+
+	// --- topic (pub/sub fan-out) ------------------------------------------
+	case containsAny(t,
+		"aws_sns_topic", "::sns::", "sns.topic", "sns_topic",
+		".sns.", "snstopic",
+		"microsoft.eventgrid/", "eventgrid",
+		"/topics", "servicebustopic",
+		"google_pubsub_topic", "pubsub.topic"):
+		return IaCCategoryTopic
+
+	// --- queue ------------------------------------------------------------
+	case containsAny(t,
+		"aws_sqs_queue", "::sqs::", "sqs.queue", "sqs_queue", ".sqs.", "sqsqueue",
+		"aws_mq_", "::mq::", "amazonmq",
+		"microsoft.servicebus/", "servicebus", "/queues", "storagequeue",
+		"google_cloud_tasks", "cloudtasks",
+		"::events::eventbus", "eventbus", "google_pubsub_subscription"):
+		return IaCCategoryQueue
+
+	// --- function (serverless) --------------------------------------------
+	case containsAny(t,
+		"aws_lambda_function", "::lambda::function", "::serverless::function",
+		"lambda.function", "lambda_function", ".lambda.", "lambdafunction",
+		"cfnfunction",
+		"microsoft.web/sites/functions", "functionapp", "azurerm_function_app",
+		"google_cloudfunctions", "cloudfunction"):
+		return IaCCategoryFunction
+
+	// --- datastore (databases + tables; tested before generic storage) ----
+	case containsAny(t,
+		"aws_db_instance", "aws_rds", "aws_db_cluster", "::rds::",
+		"aws_dynamodb", "::dynamodb::", "dynamodb.", "dynamodbtable",
+		"aws_redshift", "::redshift::", "redshift.",
+		"aws_docdb", "::docdb::", "docdb.",
+		"aws_neptune", "::neptune::", "neptune.",
+		"aws_timestream", "::timestream::", "timestream.",
+		"aws_qldb", "::qldb::", "aws_keyspaces", "::cassandra::",
+		"rds.", ".rds.", "dbinstance", "dbcluster", "database",
+		"microsoft.sql/", "microsoft.documentdb/", "cosmosdb", "cosmos_db",
+		"microsoft.dbforpostgresql/", "microsoft.dbformysql/",
+		"microsoft.dbformariadb/",
+		"google_sql_", "google_spanner", "google_bigtable", "google_firestore",
+		"sql.", "spanner.", "bigtable.", "firestore.",
+		"rds.databaseinstance", "rds.databasecluster",
+		"sql_database", "cosmosdb_account"):
+		return IaCCategoryDatastore
+
+	// --- storage (object/file/block; after datastore so DB tables win) ----
+	case containsAny(t,
+		"aws_s3_bucket", "::s3::bucket", "s3.bucket", "s3_bucket", ".s3.", "s3bucket",
+		"aws_efs", "::efs::", "efs.", "aws_fsx", "::fsx::",
+		"aws_ebs_volume", "::ec2::volume",
+		"microsoft.storage/", "storageaccount", "storage_account",
+		"google_storage_bucket", "storage.bucket",
+		"azurerm_storage", "blobcontainer", "/blobservices"):
+		return IaCCategoryStorage
+
+	// --- network ----------------------------------------------------------
+	case containsAny(t,
+		"aws_vpc", "::ec2::vpc", "aws_subnet", "::ec2::subnet",
+		"aws_security_group", "::ec2::securitygroup",
+		"aws_route", "aws_internet_gateway", "aws_nat_gateway",
+		"aws_lb", "aws_alb", "aws_elb", "::elasticloadbalancing",
+		"aws_route53", "::route53::", "aws_api_gateway", "::apigateway",
+		"ec2.vpc", "ec2.subnet", "ec2.securitygroup", ".vpc.", "vpc.",
+		"microsoft.network/", "google_compute_network",
+		"google_compute_subnetwork", "google_compute_firewall",
+		"loadbalancer", "load_balancer"):
+		return IaCCategoryNetwork
+
+	// --- compute (catch-all for VMs/containers/clusters; last) ------------
+	case containsAny(t,
+		"aws_instance", "::ec2::instance", "ec2.instance",
+		"aws_ecs", "::ecs::", "ecs.", "aws_eks", "::eks::", "eks.",
+		"aws_autoscaling", "aws_batch", "::batch::",
+		"microsoft.compute/", "microsoft.containerservice/", "microsoft.app/",
+		"microsoft.web/sites", "appservice",
+		"google_compute_instance", "google_container_cluster",
+		"compute.instance", "fargate", "virtualmachine"):
+		return IaCCategoryCompute
+
+	default:
+		return IaCCategoryOther
+	}
+}
+
+// IaCKindForCategory maps a resource_category to the semantic SCOPE.* entity
+// Kind that CloudFormation uses, so the CFN Kind and the property are derived
+// from one source and can never drift. Categories without a dedicated CFN Kind
+// fall back to SCOPE.InfraResource (the shared IaC-resource class). This keeps
+// the historical CFN Kinds (Datastore / Queue / ServerlessFunction) intact while
+// guaranteeing they agree with IaCResourceCategory.
+func IaCKindForCategory(category string) string {
+	switch category {
+	case IaCCategoryDatastore, IaCCategoryStorage, IaCCategoryCache:
+		return "SCOPE.Datastore"
+	case IaCCategoryQueue, IaCCategoryTopic, IaCCategoryStream:
+		return "SCOPE.Queue"
+	case IaCCategoryFunction:
+		return "SCOPE.ServerlessFunction"
+	default:
+		return "SCOPE.InfraResource"
+	}
+}
+
+// containsAny reports whether s contains any of the given substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #3549 (epic-adjacent #3512).

## The consistency model chosen

A single fine-grained **`resource_category` property** is the cross-tool join key. Every IaC resource entity — across Terraform/HCL, AWS CDK (TS/JS/Python), Pulumi (TS/JS/Python), CloudFormation/SAM, and Azure Bicep — now carries `resource_category`, computed by **ONE** shared classifier `types.IaCResourceCategory` (in `internal/types/iac_resource_category.go`). A query that wants "all datastores" filters on `resource_category == datastore` and gets every tool's equivalent resource.

We deliberately do **not** force a single entity Kind on every tool:
- **CloudFormation** keeps its semantic Kinds (`SCOPE.Datastore` / `SCOPE.Queue` / `SCOPE.ServerlessFunction`) — but `cfnResourceKind` now **derives** them from the same classifier via `IaCKindForCategory`, so Kind and property can never diverge.
- **CDK / Pulumi / Bicep** keep `SCOPE.InfraResource`; **Terraform** keeps `SCOPE.Component/resource`. Their QualifiedNames and `DEPENDS_ON`/`USES`/`CALLS` edges are unchanged (changing the Kind would break edge resolution). The uniform `resource_category` property gives cross-tool semantics without that risk.

The old per-tool `resource_scope` property is retained as an alias (== `resource_category`) for backward-compat.

## Example types → category per tool

| Category | Terraform | CDK | Pulumi | CloudFormation | Bicep |
|---|---|---|---|---|---|
| datastore | `aws_db_instance` | `dynamodb.Table` | `aws.rds.Instance` | `AWS::RDS::DBInstance` | `Microsoft.Sql/servers/databases` |
| queue | `aws_sqs_queue` | `sqs.Queue` | `aws.sqs.Queue` | `AWS::SQS::Queue` | `Microsoft.ServiceBus/namespaces/queues` |
| topic | `aws_sns_topic` | `sns.Topic` | `aws.sns.Topic` | `AWS::SNS::Topic` | `Microsoft.EventGrid/*` |
| stream | `aws_kinesis_stream` | `kinesis.Stream` | `aws.kinesis.Stream` | `AWS::Kinesis::Stream` | `Microsoft.EventHub/*` |
| function | `aws_lambda_function` | `lambda.Function` | `aws.lambda.Function` | `AWS::Lambda::Function` | `Microsoft.Web/sites/functions` |
| cache | `aws_elasticache_cluster` | `elasticache.*` | `aws.elasticache.*` | `AWS::ElastiCache::CacheCluster` | `Microsoft.Cache/*` |
| secret | `aws_secretsmanager_secret` | — | — | `AWS::SecretsManager::Secret` | `Microsoft.KeyVault/vaults` |
| storage | `aws_s3_bucket` | `s3.Bucket` | `aws.s3.Bucket` | `AWS::S3::Bucket` | `Microsoft.Storage/storageAccounts` |
| network | `aws_vpc` | — | — | `AWS::EC2::VPC` | `Microsoft.Network/virtualNetworks` |
| compute | `aws_instance` | — | — | `AWS::ECS::Cluster` | `Microsoft.Compute/*` |

## Tests
Value-asserting (specific category, not len>0), one per tool plus a cross-dialect classifier table:
- `internal/engine/iac_resource_category_consistency_test.go` — classifier value table + CDK/Pulumi/CFN stamp tests (incl. CFN aligned-Kind assertion)
- `internal/extractors/hcl/resource_category_test.go` — Terraform `aws_db_instance`→datastore, `aws_sqs_queue`→queue, `aws_lambda_function`→function
- `internal/extractors/bicep/resource_category_test.go` — queue/function/datastore; existing Bicep tests updated (storage account is now the more precise `storage`, vnet `network`)

All targeted suites green (`engine`, `hcl`, `bicep`, `types`, `coverage`); `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean. No `go test ./...` run (live daemon).

**DEPLOY-DEFERRED**: no live daemon rebuild/reindex was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)