### PR TITLE
feat(elixir): Broadway + elixir-grpc + Ueberauth coverage

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -10563,6 +10563,32 @@
       }
     },
     {
+      "id": "lang.elixir.framework.broadway",
+      "category": "message_broker",
+      "language": "elixir",
+      "label": "Broadway (Elixir data pipelines)",
+      "capabilities": {
+        "consumer_extraction": {
+          "status": "partial",
+          "cites": ["internal/custom/elixir/broadway.go","internal/custom/elixir/broadway_test.go"],
+          "notes": "handle_message/3 and handle_batch/4 pipeline stages emitted as SCOPE.Operation/handler flow roots bound to the use Broadway module.",
+          "verified_at": "2026-05-31"
+        },
+        "producer_extraction": {
+          "status": "partial",
+          "cites": ["internal/custom/elixir/broadway.go","internal/custom/elixir/broadway_test.go"],
+          "notes": "Broadway producer module (BroadwayKafka/BroadwaySQS/OffBroadway...) parsed from producer: [module: {Mod, opts}]; broker normalised (kafka|sqs|rabbitmq|gcp-pubsub|kinesis).",
+          "verified_at": "2026-05-31"
+        },
+        "topic_attribution": {
+          "status": "partial",
+          "cites": ["internal/custom/elixir/broadway.go","internal/custom/elixir/broadway_test.go"],
+          "notes": "Ingress topics/queues parsed from producer topics:/topic:/queue:/queue_url: options emitted as SCOPE.MessageTopic with broker + ingress=true + owning pipeline.",
+          "verified_at": "2026-05-31"
+        }
+      }
+    },
+    {
       "id": "lang.elixir.framework.cowboy",
       "category": "http_framework",
       "subcategory": "http_backend",
@@ -10933,6 +10959,141 @@
           "response_shape_extraction": {
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.grpc",
+      "category": "http_framework",
+      "subcategory": "rpc_framework",
+      "language": "elixir",
+      "label": "elixir-grpc",
+      "capabilities": {
+        "Schema": {
+          "procedure_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/elixir/grpc.go","internal/custom/elixir/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "rpc :Method, Req, Resp declarations in use GRPC.Service modules emitted as SCOPE.GrpcMethod (grpc:\u003cservice\u003e/\u003cmethod\u003e) with method + request/response message names.",
+            "verified_at": "2026-05-31"
+          },
+          "schema_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/elixir/grpc.go","internal/custom/elixir/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Request/response protobuf message names captured per rpc; stream() wrappers stripped and classified into streaming mode.",
+            "verified_at": "2026-05-31"
+          }
+        },
+        "Codegen": {
+          "client_codegen": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transport": {
+          "transport_binding": {
+            "status": "partial",
+            "cites": ["internal/custom/elixir/grpc.go","internal/custom/elixir/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "use GRPC.Server / GRPC.Service / GRPC.Stub modules emitted as SCOPE.GrpcService with grpc_role server|definition|client; service name resolved from name:/service: option.",
+            "verified_at": "2026-05-31"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "partial",
+            "cites": ["internal/custom/elixir/grpc.go","internal/custom/elixir/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Cross-repo identity grpc:\u003cservice\u003e/\u003cmethod\u003e matches the shared #725 linker convention so client stub and server impl join across repos.",
+            "verified_at": "2026-05-31"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/elixir/grpc.go","internal/custom/elixir/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "rpc request message type recorded as request_message on each SCOPE.GrpcMethod.",
+            "verified_at": "2026-05-31"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/elixir/grpc.go","internal/custom/elixir/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "rpc response message type recorded as response_message on each SCOPE.GrpcMethod.",
+            "verified_at": "2026-05-31"
           },
           "sanitizer_recognition": {
             "status": "missing",
@@ -12570,6 +12731,26 @@
             "status": "missing",
             "issue": "backfill:dictionary-completeness"
           }
+        }
+      }
+    },
+    {
+      "id": "lang.elixir.framework.ueberauth",
+      "category": "security",
+      "language": "elixir",
+      "label": "Ueberauth (Elixir OAuth)",
+      "capabilities": {
+        "auth_policy": {
+          "status": "partial",
+          "cites": ["internal/custom/elixir/ueberauth.go","internal/custom/elixir/ueberauth_test.go"],
+          "notes": "plug Ueberauth entrypoint + configured Ueberauth.Strategy.* OAuth providers + handle_request!/handle_callback! handlers emitted as auth entities (auth=true, auth_provider=\u003cprovider\u003e, auth_method=oauth2) consumed by archigraph_auth_coverage.",
+          "verified_at": "2026-05-31"
+        },
+        "secret_detection": {
+          "status": "missing"
+        },
+        "sql_injection": {
+          "status": "not_applicable"
         }
       }
     },

--- a/internal/custom/elixir/broadway.go
+++ b/internal/custom/elixir/broadway.go
@@ -1,0 +1,198 @@
+package elixir
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_elixir_broadway", &broadwayExtractor{})
+}
+
+// broadwayExtractor recognises Broadway (https://hexdocs.pm/broadway) data
+// pipelines. A Broadway pipeline is a module that does `use Broadway` and wires
+// a producer in its `start_link/1` via `producer: [module: {ProducerMod, opts}]`.
+// The producer module determines the message-broker ingress (Kafka topic, SQS
+// queue, RabbitMQ queue, …); `handle_message/3` and `handle_batch/4` are the
+// pipeline stages that process each ingested message (the flow roots).
+//
+// Emitted entities:
+//   - SCOPE.Component/pipeline  : the `use Broadway` module
+//   - SCOPE.MessageTopic        : the ingress topic/queue parsed from the
+//     producer module + its `topics:`/`queue:`/`queue_url:` option
+//   - SCOPE.Operation/handler   : handle_message/3 and handle_batch/4 stages
+type broadwayExtractor struct{}
+
+func (e *broadwayExtractor) Language() string { return "custom_elixir_broadway" }
+
+var (
+	reBroadwayUse = regexp.MustCompile(`(?m)^\s*use\s+Broadway\b`)
+	// producer: [module: {BroadwayKafka.Producer, ...}] — capture the producer
+	// module reference. Handles both `module: {Mod, opts}` and `module: Mod`.
+	reBroadwayProducerModule = regexp.MustCompile(
+		`module:\s*\{?\s*([A-Z][\w.]+)`,
+	)
+	// topics: ["orders", "payments"] — Kafka producer subscription list.
+	reBroadwayKafkaTopics = regexp.MustCompile(
+		`topics:\s*\[([^\]]*)\]`,
+	)
+	// topic: "orders" — single-topic producers (e.g. some OffBroadway adapters).
+	reBroadwayKafkaTopic = regexp.MustCompile(
+		`\btopic:\s*"([^"]+)"`,
+	)
+	// queue: "events" — SQS / RabbitMQ off_broadway producers.
+	reBroadwaySQSQueue = regexp.MustCompile(
+		`\bqueue:\s*"([^"]+)"`,
+	)
+	// queue_url: "https://sqs..../my-queue" — Broadway SQS producer.
+	reBroadwayQueueURL = regexp.MustCompile(
+		`\bqueue_url:\s*"([^"]+)"`,
+	)
+	// def handle_message(_processor, message, _context) / def handle_batch(...)
+	reBroadwayHandler = regexp.MustCompile(
+		`(?m)^\s*def\s+(handle_message|handle_batch)\s*\(`,
+	)
+	// A quoted string member of a list, e.g. `"orders"`.
+	reQuotedMember = regexp.MustCompile(`"([^"]+)"`)
+)
+
+// broadwayProducerKind maps a Broadway producer module to a normalised broker
+// name used as the MessageTopic `broker` property.
+func broadwayProducerKind(mod string) string {
+	lower := strings.ToLower(mod)
+	switch {
+	case strings.Contains(lower, "kafka"):
+		return "kafka"
+	case strings.Contains(lower, "sqs"):
+		return "sqs"
+	case strings.Contains(lower, "rabbitmq") || strings.Contains(lower, "amqp"):
+		return "rabbitmq"
+	case strings.Contains(lower, "pubsub") || strings.Contains(lower, "googlecloud"):
+		return "gcp-pubsub"
+	case strings.Contains(lower, "kinesis"):
+		return "kinesis"
+	case strings.Contains(lower, "dummy") || strings.Contains(lower, "test"):
+		return "in-memory"
+	default:
+		return "unknown"
+	}
+}
+
+func (e *broadwayExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/elixir")
+	_, span := tracer.Start(ctx, "indexer.broadway_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "broadway"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "elixir" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// Gate: only files that actually `use Broadway` are pipelines.
+	useLoc := reBroadwayUse.FindStringIndex(src)
+	if useLoc == nil {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. The pipeline module itself.
+	moduleName := "BroadwayPipeline"
+	if cm := rePhoenixModuleDecl.FindAllStringSubmatch(src[:useLoc[0]], -1); len(cm) > 0 {
+		moduleName = cm[len(cm)-1][1]
+	}
+	pipeEnt := makeEntity(moduleName, "SCOPE.Component", "pipeline", file.Path, file.Language, lineOf(src, useLoc[0]))
+	setProps(&pipeEnt, "framework", "broadway",
+		"provenance", "INFERRED_FROM_BROADWAY_USE",
+		"pipeline", "true")
+
+	// 2. Producer module + ingress topic/queue.
+	var producerMod, broker string
+	if pm := reBroadwayProducerModule.FindStringSubmatch(src); pm != nil {
+		producerMod = pm[1]
+		broker = broadwayProducerKind(producerMod)
+		setProps(&pipeEnt, "producer_module", producerMod, "broker", broker)
+	}
+	add(pipeEnt)
+
+	// Collect ingress sources from the producer options.
+	var ingress []struct{ name, kind string }
+	for _, m := range reBroadwayKafkaTopics.FindAllStringSubmatch(src, -1) {
+		for _, q := range reQuotedMember.FindAllStringSubmatch(m[1], -1) {
+			ingress = append(ingress, struct{ name, kind string }{q[1], "topic"})
+		}
+	}
+	for _, m := range reBroadwayKafkaTopic.FindAllStringSubmatch(src, -1) {
+		ingress = append(ingress, struct{ name, kind string }{m[1], "topic"})
+	}
+	for _, m := range reBroadwaySQSQueue.FindAllStringSubmatch(src, -1) {
+		ingress = append(ingress, struct{ name, kind string }{m[1], "queue"})
+	}
+	for _, m := range reBroadwayQueueURL.FindAllStringSubmatch(src, -1) {
+		// Use the last path segment of a queue URL as the queue name.
+		name := m[1]
+		if idx := strings.LastIndex(name, "/"); idx >= 0 && idx < len(name)-1 {
+			name = name[idx+1:]
+		}
+		ingress = append(ingress, struct{ name, kind string }{name, "queue"})
+	}
+
+	if broker == "" && len(ingress) > 0 {
+		broker = "unknown"
+	}
+	for _, in := range ingress {
+		topEnt := makeEntity(in.name, "SCOPE.MessageTopic", in.kind, file.Path, file.Language, lineOf(src, useLoc[0]))
+		setProps(&topEnt, "framework", "broadway",
+			"provenance", "INFERRED_FROM_BROADWAY_PRODUCER",
+			"broker", broker,
+			"topic", in.name,
+			"ingress", "true",
+			"pipeline", moduleName)
+		if producerMod != "" {
+			setProps(&topEnt, "producer_module", producerMod)
+		}
+		add(topEnt)
+	}
+
+	// 3. Pipeline stage handlers (flow roots).
+	for _, m := range reBroadwayHandler.FindAllStringSubmatchIndex(src, -1) {
+		handler := src[m[2]:m[3]]
+		ent := makeEntity(moduleName+"."+handler, "SCOPE.Operation", "handler", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "broadway",
+			"provenance", "INFERRED_FROM_BROADWAY_HANDLER",
+			"handler_type", handler,
+			"pipeline", moduleName,
+			"flow_root", "true")
+		if broker != "" {
+			setProps(&ent, "broker", broker)
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/elixir/broadway_test.go
+++ b/internal/custom/elixir/broadway_test.go
@@ -1,0 +1,123 @@
+package elixir_test
+
+import "testing"
+
+// TestBroadwayKafkaPipeline asserts that a Broadway pipeline with a Kafka
+// producer yields the ingress-topic MessageTopic entities (from the
+// producer's topics list) plus the handle_message / handle_batch stages.
+func TestBroadwayKafkaPipeline(t *testing.T) {
+	src := `
+defmodule MyApp.OrderPipeline do
+  use Broadway
+
+  def start_link(_opts) do
+    Broadway.start_link(__MODULE__,
+      name: __MODULE__,
+      producer: [
+        module: {BroadwayKafka.Producer, [
+          hosts: [localhost: 9092],
+          group_id: "order_consumers",
+          topics: ["orders", "payments"]
+        ]}
+      ],
+      processors: [default: []],
+      batchers: [default: []]
+    )
+  end
+
+  def handle_message(_processor, message, _context) do
+    message
+  end
+
+  def handle_batch(_batcher, messages, _info, _context) do
+    messages
+  end
+end
+`
+	ents := extract(t, "custom_elixir_broadway", fi("order_pipeline.ex", "elixir", src))
+
+	pipe := findEntity(ents, "SCOPE.Component", "MyApp.OrderPipeline")
+	if pipe == nil {
+		t.Fatal("expected MyApp.OrderPipeline pipeline component")
+	}
+	if got := pipe.Props["broker"]; got != "kafka" {
+		t.Errorf("expected broker kafka, got %q", got)
+	}
+	if got := pipe.Props["producer_module"]; got != "BroadwayKafka.Producer" {
+		t.Errorf("expected producer_module BroadwayKafka.Producer, got %q", got)
+	}
+
+	orders := findEntity(ents, "SCOPE.MessageTopic", "orders")
+	if orders == nil {
+		t.Fatal("expected ingress topic 'orders'")
+	}
+	if got := orders.Props["broker"]; got != "kafka" {
+		t.Errorf("expected orders broker kafka, got %q", got)
+	}
+	if got := orders.Props["ingress"]; got != "true" {
+		t.Errorf("expected ingress=true on orders topic")
+	}
+	if orders.Subtype != "topic" {
+		t.Errorf("expected orders subtype topic, got %q", orders.Subtype)
+	}
+	if findEntity(ents, "SCOPE.MessageTopic", "payments") == nil {
+		t.Error("expected ingress topic 'payments'")
+	}
+
+	hm := findEntity(ents, "SCOPE.Operation", "MyApp.OrderPipeline.handle_message")
+	if hm == nil {
+		t.Fatal("expected handle_message handler stage")
+	}
+	if got := hm.Props["flow_root"]; got != "true" {
+		t.Error("expected flow_root=true on handle_message")
+	}
+	if findEntity(ents, "SCOPE.Operation", "MyApp.OrderPipeline.handle_batch") == nil {
+		t.Error("expected handle_batch handler stage")
+	}
+}
+
+// TestBroadwaySQSPipeline asserts an SQS off_broadway producer maps the queue
+// option to an ingress queue MessageTopic with broker=sqs.
+func TestBroadwaySQSPipeline(t *testing.T) {
+	src := `
+defmodule MyApp.EventPipeline do
+  use Broadway
+
+  def start_link(_opts) do
+    Broadway.start_link(__MODULE__,
+      name: __MODULE__,
+      producer: [
+        module: {BroadwaySQS.Producer, queue: "events-queue"}
+      ]
+    )
+  end
+
+  def handle_message(_, message, _), do: message
+end
+`
+	ents := extract(t, "custom_elixir_broadway", fi("event_pipeline.ex", "elixir", src))
+
+	q := findEntity(ents, "SCOPE.MessageTopic", "events-queue")
+	if q == nil {
+		t.Fatal("expected ingress queue 'events-queue'")
+	}
+	if got := q.Props["broker"]; got != "sqs" {
+		t.Errorf("expected broker sqs, got %q", got)
+	}
+	if q.Subtype != "queue" {
+		t.Errorf("expected subtype queue, got %q", q.Subtype)
+	}
+}
+
+// TestBroadwayNoMatch ensures non-Broadway modules produce nothing.
+func TestBroadwayNoMatch(t *testing.T) {
+	src := `
+defmodule MyApp.Plain do
+  def handle_message(_, m, _), do: m
+end
+`
+	ents := extract(t, "custom_elixir_broadway", fi("plain.ex", "elixir", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities from non-Broadway module, got %d", len(ents))
+	}
+}

--- a/internal/custom/elixir/grpc.go
+++ b/internal/custom/elixir/grpc.go
@@ -1,0 +1,214 @@
+package elixir
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_elixir_grpc", &grpcExtractor{})
+}
+
+// grpcExtractor recognises elixir-grpc (https://github.com/elixir-grpc/grpc).
+//
+// Service module (generated from a .proto):
+//
+//	defmodule Helloworld.Greeter.Service do
+//	  use GRPC.Service, name: "helloworld.Greeter"
+//	  rpc :SayHello, HelloRequest, HelloReply
+//	end
+//
+// Server implementation:
+//
+//	defmodule Helloworld.Greeter.Server do
+//	  use GRPC.Server, service: Helloworld.Greeter.Service
+//	  def say_hello(request, _stream), do: ...
+//	end
+//
+// Client stub:
+//
+//	defmodule Helloworld.Greeter.Stub do
+//	  use GRPC.Stub, service: Helloworld.Greeter.Service
+//	end
+//
+// Emitted entities:
+//   - SCOPE.GrpcService : a `use GRPC.Server` or `use GRPC.Service` module.
+//   - SCOPE.GrpcMethod  : each `rpc :Method, Req, Resp` declaration. The
+//     cross-repo identity `grpc:<Service>/<Method>` matches the linker
+//     convention shared with the other-language gRPC extractors (#725).
+type grpcExtractor struct{}
+
+func (e *grpcExtractor) Language() string { return "custom_elixir_grpc" }
+
+var (
+	// use GRPC.Server, service: Helloworld.Greeter.Service
+	reGRPCServer = regexp.MustCompile(
+		`(?m)^\s*use\s+GRPC\.Server\b([^\n]*)`,
+	)
+	// use GRPC.Service, name: "helloworld.Greeter"
+	reGRPCService = regexp.MustCompile(
+		`(?m)^\s*use\s+GRPC\.Service\b([^\n]*)`,
+	)
+	// use GRPC.Stub, service: Helloworld.Greeter.Service
+	reGRPCStub = regexp.MustCompile(
+		`(?m)^\s*use\s+GRPC\.Stub\b([^\n]*)`,
+	)
+	// rpc :SayHello, HelloRequest, HelloReply
+	// rpc :ServerStream, HelloRequest, stream(HelloReply)
+	reGRPCRpc = regexp.MustCompile(
+		`(?m)^\s*rpc\s+:(\w+)\s*,\s*([\w.()]+)\s*,\s*([\w.()]+)`,
+	)
+	// service: Foo.Bar.Service  — option value capture.
+	reGRPCServiceOpt = regexp.MustCompile(`service:\s*([A-Z][\w.]+)`)
+	// name: "helloworld.Greeter" — option value capture.
+	reGRPCNameOpt = regexp.MustCompile(`name:\s*"([^"]+)"`)
+)
+
+// grpcServiceName derives the canonical service name for cross-repo identity.
+// Prefers the proto `name:` option; otherwise falls back to the module name
+// with a trailing ".Service" / ".Server" / ".Stub" suffix stripped.
+func grpcServiceName(opts, module string) string {
+	if nm := reGRPCNameOpt.FindStringSubmatch(opts); nm != nil {
+		return nm[1]
+	}
+	if so := reGRPCServiceOpt.FindStringSubmatch(opts); so != nil {
+		return strings.TrimSuffix(so[1], ".Service")
+	}
+	module = strings.TrimSuffix(module, ".Service")
+	module = strings.TrimSuffix(module, ".Server")
+	module = strings.TrimSuffix(module, ".Stub")
+	return module
+}
+
+func (e *grpcExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/elixir")
+	_, span := tracer.Start(ctx, "indexer.grpc_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "grpc"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "elixir" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	moduleAt := func(off int) string {
+		if cm := rePhoenixModuleDecl.FindAllStringSubmatch(src[:off], -1); len(cm) > 0 {
+			return cm[len(cm)-1][1]
+		}
+		return ""
+	}
+
+	// 1. Server modules -> SCOPE.GrpcService (role=server).
+	for _, m := range reGRPCServer.FindAllStringSubmatchIndex(src, -1) {
+		opts := src[m[2]:m[3]]
+		module := moduleAt(m[0])
+		svc := grpcServiceName(opts, module)
+		ent := makeEntity(svc, "SCOPE.GrpcService", "server", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "grpc",
+			"provenance", "INFERRED_FROM_GRPC_SERVER",
+			"grpc_role", "server",
+			"service_name", svc,
+			"module", module)
+		add(ent)
+	}
+
+	// 2. Service definition modules -> SCOPE.GrpcService + rpc methods.
+	for _, m := range reGRPCService.FindAllStringSubmatchIndex(src, -1) {
+		opts := src[m[2]:m[3]]
+		module := moduleAt(m[0])
+		svc := grpcServiceName(opts, module)
+		ent := makeEntity(svc, "SCOPE.GrpcService", "definition", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "grpc",
+			"provenance", "INFERRED_FROM_GRPC_SERVICE",
+			"grpc_role", "definition",
+			"service_name", svc,
+			"module", module)
+		add(ent)
+
+		// rpc declarations belong to the service definition.
+		for _, r := range reGRPCRpc.FindAllStringSubmatchIndex(src, -1) {
+			method := src[r[2]:r[3]]
+			reqType := strings.TrimSpace(src[r[4]:r[5]])
+			respType := strings.TrimSpace(src[r[6]:r[7]])
+			id := "grpc:" + svc + "/" + method
+			mEnt := makeEntity(id, "SCOPE.GrpcMethod", "rpc", file.Path, file.Language, lineOf(src, r[0]))
+			setProps(&mEnt, "framework", "grpc",
+				"provenance", "INFERRED_FROM_GRPC_RPC",
+				"service_name", svc,
+				"method_name", method,
+				"request_message", grpcStripStream(reqType),
+				"response_message", grpcStripStream(respType),
+				"streaming", grpcStreamingMode(reqType, respType))
+			add(mEnt)
+		}
+	}
+
+	// 3. Client stub modules -> SCOPE.GrpcService (role=client).
+	for _, m := range reGRPCStub.FindAllStringSubmatchIndex(src, -1) {
+		opts := src[m[2]:m[3]]
+		module := moduleAt(m[0])
+		svc := grpcServiceName(opts, module)
+		ent := makeEntity(svc, "SCOPE.GrpcService", "client", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "grpc",
+			"provenance", "INFERRED_FROM_GRPC_STUB",
+			"grpc_role", "client",
+			"service_name", svc,
+			"module", module)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// grpcStripStream removes a `stream(...)` wrapper from a message type, leaving
+// the bare message name (e.g. `stream(HelloReply)` -> `HelloReply`).
+func grpcStripStream(t string) string {
+	t = strings.TrimSpace(t)
+	if strings.HasPrefix(t, "stream(") && strings.HasSuffix(t, ")") {
+		return strings.TrimSpace(t[len("stream(") : len(t)-1])
+	}
+	return t
+}
+
+// grpcStreamingMode classifies an rpc as unary / server_streaming /
+// client_streaming / bidi_streaming based on the stream() wrappers.
+func grpcStreamingMode(req, resp string) string {
+	cs := strings.HasPrefix(strings.TrimSpace(req), "stream(")
+	ss := strings.HasPrefix(strings.TrimSpace(resp), "stream(")
+	switch {
+	case cs && ss:
+		return "bidi_streaming"
+	case ss:
+		return "server_streaming"
+	case cs:
+		return "client_streaming"
+	default:
+		return "unary"
+	}
+}

--- a/internal/custom/elixir/grpc_test.go
+++ b/internal/custom/elixir/grpc_test.go
@@ -1,0 +1,107 @@
+package elixir_test
+
+import "testing"
+
+// TestGRPCService asserts a GRPC.Service definition with rpc declarations
+// yields the service entity plus one GrpcMethod per rpc, capturing method and
+// request/response message names.
+func TestGRPCService(t *testing.T) {
+	src := `
+defmodule Helloworld.Greeter.Service do
+  use GRPC.Service, name: "helloworld.Greeter"
+
+  rpc :SayHello, HelloRequest, HelloReply
+  rpc :LotsOfReplies, HelloRequest, stream(HelloReply)
+end
+`
+	ents := extract(t, "custom_elixir_grpc", fi("greeter.pb.ex", "elixir", src))
+
+	svc := findEntity(ents, "SCOPE.GrpcService", "helloworld.Greeter")
+	if svc == nil {
+		t.Fatal("expected GrpcService helloworld.Greeter")
+	}
+	if got := svc.Props["grpc_role"]; got != "definition" {
+		t.Errorf("expected grpc_role definition, got %q", got)
+	}
+
+	sayHello := findEntity(ents, "SCOPE.GrpcMethod", "grpc:helloworld.Greeter/SayHello")
+	if sayHello == nil {
+		t.Fatal("expected GrpcMethod grpc:helloworld.Greeter/SayHello")
+	}
+	if got := sayHello.Props["method_name"]; got != "SayHello" {
+		t.Errorf("expected method_name SayHello, got %q", got)
+	}
+	if got := sayHello.Props["request_message"]; got != "HelloRequest" {
+		t.Errorf("expected request_message HelloRequest, got %q", got)
+	}
+	if got := sayHello.Props["response_message"]; got != "HelloReply" {
+		t.Errorf("expected response_message HelloReply, got %q", got)
+	}
+	if got := sayHello.Props["streaming"]; got != "unary" {
+		t.Errorf("expected streaming unary, got %q", got)
+	}
+
+	stream := findEntity(ents, "SCOPE.GrpcMethod", "grpc:helloworld.Greeter/LotsOfReplies")
+	if stream == nil {
+		t.Fatal("expected GrpcMethod LotsOfReplies")
+	}
+	if got := stream.Props["streaming"]; got != "server_streaming" {
+		t.Errorf("expected streaming server_streaming, got %q", got)
+	}
+	if got := stream.Props["response_message"]; got != "HelloReply" {
+		t.Errorf("expected stripped response_message HelloReply, got %q", got)
+	}
+}
+
+// TestGRPCServer asserts a GRPC.Server module yields a server-role service
+// entity whose name is resolved from the `service:` option.
+func TestGRPCServer(t *testing.T) {
+	src := `
+defmodule Helloworld.Greeter.Server do
+  use GRPC.Server, service: Helloworld.Greeter.Service
+
+  def say_hello(request, _stream) do
+    Helloworld.HelloReply.new(message: "Hello #{request.name}")
+  end
+end
+`
+	ents := extract(t, "custom_elixir_grpc", fi("greeter_server.ex", "elixir", src))
+
+	svc := findEntity(ents, "SCOPE.GrpcService", "Helloworld.Greeter")
+	if svc == nil {
+		t.Fatal("expected GrpcService Helloworld.Greeter (server)")
+	}
+	if got := svc.Props["grpc_role"]; got != "server" {
+		t.Errorf("expected grpc_role server, got %q", got)
+	}
+}
+
+// TestGRPCStub asserts a GRPC.Stub client module is recorded as a client-role
+// service.
+func TestGRPCStub(t *testing.T) {
+	src := `
+defmodule Helloworld.Greeter.Stub do
+  use GRPC.Stub, service: Helloworld.Greeter.Service
+end
+`
+	ents := extract(t, "custom_elixir_grpc", fi("greeter_stub.ex", "elixir", src))
+	svc := findEntity(ents, "SCOPE.GrpcService", "Helloworld.Greeter")
+	if svc == nil {
+		t.Fatal("expected client GrpcService Helloworld.Greeter")
+	}
+	if got := svc.Props["grpc_role"]; got != "client" {
+		t.Errorf("expected grpc_role client, got %q", got)
+	}
+}
+
+func TestGRPCNoMatch(t *testing.T) {
+	src := `
+defmodule MyApp.Plain do
+  def hello, do: :world
+end
+`
+	ents := extract(t, "custom_elixir_grpc", fi("plain.ex", "elixir", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities from plain module, got %d", len(ents))
+	}
+}

--- a/internal/custom/elixir/ueberauth.go
+++ b/internal/custom/elixir/ueberauth.go
@@ -1,0 +1,165 @@
+package elixir
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_elixir_ueberauth", &ueberauthExtractor{})
+}
+
+// ueberauthExtractor recognises Ueberauth (https://github.com/ueberauth/ueberauth),
+// the standard Elixir multi-provider OAuth authentication library.
+//
+// A Ueberauth pipeline is wired in three places:
+//
+//  1. The router plugs the library:           `plug Ueberauth`
+//  2. Strategies are configured (config.exs):
+//     config :ueberauth, Ueberauth,
+//     providers: [
+//     github: {Ueberauth.Strategy.Github, []},
+//     google: {Ueberauth.Strategy.Google, [default_scope: "email"]}
+//     ]
+//  3. The auth controller handles the callbacks:
+//     `def callback(%{assigns: %{ueberauth_auth: auth}} = conn, _params)` and
+//     strategy modules implement `handle_request!/1` + `handle_callback!/1`.
+//
+// Emitted entities (all carry auth=true so auth_coverage counts them):
+//   - SCOPE.Component/auth : the `plug Ueberauth` pipeline entrypoint.
+//   - SCOPE.Component/auth : each configured `Ueberauth.Strategy.<Provider>`
+//     (one OAuth provider strategy per entity, auth_provider=<provider>).
+//   - SCOPE.Operation/auth : `handle_request!` / `handle_callback!` strategy
+//     callbacks (the OAuth request/callback handlers).
+type ueberauthExtractor struct{}
+
+func (e *ueberauthExtractor) Language() string { return "custom_elixir_ueberauth" }
+
+var (
+	// plug Ueberauth   (router entrypoint; NOT Ueberauth.Strategy.* which is a
+	// strategy reference, so require end-of-token after "Ueberauth").
+	reUeberauthPlug = regexp.MustCompile(
+		`(?m)^\s*plug\s+Ueberauth\b(?:\s*,|\s*$)`,
+	)
+	// Ueberauth.Strategy.Github  /  Ueberauth.Strategy.Google
+	reUeberauthStrategy = regexp.MustCompile(
+		`Ueberauth\.Strategy\.([A-Z]\w+)`,
+	)
+	// def handle_request!(conn)  /  def handle_callback!(conn)
+	reUeberauthCallback = regexp.MustCompile(
+		`(?m)^\s*def\s+(handle_request!|handle_callback!)\s*\(`,
+	)
+	// A `provider: {Ueberauth.Strategy.X, opts}` config tuple's leading atom key,
+	// e.g. `github: {Ueberauth.Strategy.Github, []}` -> provider key "github".
+	reUeberauthProviderKey = regexp.MustCompile(
+		`(?m)^\s*(\w+):\s*\{\s*Ueberauth\.Strategy\.`,
+	)
+)
+
+// ueberauthStrategyProvider normalises a `Ueberauth.Strategy.<X>` module suffix
+// into a provider slug (e.g. "Github" -> "github").
+func ueberauthStrategyProvider(strategy string) string {
+	return strings.ToLower(strategy)
+}
+
+func (e *ueberauthExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/elixir")
+	_, span := tracer.Start(ctx, "indexer.ueberauth_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "ueberauth"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "elixir" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// Gate: the file must reference Ueberauth somewhere.
+	if !strings.Contains(src, "Ueberauth") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Router entrypoint: `plug Ueberauth`.
+	for _, m := range reUeberauthPlug.FindAllStringIndex(src, -1) {
+		ent := makeEntity("plug:Ueberauth", "SCOPE.Component", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ueberauth",
+			"provenance", "INFERRED_FROM_UEBERAUTH_PLUG",
+			"auth", "true",
+			"auth_provider", "ueberauth",
+			"auth_method", "oauth2",
+			"middleware_name", "Ueberauth")
+		add(ent)
+	}
+
+	// 2. Configured / referenced strategies -> one OAuth provider entity each.
+	for _, m := range reUeberauthStrategy.FindAllStringSubmatchIndex(src, -1) {
+		strategy := src[m[2]:m[3]]
+		provider := ueberauthStrategyProvider(strategy)
+		ent := makeEntity("Ueberauth.Strategy."+strategy, "SCOPE.Component", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ueberauth",
+			"provenance", "INFERRED_FROM_UEBERAUTH_STRATEGY",
+			"auth", "true",
+			"auth_provider", provider,
+			"auth_method", "oauth2",
+			"oauth_provider", provider,
+			"strategy", strategy,
+			"middleware_name", "Ueberauth.Strategy."+strategy)
+		add(ent)
+	}
+
+	// 3. Strategy callbacks -> OAuth request/callback handlers.
+	for _, m := range reUeberauthCallback.FindAllStringSubmatchIndex(src, -1) {
+		cb := src[m[2]:m[3]]
+		phase := "request"
+		if cb == "handle_callback!" {
+			phase = "callback"
+		}
+		ent := makeEntity(cb, "SCOPE.Operation", "auth", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ueberauth",
+			"provenance", "INFERRED_FROM_UEBERAUTH_CALLBACK",
+			"auth", "true",
+			"auth_provider", "ueberauth",
+			"auth_method", "oauth2",
+			"oauth_phase", phase,
+			"handler_type", cb)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ueberauthConfiguredProviders returns the provider atom keys declared in a
+// `providers: [ ... ]` Ueberauth config block. Exposed for tests and potential
+// reuse by config-aware passes; not all call sites need it.
+func ueberauthConfiguredProviders(src string) []string {
+	var out []string
+	for _, m := range reUeberauthProviderKey.FindAllStringSubmatch(src, -1) {
+		out = append(out, m[1])
+	}
+	return uniqueStrings(out)
+}

--- a/internal/custom/elixir/ueberauth_test.go
+++ b/internal/custom/elixir/ueberauth_test.go
@@ -1,0 +1,118 @@
+package elixir_test
+
+import "testing"
+
+// TestUeberauthConfig asserts that configured Ueberauth strategies become
+// OAuth provider auth entities, each carrying auth=true so auth_coverage
+// counts them, with the provider slug derived from the strategy module.
+func TestUeberauthConfig(t *testing.T) {
+	src := `
+config :ueberauth, Ueberauth,
+  providers: [
+    github: {Ueberauth.Strategy.Github, [default_scope: "user:email"]},
+    google: {Ueberauth.Strategy.Google, [default_scope: "email profile"]}
+  ]
+`
+	ents := extract(t, "custom_elixir_ueberauth", fi("config.exs", "elixir", src))
+
+	gh := findEntity(ents, "SCOPE.Component", "Ueberauth.Strategy.Github")
+	if gh == nil {
+		t.Fatal("expected Ueberauth.Strategy.Github auth entity")
+	}
+	if got := gh.Props["auth"]; got != "true" {
+		t.Error("expected auth=true on Github strategy")
+	}
+	if got := gh.Props["auth_provider"]; got != "github" {
+		t.Errorf("expected auth_provider github, got %q", got)
+	}
+	if got := gh.Props["auth_method"]; got != "oauth2" {
+		t.Errorf("expected auth_method oauth2, got %q", got)
+	}
+	if got := gh.Props["oauth_provider"]; got != "github" {
+		t.Errorf("expected oauth_provider github, got %q", got)
+	}
+
+	if findEntity(ents, "SCOPE.Component", "Ueberauth.Strategy.Google") == nil {
+		t.Error("expected Ueberauth.Strategy.Google auth entity")
+	}
+}
+
+// TestUeberauthRouterPlug asserts `plug Ueberauth` in a router becomes the
+// OAuth pipeline entrypoint auth entity.
+func TestUeberauthRouterPlug(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use MyAppWeb, :router
+
+  pipeline :auth do
+    plug Ueberauth
+  end
+end
+`
+	ents := extract(t, "custom_elixir_ueberauth", fi("router.ex", "elixir", src))
+	plug := findEntity(ents, "SCOPE.Component", "plug:Ueberauth")
+	if plug == nil {
+		t.Fatal("expected plug:Ueberauth entrypoint entity")
+	}
+	if got := plug.Props["auth"]; got != "true" {
+		t.Error("expected auth=true on plug:Ueberauth")
+	}
+	if got := plug.Props["auth_method"]; got != "oauth2" {
+		t.Errorf("expected auth_method oauth2, got %q", got)
+	}
+}
+
+// TestUeberauthStrategyCallbacks asserts a custom strategy's request/callback
+// handlers are recorded as OAuth auth operations.
+func TestUeberauthStrategyCallbacks(t *testing.T) {
+	src := `
+defmodule Ueberauth.Strategy.Acme do
+  use Ueberauth.Strategy
+
+  def handle_request!(conn) do
+    redirect!(conn, "https://acme.example/oauth/authorize")
+  end
+
+  def handle_callback!(conn) do
+    conn
+  end
+end
+`
+	ents := extract(t, "custom_elixir_ueberauth", fi("acme.ex", "elixir", src))
+
+	req := findEntity(ents, "SCOPE.Operation", "handle_request!")
+	if req == nil {
+		t.Fatal("expected handle_request! auth operation")
+	}
+	if got := req.Props["oauth_phase"]; got != "request" {
+		t.Errorf("expected oauth_phase request, got %q", got)
+	}
+	if got := req.Props["auth"]; got != "true" {
+		t.Error("expected auth=true on handle_request!")
+	}
+
+	cb := findEntity(ents, "SCOPE.Operation", "handle_callback!")
+	if cb == nil {
+		t.Fatal("expected handle_callback! auth operation")
+	}
+	if got := cb.Props["oauth_phase"]; got != "callback" {
+		t.Errorf("expected oauth_phase callback, got %q", got)
+	}
+
+	// The strategy module itself is detected via the Ueberauth.Strategy.Acme ref.
+	if findEntity(ents, "SCOPE.Component", "Ueberauth.Strategy.Acme") == nil {
+		t.Error("expected Ueberauth.Strategy.Acme provider entity")
+	}
+}
+
+func TestUeberauthNoMatch(t *testing.T) {
+	src := `
+defmodule MyApp.Plain do
+  def hello, do: :world
+end
+`
+	ents := extract(t, "custom_elixir_ueberauth", fi("plain.ex", "elixir", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities from non-Ueberauth module, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
Closes #3557 (epic #3505). EXPANSION — three new Elixir framework records + extractors.

## Records (docs/coverage/registry.json)
| ID | Category / Subcategory | Cells flipped |
|---|---|---|
| `lang.elixir.framework.broadway` | message_broker | producer_extraction, consumer_extraction, topic_attribution → partial |
| `lang.elixir.framework.grpc` | http_framework / rpc_framework | procedure_extraction, schema_extraction, transport_binding, request_shape_extraction, response_shape_extraction, import_resolution_quality → partial |
| `lang.elixir.framework.ueberauth` | security | auth_policy → partial; sql_injection → not_applicable |

## Extractors (internal/custom/elixir/, auto-dispatched via `custom_elixir_` prefix)
- **broadway.go** — `use Broadway` pipeline module; producer module parsing (BroadwayKafka / BroadwaySQS / OffBroadway*) with broker normalisation; `topics:`/`topic:`/`queue:`/`queue_url:` → `SCOPE.MessageTopic` ingress (broker + ingress=true + owning pipeline); `handle_message/3` + `handle_batch/4` → `SCOPE.Operation/handler` flow roots.
- **grpc.go** — `use GRPC.Server|Service|Stub` → `SCOPE.GrpcService` (server|definition|client), service name from `name:`/`service:`; `rpc :M, Req, Resp` → `SCOPE.GrpcMethod` with `grpc:<service>/<method>` cross-repo identity (#725 linker convention), request/response message names, streaming-mode classification (unary / server / client / bidi).
- **ueberauth.go** — `plug Ueberauth` entrypoint + `Ueberauth.Strategy.*` OAuth providers + `handle_request!`/`handle_callback!` → auth entities (`auth=true`, `auth_provider`, `auth_method=oauth2`) consumed by `archigraph_auth_coverage`.

## Discipline
- Value-asserting tests (not len>0): ingress topic + handler stages; RPC method + request/response messages + streaming mode; OAuth strategy/provider + auth entity props. No-match tests assert zero entities.
- `coverage validate`: 0 errors. `coverage fmt --check`: canonical.
- `gofmt -l` empty on all six files; `go vet ./internal/custom/elixir/` clean.
- Targeted tests pass: `internal/custom/elixir/`, `internal/engine/`, `internal/types/` (producer-kind validator), `tools/coverage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)