### PR TITLE
fix(mongo): resolve receiver var for correlated $lookup aggregation pipelines

### DIFF
--- a/internal/engine/orm_queries_jsts_mongo_agg_test.go
+++ b/internal/engine/orm_queries_jsts_mongo_agg_test.go
@@ -557,3 +557,68 @@ function f() {
 		t.Fatalf("stage order = %v, want %v (nested/string commas leaked)", got, want)
 	}
 }
+
+// CORRELATED $lookup (`from` + `let` + sub-`pipeline` + `as`, NO
+// localField/foreignField) in a variable-bound pipeline. The nested
+// `pipeline: [...]` array + `let: {...}` object inside each stage must not break
+// the stage split, and `from` must be extracted regardless of the other keys
+// present. Shares the splitter/parser fix with the Python pass (benefits
+// NestJS). Asserts the two specific from-collections + the `as` aliases + the
+// preserved stage order — NOT len>0.
+func TestMongoAgg_VariableBound_CorrelatedLookups(t *testing.T) {
+	src := `
+const mongoose = require('mongoose');
+async function joined() {
+  const pipeline = [
+    { $match: { active: true } },
+    { $lookup: {
+        from: 'inspection_groups',
+        let: { gid: '$group_id' },
+        pipeline: [ { $match: { $expr: { $eq: ['$_id', '$$gid'] } } } ],
+        as: 'inspections_group'
+    } },
+    { $unwind: { path: '$inspections_group', preserveNullAndEmptyArrays: true } },
+    { $lookup: {
+        from: 'm_devices',
+        let: { did: '$device_id' },
+        pipeline: [ { $match: { $expr: { $eq: ['$_id', '$$did'] } } } ],
+        as: 'device'
+    } },
+  ];
+  return Inspection.aggregate(pipeline);
+}
+`
+	ents, rels := runMongoAgg(t, src)
+
+	// Stage order preserved across the nested sub-pipelines.
+	got := stageSubtypesInOrder(ents)
+	want := []string{"$match", "$lookup", "$unwind", "$lookup"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("stage order = %v, want %v (correlated nesting broke split)", got, want)
+	}
+
+	// Two JOINS_COLLECTION edges to the SPECIFIC correlated from-collections.
+	for _, to := range []string{"Inspection_group", "M_device"} {
+		j := findJoinTo(rels, to)
+		if j == nil {
+			t.Fatalf("expected JOINS_COLLECTION edge to Class:%s; rels=%+v", to, rels)
+		}
+		if j.FromID != "Class:Inspection" {
+			t.Errorf("join to %s from = %q, want Class:Inspection", to, j.FromID)
+		}
+		if j.Properties["stage"] != "lookup" {
+			t.Errorf("join to %s stage = %q, want lookup", to, j.Properties["stage"])
+		}
+	}
+	if len(rels) != 2 {
+		t.Fatalf("expected exactly 2 correlated join edges, got %d: %+v", len(rels), rels)
+	}
+	// `as` alias captured for the correlated form (no local/foreign fields).
+	jg := findJoinTo(rels, "Inspection_group")
+	if jg.Properties["as"] != "inspections_group" {
+		t.Errorf("inspection_groups join as = %q, want inspections_group", jg.Properties["as"])
+	}
+	if jg.Properties["local_field"] != "" || jg.Properties["foreign_field"] != "" {
+		t.Errorf("correlated join must not carry local/foreign fields: %+v", jg.Properties)
+	}
+}

--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -81,6 +81,32 @@ var mongoAggPyGetCollRe = regexp.MustCompile(
 	`get_collection\(\s*['"]([a-zA-Z_][\w$.]*)['"]`,
 )
 
+// mongoAggPyGetCollAnyArgRe recovers the FIRST argument of a `get_collection(...)`
+// call whether it is a quoted string OR a bare constant identifier
+// (`get_collection(INSPECTIONS)` — the legacy idiom binds a module-level
+// collection-name constant). Group 1 is the quoted name, group 2 the bare
+// identifier; exactly one is set. Used when following a receiver variable's
+// binding (`coll = ...get_collection(X)`), where the constant name is the best
+// available collection token.
+var mongoAggPyGetCollAnyArgRe = regexp.MustCompile(
+	`get_collection\(\s*(?:['"]([a-zA-Z_][\w$.]*)['"]|([A-Za-z_][\w]*))`,
+)
+
+// mongoAggPyCollVarBindRe matches a same-function binding of a collection
+// variable: `<ident> = <rhs>` at the start of a (possibly indented) line. The
+// RHS is recovered separately and inspected for a get_collection / subscript /
+// dotted collection shape.
+var mongoAggPyCollVarBindReCache = map[string]*regexp.Regexp{}
+
+func mongoAggPyCollVarBindRe(ident string) *regexp.Regexp {
+	if re, ok := mongoAggPyCollVarBindReCache[ident]; ok {
+		return re
+	}
+	re := regexp.MustCompile(`(?m)^[ \t]*` + regexp.QuoteMeta(ident) + `\s*=\s*(.+)$`)
+	mongoAggPyCollVarBindReCache[ident] = re
+	return re
+}
+
 // scanPythonMongoAggregation walks `src`, finds pymongo `.aggregate(...)` call
 // sites, resolves the pipeline (inline list literal OR a single same-function
 // variable binding), parses each stage, and emits stage entities + join edges.
@@ -98,7 +124,7 @@ func scanPythonMongoAggregation(
 
 	for _, loc := range mongoAggPyCallRe.FindAllStringIndex(src, -1) {
 		openParen := loc[1] - 1 // index of '('
-		coll := mongoAggPyResolveReceiver(src, loc[0])
+		coll := mongoAggPyResolveReceiverFull(src, loc[0])
 		if coll == "" {
 			continue
 		}
@@ -215,6 +241,16 @@ func mongoAggPyResolveReceiver(src string, dotPos int) string {
 		}
 	}
 	// `db.orders.aggregate(...)` / `orders_cls.aggregate(...)` — last segment.
+	//
+	// A bare identifier receiver (e.g. `inspections_cls`) is frequently a local
+	// handle bound one or more statements up to a `get_collection(...)` /
+	// `db["coll"]` / `db.coll` expression (the dominant legacy pymongo idiom:
+	// `inspections_cls = MongoDBConnection.get_collection(INSPECTIONS)` then
+	// `inspections_cls.aggregate(pipeline)`). Following that binding recovers the
+	// REAL collection name so the JOINS_COLLECTION `from` side anchors on the
+	// actual collection node rather than a mangled variable name. The full source
+	// is needed to scan the binding, so this follow lives in the caller-supplied
+	// wrapper below; here we return the bare segment as a fallback.
 	if m := mongoAggPyReceiverRe.FindStringSubmatch(window); m != nil {
 		seg := m[1]
 		// Skip obvious non-collection keywords.
@@ -225,6 +261,108 @@ func mongoAggPyResolveReceiver(src string, dotPos int) string {
 	}
 	return ""
 }
+
+// mongoAggPyResolveReceiverFull recovers the aggregating collection, following a
+// bare-identifier receiver to its same-function binding when that resolves to a
+// real collection (a `get_collection(...)` call, a `db["coll"]` subscript, or a
+// `db.coll` dotted access). Falls back to the bare identifier from
+// mongoAggPyResolveReceiver when no clarifying binding is in scope — honest, and
+// preserves the existing simple-receiver behaviour. `dotPos` is the index of the
+// `.` before `aggregate`.
+func mongoAggPyResolveReceiverFull(src string, dotPos int) string {
+	recv := mongoAggPyResolveReceiver(src, dotPos)
+	if recv == "" {
+		return ""
+	}
+	// Only attempt a binding-follow for a bare identifier receiver — i.e. the
+	// quoted/subscript/get_collection forms already returned the real name, and
+	// a bare identifier is the only shape that can be a local handle. We detect
+	// "already a real name" cheaply: those forms can contain characters a Python
+	// identifier cannot, but the simplest robust check is to re-scan: if the
+	// bare-identifier path produced `recv`, the text immediately before dotPos is
+	// exactly that identifier with no preceding `]`/`)` /`.`+name chain implying
+	// a subscript or call we already resolved.
+	if !isPyBareIdentReceiver(src, dotPos, recv) {
+		return recv
+	}
+	if real := mongoAggPyFollowCollBinding(src, recv, dotPos); real != "" {
+		return real
+	}
+	return recv
+}
+
+// isPyBareIdentReceiver reports whether the receiver immediately before dotPos is
+// the bare identifier `ident` itself (not the tail of a `db.coll` dotted chain,
+// a `db["coll"]` subscript, or a `get_collection(...)` call — those were already
+// resolved to a real name). It checks that the char before the identifier is not
+// `.`, `]`, or `)`.
+func isPyBareIdentReceiver(src string, dotPos int, ident string) bool {
+	start := dotPos - len(ident)
+	if start < 0 || src[start:dotPos] != ident {
+		return false
+	}
+	if start == 0 {
+		return true
+	}
+	prev := src[start-1]
+	return prev != '.' && prev != ']' && prev != ')'
+}
+
+// mongoAggPyFollowCollBinding finds the nearest same-function binding of `ident`
+// preceding `usePos` and, if its RHS is a recognisable collection expression,
+// returns the real collection name. Returns "" when there is no clarifying
+// binding in scope (the caller then keeps the bare identifier). Recognised RHS
+// shapes: `...get_collection("c")` / `...get_collection(CONST)`, `db["c"]` /
+// `db['c']`, and a trailing `db.c` dotted access.
+func mongoAggPyFollowCollBinding(src, ident string, usePos int) string {
+	funcStart := funcStartBefore(src, usePos)
+	re := mongoAggPyCollVarBindRe(ident)
+	bestRHS := ""
+	for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
+		if m[0] >= usePos {
+			break // at/after the use — not a preceding binding.
+		}
+		if m[0] < funcStart {
+			continue // earlier function — out of scope.
+		}
+		bestRHS = src[m[2]:m[3]] // last preceding binding wins
+	}
+	if bestRHS == "" {
+		return ""
+	}
+	rhs := strings.TrimSpace(bestRHS)
+
+	// get_collection("c") / get_collection(CONST).
+	if m := mongoAggPyGetCollAnyArgRe.FindStringSubmatch(rhs); m != nil {
+		if m[1] != "" {
+			return m[1] // quoted collection name
+		}
+		if m[2] != "" {
+			return m[2] // bare constant identifier (e.g. INSPECTIONS)
+		}
+	}
+	// db["c"] / db['c'] subscript anywhere in the RHS.
+	if m := mongoAggPyCollSubscriptRe.FindStringSubmatch(rhs); m != nil {
+		return m[1]
+	}
+	// Trailing `db.coll` dotted access — last dotted segment, but only if the RHS
+	// is a pure dotted chain (no call/subscript), to avoid grabbing a method name.
+	if m := mongoAggPyCollDottedRe.FindStringSubmatch(rhs); m != nil {
+		seg := m[1]
+		if seg != "self" && seg != "cls" {
+			return seg
+		}
+	}
+	return ""
+}
+
+// mongoAggPyCollSubscriptRe matches a `db["coll"]` / `db['coll']` subscript
+// anywhere in a receiver-variable binding's RHS.
+var mongoAggPyCollSubscriptRe = regexp.MustCompile(`\[\s*['"]([a-zA-Z_][\w$.]*)['"]\s*\]`)
+
+// mongoAggPyCollDottedRe matches a pure dotted access (`db.coll`,
+// `client.db.coll`) — no trailing call or subscript — capturing the last segment.
+var mongoAggPyCollDottedRe = regexp.MustCompile(`^[A-Za-z_][\w.]*\.([A-Za-z_]\w*)$`)
 
 // mongoAggPyResolvePipeline returns the full pipeline list literal `[ ... ]`
 // (brackets included) for the aggregate call whose `(` is at `openParen`. Two

--- a/internal/engine/orm_queries_python_mongo_agg_test.go
+++ b/internal/engine/orm_queries_python_mongo_agg_test.go
@@ -119,6 +119,71 @@ def inspection_report(db):
 	}
 }
 
+// THE rewrite-BLOCKING case — variable-bound pipeline whose $lookup stages use
+// the CORRELATED sub-pipeline form (`from` + `let` + `pipeline` + `as`, NO
+// localField/foreignField). The nested `pipeline: [...]` array and `let: {...}`
+// object inside each stage must not break the multiline RHS capture nor the
+// stage split. Mirrors `_get_me_inspections` from the legacy repo.
+func TestMongoAggPy_VariableBound_CorrelatedLookups(t *testing.T) {
+	src := `
+import pymongo
+from pymongo import MongoClient
+
+def _get_me_inspections():
+    inspections_cls = MongoDBConnection.get_collection(INSPECTIONS)
+    pipeline = [
+        {"$project": {"_id": 1, "checklist_type": 1}},
+        {"$match": {"checklist_type": 4, "status": "active"}},
+        {"$lookup": {"from": "inspection_groups", "let": {"gid": "$group_id"}, "pipeline": [{"$match": {"$expr": {"$eq": ["$_id", "$$gid"]}}}], "as": "inspections_group"}},
+        {"$unwind": {"path": "$inspections_group", "preserveNullAndEmptyArrays": True}},
+        {"$lookup": {"from": "m_devices", "let": {"did": "$device_id"}, "pipeline": [{"$match": {"$expr": {"$eq": ["$_id", "$$did"]}}}], "as": "device"}},
+        {"$unwind": {"path": "$device", "preserveNullAndEmptyArrays": True}},
+        {"$lookup": {"from": "m_buildings", "let": {"bid": "$building_id"}, "pipeline": [{"$match": {"$expr": {"$eq": ["$_id", "$$bid"]}}}], "as": "building"}},
+        {"$unwind": {"path": "$building"}},
+        {"$project": {"name": 1}},
+    ]
+    return list(inspections_cls.aggregate(pipeline))
+`
+	ents, rels := runMongoAggPy(t, src)
+
+	// 3 join edges to the SPECIFIC correlated from-collections.
+	wantTo := []string{"inspection_groups", "m_devices", "m_buildings"}
+	for _, coll := range wantTo {
+		j := pyFindJoinTo(rels, capitalisedSingular(coll))
+		if j == nil {
+			t.Fatalf("expected JOINS_COLLECTION edge to %s; rels=%+v", coll, rels)
+		}
+		if j.FromID != "Class:"+capitalisedSingular("INSPECTIONS") {
+			t.Errorf("join to %s from = %q, want aggregating collection INSPECTIONS", coll, j.FromID)
+		}
+		if j.Properties["stage"] != "lookup" {
+			t.Errorf("join to %s stage = %q, want lookup", coll, j.Properties["stage"])
+		}
+	}
+	if n := len(rels); n != 3 {
+		t.Fatalf("expected exactly 3 join edges, got %d: %+v", n, rels)
+	}
+
+	// The correlated `as` alias is captured even without local/foreign fields.
+	jg := pyFindJoinTo(rels, capitalisedSingular("inspection_groups"))
+	if jg.Properties["as"] != "inspections_group" {
+		t.Errorf("inspection_groups join as = %q, want inspections_group", jg.Properties["as"])
+	}
+
+	// Stage entities + order: project, match, lookup, unwind, lookup, unwind,
+	// lookup, unwind, project (9 stages, order preserved).
+	got := pyStageSubtypesInOrder(ents)
+	want := []string{"$project", "$match", "$lookup", "$unwind", "$lookup", "$unwind", "$lookup", "$unwind", "$project"}
+	if len(got) != len(want) {
+		t.Fatalf("stage subtypes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stage[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 // Inline list-literal pipeline with $lookup + $graphLookup + $group + $facet,
 // receiver via db["collname"] subscript. Asserts both join kinds, the $group
 // _id/accumulators, and the $facet keys.


### PR DESCRIPTION
## Root cause

Rewrite-blocking case `_get_me_inspections`: a variable-bound pymongo pipeline whose `$lookup` stages use the **correlated sub-pipeline form** (`from` + `let` + sub-`pipeline` + `as`, no `localField`/`foreignField`). The `.aggregate(pipeline)` was recognised and stages/joins were produced, but the JOINS_COLLECTION **`from` (aggregating-collection) side pointed at a mangled variable name** (`Inspections_cl`) instead of the real collection — so the joins did not anchor on the actual collection node in the graph.

Three sub-areas were investigated per the brief:

1. **Var-binding multiline RHS capture** — `mongoAggPyBracketBody` is already string-/depth-aware and captures the FULL multiline `[...]` past the nested sub-`pipeline: [...]`. Verified correct; no change needed.
2. **Nested-stage split** — the shared `mongoAggSplitStages` (jsts file) is already bracket/brace/paren-depth aware, so a nested `pipeline: [...]` array or `let: {...}` object inside a stage does not break the top-level split. Verified correct via the new JS correlated test; no change needed.
3. **Correlated-lookup `from`-extraction** — `mongoAggParseLookup` / `mongoAggStringField` already match `"from"` regardless of which other keys are present (covers `$lookup` and `$graphLookup`, simple AND correlated forms). Verified correct.

The **real defect** was the Python receiver resolver: `inspections_cls` is a local handle bound one statement up to `MongoDBConnection.get_collection(INSPECTIONS)`, but the resolver used the bare identifier raw (then singularised it to garbage) and never followed the binding.

## Fix (Python pass)

`mongoAggPyResolveReceiverFull` follows a bare-identifier receiver to its nearest same-function binding and recovers the real collection from:
- `get_collection("c")` / `get_collection(CONST)` (the legacy `INSPECTIONS` constant idiom — `get_collection(...)` now accepts a bare constant-identifier arg),
- a `db["c"]` subscript, or
- a pure `db.c` dotted access.

Falls back to the bare identifier when no clarifying binding is in scope (honest; preserves existing simple-receiver behaviour, simple-form/inline/builder paths unchanged).

Because the splitter + `from`-extraction are shared, the **JS/NestJS correlated-lookup path benefits too** — confirmed by a value-asserting JS test.

## Tests (value-asserting, not `len>0`)

- **Python correlated** (exact `_get_me_inspections` shape): asserts 3 JOINS_COLLECTION edges to `inspection_groups` / `m_devices` / `m_buildings`, `from = INSPECTIONS`, 9 stage entities in order (`$project $match $lookup $unwind $lookup $unwind $lookup $unwind $project`), `as` alias on the correlated join.
- **JS correlated** `$lookup` with `let`+`pipeline`: 2 joins to the specific from-collections + `as` aliases, stage order preserved, no fabricated local/foreign fields.
- Existing simple-form + inline + builder + negative tests stay green.

`go test ./internal/engine/ ./internal/types/` green · `gofmt -l` empty on touched files · `go vet ./internal/engine/` clean.

## Retest report

The 3 inspection joins now emit with `from = INSPECTIONS` and `to = inspection_groups / m_devices / m_buildings`. Debug run confirmed `coll=INSPECTIONS` on every stage entity (was `inspections_cls` → mangled `Inspections_cl`).

**DEPLOY-DEFERRED**: rides the next live-daemon rebuild + reindex of upvate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)