### PR TITLE
docs(coverage): record Flutter framework for Dart (extractor existed, registry didn't)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 203 records · **C/C++**: 19 · **C#**: 15 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 13 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
+**Total**: 204 records · **C/C++**: 19 · **C#**: 15 · **dart**: 1 · **elixir**: 13 · **go**: 17 · **java**: 19 · **JS/TS**: 30 · **kotlin**: 17 · **lua**: 4 · **php**: 13 · **python**: 21 · **ruby**: 8 · **rust**: 14 · **scala**: 12 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -179,6 +179,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor Server](../detail/lang.csharp.framework.blazor-server.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🟢 1/1 | 🟢 21/21 | 🟢 8/8 | |
+| [dart](../by-language/dart.md) | [Flutter](../detail/lang.dart.framework.flutter.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/21 | 🟡 3/8 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🟢 1/1 | 🟢 19/19 | 🟢 3/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟢 21/21 | ✅ 17/17 | |

--- a/docs/coverage/by-language/dart.md
+++ b/docs/coverage/by-language/dart.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # dart
 
-**Frameworks**: 0 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
@@ -18,6 +18,16 @@ Each group column shows `glyph covered/applicable` — **covered** = capabilitie
 | — | **N/A** | capability does not apply to this framework |
 
 Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Frameworks
+
+
+### UI Frontend
+
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Flutter](../detail/lang.dart.framework.flutter.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/21 | 🟡 3/8 | |
+
 
 ## Tools
 

--- a/docs/coverage/detail/lang.dart.framework.flutter.md
+++ b/docs/coverage/detail/lang.dart.framework.flutter.md
@@ -5,60 +5,79 @@ Auto-generated. Back to [summary](../summary.md).
 
 - **Language:** [dart](../by-language/dart.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
-- **Subcategory:** Mobile
-- **Capability cells:** 4
+- **Subcategory:** UI Frontend
+- **Capability cells:** 33
 
 ## Capabilities
 
 
 ### Structure
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-
-### Navigation
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-
-### Platform
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-
-### Native Bridge
-
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Component extraction | ✅ `full` | — | [link](https://github.com/cajasmota/archigraph/issues/3505) | `internal/custom/dart/extractors_test.go`<br>`internal/custom/dart/flutter.go` | StatelessWidget/StatefulWidget class declarations -> SCOPE.UIComponent (widget_type stateless/stateful). Regex/heuristic but catches the canonical Flutter widget idiom; value-asserting tests (TestFlutterStatelessWidget/StatefulWidget). |
+| Context extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Data Flow
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Branch conditions | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Data fetching | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Prop extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| State management | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/dart/flutter.go` | Bloc/Cubit/ChangeNotifier/InheritedWidget classes + StreamBuilder/BlocBuilder/context.read|watch|select<T> detected as SCOPE.Pattern/Component (state_kind). PARTIAL: class/usage detection only — no state-transition or data-flow resolution, no provider->consumer edges. |
+
+### Navigation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Router pattern | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/custom/dart/flutter.go` | Navigator.pushNamed/pushReplacementNamed + GoRoute(path:) detected as SCOPE.Operation/endpoint with route_path. PARTIAL: routes emitted as standalone entities — no screen->screen NAVIGATES_TO edges, no route->widget/builder resolution. |
 
 ### Type System
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Lifecycle
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| State setter emission | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Testing
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ### Substrate
 
-| Capability | Status | Verified at | Verified SHA | Issue | Cites | Notes |
-|------------|--------|-------------|--------------|-------|-------|-------|
-| `def_use_chain_extraction` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use.go`<br>`internal/substrate/def_use_dart.go` | — |
-| `module_cycle_detection` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/module_cycle_pass.go` | — |
-| `pure_function_tagging` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/effect_propagation.go`<br>`internal/links/pure_function_pass.go` | — |
-| `template_pattern_catalog` | ⚠️ `partial` | `2026-05-28` | — | — | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern.go`<br>`internal/substrate/template_pattern_dart.go` | — |
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -9515,6 +9515,167 @@
       }
     },
     {
+      "id": "lang.dart.framework.flutter",
+      "category": "http_framework",
+      "subcategory": "ui_frontend",
+      "language": "dart",
+      "label": "Flutter",
+      "capabilities": {
+        "Structure": {
+          "component_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/dart/extractors_test.go","internal/custom/dart/flutter.go"],
+            "issue": "https://github.com/cajasmota/archigraph/issues/3505",
+            "notes": "StatelessWidget/StatefulWidget class declarations -\u003e SCOPE.UIComponent (widget_type stateless/stateful). Regex/heuristic but catches the canonical Flutter widget idiom; value-asserting tests (TestFlutterStatelessWidget/StatefulWidget)."
+          },
+          "context_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data Flow": {
+          "branch_conditions": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "data_fetching": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "prop_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "state_management": {
+            "status": "partial",
+            "cites": ["internal/custom/dart/flutter.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Bloc/Cubit/ChangeNotifier/InheritedWidget classes + StreamBuilder/BlocBuilder/context.read|watch|select\u003cT\u003e detected as SCOPE.Pattern/Component (state_kind). PARTIAL: class/usage detection only — no state-transition or data-flow resolution, no provider-\u003econsumer edges."
+          }
+        },
+        "Navigation": {
+          "router_pattern": {
+            "status": "partial",
+            "cites": ["internal/custom/dart/flutter.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Navigator.pushNamed/pushReplacementNamed + GoRoute(path:) detected as SCOPE.Operation/endpoint with route_path. PARTIAL: routes emitted as standalone entities — no screen-\u003escreen NAVIGATES_TO edges, no route-\u003ewidget/builder resolution."
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Lifecycle": {
+          "state_setter_emission": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.elixir.driver.dynamodb",
       "category": "orm",
       "subcategory": "orm_mapper",

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 203 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
+**Languages**: 38 (19 active · 19 placeholder) · **Frameworks**: 204 · **ORMs**: 151 · **Tools**: 110 · **Other**: 116
 
 ## Coverage by language
 
@@ -20,10 +20,10 @@
 | [scala](by-language/scala.md) | 12 | 3 | 6 | 0 |
 | [ruby](by-language/ruby.md) | 8 | 6 | 13 | 1 |
 | [lua](by-language/lua.md) | 4 | 0 | 0 | 0 |
+| [dart](by-language/dart.md) | 1 | 1 | 0 | 0 |
 | [swift](by-language/swift.md) | 1 | 1 | 0 | 0 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 4 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 4 |
-| [dart](by-language/dart.md) | 0 | 1 | 0 | 0 |
 | [groovy](by-language/groovy.md) | 0 | 1 | 0 | 0 |
 | [JCL](by-language/jcl.md) | 0 | 0 | 0 | 1 |
 
@@ -67,4 +67,4 @@
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 203 frameworks · 110 tools · 151 ORMs · 116 other
+Total: 204 frameworks · 110 tools · 151 ORMs · 116 other


### PR DESCRIPTION
## Why
`docs/coverage/by-language/dart.md` reported **0 frameworks** for Dart — yet `internal/custom/dart/flutter.go` (wired live via the `custom_dart_` prefix in custom_registry.go + custom_dispatch.go) has been extracting Flutter widgets, state-management classes, and routes all along, with value-asserting tests. The registry simply never had a Flutter record, so the docs misrepresented real capability. This fixes that.

## What
Adds `lang.dart.framework.flutter` (`http_framework`/`ui_frontend`, modeled on the `react` record) with **honest** stamps citing `flutter.go`:

| Capability | Status | Basis |
|---|---|---|
| `component_extraction` | **full** | StatelessWidget/StatefulWidget → `SCOPE.UIComponent` (widget_type), tested (TestFlutterStatelessWidget/StatefulWidget) |
| `state_management` | **partial** | Bloc/Cubit/ChangeNotifier/InheritedWidget + StreamBuilder/BlocBuilder/context.read\|watch\|select<T> → Pattern/Component; **no** data-flow/provider→consumer resolution |
| `router_pattern` | **partial** | Navigator.pushNamed/GoRoute(path:) → endpoint entities; **no** screen→screen `NAVIGATES_TO` edges or route→widget resolution |
| everything else (data_fetching, prop_extraction, type system, testing, substrate, …) | missing | deferred to the depth ticket |

`dart.md`: **Frameworks 0 → 1**.

## Depth follow-up (separate ticket, part of the mobile-platform audit)
The extractor is regex/heuristic, not the tree-sitter-AST + per-concern-engine-module TS/JS bar. The depth work — real Dart AST extractor, screen→screen `NAVIGATES_TO` edges, widget→viewmodel binding, Dio/http → backend `cross_links` (extends the rewrite-parity oracle to mobile) — is tracked under the mobile-platform coverage epic.

## Verification
`coverage validate` 0 errors (only pre-existing vitest/xunit capability-map warnings), `coverage fmt --check` canonical, `coverage gen` regenerated. Unrelated infra detail-page drift (from #3566) reverted to keep the diff scoped.

**DEPLOY-DEFERRED** — rides the next daemon rebuild + reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)