### PR TITLE
feat(scala): sttp HTTP-client + ScalaPB/zio-grpc/fs2-grpc gRPC extraction (#3554)

### DIFF
--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -53383,6 +53383,139 @@
       }
     },
     {
+      "id": "lang.scala.framework.scalapb-grpc",
+      "category": "http_framework",
+      "subcategory": "rpc_framework",
+      "language": "scala",
+      "label": "ScalaPB / zio-grpc / fs2-grpc",
+      "capabilities": {
+        "Schema": {
+          "procedure_extraction": {
+            "status": "full",
+            "cites": ["internal/custom/scala/grpc.go","internal/custom/scala/grpc_test.go"],
+            "notes": "custom_scala_grpc: each def \u003crpc\u003e(request: ReqT): Eff[RespT] of a ScalaPB AbstractService / zio-grpc ZGeneratedService / fs2-grpc *Fs2Grpc service trait -\u003e SCOPE.Operation endpoint at /\u003cService\u003e/\u003crpc\u003e, verb=RPC, rpc_protocol=grpc, grpc_service+grpc_method+handler_name stamped. Value-asserting tests pin sayHello/listUsers + service Greeter (Z/Fs2Grpc decorations stripped). File-local.",
+            "verified_at": "2026-05-31"
+          },
+          "schema_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/grpc.go","internal/custom/scala/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_grpc: request/response message types recovered from the method signature (Request\u003cT\u003e param + last effect type-arg of ZIO/Future/F[_]) and emitted as SCOPE.Schema DTO refs with grpc_message_role request/response. PARTIAL: message FIELD shapes live in ScalaPB-generated case-class companions; names only. Value-asserted (HelloRequest/HelloReply/UserList).",
+            "verified_at": "2026-05-31"
+          }
+        },
+        "Codegen": {
+          "client_codegen": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/grpc.go","internal/custom/scala/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "custom_scala_grpc: \u003cService\u003eGrpc.stub/blockingStub/bindService(Resource) site detected -\u003e SCOPE.Component grpc_stub with companion+accessor. PARTIAL: generated stub/companion code itself is scalapbc-emitted, not statically present; we record the use site. Value-asserted (GreeterGrpc.stub).",
+            "verified_at": "2026-05-31"
+          }
+        },
+        "Transport": {
+          "transport_binding": {
+            "status": "full",
+            "cites": ["internal/custom/scala/grpc.go","internal/custom/scala/grpc_test.go"],
+            "notes": "custom_scala_grpc: RPC endpoint synthesis /\u003cService\u003e/\u003crpc\u003e from the service-trait method set; service trait emitted as SCOPE.Service grpc_service. Value-asserting tests pin the path + grpc_service. Regex, file-local; no .proto/AST.",
+            "verified_at": "2026-05-31"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/grpc.go","internal/custom/scala/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Request message type NAME recovered from the RPC param type; field shapes live in ScalaPB-generated message companions (not statically present). Value-asserted (HelloRequest).",
+            "verified_at": "2026-05-31"
+          },
+          "response_shape_extraction": {
+            "status": "partial",
+            "cites": ["internal/custom/scala/grpc.go","internal/custom/scala/grpc_test.go"],
+            "issue": "backfill:dictionary-completeness",
+            "notes": "Response message type NAME recovered as the last effect type-argument (Future/ZIO/F[_]); generated message field shapes not statically resolvable. Value-asserted (HelloReply).",
+            "verified_at": "2026-05-31"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        }
+      }
+    },
+    {
       "id": "lang.scala.framework.scalatra",
       "category": "http_framework",
       "subcategory": "jvm_backend",
@@ -53651,6 +53784,225 @@
             "status": "partial",
             "cites": ["internal/links/taint_flow.go","internal/substrate/taint_sites_scala.go"],
             "verified_at": "2026-05-28"
+          }
+        }
+      }
+    },
+    {
+      "id": "lang.scala.framework.sttp",
+      "category": "http_framework",
+      "subcategory": "jvm_backend",
+      "language": "scala",
+      "label": "sttp (HTTP client)",
+      "capabilities": {
+        "Routing": {
+          "endpoint_synthesis": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_scala_client.go","internal/engine/http_endpoint_scala_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "sttp basicRequest/quickRequest/emptyRequest verb combinators (.get/.post/.put/.patch/.delete/.head/.options) with uri\"...\" literals -\u003e one outbound http_endpoint_call (consumer) per call site + FETCHES from the enclosing def; host stripped, $id/${...} interpolation -\u003e {param}. Value-asserted (GET/POST /v1/users, PUT /v1/users/{param}).",
+            "verified_at": "2026-05-31"
+          },
+          "handler_attribution": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_scala_client.go","internal/engine/http_endpoint_scala_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "FETCHES edge attributes each outbound sttp call to the enclosing def (nearest preceding def \u003cname\u003e). Value-asserted via requireFetches in http_endpoint_scala_client_test.go.",
+            "verified_at": "2026-05-31"
+          },
+          "route_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Auth": {
+          "auth_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Validation": {
+          "dto_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_validation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Middleware": {
+          "middleware_coverage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Testing": {
+          "tests_linkage": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Type System": {
+          "enum_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "interface_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_alias_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "type_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "DI": {
+          "di_binding_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_injection_point": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "di_scope_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Transactions": {
+          "transaction_boundary_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "transaction_rollback_rules": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "AOP": {
+          "advice_attribution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "aspect_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pointcut_resolution": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Observability": {
+          "log_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "metric_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "trace_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Data": {
+          "db_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          }
+        },
+        "Substrate": {
+          "confidence_overlay": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "constant_propagation": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "dead_code_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "def_use_chain_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "env_fallback_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "fs_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "http_effect": {
+            "status": "full",
+            "cites": ["internal/engine/http_endpoint_scala_client.go","internal/engine/http_endpoint_scala_client_test.go","internal/engine/http_endpoint_synthesis.go"],
+            "notes": "Each sttp call recorded as an outbound HTTP effect (verb + path) so the cross-repo linker pairs it with a producer-side definition. Value-asserted.",
+            "verified_at": "2026-05-31"
+          },
+          "import_resolution_quality": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "module_cycle_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "mutation_effect": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "pure_function_tagging": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "reachability_analysis": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "request_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "response_shape_extraction": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "sanitizer_recognition": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "schema_drift_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_sink_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "taint_source_detection": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "template_pattern_catalog": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
+          },
+          "vulnerability_finding": {
+            "status": "missing",
+            "issue": "backfill:dictionary-completeness"
           }
         }
       }

--- a/internal/custom/scala/grpc.go
+++ b/internal/custom/scala/grpc.go
@@ -1,0 +1,295 @@
+// Package scala — gRPC service-definition extraction for ScalaPB, zio-grpc and
+// fs2-grpc (#3554, epic #3505).
+//
+// All three Scala gRPC stacks are driven by `protoc` / `scalapbc` code
+// generation from a `.proto`. The generated Scala carries the service contract
+// as a trait whose methods are the RPCs. The trait shape differs slightly per
+// stack but is statically present in the generated source tree (unlike Rust's
+// tonic, whose trait lives in build.rs OUT_DIR):
+//
+//	// ScalaPB grpc (the base async-stub trait):
+//	trait Greeter extends _root_.scalapb.grpc.AbstractService {
+//	  def sayHello(request: HelloRequest): scala.concurrent.Future[HelloReply]
+//	  def listUsers(request: ListReq): Future[UserList]
+//	}
+//
+//	// zio-grpc:
+//	trait ZGreeter[Context] extends scalapb.zio_grpc.ZGeneratedService {
+//	  def sayHello(request: HelloRequest): ZIO[Context, Status, HelloReply]
+//	}
+//
+//	// fs2-grpc:
+//	trait GreeterFs2Grpc[F[_], A] {
+//	  def sayHello(request: HelloRequest, ctx: A): F[HelloReply]
+//	}
+//
+// We synthesise one RPC endpoint per `def <rpc>(request: ReqT...): Eff[RespT]`
+// method of a recognised gRPC service trait, path /<Service>/<rpc>, verb RPC,
+// rpc_protocol=grpc — mirroring the Rust tonic and C/C++ grpc models so the
+// cross-stack gRPC view is uniform. The request and response *message* type
+// names are recovered and emitted as SCOPE.Schema DTO references. The service
+// trait itself is emitted as a SCOPE.Service grpc_service entity. A
+// `<Service>Grpc.stub`/`bindService`/`.<rpc>(req)` stub call site is recorded
+// as a stub registration.
+//
+// HONEST LIMIT: the message *field shapes* live in the generated message
+// case-class companions; we recover the message type NAMES from the trait
+// method signatures (request param type + effect type-argument) but not their
+// fields. The service<->binding wiring (`bindService` / `.scheduleAtFixedRate`)
+// and cross-file stub usage are file-local. All matching is regex-based.
+package scala
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_scala_grpc", &scalaGRPCExtractor{})
+}
+
+type scalaGRPCExtractor struct{}
+
+func (e *scalaGRPCExtractor) Language() string { return "custom_scala_grpc" }
+
+var (
+	// reScalaGRPCServiceTrait matches the head of a generated gRPC service
+	// trait. Three accepted shapes:
+	//   - any trait extending a recognised gRPC base
+	//     (scalapb.grpc.AbstractService / AbstractService / ZGeneratedService /
+	//     a *Grpc companion base);
+	//   - a trait whose name ends in `Grpc` / `Fs2Grpc` (fs2-grpc / generated
+	//     stub trait), which need not extend an explicit base.
+	// Capture group 1 = trait name. The optional `[...]` type-param list and the
+	// optional `extends <base>` clause are tolerated but not captured here; the
+	// body is walked separately.
+	reScalaGRPCServiceTrait = regexp.MustCompile(
+		`\btrait\s+([A-Za-z_]\w*)\s*(?:\[[^\[\]]*(?:\[[^\]]*\][^\[\]]*)*\])?\s*(?:extends\s+[\w.]*(?:AbstractService|ZGeneratedService|GeneratedService|Fs2Grpc|Grpc)\b|(?:extends\s+[^\n{]*)?)\s*\{`,
+	)
+
+	// reScalaGRPCRpcMethod matches one RPC method declaration inside a service
+	// trait body:
+	//   def sayHello(request: HelloRequest): Future[HelloReply]
+	//   def listUsers(request: ListReq, ctx: A): F[UserList]
+	//   def stream(request: Req): ZStream[Any, Status, Resp]
+	// Capture group 1 = rpc name, group 2 = the request message type (first
+	// param type), group 3 = the effect-wrapped response type-argument blob
+	// (everything between the effect's `[` and its matching `]`, resolved to the
+	// last type argument by scalaGRPCResponseType).
+	reScalaGRPCRpcMethod = regexp.MustCompile(
+		`\bdef\s+([A-Za-z_]\w*)\s*\(\s*[A-Za-z_]\w*\s*:\s*([A-Za-z_][\w.]*)[^)]*\)\s*:\s*[A-Za-z_][\w.]*\s*\[\s*([^\n]+?)\]`,
+	)
+
+	// reScalaGRPCStub matches a generated-stub access / service-binding site:
+	//   GreeterGrpc.stub(channel) / GreeterGrpc.blockingStub(channel)
+	//   GreeterGrpc.bindService(impl, ec)
+	//   GreeterFs2Grpc.bindServiceResource(impl)
+	// Capture group 1 = the `<Service>Grpc`/`<Service>Fs2Grpc` companion,
+	// group 2 = the accessor (stub / blockingStub / bindService / ...).
+	reScalaGRPCStub = regexp.MustCompile(
+		`\b([A-Za-z_]\w*(?:Fs2Grpc|Grpc))\s*\.\s*(stub|blockingStub|asyncStub|bindService|bindServiceResource|client)\b`,
+	)
+)
+
+func (e *scalaGRPCExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/scala")
+	_, span := tracer.Start(ctx, "indexer.scala_grpc.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "scalapb-grpc"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "scala" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// File-signal gate: require a Scala gRPC marker so the extractor is a no-op
+	// on plain Scala / tapir / akka files.
+	if !strings.Contains(src, "scalapb") &&
+		!strings.Contains(src, "AbstractService") &&
+		!strings.Contains(src, "ZGeneratedService") &&
+		!strings.Contains(src, "Fs2Grpc") &&
+		!strings.Contains(src, "zio_grpc") &&
+		!strings.Contains(src, "Grpc") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Service traits → one RPC endpoint per def method + grpc_service entity.
+	for _, m := range reScalaGRPCServiceTrait.FindAllStringSubmatchIndex(src, -1) {
+		service := src[m[2]:m[3]]
+		// Skip obvious non-gRPC traits whose name doesn't end in Grpc and which
+		// don't extend a recognised base. The regex already requires one of those
+		// two when it matched the `extends ...AbstractService|...Grpc` arm, but the
+		// permissive `(?:extends [^\n{]*)?` arm can match a plain trait; gate it
+		// here by requiring a gRPC signal in the header slice OR a Grpc-suffixed
+		// name.
+		header := src[m[0]:m[1]]
+		grpcTrait := strings.HasSuffix(service, "Grpc") || strings.HasSuffix(service, "Fs2Grpc") ||
+			strings.Contains(header, "AbstractService") ||
+			strings.Contains(header, "ZGeneratedService") ||
+			strings.Contains(header, "GeneratedService") ||
+			strings.Contains(header, "Fs2Grpc")
+		if !grpcTrait {
+			continue
+		}
+
+		bodyStart, bodyEnd := scalaGRPCBlockBody(src, m[1]-1)
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+
+		// Canonical service name strips a generated `Grpc`/`Fs2Grpc`/leading `Z`
+		// decoration so /<Service>/<rpc> is the proto service name.
+		svcName := scalaGRPCCanonicalService(service)
+
+		var rpcCount int
+		for _, rm := range reScalaGRPCRpcMethod.FindAllStringSubmatchIndex(body, -1) {
+			rpc := body[rm[2]:rm[3]]
+			reqType := normalizeScalaType(body[rm[4]:rm[5]])
+			respType := scalaGRPCResponseType(body[rm[6]:rm[7]])
+			methodOff := bodyStart + rm[0]
+
+			path := "/" + svcName + "/" + rpc
+			name := "RPC " + path
+			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, methodOff))
+			setProps(&ent, "framework", "scalapb-grpc",
+				"provenance", "INFERRED_FROM_SCALA_GRPC_RPC",
+				"http_method", "RPC", "verb", "RPC",
+				"route_path", path, "rpc_protocol", "grpc",
+				"grpc_service", svcName, "grpc_method", rpc,
+				"service_trait", service,
+				"request_message", reqType,
+				"handler_name", svcName+"."+rpc)
+			if respType != "" {
+				setProps(&ent, "response_message", respType)
+			}
+			add(ent)
+
+			scalaGRPCAddDTO(add, reqType, "request", file, lineOf(src, methodOff))
+			if respType != "" {
+				scalaGRPCAddDTO(add, respType, "response", file, lineOf(src, methodOff))
+			}
+			rpcCount++
+		}
+
+		// Only emit the service entity when the trait actually declared RPCs —
+		// this keeps a non-RPC trait that happened to match the permissive header
+		// arm from producing a phantom service.
+		if rpcCount == 0 {
+			continue
+		}
+		svcEnt := makeEntity("grpc_service:"+service, "SCOPE.Service", "grpc_service", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&svcEnt, "framework", "scalapb-grpc",
+			"provenance", "INFERRED_FROM_SCALA_GRPC_SERVICE",
+			"grpc_service", svcName, "service_trait", service,
+			"rpc_protocol", "grpc")
+		add(svcEnt)
+	}
+
+	// 2. Stub / bindService call sites → SCOPE.Component grpc_stub registration.
+	for _, m := range reScalaGRPCStub.FindAllStringSubmatchIndex(src, -1) {
+		companion := src[m[2]:m[3]]
+		accessor := src[m[4]:m[5]]
+		svcName := scalaGRPCCanonicalService(companion)
+		ent := makeEntity("grpc_stub:"+companion+"."+accessor, "SCOPE.Component", "grpc_stub", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "scalapb-grpc",
+			"provenance", "INFERRED_FROM_SCALA_GRPC_STUB",
+			"grpc_service", svcName, "grpc_companion", companion,
+			"grpc_accessor", accessor, "rpc_protocol", "grpc")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// scalaGRPCAddDTO emits a SCOPE.Schema DTO reference for a gRPC message type.
+func scalaGRPCAddDTO(add func(types.EntityRecord), msg, role string, file extractor.FileInput, line int) {
+	if msg == "" {
+		return
+	}
+	ent := makeEntity("grpc_dto:"+msg, "SCOPE.Schema", "dto", file.Path, file.Language, line)
+	setProps(&ent, "framework", "scalapb-grpc",
+		"provenance", "INFERRED_FROM_SCALA_GRPC_MESSAGE",
+		"dto_name", msg, "grpc_message_role", role, "rpc_protocol", "grpc")
+	add(ent)
+}
+
+// scalaGRPCCanonicalService normalises a generated service/companion name to the
+// proto service name: strip a trailing `Fs2Grpc`/`Grpc` companion suffix and a
+// leading `Z` (zio-grpc `ZGreeter` → `Greeter`).
+func scalaGRPCCanonicalService(name string) string {
+	name = strings.TrimSuffix(name, "Fs2Grpc")
+	name = strings.TrimSuffix(name, "Grpc")
+	if strings.HasPrefix(name, "Z") && len(name) > 1 {
+		// Only strip a leading Z when the next rune is upper-case (ZGreeter), not
+		// for an all-name like "Zoo".
+		if c := name[1]; c >= 'A' && c <= 'Z' {
+			name = name[1:]
+		}
+	}
+	return name
+}
+
+// scalaGRPCResponseType resolves the response message type from the effect
+// type-argument blob captured for a method, e.g.:
+//
+//	"HelloReply"                  -> HelloReply        (Future[HelloReply])
+//	"Context, Status, HelloReply" -> HelloReply        (ZIO[Context,Status,Reply])
+//	"List[User]"                  -> List              (head type)
+//
+// The response message is the LAST top-level type argument (ZIO/ZStream put the
+// success value last; Future/F have a single argument).
+func scalaGRPCResponseType(blob string) string {
+	args := splitTopLevelCommas(blob)
+	last := strings.TrimSpace(args[len(args)-1])
+	return normalizeScalaType(last)
+}
+
+// scalaGRPCBlockBody returns the [start,end) byte range of the trait body whose
+// opening `{` is at or after openBrace. Brace-balanced.
+func scalaGRPCBlockBody(src string, openBrace int) (int, int) {
+	open := strings.IndexByte(src[openBrace:], '{')
+	if open < 0 {
+		return -1, -1
+	}
+	open += openBrace
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return open + 1, i
+			}
+		}
+	}
+	return -1, -1
+}

--- a/internal/custom/scala/grpc_test.go
+++ b/internal/custom/scala/grpc_test.go
@@ -1,0 +1,148 @@
+package scala_test
+
+import (
+	"testing"
+)
+
+// TestScalaGRPC_ScalaPBService asserts that a ScalaPB AbstractService trait
+// yields RPC endpoints at /<Service>/<rpc> with the SPECIFIC service + method
+// names and request/response message types.
+func TestScalaGRPC_ScalaPBService(t *testing.T) {
+	src := `
+package example.grpc
+
+trait Greeter extends _root_.scalapb.grpc.AbstractService {
+  def sayHello(request: HelloRequest): scala.concurrent.Future[HelloReply]
+  def listUsers(request: ListUsersRequest): Future[UserList]
+}
+`
+	ents := extract(t, "custom_scala_grpc", fi("GreeterGrpc.scala", "scala", src))
+
+	ep, ok := findBySubtype(ents, "endpoint", "RPC /Greeter/sayHello")
+	if !ok {
+		t.Fatalf("expected RPC /Greeter/sayHello endpoint; got %d entities", len(ents))
+	}
+	if ep.Props["grpc_service"] != "Greeter" {
+		t.Errorf("grpc_service = %q, want Greeter", ep.Props["grpc_service"])
+	}
+	if ep.Props["grpc_method"] != "sayHello" {
+		t.Errorf("grpc_method = %q, want sayHello", ep.Props["grpc_method"])
+	}
+	if ep.Props["request_message"] != "HelloRequest" {
+		t.Errorf("request_message = %q, want HelloRequest", ep.Props["request_message"])
+	}
+	if ep.Props["response_message"] != "HelloReply" {
+		t.Errorf("response_message = %q, want HelloReply", ep.Props["response_message"])
+	}
+	if ep.Props["rpc_protocol"] != "grpc" || ep.Props["verb"] != "RPC" {
+		t.Errorf("rpc_protocol/verb = %q/%q, want grpc/RPC", ep.Props["rpc_protocol"], ep.Props["verb"])
+	}
+
+	// Second RPC.
+	ep2, ok := findBySubtype(ents, "endpoint", "RPC /Greeter/listUsers")
+	if !ok {
+		t.Fatalf("expected RPC /Greeter/listUsers endpoint")
+	}
+	if ep2.Props["response_message"] != "UserList" {
+		t.Errorf("listUsers response_message = %q, want UserList", ep2.Props["response_message"])
+	}
+
+	// Service entity.
+	if _, ok := findBySubtype(ents, "grpc_service", "grpc_service:Greeter"); !ok {
+		t.Error("expected grpc_service:Greeter SCOPE.Service entity")
+	}
+
+	// Request/response DTO references.
+	dto, ok := findBySubtype(ents, "dto", "grpc_dto:HelloRequest")
+	if !ok {
+		t.Error("expected grpc_dto:HelloRequest DTO ref")
+	} else if dto.Props["grpc_message_role"] != "request" {
+		t.Errorf("HelloRequest role = %q, want request", dto.Props["grpc_message_role"])
+	}
+	if _, ok := findBySubtype(ents, "dto", "grpc_dto:HelloReply"); !ok {
+		t.Error("expected grpc_dto:HelloReply DTO ref")
+	}
+}
+
+// TestScalaGRPC_ZioGrpcService asserts zio-grpc ZIO[Context, Status, Resp]
+// effect handling: the response message is the LAST type argument, and a
+// leading `Z` on the trait name is stripped for the proto service name.
+func TestScalaGRPC_ZioGrpcService(t *testing.T) {
+	src := `
+import scalapb.zio_grpc.ZGeneratedService
+
+trait ZGreeter[Context] extends scalapb.zio_grpc.ZGeneratedService {
+  def sayHello(request: HelloRequest): ZIO[Context, Status, HelloReply]
+}
+`
+	ents := extract(t, "custom_scala_grpc", fi("ZGreeterGrpc.scala", "scala", src))
+	ep, ok := findBySubtype(ents, "endpoint", "RPC /Greeter/sayHello")
+	if !ok {
+		t.Fatalf("expected RPC /Greeter/sayHello (Z-stripped); got %d entities", len(ents))
+	}
+	if ep.Props["response_message"] != "HelloReply" {
+		t.Errorf("response_message = %q, want HelloReply (last ZIO type arg)", ep.Props["response_message"])
+	}
+	if ep.Props["service_trait"] != "ZGreeter" {
+		t.Errorf("service_trait = %q, want ZGreeter", ep.Props["service_trait"])
+	}
+}
+
+// TestScalaGRPC_Fs2GrpcService asserts fs2-grpc: a `*Fs2Grpc` trait (no explicit
+// gRPC base) with an `F[Resp]` effect and a trailing ctx param.
+func TestScalaGRPC_Fs2GrpcService(t *testing.T) {
+	src := `
+trait GreeterFs2Grpc[F[_], A] {
+  def sayHello(request: HelloRequest, ctx: A): F[HelloReply]
+}
+`
+	ents := extract(t, "custom_scala_grpc", fi("GreeterFs2Grpc.scala", "scala", src))
+	ep, ok := findBySubtype(ents, "endpoint", "RPC /Greeter/sayHello")
+	if !ok {
+		t.Fatalf("expected RPC /Greeter/sayHello (Fs2Grpc-stripped); got %d entities", len(ents))
+	}
+	if ep.Props["request_message"] != "HelloRequest" {
+		t.Errorf("request_message = %q, want HelloRequest", ep.Props["request_message"])
+	}
+	if ep.Props["response_message"] != "HelloReply" {
+		t.Errorf("response_message = %q, want HelloReply", ep.Props["response_message"])
+	}
+}
+
+// TestScalaGRPC_StubSite asserts a generated-stub access site is recorded with
+// the SPECIFIC companion + accessor.
+func TestScalaGRPC_StubSite(t *testing.T) {
+	src := `
+import example.grpc.GreeterGrpc
+
+object Client {
+  val stub = GreeterGrpc.stub(channel)
+}
+`
+	ents := extract(t, "custom_scala_grpc", fi("Client.scala", "scala", src))
+	st, ok := findBySubtype(ents, "grpc_stub", "grpc_stub:GreeterGrpc.stub")
+	if !ok {
+		t.Fatalf("expected grpc_stub:GreeterGrpc.stub component")
+	}
+	if st.Props["grpc_service"] != "Greeter" {
+		t.Errorf("grpc_service = %q, want Greeter", st.Props["grpc_service"])
+	}
+	if st.Props["grpc_accessor"] != "stub" {
+		t.Errorf("grpc_accessor = %q, want stub", st.Props["grpc_accessor"])
+	}
+}
+
+// TestScalaGRPC_NoMatch asserts a plain Scala file with no gRPC markers emits
+// nothing.
+func TestScalaGRPC_NoMatch(t *testing.T) {
+	src := `
+trait UserRepository {
+  def find(id: Long): Option[User]
+}
+object Main extends App { println("hi") }
+`
+	ents := extract(t, "custom_scala_grpc", fi("UserRepository.scala", "scala", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-gRPC file, got %d", len(ents))
+	}
+}

--- a/internal/engine/http_endpoint_scala_client.go
+++ b/internal/engine/http_endpoint_scala_client.go
@@ -1,0 +1,121 @@
+// Scala consumer-side HTTP client synthesis — sttp (#3554, epic #3505).
+//
+// sttp (https://sttp.softwaremill.com) is the dominant Scala HTTP client. A
+// request is described as a value built from `basicRequest` / `quickRequest`
+// (or `emptyRequest`) with a verb combinator carrying the target URL, where the
+// URL is a `uri"..."` string-interpolator literal:
+//
+//	val r = basicRequest.get(uri"https://api.example.com/v1/users")
+//	basicRequest
+//	  .body(payload)
+//	  .post(uri"https://api.example.com/v1/users")
+//	quickRequest.get(uri"http://catalog:8080/products/$id")
+//	basicRequest.response(asJson[User]).put(uri"https://api.example.com/v1/users/$id")
+//
+// Before this pass any Scala service that called a downstream API via sttp
+// produced no http_endpoint_call entity and no cross-repo FETCHES edge — the
+// Scala side of the cross-link graph was producer-only (tapir/http4s/akka).
+//
+// This emits one synthetic http_endpoint_call per detected sttp verb call site
+// (via the shared emitClient from applyHTTPEndpointSynthesis), so the existing
+// cross-repo linker pairs them with producer-side definitions by canonical path
+// Name. The `uri"..."` host is stripped (the producer serves "/v1/users"
+// without the host); `$id` / `${...}` interpolations become `{id}` placeholders.
+// The enclosing `def <name>` is attributed as the calling reference.
+//
+// Verbs: get, post, put, patch, delete, head, options. The combinator may
+// appear before OR after intermediate builder combinators (.body / .response /
+// .header / .auth …); we match the verb+uri pair directly so ordering on the
+// chain is irrelevant.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// scSttpVerbURIRe matches an sttp verb combinator whose argument is a
+// `uri"..."` interpolator literal: `.get(uri"https://host/path")`,
+// `.post(uri"...")`. Group 1 = verb, group 2 = the URL body inside the uri
+// interpolator (interpolation markers `$x` / `${...}` are left in place and
+// canonicalised to `{x}` downstream).
+var scSttpVerbURIRe = regexp.MustCompile(
+	`\.(get|post|put|patch|delete|head|options)\s*\(\s*uri"([^"\n\r]*)"`,
+)
+
+// scEnclosingDefRe captures Scala method declarations for caller attribution:
+// `def foo(...)`, `override def foo(...)`, `private def foo[...](...)`.
+var scEnclosingDefRe = regexp.MustCompile(
+	`(?m)^[ \t]*(?:(?:private|protected|final|override|implicit|lazy|\s)+\s+)?def\s+([A-Za-z_]\w*)\s*[\[(]`,
+)
+
+// scSttpInterpRe rewrites a Scala interpolation marker (`$id` or `${expr}`) in a
+// `uri"..."` body into a `{id}` / `{param}` placeholder so the canonical path is
+// stable across call sites.
+var scSttpInterpRe = regexp.MustCompile(`\$\{[^}]*\}|\$[A-Za-z_]\w*`)
+
+// scClientEmitFn is the runtime-aware emitter type for the Scala client.
+type scClientEmitFn func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool)
+
+// synthesizeScalaClientWithRuntime is the package-level entry point referenced
+// from applyHTTPEndpointSynthesis. Emits one outbound http_endpoint_call per
+// sttp verb call site + a FETCHES edge from the enclosing def.
+func synthesizeScalaClientWithRuntime(content string, emit scClientEmitFn) {
+	if !strings.Contains(content, "basicRequest") &&
+		!strings.Contains(content, "quickRequest") &&
+		!strings.Contains(content, "emptyRequest") &&
+		!strings.Contains(content, "uri\"") {
+		return
+	}
+
+	funcs := indexScalaDefs(content)
+
+	for _, m := range scSttpVerbURIRe.FindAllStringSubmatchIndex(content, -1) {
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]]
+		// runtimeDynamic when the uri carried a Scala interpolation marker.
+		runtimeDynamic := strings.Contains(raw, "$")
+		raw = canonicalizeSttpInterpolation(raw)
+		path, ok := normalizeRawClientPath(raw)
+		if !ok {
+			continue
+		}
+		caller := enclosingScalaDefAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, path)
+		emit(verb, canonical, "sttp", "Function", caller, runtimeDynamic)
+	}
+}
+
+// canonicalizeSttpInterpolation rewrites Scala `$x` / `${expr}` interpolation
+// markers inside a uri-literal body to `{param}` placeholders, and trims a
+// trailing `/` segment introduced by a removed interpolation when needed.
+func canonicalizeSttpInterpolation(raw string) string {
+	return scSttpInterpRe.ReplaceAllStringFunc(raw, func(tok string) string {
+		// `$id` -> {id}; `${user.id}` -> {param} (expression form has no clean name).
+		if strings.HasPrefix(tok, "${") {
+			return "{param}"
+		}
+		name := strings.TrimPrefix(tok, "$")
+		return "{" + name + "}"
+	})
+}
+
+// indexScalaDefs builds a sorted (offset, name) list for every Scala method
+// declaration in the file, for enclosing-def attribution.
+func indexScalaDefs(content string) []jsFuncSpan {
+	var out []jsFuncSpan
+	for _, m := range scEnclosingDefRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, jsFuncSpan{offset: m[0], name: content[m[2]:m[3]]})
+	}
+	return out
+}
+
+// enclosingScalaDefAt returns the nearest preceding def name for a call site.
+func enclosingScalaDefAt(funcs []jsFuncSpan, pos int) string {
+	return enclosingJSFuncAt(funcs, pos)
+}

--- a/internal/engine/http_endpoint_scala_client_test.go
+++ b/internal/engine/http_endpoint_scala_client_test.go
@@ -1,0 +1,79 @@
+package engine
+
+import "testing"
+
+// TestScalaClient_SttpBasicRequestLiteral covers the canonical sttp form
+// `basicRequest.get(uri"https://api.example.com/v1/users")` and a POST, and
+// asserts the SPECIFIC canonical paths + FETCHES edges (value-asserting; the
+// host api.example.com is stripped to leave the producer route /v1/users).
+func TestScalaClient_SttpBasicRequestLiteral(t *testing.T) {
+	src := `
+import sttp.client3._
+
+def fetchUsers() = {
+  basicRequest.get(uri"https://api.example.com/v1/users")
+}
+
+def createUser(payload: String) = {
+  basicRequest
+    .body(payload)
+    .post(uri"https://api.example.com/v1/users")
+}
+`
+	ids, rels := runDetectWithRels(t, "scala", "UsersClient.scala", src)
+	requireContains(t, ids, []string{
+		"http:GET:/v1/users",
+		"http:POST:/v1/users",
+	}, "sttp-basic-literal")
+	requireFetches(t, rels, "http:GET:/v1/users", "sttp-basic-literal")
+	requireFetches(t, rels, "http:POST:/v1/users", "sttp-basic-literal")
+}
+
+// TestScalaClient_SttpQuickRequestInterpolated covers `quickRequest.get(...)`
+// with a `$id` path interpolation → {id} placeholder, asserting the specific
+// path /products/{id} on host catalog:8080 (host stripped).
+func TestScalaClient_SttpQuickRequestInterpolated(t *testing.T) {
+	src := `
+import sttp.client3.quick._
+
+def getProduct(id: String) = {
+  quickRequest.get(uri"http://catalog:8080/products/$id")
+}
+`
+	ids, _ := runDetectWithRels(t, "scala", "ProductClient.scala", src)
+	requireContains(t, ids, []string{"http:GET:/products/{id}"}, "sttp-quick-interp")
+}
+
+// TestScalaClient_SttpVerbAfterBuilderChain covers a verb combinator that
+// follows intermediate builder combinators (.response(asJson[T])) and a PUT
+// with `${...}` interpolation → {param}. Asserts the exact PUT path.
+func TestScalaClient_SttpVerbAfterBuilderChain(t *testing.T) {
+	src := `
+import sttp.client3._
+
+def updateUser(user: User) = {
+  basicRequest
+    .response(asJson[User])
+    .put(uri"https://api.example.com/v1/users/${user.id}")
+}
+`
+	ids, rels := runDetectWithRels(t, "scala", "UpdateClient.scala", src)
+	requireContains(t, ids, []string{"http:PUT:/v1/users/{param}"}, "sttp-chain-put")
+	requireFetches(t, rels, "http:PUT:/v1/users/{param}", "sttp-chain-put")
+}
+
+// TestScalaClient_SttpNoMatch asserts a non-sttp Scala file produces no
+// outbound endpoint synthetic.
+func TestScalaClient_SttpNoMatch(t *testing.T) {
+	src := `
+object Main extends App {
+  println("no http client here")
+}
+`
+	ids, _ := runDetectWithRels(t, "scala", "Main.scala", src)
+	for _, id := range ids {
+		if len(id) >= 5 && id[:5] == "http:" {
+			t.Errorf("sttp-no-match: unexpected http synthetic %q", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -101,6 +101,12 @@ func synthesisSupportsLanguage(lang string) bool {
 	// #1483: Elixir Finch / HTTPoison consumer-side extraction.
 	case "elixir":
 		return true
+	// #3554: Scala sttp consumer-side HTTP client extraction. The Scala
+	// producer side (tapir/http4s/akka) is handled by custom_scala_*
+	// extractors, but outbound sttp calls have no YAML rules, so allow Scala
+	// through for the client synthesizer; files without sttp markers are no-ops.
+	case "scala":
+		return true
 	// #3484: Lua Lapis / OpenResty producer-side route synthesis.
 	case "lua":
 		return true
@@ -800,6 +806,11 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Producer side (#3484): OpenResty nginx `location` stanzas (in
 		// lua-classified config-driver files) + lua-resty-router DSL routes.
 		synthesizeOpenResty(string(content), emit)
+	case "scala":
+		// Consumer side (#3554): sttp (basicRequest/quickRequest verb
+		// combinators with uri"..." literals) outbound HTTP client. The Scala
+		// producer side is handled by the custom_scala_* framework extractors.
+		synthesizeScalaClientWithRuntime(string(content), emitClientRuntime)
 	}
 
 	// #722 — response/request shape extraction. Mutates Properties on


### PR DESCRIPTION
Closes #3554 (epic #3505). Adds two Scala framework records to archigraph.

## sttp — HTTP client (`lang.scala.framework.sttp`, jvm_backend) — **full**
Engine-side consumer synthesis (`internal/engine/http_endpoint_scala_client.go`), mirroring the Kotlin Retrofit/Ktor client.

- `basicRequest`/`quickRequest`/`emptyRequest` verb combinators (`.get/.post/.put/.patch/.delete/.head/.options`) with `uri"..."` literals → one outbound `http_endpoint_call` per call site **+ a FETCHES edge** from the enclosing `def`. Feeds cross-repo HTTP linking (the Scala side was previously producer-only).
- Host stripped (producer serves `/v1/users` without host); `$id` / `${...}` interpolation → `{param}`; verb may appear before or after intermediate builder combinators.
- Wired `scala` into `synthesisSupportsLanguage` + the `applyHTTPEndpointSynthesis` dispatch.

Cells: Routing/endpoint_synthesis **full**, Routing/handler_attribution **full**, Substrate/http_effect **full**. Remaining cells `missing` (DTO-shape extraction is not an sttp-client concern, mirroring Retrofit).

## ScalaPB / zio-grpc / fs2-grpc — gRPC (`lang.scala.framework.scalapb-grpc`, rpc_framework)
Custom extractor `custom_scala_grpc` (`internal/custom/scala/grpc.go`), mirroring Rust tonic / C++ grpc. Auto-dispatched via the `custom_scala_` prefix (blank import already wired).

- Service-trait `def <rpc>(req: ReqT): Eff[RespT]` methods → SCOPE.Operation RPC endpoints at `/<Service>/<rpc>` (verb=RPC, rpc_protocol=grpc).
- Service trait → SCOPE.Service `grpc_service`; req/resp message names → SCOPE.Schema DTO refs; `<Svc>Grpc.stub`/`bindService` → SCOPE.Component `grpc_stub`.
- `Z`/`Fs2Grpc`/`Grpc` name decorations stripped to the proto service name; `ZIO[Ctx,Status,Resp]` / `Future[Resp]` / `F[Resp]` effect handled (last type-arg = response).

Cells: Schema/procedure_extraction **full**, Transport/transport_binding **full**; Schema/schema_extraction **partial**, Codegen/client_codegen **partial**, Substrate/request_shape & response_shape **partial** (message NAMES recovered; field shapes live in ScalaPB-generated companions — honest partial, same as tonic/c-cpp grpc).

## Discipline
- Value-asserting tests pin specific URLs/hosts (`GET`/`POST` `/v1/users`, `PUT /v1/users/{param}`, host `api.example.com`/`catalog:8080` stripped) and specific rpc/service/message names (`Greeter.sayHello`, `HelloRequest`/`HelloReply`, `UserList`, `GreeterGrpc.stub`).
- Targeted tests green (`custom/scala`, `extractors/scala`, `engine`, `types`, `tools/coverage`); `coverage validate` 0 errors; `coverage fmt --check` canonical; `gofmt -l` empty; `go vet` clean.
- Registry diff is a pure 2-record insertion; no detail-page or sibling drift.

**DEPLOY-DEFERRED** — daemon rebuild + reindex are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)