### PR TITLE
fix(coverage): correct CI/infra cells citing dormant rule buckets (#3593)

### DIFF
--- a/docs/coverage/by-category/ci_cd.md
+++ b/docs/coverage/by-category/ci_cd.md
@@ -7,15 +7,15 @@ Back to [summary](../summary.md). Bucket: **Other**.
 
 | Language | Name | Env resolution | File parsing | Status | Notes |
 |---|---|---|---|---|---|
-| [multi](../by-language/multi.md) | [Azure Pipelines](../detail/ci.azure-pipelines.md) | 🟢 | ✅ | 🟢 | |
-| [multi](../by-language/multi.md) | [Bitbucket Pipelines](../detail/ci.bitbucket.md) | 🟢 | ✅ | 🟢 | |
-| [multi](../by-language/multi.md) | [Buildkite](../detail/ci.buildkite.md) | 🟢 | ✅ | 🟢 | |
-| [multi](../by-language/multi.md) | [CircleCI](../detail/ci.circleci.md) | 🟢 | ✅ | 🟢 | |
+| [multi](../by-language/multi.md) | [Azure Pipelines](../detail/ci.azure-pipelines.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Bitbucket Pipelines](../detail/ci.bitbucket.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [Buildkite](../detail/ci.buildkite.md) | 🟢 | 🟢 | 🟢 | |
+| [multi](../by-language/multi.md) | [CircleCI](../detail/ci.circleci.md) | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Drone CI](../detail/ci.drone.md) | 🔴 | 🔴 | 🔴 | |
 | [multi](../by-language/multi.md) | [GitHub Actions](../detail/ci.github-actions.md) | 🟢 | ✅ | 🟢 | |
 | [multi](../by-language/multi.md) | [GitHub Actions workflows](../detail/config.github-actions.md) | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [GitLab CI](../detail/ci.gitlab.md) | 🟢 | ✅ | 🟢 | |
 | [multi](../by-language/multi.md) | [GitLab CI](../detail/config.gitlab-ci.md) | — | 🟢 | 🟢 | |
-| [multi](../by-language/multi.md) | [Jenkins (Jenkinsfile)](../detail/ci.jenkins.md) | 🔴 | 🟢 | 🔴 | |
+| [multi](../by-language/multi.md) | [Jenkins (Jenkinsfile)](../detail/ci.jenkins.md) | 🔴 | 🔴 | 🔴 | |
 | [multi](../by-language/multi.md) | [Jenkinsfile / Jenkins Pipeline DSL](../detail/config.jenkins.md) | — | 🔴 | 🔴 | |
-| [multi](../by-language/multi.md) | [Travis CI](../detail/ci.travis.md) | 🟢 | ✅ | 🟢 | |
+| [multi](../by-language/multi.md) | [Travis CI](../detail/ci.travis.md) | 🟢 | 🟢 | 🟢 | |

--- a/docs/coverage/detail/ci.azure-pipelines.md
+++ b/docs/coverage/detail/ci.azure-pipelines.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Env resolution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
-| File parsing | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/cicd/frameworks/azure_pipelines.yaml` | — |
+| File parsing | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3593) | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.bitbucket.md
+++ b/docs/coverage/detail/ci.bitbucket.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Env resolution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
-| File parsing | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml` | — |
+| File parsing | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3593) | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.buildkite.md
+++ b/docs/coverage/detail/ci.buildkite.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Env resolution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
-| File parsing | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/cicd/frameworks/buildkite.yaml` | — |
+| File parsing | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3593) | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.circleci.md
+++ b/docs/coverage/detail/ci.circleci.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Env resolution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
-| File parsing | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/cicd/frameworks/circleci.yaml` | — |
+| File parsing | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3593) | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.github-actions.md
+++ b/docs/coverage/detail/ci.github-actions.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Env resolution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
-| File parsing | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/cicd/frameworks/github_actions.yaml`<br>`internal/extractors/yaml/extractor.go` | — |
+| File parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.gitlab.md
+++ b/docs/coverage/detail/ci.gitlab.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Env resolution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
-| File parsing | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/cicd/frameworks/gitlab_ci.yaml` | — |
+| File parsing | ✅ `full` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.jenkins.md
+++ b/docs/coverage/detail/ci.jenkins.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Env resolution | 🔴 `missing` | — | — | — | — |
-| File parsing | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/cicd/_manifest.yaml` | — |
+| File parsing | 🔴 `missing` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3593) | — | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/ci.travis.md
+++ b/docs/coverage/detail/ci.travis.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Env resolution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
-| File parsing | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/cicd/frameworks/travis_ci.yaml` | — |
+| File parsing | 🟢 `partial` | `2026-05-31` | [link](https://github.com/cajasmota/archigraph/issues/3593) | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.container.docker-compose.md
+++ b/docs/coverage/detail/infra.container.docker-compose.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | ✅ `full` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
-| Resource extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/docker/frameworks/docker_compose.yaml`<br>`internal/extractors/yaml/extractor.go` | — |
+| Resource extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.container.dockerfile.md
+++ b/docs/coverage/detail/infra.container.dockerfile.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | ✅ `full` | `2026-05-28` | — | `internal/extractors/dockerfile/dockerfile.go` | — |
-| Resource extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/docker/frameworks/dockerfile.yaml`<br>`internal/extractors/dockerfile/dockerfile.go` | — |
+| Resource extraction | ✅ `full` | `2026-05-28` | — | `internal/extractors/dockerfile/dockerfile.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.container.kubernetes.md
+++ b/docs/coverage/detail/infra.container.kubernetes.md
@@ -12,7 +12,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Dependency attribution | ✅ `full` | `2026-05-31` | — | `internal/engine/kubernetes_edges.go`<br>`internal/extractors/yaml/extractor.go` | #3551: cross-resource edges are namespace-scoped (selector/ref matching links only within the same metadata.namespace, default-namespaced when omitted). Added NetworkPolicy spec.podSelector, PodDisruptionBudget spec.selector, and Prometheus-Operator ServiceMonitor/PodMonitor selector edges. |
-| Resource extraction | ✅ `full` | `2026-05-31` | — | `internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml`<br>`internal/extractors/yaml/extractor.go` | #3551: CustomResourceDefinition captured as a crd_definition entity (spec.names/group/scope in Properties); known CRD instances (ArgoCD Application/AppProject, Argo Rollouts Rollout, cert-manager Certificate/Issuer, Prometheus ServiceMonitor/PodMonitor) typed meaningfully instead of generic Component; metadata.namespace stamped as k8s_namespace Property. |
+| Resource extraction | ✅ `full` | `2026-05-31` | — | `internal/extractors/yaml/extractor.go` | #3551: CustomResourceDefinition captured as a crd_definition entity (spec.names/group/scope in Properties); known CRD instances (ArgoCD Application/AppProject, Argo Rollouts Rollout, cert-manager Certificate/Issuer, Prometheus ServiceMonitor/PodMonitor) typed meaningfully instead of generic Component; metadata.namespace stamped as k8s_namespace Property. |
 
 ## Provenance
 

--- a/docs/coverage/detail/infra.iac.ansible.md
+++ b/docs/coverage/detail/infra.iac.ansible.md
@@ -11,8 +11,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ansible/_manifest.yaml` | — |
-| Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/engine/rules/ansible/_manifest.yaml` | — |
+| Dependency attribution | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
+| Resource extraction | 🟢 `partial` | `2026-05-28` | — | `internal/extractors/yaml/extractor.go` | — |
 
 ## Provenance
 

--- a/docs/coverage/registry.json
+++ b/docs/coverage/registry.json
@@ -723,9 +723,10 @@
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
-          "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/azure_pipelines.yaml"],
-          "verified_at": "2026-05-28"
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3593",
+          "verified_at": "2026-05-31"
         }
       }
     },
@@ -741,9 +742,10 @@
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
-          "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/bitbucket_pipelines.yaml"],
-          "verified_at": "2026-05-28"
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3593",
+          "verified_at": "2026-05-31"
         }
       }
     },
@@ -759,9 +761,10 @@
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
-          "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/buildkite.yaml"],
-          "verified_at": "2026-05-28"
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3593",
+          "verified_at": "2026-05-31"
         }
       }
     },
@@ -777,9 +780,10 @@
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
-          "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/circleci.yaml"],
-          "verified_at": "2026-05-28"
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3593",
+          "verified_at": "2026-05-31"
         }
       }
     },
@@ -810,7 +814,7 @@
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/github_actions.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -828,7 +832,7 @@
         },
         "file_parsing": {
           "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/gitlab_ci.yaml"],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -843,9 +847,9 @@
           "status": "missing"
         },
         "file_parsing": {
-          "status": "partial",
-          "cites": ["internal/engine/rules/cicd/_manifest.yaml"],
-          "verified_at": "2026-05-28"
+          "status": "missing",
+          "issue": "https://github.com/cajasmota/archigraph/issues/3593",
+          "verified_at": "2026-05-31"
         }
       }
     },
@@ -861,9 +865,10 @@
           "verified_at": "2026-05-28"
         },
         "file_parsing": {
-          "status": "full",
-          "cites": ["internal/engine/rules/cicd/frameworks/travis_ci.yaml"],
-          "verified_at": "2026-05-28"
+          "status": "partial",
+          "cites": ["internal/extractors/yaml/extractor.go"],
+          "issue": "https://github.com/cajasmota/archigraph/issues/3593",
+          "verified_at": "2026-05-31"
         }
       }
     },
@@ -1196,7 +1201,7 @@
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/docker/frameworks/docker_compose.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1214,7 +1219,7 @@
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/docker/frameworks/dockerfile.yaml","internal/extractors/dockerfile/dockerfile.go"],
+          "cites": ["internal/extractors/dockerfile/dockerfile.go"],
           "verified_at": "2026-05-28"
         }
       }
@@ -1251,7 +1256,7 @@
         },
         "resource_extraction": {
           "status": "full",
-          "cites": ["internal/engine/rules/kubernetes/frameworks/kubernetes_manifests.yaml","internal/extractors/yaml/extractor.go"],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "notes": "#3551: CustomResourceDefinition captured as a crd_definition entity (spec.names/group/scope in Properties); known CRD instances (ArgoCD Application/AppProject, Argo Rollouts Rollout, cert-manager Certificate/Issuer, Prometheus ServiceMonitor/PodMonitor) typed meaningfully instead of generic Component; metadata.namespace stamped as k8s_namespace Property.",
           "verified_at": "2026-05-31"
         }
@@ -1283,12 +1288,12 @@
       "capabilities": {
         "dependency_attribution": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         },
         "resource_extraction": {
           "status": "partial",
-          "cites": ["internal/engine/rules/ansible/_manifest.yaml"],
+          "cites": ["internal/extractors/yaml/extractor.go"],
           "verified_at": "2026-05-28"
         }
       }


### PR DESCRIPTION
## Summary

Part of #3593 (cell-integrity half). The engine loads YAML rule buckets by **dirname**, but the detector resolves flavor by **`file.Language`** — so 7 buckets (`cicd` / `ansible` / `docker` / `kubernetes` / `html_templates` + stale `cdk`/`pulumi` dups) **never fire**. Live CI/infra coverage actually comes from `internal/extractors/yaml/` (via `detectFlavor`) and `internal/extractors/dockerfile/`, **not** the rule buckets.

This PR corrects `docs/coverage/registry.json` cells that mis-attributed coverage to those dormant buckets. **Registry-only** — the buckets are not wired here; the bucket-wiring half of #3593 stays open.

Confirmed against `internal/extractors/yaml/extractor.go::detectFlavor`, which handles only: `github_actions`, `gitlab_ci`, `docker_compose`, `kubernetes`, `ansible`, `kustomize`, helm, generic. Azure/Bitbucket/Buildkite/CircleCI/Travis/Jenkins are **not** handled → fall through to `extractGeneric` (or, for Jenkinsfile, are Groovy and untouched by the YAML extractor).

## Group A — downgraded (cited ONLY a dormant bucket)

| Cell | Old → New | Why |
|---|---|---|
| `ci.azure-pipelines` / file_parsing | `full` → `partial` | flavor unhandled; only generic YAML extraction runs |
| `ci.bitbucket` / file_parsing | `full` → `partial` | same |
| `ci.buildkite` / file_parsing | `full` → `partial` | same |
| `ci.circleci` / file_parsing | `full` → `partial` | same |
| `ci.travis` / file_parsing | `full` → `partial` | same |
| `ci.jenkins` / file_parsing | `partial` → `missing` | Jenkinsfile is Groovy, not YAML; no Jenkins-aware extractor exists |

All Group A cells get `issue: #3593`; downgraded cells re-cite the real generic path (`yaml/extractor.go`), and the jenkins `missing` cell drops the dormant cite entirely.

## Group B — re-cited (live; status unchanged)

| Cell | Re-cite | (status) |
|---|---|---|
| `ci.github-actions` / file_parsing | drop `cicd/frameworks/github_actions.yaml` → keep `yaml/extractor.go` | `full` |
| `ci.gitlab` / file_parsing | `gitlab_ci.yaml` → `yaml/extractor.go` | `full` |
| `infra.iac.ansible` / dependency_attribution | `ansible/_manifest.yaml` → `yaml/extractor.go` | `partial` |
| `infra.iac.ansible` / resource_extraction | `ansible/_manifest.yaml` → `yaml/extractor.go` | `partial` |
| `infra.container.docker-compose` / resource_extraction | drop `docker/frameworks/docker_compose.yaml` → keep `yaml/extractor.go` | `full` |
| `infra.container.dockerfile` / resource_extraction | drop `docker/frameworks/dockerfile.yaml` → keep `dockerfile/dockerfile.go` | `full` |
| `infra.container.kubernetes` / resource_extraction | drop `kubernetes/frameworks/kubernetes_manifests.yaml` → keep `yaml/extractor.go` | `full` |

## Verification

- `coverage validate` → **0 errors** (580 records; pre-existing capability-map warnings only)
- `coverage fmt --check` → canonical
- `coverage gen` → regenerated; unrelated detail-page drift (terraform/bicep/aws-cdk/cloudformation/pulumi, from #3549) reverted

**Counts:** 6 downgraded (5 → partial, 1 → missing) / 7 re-cited.

**DEPLOY-DEFERRED:** registry + generated-doc change only. No daemon rebuild, reindex, or MCP restart.