### PR TITLE
feat(iac): add OpenTofu support (.tofu / .tofu.json) (#3553)

### DIFF
--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # platform
 
-**Total**: 25 records · **java**: 1 · **JS/TS**: 1 · **multi**: 23
+**Total**: 26 records · **java**: 1 · **JS/TS**: 1 · **multi**: 24
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -25,6 +25,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.container.kubernetes.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Kubernetes manifests](../detail/infra.resource.kubernetes.md) | — | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Kustomize](../detail/infra.container.kustomize.md) | ✅ | — | — | ✅ | ✅ | |
+| [multi](../by-language/multi.md) | [OpenTofu (HCL)](../detail/infra.iac.opentofu.md) | ✅ | — | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | — | — | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Pulumi](../detail/infra.resource.pulumi.md) | — | — | — | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | — | ✅ | ✅ | |

--- a/docs/coverage/detail/infra.iac.opentofu.md
+++ b/docs/coverage/detail/infra.iac.opentofu.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `infra.iac.opentofu` — OpenTofu (HCL)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [multi](../by-language/multi.md)
+- **Category:** [platform](../by-category/platform.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency attribution | ✅ `full` | `2026-05-31` | — | `internal/extractors/hcl` | Full dependency_attribution parity with Terraform via the shared hcl extractor: depends_on->DEPENDS_ON edges, for_each/count USES iteration-source edges, module I/O data-flow edges, and data.terraform_remote_state cross-stack DEPENDS_ON all fire for .tofu identically to .tf because entities carry Language="terraform". Same downstream IaC engine passes apply (iac_sns_edges, event_bus_edges, dynamic_patterns_terraform are gated on lang=="terraform"). |
+| Resource extraction | ✅ `full` | `2026-05-31` | — | `internal/extractors/hcl` | OpenTofu (#3553) is the Apache-licensed Terraform fork with byte-for-byte identical HCL; the classifier routes .tofu / .tofu.json to the shared "terraform" language token, so .tofu files flow through the same hcl/terraform tree-sitter extractor as .tf with zero extra code. Full resource_extraction parity: resource/data/module/provider/variable/output/locals blocks, dynamic-block child entities, terraform{} settings, and the uniform resource_category classifier (#3549) all apply unchanged. Cited at the extractor package; classifier routing in internal/classifier/classifier.go. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update infra.iac.opentofu ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -1354,6 +1354,26 @@
       }
     },
     {
+      "id": "infra.iac.opentofu",
+      "category": "platform",
+      "language": "multi",
+      "label": "OpenTofu (HCL)",
+      "capabilities": {
+        "dependency_attribution": {
+          "status": "full",
+          "cites": ["internal/extractors/hcl"],
+          "notes": "Full dependency_attribution parity with Terraform via the shared hcl extractor: depends_on-\u003eDEPENDS_ON edges, for_each/count USES iteration-source edges, module I/O data-flow edges, and data.terraform_remote_state cross-stack DEPENDS_ON all fire for .tofu identically to .tf because entities carry Language=\"terraform\". Same downstream IaC engine passes apply (iac_sns_edges, event_bus_edges, dynamic_patterns_terraform are gated on lang==\"terraform\").",
+          "verified_at": "2026-05-31"
+        },
+        "resource_extraction": {
+          "status": "full",
+          "cites": ["internal/extractors/hcl"],
+          "notes": "OpenTofu (#3553) is the Apache-licensed Terraform fork with byte-for-byte identical HCL; the classifier routes .tofu / .tofu.json to the shared \"terraform\" language token, so .tofu files flow through the same hcl/terraform tree-sitter extractor as .tf with zero extra code. Full resource_extraction parity: resource/data/module/provider/variable/output/locals blocks, dynamic-block child entities, terraform{} settings, and the uniform resource_category classifier (#3549) all apply unchanged. Cited at the extractor package; classifier routing in internal/classifier/classifier.go.",
+          "verified_at": "2026-05-31"
+        }
+      }
+    },
+    {
       "id": "infra.iac.pulumi",
       "category": "platform",
       "language": "multi",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 203 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 203 · **ORMs**: 151 · **Tools**: 110 · **Other**: 117
 
 ## Coverage by language
 
@@ -32,14 +32,14 @@
 | Category | Records | Full | Partial | Missing |
 |---|---:|---:|---:|---:|
 | [Databases](by-category/databases.md) | 11 | 0 | 7 | 4 |
-| [Platform / k8s](by-category/platform.md) | 23 | 17 | 6 | 0 |
+| [Platform / k8s](by-category/platform.md) | 24 | 18 | 6 | 0 |
 | [Message Brokers](by-category/message_broker.md) | 20 | 9 | 9 | 2 |
 | [CI/CD](by-category/ci_cd.md) | 12 | 1 | 8 | 3 |
 | [Security](by-category/security.md) | 10 | 3 | 0 | 7 |
 | [Observability](by-category/observability.md) | 9 | 1 | 1 | 7 |
 | [Protocols](by-category/protocol.md) | 8 | 3 | 3 | 2 |
 | [Build Systems](by-category/build_system.md) | 4 | 3 | 0 | 1 |
-| **Total** | 97 | 37 | 34 | 26 |
+| **Total** | 98 | 38 | 34 | 26 |
 
 ## Languages with extractor support, no records yet
 
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 203 frameworks · 110 tools · 151 ORMs · 116 other
+Total: 203 frameworks · 110 tools · 151 ORMs · 117 other

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -469,6 +469,15 @@ var extensionLanguageMap = map[string]string{
 	".tf":     "terraform",
 	".tfvars": "terraform",
 	".hcl":    "hcl",
+	// OpenTofu (#3553) — the Apache-licensed Terraform fork uses byte-for-byte
+	// identical HCL with .tofu / .tofu.json extensions. Route to the same
+	// "terraform" token so the shared hcl/terraform extractor produces full
+	// resource + dependency parity and every downstream IaC engine pass
+	// (lang=="terraform" gates in iac_sns_edges, event_bus_edges,
+	// http_endpoint_synthesis, dynamic_patterns_terraform) fires unchanged.
+	// .tofu.json is handled as a compound suffix in detectLanguage (filepath.Ext
+	// only sees ".json"), mirroring the .scala.html precedent.
+	".tofu": "terraform",
 	// Azure Bicep — Azure-native IaC DSL (resource/module/param/var/output).
 	// No tree-sitter grammar is vendored; the bicep extractor is regex/line-
 	// based (internal/extractors/bicep) so the tree is nil at dispatch time.
@@ -498,8 +507,8 @@ var extensionLanguageMap = map[string]string{
 	".svelte": "svelte",
 	".astro":  "astro",
 	// HTML / Templates — all route to "html" to match extractor.Register("html", …)
-	".html": "html",
-	".htm":  "html",
+	".html":       "html",
+	".htm":        "html",
 	".erb":        "html",
 	".ejs":        "html",
 	".hbs":        "html",
@@ -625,6 +634,15 @@ func detectLanguage(norm string) string {
 	lower := strings.ToLower(norm)
 	if strings.HasSuffix(lower, ".scala.html") {
 		return "scala"
+	}
+
+	// OpenTofu (#3553) — .tofu.json carries a compound extension; filepath.Ext
+	// only returns ".json", which would otherwise fall through to the Debezium
+	// JSON routing below (or be dropped). Route it to "terraform" — the same
+	// token as .tf/.tofu — for full Terraform extraction parity. Checked before
+	// the generic .json branch so OpenTofu JSON config always wins.
+	if strings.HasSuffix(lower, ".tofu.json") {
+		return "terraform"
 	}
 
 	// Issue #1708 — narrow JSON routing for Debezium / Kafka-Connect

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -402,6 +402,7 @@ func TestExtensionCoverage(t *testing.T) {
 		{"foo.lua", "lua"},
 		{"foo.sql", "sql"},
 		{"foo.tf", "terraform"},
+		{"foo.tofu", "terraform"},
 		{"foo.hcl", "hcl"},
 		{"foo.proto", "protobuf"},
 		{"foo.graphql", "graphql"},
@@ -423,6 +424,31 @@ func TestExtensionCoverage(t *testing.T) {
 			}
 			if r.Skip {
 				t.Errorf("file=%q: expected Skip=false, got true reason=%q", tc.file, r.SkipReason)
+			}
+		})
+	}
+}
+
+// TestOpenTofuExtensions verifies OpenTofu config files (#3553) classify to the
+// "terraform" token — both the plain .tofu extension and the .tofu.json compound
+// suffix (which filepath.Ext sees only as ".json") — and are never skipped.
+func TestOpenTofuExtensions(t *testing.T) {
+	c := newTestClassifier(t)
+	ctx := context.Background()
+	cases := []string{
+		"main.tofu",
+		"infra/network.tofu",
+		"main.tofu.json",
+		"infra/prod/main.tofu.json",
+	}
+	for _, f := range cases {
+		t.Run(f, func(t *testing.T) {
+			r := c.Classify(ctx, f)
+			if r.Language != "terraform" {
+				t.Errorf("file=%q: expected Language=terraform, got %q", f, r.Language)
+			}
+			if r.Skip {
+				t.Errorf("file=%q: expected Skip=false, got true reason=%q", f, r.SkipReason)
 			}
 		})
 	}

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -1,7 +1,11 @@
 // Package hcl implements the HCL/Terraform language extractor for archigraph.
 //
 // It extracts infrastructure entities from HCL files (Terraform .tf, .tfvars,
-// and generic .hcl) using the smacker/go-tree-sitter HCL grammar.
+// OpenTofu .tofu / .tofu.json, and generic .hcl) using the smacker/go-tree-sitter
+// HCL grammar. OpenTofu (#3553) is the Apache-licensed Terraform fork with
+// byte-for-byte identical HCL syntax; the classifier routes .tofu to the
+// "terraform" language token, so .tofu files flow through this exact extractor
+// and receive full resource + dependency-edge parity with .tf.
 //
 // Entity mapping:
 //

--- a/internal/extractors/hcl/extractor_test.go
+++ b/internal/extractors/hcl/extractor_test.go
@@ -539,6 +539,64 @@ func TestNoDependsOn(t *testing.T) {
 }
 
 // ----------------------------------------------------------------
+// OpenTofu (#3553) — .tofu files are byte-for-byte identical HCL and the
+// classifier routes them to the "terraform" token, so they flow through this
+// exact extractor. This value-asserting test proves a .tofu file with two
+// resources, one referencing the other, yields both resource entities AND the
+// DEPENDS_ON edge via the same path as .tf — full parity, not just len>0.
+// ----------------------------------------------------------------
+
+func TestOpenTofuTwoResourcesDependencyEdge(t *testing.T) {
+	src := `
+resource "aws_iam_role" "lambda_role" {
+  name = "lambda-exec"
+}
+
+resource "aws_lambda_function" "fn" {
+  function_name = "processor"
+  role          = aws_iam_role.lambda_role.arn
+  depends_on    = [aws_iam_role.lambda_role]
+}
+`
+	// Extract through the "terraform" key (the classifier's target for .tofu)
+	// using a .tofu path to assert the file-extension travels through unchanged.
+	records, err := extractTerraform(src, "infra/main.tofu")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both resources must be present.
+	role := findBySubtypeAndName(records, "resource", "lambda_role")
+	if role == nil {
+		t.Fatalf("expected resource 'lambda_role' from .tofu file, got %v", records)
+	}
+	fn := findBySubtypeAndName(records, "resource", "fn")
+	if fn == nil {
+		t.Fatalf("expected resource 'fn' from .tofu file, got %v", records)
+	}
+
+	// The dependency edge fn -> lambda_role must exist, with the canonical
+	// terraform-token ToID, proving the same DEPENDS_ON path as .tf.
+	wantToID := "scope:operation:method:terraform:infra/main.tofu:aws_iam_role.lambda_role"
+	var found bool
+	for _, rel := range fn.Relationships {
+		if rel.Kind == "DEPENDS_ON" && rel.ToID == wantToID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DEPENDS_ON edge fn -> lambda_role with ToID %q; got relationships %v",
+			wantToID, fn.Relationships)
+	}
+
+	// Language must be the shared "terraform" token for downstream IaC gates.
+	if fn.Language != "terraform" {
+		t.Errorf("expected Language=terraform on .tofu entity, got %s", fn.Language)
+	}
+}
+
+// ----------------------------------------------------------------
 // terraform language key
 // ----------------------------------------------------------------
 

--- a/tools/coverage/discover.go
+++ b/tools/coverage/discover.go
@@ -30,23 +30,23 @@ import (
 // subcommand. Field order in this struct controls JSON ordering when
 // serialised with encoding/json + sorted maps. Slices are sorted by ID.
 type DiscoverResult struct {
-	Proposal                 []Candidate              `json:"proposal"`
-	OrphansInRegistry        []Orphan                 `json:"orphans_in_registry"`
-	StatusUpgradeCandidates  []StatusUpgradeCandidate `json:"status_upgrade_candidates"`
-	CiteDrift                []CiteDriftItem          `json:"cite_drift"`
-	Summary                  DiscoverSummary          `json:"summary"`
+	Proposal                []Candidate              `json:"proposal"`
+	OrphansInRegistry       []Orphan                 `json:"orphans_in_registry"`
+	StatusUpgradeCandidates []StatusUpgradeCandidate `json:"status_upgrade_candidates"`
+	CiteDrift               []CiteDriftItem          `json:"cite_drift"`
+	Summary                 DiscoverSummary          `json:"summary"`
 }
 
 // Candidate is a discovered record proposal keyed by stable slug ID.
 type Candidate struct {
-	CandidateID           string                          `json:"candidate_id"`
-	Category              string                          `json:"category"`
-	Language              string                          `json:"language"`
-	Label                 string                          `json:"label"`
-	Evidence              []Evidence                      `json:"evidence"`
-	InferredCapabilities  map[string]InferredCapability   `json:"inferred_capabilities"`
-	AlreadyInRegistry     bool                            `json:"already_in_registry"`
-	RegistryID            string                          `json:"registry_id,omitempty"`
+	CandidateID          string                        `json:"candidate_id"`
+	Category             string                        `json:"category"`
+	Language             string                        `json:"language"`
+	Label                string                        `json:"label"`
+	Evidence             []Evidence                    `json:"evidence"`
+	InferredCapabilities map[string]InferredCapability `json:"inferred_capabilities"`
+	AlreadyInRegistry    bool                          `json:"already_in_registry"`
+	RegistryID           string                        `json:"registry_id,omitempty"`
 }
 
 // Evidence is a single citation: kind of signal + repo-relative path,
@@ -90,22 +90,22 @@ type CiteDriftItem struct {
 
 // DiscoverSummary aggregates counters for the result.
 type DiscoverSummary struct {
-	ProposalTotal        int `json:"proposal_total"`
-	InRegistry           int `json:"in_registry"`
-	NewCandidates        int `json:"new_candidates"`
-	Orphans              int `json:"orphans"`
+	ProposalTotal           int `json:"proposal_total"`
+	InRegistry              int `json:"in_registry"`
+	NewCandidates           int `json:"new_candidates"`
+	Orphans                 int `json:"orphans"`
 	StatusUpgradeCandidates int `json:"status_upgrade_candidates"`
-	CitesDrifted         int `json:"cites_drifted"`
+	CitesDrifted            int `json:"cites_drifted"`
 }
 
 // confidence values are hard-coded per evidence pattern (v1). Future
 // revisions may make these data-driven.
 const (
-	confidenceFull          = 0.95 // YAML + synthesizer + fixture
-	confidenceStrong        = 0.85 // YAML + synthesizer
-	confidenceFixtureBoost  = 0.80 // YAML + fixture
-	confidencePartial       = 0.60 // YAML only
-	confidenceLanguageStrong = 0.90 // extractor + rules dir
+	confidenceFull            = 0.95 // YAML + synthesizer + fixture
+	confidenceStrong          = 0.85 // YAML + synthesizer
+	confidenceFixtureBoost    = 0.80 // YAML + fixture
+	confidencePartial         = 0.60 // YAML only
+	confidenceLanguageStrong  = 0.90 // extractor + rules dir
 	confidenceLanguagePartial = 0.70 // one of (extractor | rules dir)
 )
 
@@ -123,15 +123,15 @@ var languageDirAlias = map[string]string{
 // The key is "<langSlug>.<seg>.<file-derived-slug>", the value is the
 // registry's expected slug for that ID.
 var frameworkSlugAliases = map[string]string{
-	"rust.framework.actix-web":              "actix",
-	"ruby.framework.ruby-on-rails":          "rails",
-	"ruby.orm.rom-rb-ruby-object-mapper":    "rom-rb",
-	"python.orm.django-orm":                 "django",
-	"python.orm.pony-orm":                   "pony",
-	"python.orm.tortoise-orm":               "tortoise",
+	"rust.framework.actix-web":                "actix",
+	"ruby.framework.ruby-on-rails":            "rails",
+	"ruby.orm.rom-rb-ruby-object-mapper":      "rom-rb",
+	"python.orm.django-orm":                   "django",
+	"python.orm.pony-orm":                     "pony",
+	"python.orm.tortoise-orm":                 "tortoise",
 	"ruby.orm.datamapper-hanami-model-legacy": "datamapper",
-	"php.orm.doctrine-orm":                  "doctrine",
-	"php.orm.eloquent-laravel":              "eloquent",
+	"php.orm.doctrine-orm":                    "doctrine",
+	"php.orm.eloquent-laravel":                "eloquent",
 }
 
 // engineNamePrefixes are the file-prefix tokens we treat as framework
@@ -1057,6 +1057,11 @@ func iacWalker(repoRoot string, cands map[string]*Candidate) {
 	if _, err := os.Stat(filepath.Join(repoRoot, hclExtractorRel)); err == nil {
 		c := ensureCandidate(cands, "infra.iac.terraform", "iac", "multi", "Terraform")
 		addEvidence(c, "extractor_source", hclExtractorRel, "")
+		// OpenTofu (#3553) — Apache-licensed Terraform fork, identical HCL with
+		// .tofu / .tofu.json extensions routed to the "terraform" token. Shares
+		// this exact extractor, so cite the same source for the opentofu record.
+		ot := ensureCandidate(cands, "infra.iac.opentofu", "iac", "multi", "OpenTofu")
+		addEvidence(ot, "extractor_source", hclExtractorRel, "")
 	}
 	// serverless-framework + cloudformation: look in engine sources by name.
 	engineRel := func(name string) string {
@@ -1911,10 +1916,10 @@ func MergeWithRegistry(discovered map[string]*Candidate, reg *Registry, repoRoot
 		}
 	}
 	return DiscoverResult{
-		Proposal:                 proposal,
-		OrphansInRegistry:        orphans,
-		StatusUpgradeCandidates:  statusUpgradeCandidates,
-		CiteDrift:                drifts,
+		Proposal:                proposal,
+		OrphansInRegistry:       orphans,
+		StatusUpgradeCandidates: statusUpgradeCandidates,
+		CiteDrift:               drifts,
 		Summary: DiscoverSummary{
 			ProposalTotal:           len(proposal),
 			InRegistry:              inRegistry,


### PR DESCRIPTION
## Summary

Adds OpenTofu support to archigraph. OpenTofu is the Apache-licensed Terraform fork with **byte-for-byte identical HCL** syntax and `.tofu` / `.tofu.json` extensions. Implemented as a cheap alias to the existing `hcl`/`terraform` extractor — **zero new extraction code**.

## What changed

**Classifier** (`internal/classifier/classifier.go`)
- `.tofu` → `"terraform"` language token (`extensionLanguageMap`).
- `.tofu.json` → `"terraform"` via a compound-suffix check in `detectLanguage` (since `filepath.Ext` only sees `.json`; mirrors the existing `.scala.html` precedent), placed **before** the Debezium `.json` routing so OpenTofu JSON config wins.

Routing to the shared `"terraform"` token (rather than a new `opentofu` token) is deliberate: `.tofu` files then flow through the exact `hcl`/`terraform` tree-sitter extractor as `.tf`, and every downstream IaC engine pass gated on `lang == "terraform"` (`iac_sns_edges`, `event_bus_edges`, `http_endpoint_synthesis`, `dynamic_patterns_terraform`) fires unchanged — **full resource + dependency-edge parity**.

**Coverage registry**
- New `infra.iac.opentofu` record (`language=multi`, mirrors `infra.iac.terraform`), `resource_extraction` + `dependency_attribution` honestly flipped to `full`, citing `internal/extractors/hcl`.
- `discover.go` emits a matching candidate from the hcl extractor source so drift detection stays consistent.

## Tests (value-asserting, not `len>0`)
- **hcl**: `TestOpenTofuTwoResourcesDependencyEdge` — a `.tofu` file with two resources where the lambda references the iam_role asserts both resource entities **AND** the `DEPENDS_ON` edge with the canonical terraform-token `ToID`, via the same path as `.tf`.
- **classifier**: `.tofu` and `.tofu.json` classify to `"terraform"` and are not skipped.

## Verification
- `coverage validate`: 0 errors (only the pre-existing capability-map warnings shared by every `infra.iac.*` record).
- `coverage fmt --check`: registry.json canonical.
- `gofmt` clean, `go vet` clean on touched packages.
- Targeted tests pass: `internal/extractors/hcl`, `internal/classifier`, `internal/engine`, `internal/types`, `tools/coverage`.

Closes #3553 (epic #3512).

**DEPLOY-DEFERRED**: requires a live-daemon rebuild + reindex to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)